### PR TITLE
wasm-jit: C's assert channels for an FMU

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -97,6 +97,28 @@ fn host_runtime_error() {
 #[cfg(not(all(target_arch = "wasm32", feature = "host_log", not(feature = "standalone"))))]
 fn host_runtime_error() {}
 
+/// C's `omc_assert` with no thread context. A simulation installs
+/// `omc_assert_simulation`: `LOG_ASSERT` at error level, then unwind.
+#[cfg(not(all(target_arch = "wasm32", not(feature = "host_log"), not(feature = "standalone"))))]
+pub(crate) fn omc_assert(msg: &str) -> ! {
+    omclog::error(omclog::ASSERT, false, msg);
+    openmodelica_sim_meta::driver::note_runtime_error_flag();
+    host_runtime_error();
+    trap()
+}
+
+/// The FMI3 adapter's build, the only one with no simulation, keeps C's
+/// `omc_assert_fmi`: thread-less, so stderr rather than the FMI logger.
+#[cfg(all(target_arch = "wasm32", not(feature = "host_log"), not(feature = "standalone")))]
+pub(crate) fn omc_assert(msg: &str) -> ! {
+    unsafe extern "C" {
+        fn rt_stderr_write(ptr: *const u8, len: usize);
+    }
+    let line = format!("[:0:0-0:0:writable]Modelica Assert: {msg}!\n");
+    unsafe { rt_stderr_write(line.as_ptr(), line.len()) };
+    trap()
+}
+
 // `rt_reinit_note(state_off, value)`: the model records an executed `reinit` for
 // the driver's `LOG_EVENTS` block. Every generated model imports it, so every
 // host-free consumer must define it — the standalone export and the FMI3 adapter
@@ -1984,13 +2006,38 @@ struct FmtSpec {
     conv: u8,
 }
 
+/// The `omc_assert`s in `modelica_string_format_to_c_string_format`.
+enum FmtParseError {
+    LengthModifier,
+    /// 0 for a directive that ends before its specifier.
+    InvalidSpecifier(u8),
+    TrailingData,
+}
+
+/// The `omc_assert` `modelica_string_format_to_c_string_format` reaches for `err`.
+fn assert_format_error(bytes: &[u8], err: FmtParseError) -> ! {
+    let str = String::from_utf8_lossy(bytes);
+    let msg = match err {
+        FmtParseError::LengthModifier => {
+            format!("Length modifiers are not legal in Modelica format strings: {str}")
+        }
+        FmtParseError::InvalidSpecifier(c) => {
+            // C's `%c` of the terminating NUL contributes nothing.
+            let c = match c { 0 => String::new(), c => String::from(c as char) };
+            format!("Could not parse format string: invalid conversion specifier: {c} in {str}")
+        }
+        FmtParseError::TrailingData => {
+            "Could not parse format string: trailing data after the format directive".to_string()
+        }
+    };
+    omc_assert(&msg)
+}
+
 /// Parse a Modelica format directive (the body after the implicit leading `%`)
 /// into a [`FmtSpec`], mirroring `modelica_string_format_to_c_string_format`:
 /// flags, optional width, optional `.precision`, then a single conversion
-/// specifier. Returns `None` for an unparseable directive (length modifiers,
-/// unknown specifier, trailing data) — the caller traps, matching the C
-/// runtime's `omc_assert`.
-fn parse_modelica_format(bytes: &[u8]) -> Option<FmtSpec> {
+/// specifier. An unparseable directive is the caller's [`assert_format_error`].
+fn parse_modelica_format(bytes: &[u8]) -> Result<FmtSpec, FmtParseError> {
     let mut spec = FmtSpec {
         minus: false, zero: false, plus: false, space: false, hash: false,
         width: 0, prec: None, conv: 0,
@@ -2023,23 +2070,21 @@ fn parse_modelica_format(bytes: &[u8]) -> Option<FmtSpec> {
         }
         spec.prec = Some(p);
     }
-    // Conversion specifier (single character; length modifiers are rejected, as
-    // in the C runtime).
     if i >= bytes.len() {
-        return None;
+        return Err(FmtParseError::InvalidSpecifier(0));
     }
     let conv = bytes[i];
     match conv {
         b'f' | b'e' | b'E' | b'g' | b'G' | b'c' | b'd' | b'i' | b'o' | b'x' | b'X' | b'u' => {}
-        _ => return None, // length modifier / unknown specifier
+        b'h' | b'l' | b'L' | b'q' | b'j' | b'z' | b't' => return Err(FmtParseError::LengthModifier),
+        _ => return Err(FmtParseError::InvalidSpecifier(conv)),
     }
     spec.conv = conv;
     i += 1;
-    // No trailing data after the directive.
     if i != bytes.len() {
-        return None;
+        return Err(FmtParseError::TrailingData);
     }
-    Some(spec)
+    Ok(spec)
 }
 
 /// Apply a [`FmtSpec`]'s sign flag and field width to an already-rendered numeric
@@ -2115,9 +2160,10 @@ fn format_float_body(r: f64, spec: &FmtSpec) -> String {
 /// parse the directive, render the double, apply sign/width.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_string_format_real(r: f64, fmt: u32) -> u32 {
-    let spec = match parse_modelica_format(unsafe { str_bytes(fmt) }) {
-        Some(s) => s,
-        None => trap(),
+    let bytes = unsafe { str_bytes(fmt) };
+    let spec = match parse_modelica_format(bytes) {
+        Ok(s) => s,
+        Err(e) => assert_format_error(bytes, e),
     };
     let body = format_float_body(r, &spec);
     new_str_from(&apply_sign_width(body, &spec))
@@ -2130,9 +2176,10 @@ pub extern "C" fn rt_string_format_real(r: f64, fmt: u32) -> u32 {
 /// precision is the minimum digit count (zero-padded), as in C printf.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_string_format_int(i: i32, fmt: u32) -> u32 {
-    let spec = match parse_modelica_format(unsafe { str_bytes(fmt) }) {
-        Some(s) => s,
-        None => trap(),
+    let bytes = unsafe { str_bytes(fmt) };
+    let spec = match parse_modelica_format(bytes) {
+        Ok(s) => s,
+        Err(e) => assert_format_error(bytes, e),
     };
     match spec.conv {
         b'f' | b'F' | b'e' | b'E' | b'g' | b'G' => {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -79,6 +79,7 @@ unsafe extern "C" {
 /// bridges to `wasi:cli/stdout`.
 mod stdio {
     const STDOUT: i32 = 1;
+    const STDERR: i32 = 2;
 
     #[repr(C)]
     struct Ciovec {
@@ -92,19 +93,28 @@ mod stdio {
         fn fd_write(fd: i32, iovs: *const Ciovec, iovs_len: usize, nwritten: *mut usize) -> i32;
     }
 
-    /// C's `printf` + `fflush(NULL)`: written whole and now, so it interleaves
-    /// with the importer's own output in the order the two produced it.
-    pub fn print(bytes: &[u8]) {
+    fn write(fd: i32, bytes: &[u8]) {
         let mut rest = bytes;
         while !rest.is_empty() {
             let iov = Ciovec { buf: rest.as_ptr(), len: rest.len() };
             let mut n = 0usize;
-            let rc = unsafe { fd_write(STDOUT, &iov, 1, &mut n) };
+            let rc = unsafe { fd_write(fd, &iov, 1, &mut n) };
             if rc != 0 || n == 0 || n > rest.len() {
                 return;
             }
             rest = &rest[n..];
         }
+    }
+
+    /// C's `printf` + `fflush(NULL)`: written whole and now, so it interleaves
+    /// with the importer's own output in the order the two produced it.
+    pub fn print(bytes: &[u8]) {
+        write(STDOUT, bytes);
+    }
+
+    /// The same for fd 2, where C's `omc_assert_fmi` writes a thread-less assertion.
+    pub fn stderr(bytes: &[u8]) {
+        write(STDERR, bytes);
     }
 }
 
@@ -243,6 +253,13 @@ pub extern "C" fn rt_assert_warning(
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_print(str: i32) {
     stdio::print(rt_string(str).as_bytes());
+}
+
+/// Where the runtime's `omc_assert` writes: it has no WASI of its own.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_stderr_write(ptr: *const u8, len: usize) {
+    let bytes = unsafe { core::slice::from_raw_parts(ptr, len) };
+    stdio::stderr(bytes);
 }
 
 /// Per-row assert formatting: the FMI master steps the model instead of the emitted

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_ls_wasm_to_native/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_ls_wasm_to_native/Cargo.toml
@@ -11,7 +11,7 @@
 [package]
 name = "openmodelica_fmi_ls_wasm_to_native"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_ls_wasm_to_native/src/fmi2.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_ls_wasm_to_native/src/fmi2.rs
@@ -145,22 +145,22 @@ unsafe fn shift(inst: &Instance, vr: *const u32, nvr: usize, base: Base) -> Opti
         return None;
     }
     let off = inst.fmi2.as_ref()?.offset(base);
-    Some((0..nvr).map(|i| *vr.add(i) + off).collect())
+    Some((0..nvr).map(|i| unsafe { *vr.add(i) + off }).collect())
 }
 
 // ── Lifecycle ───────────────────────────────────────────────────────────────
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn fmi2GetTypesPlatform() -> *const c_char {
     c"default".as_ptr()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn fmi2GetVersion() -> *const c_char {
     c"2.0".as_ptr()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2Instantiate(
     instance_name: *const c_char,
     fmu_type: i32,
@@ -170,14 +170,19 @@ pub unsafe extern "C" fn fmi2Instantiate(
     visible: i32,
     logging_on: i32,
 ) -> *mut c_void {
-    let name = cstr(instance_name);
-    let token = cstr(fmu_guid);
-    let res = resource_dir(&cstr(fmu_resource_location));
-    let (env, logger) = match functions.as_ref() {
+    let name = unsafe { cstr(instance_name) };
+    let token = unsafe { cstr(fmu_guid) };
+    let res = resource_dir(&unsafe { cstr(fmu_resource_location) });
+    let (env, logger) = match unsafe { functions.as_ref() } {
         Some(f) => (f.component_environment, f.logger),
         None => (std::ptr::null_mut(), None),
     };
-    let log = || Log::Fmi2 { cb: logger, name: CString::new(name.as_str()).unwrap_or_default() };
+    // C's `fmi2Instantiate` sets every category to `loggingOn`.
+    let log = || Log::Fmi2 {
+        cb: logger,
+        name: CString::new(name.as_str()).unwrap_or_default(),
+        call_log: b(logging_on),
+    };
     let built = (|| -> wasmtime::Result<Box<Instance>> {
         let offsets = read_offsets(&res).map_err(wasmtime::Error::msg)?;
         let mut inst = match fmu_type {
@@ -209,45 +214,56 @@ pub unsafe extern "C" fn fmi2Instantiate(
             step_status: OK,
             last_successful_time: 0.0,
             terminated: false,
-        });
+       });
         Ok(inst)
-    })();
+   })();
     match built {
         Ok(b) => Box::into_raw(b) as *mut c_void,
         Err(e) => crate::report(&name, env, &log(), e),
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2FreeInstance(c: *mut c_void) {
-    crate::fmi3FreeInstance(c)
+    unsafe {
+        crate::fmi3FreeInstance(c)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2SetDebugLogging(
     c: *mut c_void,
     logging_on: i32,
     n_categories: usize,
     categories: *const *const c_char,
 ) -> i32 {
-    // Only the call-trace category has a different name in 3.0.
-    let cats: Vec<String> = if categories.is_null() {
+    let raw: Vec<String> = if categories.is_null() {
         Vec::new()
     } else {
-        (0..n_categories)
-            .map(|i| match cstr(*categories.add(i)) {
-                s if s == "logFmi2Call" => "logFmi3Call".to_owned(),
-                s => s,
-            })
-            .collect()
+        (0..n_categories).map(|i| unsafe { cstr(*categories.add(i)) }).collect()
     };
+    // C's `fmi2SetDebugLogging`: every category off, then the named ones to
+    // `loggingOn`, with `logAll` covering the rest.
+    if let Some(inst) = inst_mut(c)
+        && let Log::Fmi2 { call_log, .. } = &mut inst.store.data_mut().log
+    {
+        *call_log = b(logging_on) && raw.iter().any(|c| c == "logFmi2Call" || c == "logAll");
+    }
+    // Only the call-trace category has a different name in 3.0.
+    let cats: Vec<String> = raw
+        .iter()
+        .map(|s| match s.as_str() {
+            "logFmi2Call" => "logFmi3Call".to_owned(),
+            _ => s.clone(),
+       })
+        .collect();
     on_instance!(inst_mut(c), |store, g, h, st| match g.call_set_debug_logging(store, h, b(logging_on), &cats) {
         Ok(s) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2SetupExperiment(
     c: *mut c_void,
     tolerance_defined: i32,
@@ -264,24 +280,28 @@ pub unsafe extern "C" fn fmi2SetupExperiment(
     OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2EnterInitializationMode(c: *mut c_void) -> i32 {
     let Some(inst) = inst_mut(c) else { return ERROR };
     let Some(&State { tolerance, start_time, stop_time, .. }) = inst.fmi2.as_ref() else { return ERROR };
     on_instance!(Some(inst), |store, g, h, st| match g.call_enter_initialization_mode(store, h, tolerance, start_time, stop_time) {
         Ok(s) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
 macro_rules! nullary {
     ($cfn:ident, $wfn:ident) => {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub unsafe extern "C" fn $cfn(c: *mut c_void) -> i32 {
-            on_instance!(inst_mut(c), |store, g, h, st| match g.$wfn(store, h) {
+            on_instance!(inst_mut(c), |store, g, h, st| match g.$wfn(&mut *store, h) {
                 Ok(s) => st(s),
-                Err(_) => ERROR,
-            })
+                Err(_) => {
+                    let msg = format!("{}: terminated by an assertion.", stringify!($cfn));
+                    store.data_mut().log_fmi2_call(ERROR, &msg);
+                    ERROR
+                }
+           })
         }
     };
 }
@@ -290,7 +310,7 @@ nullary!(fmi2Terminate, call_terminate);
 nullary!(fmi2EnterEventMode, call_enter_event_mode);
 
 /// Back to the instantiated state: the experiment and the last step's status go.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2Reset(c: *mut c_void) -> i32 {
     let Some(inst) = inst_mut(c) else { return ERROR };
     if let Some(st) = inst.fmi2.as_mut() {
@@ -300,14 +320,14 @@ pub unsafe extern "C" fn fmi2Reset(c: *mut c_void) -> i32 {
     on_instance!(Some(inst), |store, g, h, st| match g.call_reset(store, h) {
         Ok(s) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
 // ── Variable access ─────────────────────────────────────────────────────────
 
 macro_rules! getter {
     ($cfn:ident, $wfn:ident, $base:expr, $ty:ty, $conv:expr) => {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub unsafe extern "C" fn $cfn(
             c: *mut c_void,
             value_references: *const u32,
@@ -315,23 +335,29 @@ macro_rules! getter {
             values: *mut $ty,
         ) -> i32 {
             let Some(inst) = inst_mut(c) else { return ERROR };
-            let Some(refs) = shift(inst, value_references, n_value_references, $base) else { return ERROR };
+            let Some(refs) = (unsafe { shift(inst, value_references, n_value_references, $base) }) else { return ERROR };
             if values.is_null() && n_value_references != 0 {
                 return ERROR;
             }
-            on_instance!(Some(inst), |store, g, h, st| match g.$wfn(store, h, &refs) {
+            on_instance!(Some(inst), |store, g, h, st| match g.$wfn(&mut *store, h, &refs) {
                 Ok(Ok(v)) => {
                     if v.len() != n_value_references {
                         return ERROR;
                     }
-                    for (i, x) in v.into_iter().enumerate() {
-                        *values.add(i) = $conv(x);
+                    unsafe {
+                        for (i, x) in v.into_iter().enumerate() {
+                            *values.add(i) = $conv(x);
+                        }
                     }
                     OK
                 }
                 Ok(Err(s)) => st(s),
-                Err(_) => ERROR,
-            })
+                Err(_) => {
+                    let msg = format!("{}: terminated by an assertion.", stringify!($cfn));
+                    store.data_mut().log_fmi2_call(ERROR, &msg);
+                    ERROR
+                }
+           })
         }
     };
 }
@@ -341,7 +367,7 @@ getter!(fmi2GetBoolean, call_get_boolean, Base::Boolean, i32, fmi2_bool);
 
 macro_rules! setter {
     ($cfn:ident, $wfn:ident, $base:expr, $ty:ty, $conv:expr) => {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub unsafe extern "C" fn $cfn(
             c: *mut c_void,
             value_references: *const u32,
@@ -349,15 +375,19 @@ macro_rules! setter {
             values: *const $ty,
         ) -> i32 {
             let Some(inst) = inst_mut(c) else { return ERROR };
-            let Some(refs) = shift(inst, value_references, n_value_references, $base) else { return ERROR };
+            let Some(refs) = (unsafe { shift(inst, value_references, n_value_references, $base) }) else { return ERROR };
             if values.is_null() && n_value_references != 0 {
                 return ERROR;
             }
-            let vals: Vec<_> = (0..n_value_references).map(|i| $conv(*values.add(i))).collect();
-            on_instance!(Some(inst), |store, g, h, st| match g.$wfn(store, h, &refs, &vals) {
+            let vals: Vec<_> = (0..n_value_references).map(|i| unsafe { $conv(*values.add(i)) }).collect();
+            on_instance!(Some(inst), |store, g, h, st| match g.$wfn(&mut *store, h, &refs, &vals) {
                 Ok(s) => st(s),
-                Err(_) => ERROR,
-            })
+                Err(_) => {
+                    let msg = format!("{}: terminated by an assertion.", stringify!($cfn));
+                    store.data_mut().log_fmi2_call(ERROR, &msg);
+                    ERROR
+                }
+           })
         }
     };
 }
@@ -366,7 +396,7 @@ setter!(fmi2SetInteger, call_set_int32, Base::Integer, i32, |v| v);
 setter!(fmi2SetBoolean, call_set_boolean, Base::Boolean, i32, b);
 
 /// The pointers borrow from the instance until the next `fmi2GetString` on it.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2GetString(
     c: *mut c_void,
     value_references: *const u32,
@@ -374,7 +404,7 @@ pub unsafe extern "C" fn fmi2GetString(
     values: *mut *const c_char,
 ) -> i32 {
     let Some(inst) = inst_mut(c) else { return ERROR };
-    let Some(refs) = shift(inst, value_references, n_value_references, Base::Str) else { return ERROR };
+    let Some(refs) = (unsafe { shift(inst, value_references, n_value_references, Base::Str) }) else { return ERROR };
     if values.is_null() && n_value_references != 0 {
         return ERROR;
     }
@@ -402,13 +432,15 @@ pub unsafe extern "C" fn fmi2GetString(
         return ERROR;
     }
     inst.strings = strings.into_iter().map(|s| CString::new(s).unwrap_or_default()).collect();
-    for (i, s) in inst.strings.iter().enumerate() {
-        *values.add(i) = s.as_ptr();
+    unsafe {
+        for (i, s) in inst.strings.iter().enumerate() {
+            *values.add(i) = s.as_ptr();
+        }
     }
     OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2SetString(
     c: *mut c_void,
     value_references: *const u32,
@@ -416,61 +448,73 @@ pub unsafe extern "C" fn fmi2SetString(
     values: *const *const c_char,
 ) -> i32 {
     let Some(inst) = inst_mut(c) else { return ERROR };
-    let Some(refs) = shift(inst, value_references, n_value_references, Base::Str) else { return ERROR };
+    let Some(refs) = (unsafe { shift(inst, value_references, n_value_references, Base::Str) }) else { return ERROR };
     if values.is_null() && n_value_references != 0 {
         return ERROR;
     }
-    let vals: Vec<String> = (0..n_value_references).map(|i| cstr(*values.add(i))).collect();
+    let vals: Vec<String> = (0..n_value_references).map(|i| unsafe { cstr(*values.add(i)) }).collect();
     on_instance!(Some(inst), |store, g, h, st| match g.call_set_string(store, h, &refs, &vals) {
         Ok(s) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
 // ── FMU state ───────────────────────────────────────────────────────────────
 // Identical in both versions, down to the opaque pointer being a boxed `Vec<u8>`.
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2GetFMUstate(c: *mut c_void, state: *mut *mut c_void) -> i32 {
-    crate::fmi3GetFMUState(c, state)
+    unsafe {
+        crate::fmi3GetFMUState(c, state)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2SetFMUstate(c: *mut c_void, state: *mut c_void) -> i32 {
-    crate::fmi3SetFMUState(c, state)
+    unsafe {
+        crate::fmi3SetFMUState(c, state)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2FreeFMUstate(c: *mut c_void, state: *mut *mut c_void) -> i32 {
-    crate::fmi3FreeFMUState(c, state)
+    unsafe {
+        crate::fmi3FreeFMUState(c, state)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2SerializedFMUstateSize(c: *mut c_void, state: *mut c_void, size: *mut usize) -> i32 {
-    crate::fmi3SerializedFMUStateSize(c, state, size)
+    unsafe {
+        crate::fmi3SerializedFMUStateSize(c, state, size)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2SerializeFMUstate(
     c: *mut c_void,
     state: *mut c_void,
     serialized: *mut u8,
     size: usize,
 ) -> i32 {
-    crate::fmi3SerializeFMUState(c, state, serialized, size)
+    unsafe {
+        crate::fmi3SerializeFMUState(c, state, serialized, size)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2DeSerializeFMUstate(
     c: *mut c_void,
     serialized: *const u8,
     size: usize,
     state: *mut *mut c_void,
 ) -> i32 {
-    crate::fmi3DeserializeFMUState(c, serialized, size, state)
+    unsafe {
+        crate::fmi3DeserializeFMUState(c, serialized, size, state)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2GetDirectionalDerivative(
     c: *mut c_void,
     unknowns: *const u32,
@@ -482,70 +526,84 @@ pub unsafe extern "C" fn fmi2GetDirectionalDerivative(
 ) -> i32 {
     let Some(inst) = inst_mut(c) else { return ERROR };
     // Both directions are Real-valued, so both index the Real block.
-    let (Some(u), Some(k)) = (
-        shift(inst, unknowns, n_unknowns, Base::Real),
-        shift(inst, knowns, n_knowns, Base::Real),
-    ) else {
+    let (u, k) = unsafe {
+        (shift(inst, unknowns, n_unknowns, Base::Real), shift(inst, knowns, n_knowns, Base::Real))
+    };
+    let (Some(u), Some(k)) = (u, k) else {
         return ERROR;
     };
     if (dv_known.is_null() && n_knowns != 0) || (dv_unknown.is_null() && n_unknowns != 0) {
         return ERROR;
     }
-    let seed = if n_knowns == 0 { &[][..] } else { std::slice::from_raw_parts(dv_known, n_knowns) };
+    let seed = if n_knowns == 0 { &[][..] } else { unsafe { std::slice::from_raw_parts(dv_known, n_knowns) } };
     on_instance!(Some(inst), |store, g, h, st| match g.call_get_directional_derivative(store, h, &u, &k, seed) {
         Ok(Ok(v)) => {
             if v.len() != n_unknowns {
                 return ERROR;
             }
-            std::slice::from_raw_parts_mut(dv_unknown, n_unknowns).copy_from_slice(&v);
+            unsafe { std::slice::from_raw_parts_mut(dv_unknown, n_unknowns).copy_from_slice(&v); }
             OK
         }
         Ok(Err(s)) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
 // ── Model Exchange ──────────────────────────────────────────────────────────
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2EnterContinuousTimeMode(c: *mut c_void) -> i32 {
-    crate::fmi3EnterContinuousTimeMode(c)
+    unsafe {
+        crate::fmi3EnterContinuousTimeMode(c)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2SetTime(c: *mut c_void, time: f64) -> i32 {
-    crate::fmi3SetTime(c, time)
+    unsafe {
+        crate::fmi3SetTime(c, time)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2SetContinuousStates(c: *mut c_void, x: *const f64, nx: usize) -> i32 {
-    crate::fmi3SetContinuousStates(c, x, nx)
+    unsafe {
+        crate::fmi3SetContinuousStates(c, x, nx)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2GetDerivatives(c: *mut c_void, derivatives: *mut f64, nx: usize) -> i32 {
-    crate::fmi3GetContinuousStateDerivatives(c, derivatives, nx)
+    unsafe {
+        crate::fmi3GetContinuousStateDerivatives(c, derivatives, nx)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2GetEventIndicators(c: *mut c_void, event_indicators: *mut f64, ni: usize) -> i32 {
-    crate::fmi3GetEventIndicators(c, event_indicators, ni)
+    unsafe {
+        crate::fmi3GetEventIndicators(c, event_indicators, ni)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2GetContinuousStates(c: *mut c_void, x: *mut f64, nx: usize) -> i32 {
-    crate::fmi3GetContinuousStates(c, x, nx)
+    unsafe {
+        crate::fmi3GetContinuousStates(c, x, nx)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2GetNominalsOfContinuousStates(c: *mut c_void, x_nominal: *mut f64, nx: usize) -> i32 {
-    crate::fmi3GetNominalsOfContinuousStates(c, x_nominal, nx)
+    unsafe {
+        crate::fmi3GetNominalsOfContinuousStates(c, x_nominal, nx)
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2NewDiscreteStates(c: *mut c_void, event_info: *mut EventInfo) -> i32 {
-    let Some(info) = event_info.as_mut() else { return ERROR };
-    on_instance!(inst_mut(c), |store, g, h, st| match g.call_update_discrete_states(store, h) {
+    let Some(info) = (unsafe { event_info.as_mut() }) else { return ERROR };
+    on_instance!(inst_mut(c), |store, g, h, st| match g.call_update_discrete_states(&mut *store, h) {
         Ok(Ok(u)) => {
             info.new_discrete_states_needed = fmi2_bool(u.new_discrete_states_needed);
             info.terminate_simulation = fmi2_bool(u.terminate_simulation);
@@ -556,11 +614,14 @@ pub unsafe extern "C" fn fmi2NewDiscreteStates(c: *mut c_void, event_info: *mut 
             OK
         }
         Ok(Err(s)) => st(s),
-        Err(_) => ERROR,
-    })
+        Err(_) => {
+            store.data_mut().log_fmi2_call(ERROR, "fmi2NewDiscreteStates: terminated by an assertion.");
+            ERROR
+        }
+   })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2CompletedIntegratorStep(
     c: *mut c_void,
     no_set_fmu_state_prior: i32,
@@ -571,10 +632,12 @@ pub unsafe extern "C" fn fmi2CompletedIntegratorStep(
         return ERROR;
     }
     let (mut enter, mut terminate) = (false, false);
-    let status = crate::fmi3CompletedIntegratorStep(c, b(no_set_fmu_state_prior), &mut enter, &mut terminate);
+    let status = unsafe { crate::fmi3CompletedIntegratorStep(c, b(no_set_fmu_state_prior), &mut enter, &mut terminate) };
     if status == OK {
-        *enter_event_mode = fmi2_bool(enter);
-        *terminate_simulation = fmi2_bool(terminate);
+        unsafe {
+            *enter_event_mode = fmi2_bool(enter);
+            *terminate_simulation = fmi2_bool(terminate);
+        }
     }
     status
 }
@@ -583,7 +646,7 @@ pub unsafe extern "C" fn fmi2CompletedIntegratorStep(
 
 /// No early return in 2.0: a step that did not reach the communication point is
 /// `fmi2Discard`, with the reason in `fmi2GetBooleanStatus(fmi2Terminated)`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2DoStep(
     c: *mut c_void,
     current_communication_point: f64,
@@ -592,7 +655,7 @@ pub unsafe extern "C" fn fmi2DoStep(
 ) -> i32 {
     let target = current_communication_point + communication_step_size;
     let (mut event, mut terminate, mut early, mut last) = (false, false, false, target);
-    let status = crate::fmi3DoStep(
+    let status = unsafe { crate::fmi3DoStep(
         c,
         current_communication_point,
         communication_step_size,
@@ -601,7 +664,7 @@ pub unsafe extern "C" fn fmi2DoStep(
         &mut terminate,
         &mut early,
         &mut last,
-    );
+    ) };
     let Some(inst) = inst_mut(c) else { return ERROR };
     let Some(st) = inst.fmi2.as_mut() else { return ERROR };
     st.last_successful_time = last;
@@ -617,31 +680,31 @@ pub unsafe extern "C" fn fmi2DoStep(
 }
 
 /// `fmi2DoStep` never returns `fmi2Pending`, so there is never a step to cancel.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2CancelStep(_c: *mut c_void) -> i32 {
     ERROR
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2GetStatus(c: *mut c_void, kind: i32, value: *mut i32) -> i32 {
     let (Some(inst), false) = (inst_mut(c), value.is_null()) else { return ERROR };
     let Some(st) = inst.fmi2.as_ref() else { return ERROR };
     match kind {
         DO_STEP_STATUS => {
-            *value = st.step_status;
+            unsafe { *value = st.step_status; }
             OK
         }
         _ => ERROR,
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2GetRealStatus(c: *mut c_void, kind: i32, value: *mut f64) -> i32 {
     let (Some(inst), false) = (inst_mut(c), value.is_null()) else { return ERROR };
     let Some(st) = inst.fmi2.as_ref() else { return ERROR };
     match kind {
         LAST_SUCCESSFUL_TIME => {
-            *value = st.last_successful_time;
+            unsafe { *value = st.last_successful_time; }
             OK
         }
         _ => ERROR,
@@ -649,18 +712,18 @@ pub unsafe extern "C" fn fmi2GetRealStatus(c: *mut c_void, kind: i32, value: *mu
 }
 
 /// No status kind is integer-valued.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2GetIntegerStatus(_c: *mut c_void, _kind: i32, _value: *mut i32) -> i32 {
     ERROR
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2GetBooleanStatus(c: *mut c_void, kind: i32, value: *mut i32) -> i32 {
     let (Some(inst), false) = (inst_mut(c), value.is_null()) else { return ERROR };
     let Some(st) = inst.fmi2.as_ref() else { return ERROR };
     match kind {
         TERMINATED => {
-            *value = fmi2_bool(st.terminated);
+            unsafe { *value = fmi2_bool(st.terminated); }
             OK
         }
         _ => ERROR,
@@ -668,17 +731,17 @@ pub unsafe extern "C" fn fmi2GetBooleanStatus(c: *mut c_void, kind: i32, value: 
 }
 
 /// `fmi2PendingStatus` is the only string-valued kind, and nothing is ever pending.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2GetStringStatus(_c: *mut c_void, kind: i32, value: *mut *const c_char) -> i32 {
     if kind != PENDING_STATUS || value.is_null() {
         return ERROR;
     }
-    *value = c"".as_ptr();
+    unsafe { *value = c"".as_ptr(); }
     OK
 }
 
 /// The component's Co-Simulation driver takes no derivative information.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2SetRealInputDerivatives(
     _c: *mut c_void,
     _value_references: *const u32,
@@ -690,7 +753,7 @@ pub unsafe extern "C" fn fmi2SetRealInputDerivatives(
 }
 
 /// The derivative of each named output.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi2GetRealOutputDerivatives(
     c: *mut c_void,
     value_references: *const u32,
@@ -699,24 +762,26 @@ pub unsafe extern "C" fn fmi2GetRealOutputDerivatives(
     values: *mut f64,
 ) -> i32 {
     let Some(inst) = inst_mut(c) else { return ERROR };
-    let Some(refs) = shift(inst, value_references, n_value_references, Base::Real) else { return ERROR };
+    let Some(refs) = (unsafe { shift(inst, value_references, n_value_references, Base::Real) }) else { return ERROR };
     if (values.is_null() || orders.is_null()) && n_value_references != 0 {
         return ERROR;
     }
     // The order reaches the component unused, as in C.
     let requests: Vec<(u32, u32)> =
-        refs.iter().enumerate().map(|(i, vr)| (*vr, (*orders.add(i)).max(0) as u32)).collect();
+        refs.iter().enumerate().map(|(i, vr)| unsafe { (*vr, (*orders.add(i)).max(0) as u32) }).collect();
     on_instance!(Some(inst), |store, g, h, st| match g.call_get_output_derivatives(store, h, &requests) {
         Ok(Ok(v)) => {
             if v.len() != n_value_references {
                 return ERROR;
             }
-            for (i, x) in v.into_iter().enumerate() {
-                *values.add(i) = x;
+            unsafe {
+                for (i, x) in v.into_iter().enumerate() {
+                    *values.add(i) = x;
+                }
             }
             OK
         }
         Ok(Err(s)) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_ls_wasm_to_native/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_ls_wasm_to_native/src/lib.rs
@@ -38,13 +38,13 @@ mod bindings {
         wasmtime::component::bindgen!({
             path: "../openmodelica_fmi3_wasm/wit",
             world: "model-exchange-fmu",
-        });
+       });
     }
     pub mod cs {
         wasmtime::component::bindgen!({
             path: "../openmodelica_fmi3_wasm/wit",
             world: "co-simulation-fmu",
-        });
+       });
     }
 }
 
@@ -88,7 +88,9 @@ type IntermediateUpdateCb = Option<
 /// between the two APIs (see [`fmi2::LogCb`]).
 pub(crate) enum Log {
     Fmi3(LogCb),
-    Fmi2 { cb: fmi2::LogCb, name: CString },
+    /// `call_log` is C's `logCategories[LOG_FMI2CALL]`, the one category this
+    /// layer logs on itself; the rest belong to the component.
+    Fmi2 { cb: fmi2::LogCb, name: CString, call_log: bool },
 }
 
 impl Log {
@@ -96,7 +98,7 @@ impl Log {
         let (Ok(cat), Ok(msg)) = (CString::new(category), CString::new(message)) else { return };
         match self {
             Log::Fmi3(Some(cb)) => cb(env, status, cat.as_ptr(), msg.as_ptr()),
-            Log::Fmi2 { cb: Some(cb), name } => unsafe {
+            Log::Fmi2 { cb: Some(cb), name, .. } => unsafe {
                 cb(env, name.as_ptr(), status, cat.as_ptr(), msg.as_ptr())
             },
             _ => {}
@@ -124,6 +126,14 @@ impl wasmtime_wasi::WasiView for Host {
 impl Host {
     fn log(&mut self, status: i32, category: &str, message: &str) {
         self.log.emit(self.env, status, category, message);
+    }
+
+    /// C's `FILTERED_LOG(comp, …, LOG_FMI2_CALL, …)`, whose `fmu2_model_interface.c`
+    /// this layer is. A no-op for FMI 3.0: the component logs its own call trace.
+    pub(crate) fn log_fmi2_call(&mut self, status: i32, message: &str) {
+        if matches!(self.log, Log::Fmi2 { call_log: true, .. }) {
+            self.log(status, "logFmi2Call", message);
+        }
     }
 }
 
@@ -233,7 +243,7 @@ fn inst_mut<'a>(c: *mut c_void) -> Option<&'a mut Instance> {
 }
 
 unsafe fn cstr(p: *const c_char) -> String {
-    if p.is_null() { String::new() } else { CStr::from_ptr(p).to_string_lossy().into_owned() }
+    if p.is_null() { String::new() } else { unsafe { CStr::from_ptr(p).to_string_lossy().into_owned() } }
 }
 
 // After `on_instance!`: a `macro_rules!` is in scope only for what follows it.
@@ -249,15 +259,15 @@ unsafe fn requests(vr: *const u32, n: usize, orders: *const i32) -> Option<Vec<(
         return None;
     }
     (0..n)
-        .map(|i| {
+        .map(|i| unsafe {
             let order = *orders.add(i);
             (order >= 0).then(|| (*vr.add(i), order as u32))
-        })
+       })
         .collect()
 }
 
 unsafe fn vrs<'a>(p: *const u32, n: usize) -> &'a [u32] {
-    if p.is_null() || n == 0 { &[] } else { std::slice::from_raw_parts(p, n) }
+    if p.is_null() || n == 0 { &[] } else { unsafe { std::slice::from_raw_parts(p, n) } }
 }
 
 // ── Loading the component ───────────────────────────────────────────────────
@@ -353,7 +363,7 @@ fn report(name: &str, env: *mut c_void, log: &Log, e: impl std::fmt::Display) ->
 
 // ── Lifecycle ───────────────────────────────────────────────────────────────
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn fmi3GetVersion() -> *const c_char {
     c"3.0".as_ptr()
 }
@@ -390,7 +400,7 @@ pub(crate) fn instantiate_me(
         strings: Vec::new(),
         binaries: Vec::new(),
         fmi2: None,
-    }))
+   }))
 }
 
 /// The Co-Simulation counterpart of [`instantiate_me`].
@@ -429,10 +439,10 @@ pub(crate) fn instantiate_cs(
         strings: Vec::new(),
         binaries: Vec::new(),
         fmi2: None,
-    }))
+   }))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3InstantiateModelExchange(
     instance_name: *const c_char,
     instantiation_token: *const c_char,
@@ -442,15 +452,15 @@ pub unsafe extern "C" fn fmi3InstantiateModelExchange(
     instance_environment: *mut c_void,
     log_message: LogCb,
 ) -> *mut c_void {
-    let name = cstr(instance_name);
-    let (token, res) = (cstr(instantiation_token), cstr(resource_path));
+    let name = unsafe { cstr(instance_name) };
+    let (token, res) = unsafe { (cstr(instantiation_token), cstr(resource_path)) };
     match instantiate_me(&name, &token, &res, visible, logging_on, instance_environment, Log::Fmi3(log_message)) {
         Ok(b) => Box::into_raw(b) as *mut c_void,
         Err(e) => report(&name, instance_environment, &Log::Fmi3(log_message), e),
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3InstantiateCoSimulation(
     instance_name: *const c_char,
     instantiation_token: *const c_char,
@@ -465,9 +475,9 @@ pub unsafe extern "C" fn fmi3InstantiateCoSimulation(
     log_message: LogCb,
     intermediate_update: IntermediateUpdateCb,
 ) -> *mut c_void {
-    let name = cstr(instance_name);
-    let (token, res) = (cstr(instantiation_token), cstr(resource_path));
-    let required = vrs(required_intermediate_variables, n_required_intermediate_variables).to_vec();
+    let name = unsafe { cstr(instance_name) };
+    let (token, res) = unsafe { (cstr(instantiation_token), cstr(resource_path)) };
+    let required = unsafe { vrs(required_intermediate_variables, n_required_intermediate_variables) }.to_vec();
     let built = instantiate_cs(
         &name, &token, &res, visible, logging_on, event_mode_used, early_return_allowed, &required,
         instance_environment, Log::Fmi3(log_message), intermediate_update,
@@ -479,7 +489,7 @@ pub unsafe extern "C" fn fmi3InstantiateCoSimulation(
 }
 
 /// Scheduled Execution: no fmi-ls-wasm exporter emits that world yet.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3InstantiateScheduledExecution(
     instance_name: *const c_char,
     _instantiation_token: *const c_char,
@@ -492,14 +502,14 @@ pub unsafe extern "C" fn fmi3InstantiateScheduledExecution(
     _lock_preemption: *mut c_void,
     _unlock_preemption: *mut c_void,
 ) -> *mut c_void {
-    let name = cstr(instance_name);
+    let name = unsafe { cstr(instance_name) };
     report(&name, instance_environment, &Log::Fmi3(log_message), "Scheduled Execution is not supported by this FMU")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3FreeInstance(c: *mut c_void) {
     if !c.is_null() {
-        drop(Box::from_raw(c as *mut Instance));
+        drop(unsafe { Box::from_raw(c as *mut Instance) });
     }
 }
 
@@ -507,12 +517,12 @@ pub unsafe extern "C" fn fmi3FreeInstance(c: *mut c_void) {
 
 macro_rules! nullary {
     ($cfn:ident, $wfn:ident) => {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub unsafe extern "C" fn $cfn(c: *mut c_void) -> i32 {
             on_instance!(inst_mut(c), |store, g, h, st| match g.$wfn(store, h) {
                 Ok(s) => st(s),
                 Err(_) => ERROR,
-            })
+           })
         }
     };
 }
@@ -525,7 +535,7 @@ nullary!(fmi3ExitConfigurationMode, call_exit_configuration_mode);
 nullary!(fmi3EvaluateDiscreteStates, call_evaluate_discrete_states);
 nullary!(fmi3EnterStepMode, call_enter_step_mode);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3EnterInitializationMode(
     c: *mut c_void,
     tolerance_defined: bool,
@@ -539,10 +549,10 @@ pub unsafe extern "C" fn fmi3EnterInitializationMode(
     on_instance!(inst_mut(c), |store, g, h, st| match g.call_enter_initialization_mode(store, h, tol, start_time, stop) {
         Ok(s) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3SetDebugLogging(
     c: *mut c_void,
     logging_on: bool,
@@ -552,15 +562,15 @@ pub unsafe extern "C" fn fmi3SetDebugLogging(
     let cats: Vec<String> = if categories.is_null() {
         Vec::new()
     } else {
-        (0..n_categories).map(|i| cstr(*categories.add(i))).collect()
+        (0..n_categories).map(|i| unsafe { cstr(*categories.add(i)) }).collect()
     };
     on_instance!(inst_mut(c), |store, g, h, st| match g.call_set_debug_logging(store, h, logging_on, &cats) {
         Ok(s) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3UpdateDiscreteStates(
     c: *mut c_void,
     discrete_states_need_update: *mut bool,
@@ -573,12 +583,14 @@ pub unsafe extern "C" fn fmi3UpdateDiscreteStates(
     macro_rules! out {
         ($info:expr) => {{
             let i = $info;
-            if !discrete_states_need_update.is_null() { *discrete_states_need_update = i.new_discrete_states_needed; }
-            if !terminate_simulation.is_null() { *terminate_simulation = i.terminate_simulation; }
-            if !nominals_changed.is_null() { *nominals_changed = i.nominals_of_continuous_states_changed; }
-            if !values_changed.is_null() { *values_changed = i.values_of_continuous_states_changed; }
-            if !next_event_time_defined.is_null() { *next_event_time_defined = i.next_event_time_defined; }
-            if !next_event_time.is_null() { *next_event_time = i.next_event_time; }
+            unsafe {
+                if !discrete_states_need_update.is_null() { *discrete_states_need_update = i.new_discrete_states_needed; }
+                if !terminate_simulation.is_null() { *terminate_simulation = i.terminate_simulation; }
+                if !nominals_changed.is_null() { *nominals_changed = i.nominals_of_continuous_states_changed; }
+                if !values_changed.is_null() { *values_changed = i.values_of_continuous_states_changed; }
+                if !next_event_time_defined.is_null() { *next_event_time_defined = i.next_event_time_defined; }
+                if !next_event_time.is_null() { *next_event_time = i.next_event_time; }
+            }
             OK
         }};
     }
@@ -586,14 +598,14 @@ pub unsafe extern "C" fn fmi3UpdateDiscreteStates(
         Ok(Ok(info)) => out!(info),
         Ok(Err(s)) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
 // ── Variable access ─────────────────────────────────────────────────────────
 
 macro_rules! getter {
     ($cfn:ident, $wfn:ident, $ty:ty) => {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub unsafe extern "C" fn $cfn(
             c: *mut c_void,
             value_references: *const u32,
@@ -601,18 +613,18 @@ macro_rules! getter {
             values: *mut $ty,
             n_values: usize,
         ) -> i32 {
-            let refs = vrs(value_references, n_value_references);
+            let refs = unsafe { vrs(value_references, n_value_references) };
             on_instance!(inst_mut(c), |store, g, h, st| match g.$wfn(store, h, refs) {
                 Ok(Ok(v)) => {
                     if v.len() != n_values || values.is_null() {
                         return ERROR;
                     }
-                    std::slice::from_raw_parts_mut(values, n_values).copy_from_slice(&v);
+                    unsafe { std::slice::from_raw_parts_mut(values, n_values).copy_from_slice(&v); }
                     OK
                 }
                 Ok(Err(s)) => st(s),
                 Err(_) => ERROR,
-            })
+           })
         }
     };
 }
@@ -630,7 +642,7 @@ getter!(fmi3GetBoolean, call_get_boolean, bool);
 
 macro_rules! setter {
     ($cfn:ident, $wfn:ident, $ty:ty) => {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub unsafe extern "C" fn $cfn(
             c: *mut c_void,
             value_references: *const u32,
@@ -638,15 +650,15 @@ macro_rules! setter {
             values: *const $ty,
             n_values: usize,
         ) -> i32 {
-            let refs = vrs(value_references, n_value_references);
+            let refs = unsafe { vrs(value_references, n_value_references) };
             if values.is_null() && n_values != 0 {
                 return ERROR;
             }
-            let vals = if n_values == 0 { &[][..] } else { std::slice::from_raw_parts(values, n_values) };
+            let vals = if n_values == 0 { &[][..] } else { unsafe { std::slice::from_raw_parts(values, n_values) } };
             on_instance!(inst_mut(c), |store, g, h, st| match g.$wfn(store, h, refs, vals) {
                 Ok(s) => st(s),
                 Err(_) => ERROR,
-            })
+           })
         }
     };
 }
@@ -663,47 +675,47 @@ setter!(fmi3SetUInt64, call_set_uint64, u64);
 setter!(fmi3SetBoolean, call_set_boolean, bool);
 
 /// `fmi3Clock` has no `nValues`: one value per reference.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3GetClock(
     c: *mut c_void,
     value_references: *const u32,
     n_value_references: usize,
     values: *mut bool,
 ) -> i32 {
-    let refs = vrs(value_references, n_value_references);
+    let refs = unsafe { vrs(value_references, n_value_references) };
     on_instance!(inst_mut(c), |store, g, h, st| match g.call_get_clock(store, h, refs) {
         Ok(Ok(v)) => {
             if v.len() != n_value_references || values.is_null() {
                 return ERROR;
             }
-            std::slice::from_raw_parts_mut(values, n_value_references).copy_from_slice(&v);
+            unsafe { std::slice::from_raw_parts_mut(values, n_value_references).copy_from_slice(&v); }
             OK
         }
         Ok(Err(s)) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3SetClock(
     c: *mut c_void,
     value_references: *const u32,
     n_value_references: usize,
     values: *const bool,
 ) -> i32 {
-    let refs = vrs(value_references, n_value_references);
+    let refs = unsafe { vrs(value_references, n_value_references) };
     if values.is_null() && n_value_references != 0 {
         return ERROR;
     }
-    let vals = if n_value_references == 0 { &[][..] } else { std::slice::from_raw_parts(values, n_value_references) };
+    let vals = if n_value_references == 0 { &[][..] } else { unsafe { std::slice::from_raw_parts(values, n_value_references) } };
     on_instance!(inst_mut(c), |store, g, h, st| match g.call_set_clock(store, h, refs, vals) {
         Ok(s) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
 /// The returned pointers borrow from the instance until the next `fmi3GetString`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3GetString(
     c: *mut c_void,
     value_references: *const u32,
@@ -711,7 +723,7 @@ pub unsafe extern "C" fn fmi3GetString(
     values: *mut *const c_char,
     n_values: usize,
 ) -> i32 {
-    let refs = vrs(value_references, n_value_references);
+    let refs = unsafe { vrs(value_references, n_value_references) };
     let Some(inst) = inst_mut(c) else { return ERROR };
     let got = {
         let Instance { store, kind, .. } = inst;
@@ -740,13 +752,15 @@ pub unsafe extern "C" fn fmi3GetString(
         .into_iter()
         .map(|s| CString::new(s).unwrap_or_default())
         .collect();
-    for (i, s) in inst.strings.iter().enumerate() {
-        *values.add(i) = s.as_ptr();
+    unsafe {
+        for (i, s) in inst.strings.iter().enumerate() {
+            *values.add(i) = s.as_ptr();
+        }
     }
     OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3SetString(
     c: *mut c_void,
     value_references: *const u32,
@@ -754,19 +768,19 @@ pub unsafe extern "C" fn fmi3SetString(
     values: *const *const c_char,
     n_values: usize,
 ) -> i32 {
-    let refs = vrs(value_references, n_value_references);
+    let refs = unsafe { vrs(value_references, n_value_references) };
     if values.is_null() && n_values != 0 {
         return ERROR;
     }
-    let vals: Vec<String> = (0..n_values).map(|i| cstr(*values.add(i))).collect();
+    let vals: Vec<String> = (0..n_values).map(|i| unsafe { cstr(*values.add(i)) }).collect();
     on_instance!(inst_mut(c), |store, g, h, st| match g.call_set_string(store, h, refs, &vals) {
         Ok(s) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
 /// The returned pointers borrow from the instance until the next `fmi3GetBinary`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3GetBinary(
     c: *mut c_void,
     value_references: *const u32,
@@ -775,7 +789,7 @@ pub unsafe extern "C" fn fmi3GetBinary(
     values: *mut *const u8,
     n_values: usize,
 ) -> i32 {
-    let refs = vrs(value_references, n_value_references);
+    let refs = unsafe { vrs(value_references, n_value_references) };
     let Some(inst) = inst_mut(c) else { return ERROR };
     let got = {
         let Instance { store, kind, .. } = inst;
@@ -801,14 +815,16 @@ pub unsafe extern "C" fn fmi3GetBinary(
         return ERROR;
     }
     inst.binaries = blobs;
-    for (i, b) in inst.binaries.iter().enumerate() {
-        *value_sizes.add(i) = b.len();
-        *values.add(i) = b.as_ptr();
+    unsafe {
+        for (i, b) in inst.binaries.iter().enumerate() {
+            *value_sizes.add(i) = b.len();
+            *values.add(i) = b.as_ptr();
+        }
     }
     OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3SetBinary(
     c: *mut c_void,
     value_references: *const u32,
@@ -817,21 +833,21 @@ pub unsafe extern "C" fn fmi3SetBinary(
     values: *const *const u8,
     n_values: usize,
 ) -> i32 {
-    let refs = vrs(value_references, n_value_references);
+    let refs = unsafe { vrs(value_references, n_value_references) };
     if (values.is_null() || value_sizes.is_null()) && n_values != 0 {
         return ERROR;
     }
     let vals: Vec<Vec<u8>> = (0..n_values)
-        .map(|i| {
+        .map(|i| unsafe {
             let p = *values.add(i);
             let n = *value_sizes.add(i);
             if p.is_null() { Vec::new() } else { std::slice::from_raw_parts(p, n).to_vec() }
-        })
+       })
         .collect();
     on_instance!(inst_mut(c), |store, g, h, st| match g.call_set_binary(store, h, refs, &vals) {
         Ok(s) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
 // ── FMU state ───────────────────────────────────────────────────────────────
@@ -839,7 +855,7 @@ pub unsafe extern "C" fn fmi3SetBinary(
 // The WIT models a state as its serialized bytes, so `fmi3FMUState` is a boxed
 // `Vec<u8>`.
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3GetFMUState(c: *mut c_void, state: *mut *mut c_void) -> i32 {
     if state.is_null() {
         return ERROR;
@@ -847,61 +863,65 @@ pub unsafe extern "C" fn fmi3GetFMUState(c: *mut c_void, state: *mut *mut c_void
     on_instance!(inst_mut(c), |store, g, h, st| match g.call_get_fmu_state(store, h) {
         Ok(Ok(bytes)) => {
             // A non-null incoming state is a buffer to reuse.
-            if !(*state).is_null() {
-                drop(Box::from_raw(*state as *mut Vec<u8>));
+            unsafe {
+                if !(*state).is_null() {
+                    drop(Box::from_raw(*state as *mut Vec<u8>));
+                }
+                *state = Box::into_raw(Box::new(bytes)) as *mut c_void;
             }
-            *state = Box::into_raw(Box::new(bytes)) as *mut c_void;
             OK
         }
         Ok(Err(s)) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3SetFMUState(c: *mut c_void, state: *mut c_void) -> i32 {
-    let Some(bytes) = (state as *const Vec<u8>).as_ref() else { return ERROR };
+    let Some(bytes) = (unsafe { (state as *const Vec<u8>).as_ref() }) else { return ERROR };
     on_instance!(inst_mut(c), |store, g, h, st| match g.call_set_fmu_state(store, h, bytes) {
         Ok(s) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3FreeFMUState(_c: *mut c_void, state: *mut *mut c_void) -> i32 {
     if state.is_null() {
         return ERROR;
     }
-    if !(*state).is_null() {
-        drop(Box::from_raw(*state as *mut Vec<u8>));
-        *state = std::ptr::null_mut();
+    unsafe {
+        if !(*state).is_null() {
+            drop(Box::from_raw(*state as *mut Vec<u8>));
+            *state = std::ptr::null_mut();
+        }
     }
     OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3SerializedFMUStateSize(_c: *mut c_void, state: *mut c_void, size: *mut usize) -> i32 {
-    let (Some(bytes), false) = ((state as *const Vec<u8>).as_ref(), size.is_null()) else { return ERROR };
-    *size = bytes.len();
+    let (Some(bytes), false) = (unsafe { (state as *const Vec<u8>).as_ref() }, size.is_null()) else { return ERROR };
+    unsafe { *size = bytes.len(); }
     OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3SerializeFMUState(
     _c: *mut c_void,
     state: *mut c_void,
     serialized: *mut u8,
     size: usize,
 ) -> i32 {
-    let Some(bytes) = (state as *const Vec<u8>).as_ref() else { return ERROR };
+    let Some(bytes) = (unsafe { (state as *const Vec<u8>).as_ref() }) else { return ERROR };
     if serialized.is_null() || size != bytes.len() {
         return ERROR;
     }
-    std::slice::from_raw_parts_mut(serialized, size).copy_from_slice(bytes);
+    unsafe { std::slice::from_raw_parts_mut(serialized, size).copy_from_slice(bytes); }
     OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3DeserializeFMUState(
     _c: *mut c_void,
     serialized: *const u8,
@@ -911,8 +931,8 @@ pub unsafe extern "C" fn fmi3DeserializeFMUState(
     if state.is_null() || (serialized.is_null() && size != 0) {
         return ERROR;
     }
-    let bytes = if size == 0 { Vec::new() } else { std::slice::from_raw_parts(serialized, size).to_vec() };
-    *state = Box::into_raw(Box::new(bytes)) as *mut c_void;
+    let bytes = if size == 0 { Vec::new() } else { unsafe { std::slice::from_raw_parts(serialized, size).to_vec() } };
+    unsafe { *state = Box::into_raw(Box::new(bytes)) as *mut c_void; }
     OK
 }
 
@@ -920,7 +940,7 @@ pub unsafe extern "C" fn fmi3DeserializeFMUState(
 
 macro_rules! derivative {
     ($cfn:ident, $wfn:ident) => {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub unsafe extern "C" fn $cfn(
             c: *mut c_void,
             unknowns: *const u32,
@@ -932,29 +952,29 @@ macro_rules! derivative {
             sensitivity: *mut f64,
             n_sensitivity: usize,
         ) -> i32 {
-            let (u, k) = (vrs(unknowns, n_unknowns), vrs(knowns, n_knowns));
+            let (u, k) = unsafe { (vrs(unknowns, n_unknowns), vrs(knowns, n_knowns)) };
             if seed.is_null() && n_seed != 0 {
                 return ERROR;
             }
-            let s = if n_seed == 0 { &[][..] } else { std::slice::from_raw_parts(seed, n_seed) };
+            let s = if n_seed == 0 { &[][..] } else { unsafe { std::slice::from_raw_parts(seed, n_seed) } };
             on_instance!(inst_mut(c), |store, g, h, st| match g.$wfn(store, h, u, k, s) {
                 Ok(Ok(v)) => {
                     if v.len() != n_sensitivity || sensitivity.is_null() {
                         return ERROR;
                     }
-                    std::slice::from_raw_parts_mut(sensitivity, n_sensitivity).copy_from_slice(&v);
+                    unsafe { std::slice::from_raw_parts_mut(sensitivity, n_sensitivity).copy_from_slice(&v); }
                     OK
                 }
                 Ok(Err(s)) => st(s),
                 Err(_) => ERROR,
-            })
+           })
         }
     };
 }
 derivative!(fmi3GetDirectionalDerivative, call_get_directional_derivative);
 derivative!(fmi3GetAdjointDerivative, call_get_adjoint_derivative);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3GetNumberOfVariableDependencies(
     c: *mut c_void,
     value_reference: u32,
@@ -965,15 +985,15 @@ pub unsafe extern "C" fn fmi3GetNumberOfVariableDependencies(
     }
     on_instance!(inst_mut(c), |store, g, h, st| match g.call_get_number_of_variable_dependencies(store, h, value_reference) {
         Ok(Ok(n)) => {
-            *n_dependencies = n as usize;
+            unsafe { *n_dependencies = n as usize; }
             OK
         }
         Ok(Err(s)) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3GetVariableDependencies(
     c: *mut c_void,
     dependent: u32,
@@ -989,18 +1009,20 @@ pub unsafe extern "C" fn fmi3GetVariableDependencies(
             if deps.len() != n_dependencies {
                 return ERROR;
             }
-            for (i, d) in deps.iter().enumerate() {
-                if !element_indices_of_dependent.is_null() {
-                    *element_indices_of_dependent.add(i) = d.element_index_of_dependent as usize;
-                }
-                if !independents.is_null() {
-                    *independents.add(i) = d.independent_value_reference;
-                }
-                if !element_indices_of_independents.is_null() {
-                    *element_indices_of_independents.add(i) = d.element_index_of_independent as usize;
-                }
-                if !dependency_kinds.is_null() {
-                    *dependency_kinds.add(i) = d.kind as i32;
+            unsafe {
+                for (i, d) in deps.iter().enumerate() {
+                    if !element_indices_of_dependent.is_null() {
+                        *element_indices_of_dependent.add(i) = d.element_index_of_dependent as usize;
+                    }
+                    if !independents.is_null() {
+                        *independents.add(i) = d.independent_value_reference;
+                    }
+                    if !element_indices_of_independents.is_null() {
+                        *element_indices_of_independents.add(i) = d.element_index_of_independent as usize;
+                    }
+                    if !dependency_kinds.is_null() {
+                        *dependency_kinds.add(i) = d.kind as i32;
+                    }
                 }
             }
             OK
@@ -1010,12 +1032,12 @@ pub unsafe extern "C" fn fmi3GetVariableDependencies(
         Ok(Ok(deps)) => out!(deps),
         Ok(Err(s)) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
 // ── Clocks ──────────────────────────────────────────────────────────────────
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3GetIntervalDecimal(
     c: *mut c_void,
     value_references: *const u32,
@@ -1023,24 +1045,26 @@ pub unsafe extern "C" fn fmi3GetIntervalDecimal(
     intervals: *mut f64,
     qualifiers: *mut i32,
 ) -> i32 {
-    let refs = vrs(value_references, n_value_references);
+    let refs = unsafe { vrs(value_references, n_value_references) };
     on_instance!(inst_mut(c), |store, g, h, st| match g.call_get_interval_decimal(store, h, refs) {
         Ok(Ok(v)) => {
             if v.len() != n_value_references {
                 return ERROR;
             }
-            for (i, (interval, q)) in v.iter().enumerate() {
-                if !intervals.is_null() { *intervals.add(i) = *interval; }
-                if !qualifiers.is_null() { *qualifiers.add(i) = *q as i32; }
+            unsafe {
+                for (i, (interval, q)) in v.iter().enumerate() {
+                    if !intervals.is_null() { *intervals.add(i) = *interval; }
+                    if !qualifiers.is_null() { *qualifiers.add(i) = *q as i32; }
+                }
             }
             OK
         }
         Ok(Err(s)) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3GetIntervalFraction(
     c: *mut c_void,
     value_references: *const u32,
@@ -1049,46 +1073,48 @@ pub unsafe extern "C" fn fmi3GetIntervalFraction(
     resolutions: *mut u64,
     qualifiers: *mut i32,
 ) -> i32 {
-    let refs = vrs(value_references, n_value_references);
+    let refs = unsafe { vrs(value_references, n_value_references) };
     on_instance!(inst_mut(c), |store, g, h, st| match g.call_get_interval_fraction(store, h, refs) {
         Ok(Ok(v)) => {
             if v.len() != n_value_references {
                 return ERROR;
             }
-            for (i, (f, q)) in v.iter().enumerate() {
-                if !counters.is_null() { *counters.add(i) = f.counter; }
-                if !resolutions.is_null() { *resolutions.add(i) = f.resolution; }
-                if !qualifiers.is_null() { *qualifiers.add(i) = *q as i32; }
+            unsafe {
+                for (i, (f, q)) in v.iter().enumerate() {
+                    if !counters.is_null() { *counters.add(i) = f.counter; }
+                    if !resolutions.is_null() { *resolutions.add(i) = f.resolution; }
+                    if !qualifiers.is_null() { *qualifiers.add(i) = *q as i32; }
+                }
             }
             OK
         }
         Ok(Err(s)) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3GetShiftDecimal(
     c: *mut c_void,
     value_references: *const u32,
     n_value_references: usize,
     shifts: *mut f64,
 ) -> i32 {
-    let refs = vrs(value_references, n_value_references);
+    let refs = unsafe { vrs(value_references, n_value_references) };
     on_instance!(inst_mut(c), |store, g, h, st| match g.call_get_shift_decimal(store, h, refs) {
         Ok(Ok(v)) => {
             if v.len() != n_value_references || shifts.is_null() {
                 return ERROR;
             }
-            std::slice::from_raw_parts_mut(shifts, n_value_references).copy_from_slice(&v);
+            unsafe { std::slice::from_raw_parts_mut(shifts, n_value_references).copy_from_slice(&v); }
             OK
         }
         Ok(Err(s)) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3GetShiftFraction(
     c: *mut c_void,
     value_references: *const u32,
@@ -1096,62 +1122,64 @@ pub unsafe extern "C" fn fmi3GetShiftFraction(
     counters: *mut u64,
     resolutions: *mut u64,
 ) -> i32 {
-    let refs = vrs(value_references, n_value_references);
+    let refs = unsafe { vrs(value_references, n_value_references) };
     on_instance!(inst_mut(c), |store, g, h, st| match g.call_get_shift_fraction(store, h, refs) {
         Ok(Ok(v)) => {
             if v.len() != n_value_references {
                 return ERROR;
             }
-            for (i, f) in v.iter().enumerate() {
-                if !counters.is_null() { *counters.add(i) = f.counter; }
-                if !resolutions.is_null() { *resolutions.add(i) = f.resolution; }
+            unsafe {
+                for (i, f) in v.iter().enumerate() {
+                    if !counters.is_null() { *counters.add(i) = f.counter; }
+                    if !resolutions.is_null() { *resolutions.add(i) = f.resolution; }
+                }
             }
             OK
         }
         Ok(Err(s)) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3SetIntervalDecimal(
     c: *mut c_void,
     value_references: *const u32,
     n_value_references: usize,
     intervals: *const f64,
 ) -> i32 {
-    let refs = vrs(value_references, n_value_references);
+    let refs = unsafe { vrs(value_references, n_value_references) };
     if intervals.is_null() && n_value_references != 0 {
         return ERROR;
     }
-    let v = if n_value_references == 0 { &[][..] } else { std::slice::from_raw_parts(intervals, n_value_references) };
+    let v = if n_value_references == 0 { &[][..] } else { unsafe { std::slice::from_raw_parts(intervals, n_value_references) } };
     on_instance!(inst_mut(c), |store, g, h, st| match g.call_set_interval_decimal(store, h, refs, v) {
         Ok(s) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3SetShiftDecimal(
     c: *mut c_void,
     value_references: *const u32,
     n_value_references: usize,
     shifts: *const f64,
 ) -> i32 {
-    let refs = vrs(value_references, n_value_references);
+    let refs = unsafe { vrs(value_references, n_value_references) };
     if shifts.is_null() && n_value_references != 0 {
         return ERROR;
     }
-    let v = if n_value_references == 0 { &[][..] } else { std::slice::from_raw_parts(shifts, n_value_references) };
+    let v = if n_value_references == 0 { &[][..] } else { unsafe { std::slice::from_raw_parts(shifts, n_value_references) } };
     on_instance!(inst_mut(c), |store, g, h, st| match g.call_set_shift_decimal(store, h, refs, v) {
         Ok(s) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
 macro_rules! set_fraction {
     ($cfn:ident, $wfn:ident, $rec_me:path, $rec_cs:path) => {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub unsafe extern "C" fn $cfn(
             c: *mut c_void,
             value_references: *const u32,
@@ -1159,7 +1187,7 @@ macro_rules! set_fraction {
             counters: *const u64,
             resolutions: *const u64,
         ) -> i32 {
-            let refs = vrs(value_references, n_value_references);
+            let refs = unsafe { vrs(value_references, n_value_references) };
             if (counters.is_null() || resolutions.is_null()) && n_value_references != 0 {
                 return ERROR;
             }
@@ -1169,7 +1197,7 @@ macro_rules! set_fraction {
                 Kind::Me { world, handle } => {
                     type Frac = $rec_me;
                     let v: Vec<_> = (0..n_value_references)
-                        .map(|i| Frac { counter: *counters.add(i), resolution: *resolutions.add(i) })
+                        .map(|i| unsafe { Frac { counter: *counters.add(i), resolution: *resolutions.add(i) } })
                         .collect();
                     match world.fmi_fmi3_model_exchange().model_exchange_instance().$wfn(store, *handle, refs, &v) {
                         Ok(s) => st_me(s),
@@ -1179,7 +1207,7 @@ macro_rules! set_fraction {
                 Kind::Cs { world, handle } => {
                     type Frac = $rec_cs;
                     let v: Vec<_> = (0..n_value_references)
-                        .map(|i| Frac { counter: *counters.add(i), resolution: *resolutions.add(i) })
+                        .map(|i| unsafe { Frac { counter: *counters.add(i), resolution: *resolutions.add(i) } })
                         .collect();
                     match world.fmi_fmi3_co_simulation().co_simulation_instance().$wfn(store, *handle, refs, &v) {
                         Ok(s) => st_cs(s),
@@ -1205,7 +1233,7 @@ set_fraction!(
 
 // ── Model Exchange ──────────────────────────────────────────────────────────
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3EnterContinuousTimeMode(c: *mut c_void) -> i32 {
     let Some(inst) = inst_mut(c) else { return ERROR };
     let Some((store, g, h)) = inst.me() else { return ERROR };
@@ -1215,7 +1243,7 @@ pub unsafe extern "C" fn fmi3EnterContinuousTimeMode(c: *mut c_void) -> i32 {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3SetTime(c: *mut c_void, time: f64) -> i32 {
     let Some(inst) = inst_mut(c) else { return ERROR };
     let Some((store, g, h)) = inst.me() else { return ERROR };
@@ -1225,12 +1253,12 @@ pub unsafe extern "C" fn fmi3SetTime(c: *mut c_void, time: f64) -> i32 {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3SetContinuousStates(c: *mut c_void, states: *const f64, n: usize) -> i32 {
     if states.is_null() && n != 0 {
         return ERROR;
     }
-    let v = if n == 0 { &[][..] } else { std::slice::from_raw_parts(states, n) };
+    let v = if n == 0 { &[][..] } else { unsafe { std::slice::from_raw_parts(states, n) } };
     let Some(inst) = inst_mut(c) else { return ERROR };
     let Some((store, g, h)) = inst.me() else { return ERROR };
     match g.call_set_continuous_states(store, h, v) {
@@ -1241,7 +1269,7 @@ pub unsafe extern "C" fn fmi3SetContinuousStates(c: *mut c_void, states: *const 
 
 macro_rules! me_vector {
     ($cfn:ident, $wfn:ident) => {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub unsafe extern "C" fn $cfn(c: *mut c_void, values: *mut f64, n: usize) -> i32 {
             let Some(inst) = inst_mut(c) else { return ERROR };
             let Some((store, g, h)) = inst.me() else { return ERROR };
@@ -1250,7 +1278,7 @@ macro_rules! me_vector {
                     if v.len() != n || values.is_null() {
                         return ERROR;
                     }
-                    std::slice::from_raw_parts_mut(values, n).copy_from_slice(&v);
+                    unsafe { std::slice::from_raw_parts_mut(values, n).copy_from_slice(&v); }
                     OK
                 }
                 Ok(Err(s)) => st_me(s),
@@ -1266,7 +1294,7 @@ me_vector!(fmi3GetNominalsOfContinuousStates, call_get_nominals_of_continuous_st
 
 macro_rules! me_count {
     ($cfn:ident, $wfn:ident) => {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub unsafe extern "C" fn $cfn(c: *mut c_void, n: *mut usize) -> i32 {
             if n.is_null() {
                 return ERROR;
@@ -1275,7 +1303,7 @@ macro_rules! me_count {
             let Some((store, g, h)) = inst.me() else { return ERROR };
             match g.$wfn(store, h) {
                 Ok(Ok(v)) => {
-                    *n = v as usize;
+                    unsafe { *n = v as usize; }
                     OK
                 }
                 Ok(Err(s)) => st_me(s),
@@ -1287,7 +1315,7 @@ macro_rules! me_count {
 me_count!(fmi3GetNumberOfEventIndicators, call_get_number_of_event_indicators);
 me_count!(fmi3GetNumberOfContinuousStates, call_get_number_of_continuous_states);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3CompletedIntegratorStep(
     c: *mut c_void,
     no_set_fmu_state_prior: bool,
@@ -1298,11 +1326,13 @@ pub unsafe extern "C" fn fmi3CompletedIntegratorStep(
     let Some((store, g, h)) = inst.me() else { return ERROR };
     match g.call_completed_integrator_step(store, h, no_set_fmu_state_prior) {
         Ok(Ok(r)) => {
-            if !enter_event_mode.is_null() {
-                *enter_event_mode = r.enter_event_mode;
-            }
-            if !terminate_simulation.is_null() {
-                *terminate_simulation = r.terminate_simulation;
+            unsafe {
+                if !enter_event_mode.is_null() {
+                    *enter_event_mode = r.enter_event_mode;
+                }
+                if !terminate_simulation.is_null() {
+                    *terminate_simulation = r.terminate_simulation;
+                }
             }
             OK
         }
@@ -1313,7 +1343,7 @@ pub unsafe extern "C" fn fmi3CompletedIntegratorStep(
 
 // ── Co-Simulation ───────────────────────────────────────────────────────────
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3DoStep(
     c: *mut c_void,
     current_communication_point: f64,
@@ -1328,17 +1358,19 @@ pub unsafe extern "C" fn fmi3DoStep(
     let Some((store, g, h)) = inst.cs() else { return ERROR };
     match g.call_do_step(store, h, current_communication_point, communication_step_size, no_set_fmu_state_prior) {
         Ok(Ok(r)) => {
-            if !event_handling_needed.is_null() {
-                *event_handling_needed = r.event_handling_needed;
-            }
-            if !terminate_simulation.is_null() {
-                *terminate_simulation = r.terminate_simulation;
-            }
-            if !early_return.is_null() {
-                *early_return = r.early_return;
-            }
-            if !last_successful_time.is_null() {
-                *last_successful_time = r.last_successful_time;
+            unsafe {
+                if !event_handling_needed.is_null() {
+                    *event_handling_needed = r.event_handling_needed;
+                }
+                if !terminate_simulation.is_null() {
+                    *terminate_simulation = r.terminate_simulation;
+                }
+                if !early_return.is_null() {
+                    *early_return = r.early_return;
+                }
+                if !last_successful_time.is_null() {
+                    *last_successful_time = r.last_successful_time;
+                }
             }
             OK
         }
@@ -1347,7 +1379,7 @@ pub unsafe extern "C" fn fmi3DoStep(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3SetInputDerivatives(
     c: *mut c_void,
     value_references: *const u32,
@@ -1356,11 +1388,11 @@ pub unsafe extern "C" fn fmi3SetInputDerivatives(
     values: *const f64,
     n_values: usize,
 ) -> i32 {
-    let Some(requests) = requests(value_references, n_value_references, orders) else { return ERROR };
+    let Some(requests) = (unsafe { requests(value_references, n_value_references, orders) }) else { return ERROR };
     if values.is_null() && n_values != 0 {
         return ERROR;
     }
-    let v = if n_values == 0 { &[][..] } else { std::slice::from_raw_parts(values, n_values) };
+    let v = if n_values == 0 { &[][..] } else { unsafe { std::slice::from_raw_parts(values, n_values) } };
     let Some(inst) = inst_mut(c) else { return ERROR };
     let Some((store, g, h)) = inst.cs() else { return ERROR };
     match g.call_set_input_derivatives(store, h, &requests, v) {
@@ -1369,7 +1401,7 @@ pub unsafe extern "C" fn fmi3SetInputDerivatives(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3GetOutputDerivatives(
     c: *mut c_void,
     value_references: *const u32,
@@ -1378,22 +1410,22 @@ pub unsafe extern "C" fn fmi3GetOutputDerivatives(
     values: *mut f64,
     n_values: usize,
 ) -> i32 {
-    let Some(requests) = requests(value_references, n_value_references, orders) else { return ERROR };
+    let Some(requests) = (unsafe { requests(value_references, n_value_references, orders) }) else { return ERROR };
     on_instance!(inst_mut(c), |store, g, h, st| match g.call_get_output_derivatives(store, h, &requests) {
         Ok(Ok(v)) => {
             if v.len() != n_values || values.is_null() {
                 return ERROR;
             }
-            std::slice::from_raw_parts_mut(values, n_values).copy_from_slice(&v);
+            unsafe { std::slice::from_raw_parts_mut(values, n_values).copy_from_slice(&v); }
             OK
         }
         Ok(Err(s)) => st(s),
         Err(_) => ERROR,
-    })
+   })
 }
 
 /// Scheduled Execution only; no world exports it yet.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fmi3ActivateModelPartition(_c: *mut c_void, _clock: u32, _activation_time: f64) -> i32 {
     ERROR
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi/src/wasi.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi/src/wasi.rs
@@ -23,12 +23,12 @@ thread_local! {
 /// console on the web target.
 pub fn start_stdout_capture() {
     STDOUT_CAPTURE.with(|c| *c.borrow_mut() = Some(Vec::new()));
-    NATIVE_CAPTURE.with(|h| h.get().map(|(begin, _)| begin()));
+    NATIVE_CAPTURE.with(|h| h.get().map(|n| (n.begin)()));
 }
 
 /// End capture and return the accumulated bytes as a lossy-UTF-8 string.
 pub fn take_stdout_capture() -> String {
-    let native = NATIVE_CAPTURE.with(|h| h.get().map(|(_, end)| end())).unwrap_or_default();
+    let native = NATIVE_CAPTURE.with(|h| h.get().map(|n| (n.end)())).unwrap_or_default();
     STDOUT_CAPTURE
         .with(|c| c.borrow_mut().take())
         .map(|mut v| {
@@ -38,16 +38,26 @@ pub fn take_stdout_capture() -> String {
         .unwrap_or_default()
 }
 
+/// While the redirect is in place the process's fds *are* the capture, so
+/// [`write_std`] writes there too and the run's log stays one stream, as the C
+/// simulation executable's is. `write` is false with no redirect in place.
+#[derive(Clone, Copy)]
+pub struct NativeCapture {
+    pub begin: fn(),
+    pub write: fn(&[u8], bool) -> bool,
+    pub end: fn() -> Vec<u8>,
+}
+
 thread_local! {
-    static NATIVE_CAPTURE: std::cell::Cell<Option<(fn(), fn() -> Vec<u8>)>> = const { std::cell::Cell::new(None) };
+    static NATIVE_CAPTURE: std::cell::Cell<Option<NativeCapture>> = const { std::cell::Cell::new(None) };
 }
 
 /// Extend the capture over the *process's* stdout, which a `dlopen`ed external "C"
 /// library's `printf` reaches directly — past the WASI shim, past `ModelicaMessage`.
 /// C's simulation executable has a stdout of its own, so that output belongs in the
 /// run's log too.
-pub fn set_native_capture(begin: fn(), end: fn() -> Vec<u8>) {
-    NATIVE_CAPTURE.with(|h| h.set(Some((begin, end))));
+pub fn set_native_capture(n: NativeCapture) {
+    NATIVE_CAPTURE.with(|h| h.set(Some(n)));
 }
 
 /// Write to stdout (fd 1) through the same capture/host routing as a guest
@@ -57,8 +67,12 @@ pub fn stdout_write(bytes: &[u8]) {
     write_std(bytes, false);
 }
 
-/// Route a stdout/stderr write to the capture buffer if active, else to the host.
+/// Route a stdout/stderr write to the redirected process fds, else to the capture
+/// buffer if active, else to the host.
 fn write_std(bytes: &[u8], is_err: bool) {
+    if NATIVE_CAPTURE.with(|h| h.get()).is_some_and(|n| (n.write)(bytes, is_err)) {
+        return;
+    }
     let captured = STDOUT_CAPTURE.with(|c| match c.borrow_mut().as_mut() {
         Some(buf) => { buf.extend_from_slice(bytes); true }
         None => false,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
@@ -824,7 +824,34 @@ pub mod native_stdout {
     }
 
     pub fn install() {
-        openmodelica_wasi::wasi::set_native_capture(begin, end);
+        openmodelica_wasi::wasi::set_native_capture(openmodelica_wasi::wasi::NativeCapture {
+            begin,
+            write,
+            end,
+        });
+    }
+
+    /// C's `messageText`: written whole and now, so our log lines and a `dlopen`ed
+    /// external's own output reach the log in the order the two produced them.
+    /// To the capture's own fd, which fds 1 and 2 are dups of: fd 1 may be
+    /// redirected on top of ours, as the Ipopt solve pipes it.
+    fn write(bytes: &[u8], _is_err: bool) -> bool {
+        let Some(fd) = ACTIVE.with(|a| a.borrow().as_ref().map(|r| r.fd)) else {
+            return false;
+        };
+        let mut rest = bytes;
+        unsafe {
+            // Whatever an external left in libc's buffers happened before this line.
+            libc::fflush(std::ptr::null_mut());
+            while !rest.is_empty() {
+                let n = libc::write(fd, rest.as_ptr() as *const _, rest.len());
+                if n <= 0 {
+                    break;
+                }
+                rest = &rest[n as usize..];
+            }
+        }
+        true
     }
 
     fn begin() {


### PR DESCRIPTION
`String(x, format="n")` inside an exported FMU is C's `modelica_string_format_to_c_string_format` calling `omc_assert(NULL, ...)`. The runtime trapped instead, so `issue10978.mos` lost the whole report.

C picks the `omc_assert` implementation through a function pointer the executable installs: a simulation gets `omc_assert_simulation` (`LOG_ASSERT` at error level), an FMU keeps `omc_assert_fmi`, whose thread-less branch writes `[<info>]Modelica Assert: <msg>!` to stderr rather than to the FMI logger. Add both, chosen by the build
- the FMI3 adapter's is the only one with no simulation driver - and reach fd 2 through the adapter, which owns the descriptors.

Where C's FMU catches that throw and reports
`fmi2ExitInitializationMode: terminated by an assertion.` on `logFmi2Call`, a wasm FMU traps out to
`openmodelica_fmi_ls_wasm_to_native`, which is that FMU's `fmu2_model_interface.c`. Log it there, filtered as C's `isCategoryLogged` filters it.

That left the four lines in the wrong order. A run has two log channels: the driver's own lines went to a buffer while a `dlopen`ed external's `printf` and the FMU's stderr went to the redirected process fds, and the two were concatenated rather than interleaved. C has one stdout, so let the runtime's lines go into the redirect too while it is in place - written whole and now, as `messageText`'s `printf` + `fflush(NULL)` is.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
