### PR TITLE
Fix MAT v4 write from a wasm host

### DIFF
--- a/OMCompiler/SimulationRuntime/ModelicaExternalC/C-Sources/ModelicaMatIO.c
+++ b/OMCompiler/SimulationRuntime/ModelicaExternalC/C-Sources/ModelicaMatIO.c
@@ -5446,7 +5446,7 @@ Mat_VarWrite4(mat_t *mat, matvar_t *matvar)
 #elif defined(__i386__) || defined(__alpha__) || defined(__ia64) || defined(__ia64__) ||   \
     defined(_M_IX86) || defined(_M_IA64) || defined(_M_ALPHA) || defined(__amd64) ||       \
     defined(__amd64__) || defined(_M_AMD64) || defined(__x86_64) || defined(__x86_64__) || \
-    defined(_M_X64) || defined(__bfin__)
+    defined(_M_X64) || defined(__bfin__) || defined(__wasm__)
 #else
     return MATIO_E_OPERATION_NOT_SUPPORTED;
 #endif

--- a/testsuite/simulation/modelica/external_functions/Makefile
+++ b/testsuite/simulation/modelica/external_functions/Makefile
@@ -13,6 +13,7 @@ ImplicitArray.mos \
 LapackInverse.mos \
 Matrix.mos \
 MDD_test.mos \
+ModelicaIOMatrix.mos \
 ModelicaUtilities.mos \
 QualifiedCrefArg.mos \
 RecordMemberArguments.mos \

--- a/testsuite/simulation/modelica/external_functions/ModelicaIOMatrix.mo
+++ b/testsuite/simulation/modelica/external_functions/ModelicaIOMatrix.mo
@@ -1,0 +1,11 @@
+model ModelicaIOMatrix
+  parameter Real m[2,3](each fixed = false);
+  Real x(start = 0.0, fixed = true);
+protected
+  parameter Boolean written(fixed = false);
+initial algorithm
+  written := Modelica.Utilities.Streams.writeRealMatrix("ModelicaIOMatrix.mat", "M", {{1.5,2.5,3.5},{4.5,5.5,6.5}}, false, "4");
+  m := Modelica.Utilities.Streams.readRealMatrix("ModelicaIOMatrix.mat", "M", 2, 3);
+equation
+  der(x) = sum(m);
+end ModelicaIOMatrix;

--- a/testsuite/simulation/modelica/external_functions/ModelicaIOMatrix.mos
+++ b/testsuite/simulation/modelica/external_functions/ModelicaIOMatrix.mos
@@ -1,0 +1,26 @@
+// name:     ModelicaIOMatrix
+// keywords: ModelicaIO, writeRealMatrix, readRealMatrix
+// status:   correct
+// teardown_command: rm -rf ModelicaIOMatrix_* ModelicaIOMatrix ModelicaIOMatrix.exe ModelicaIOMatrix.mat ModelicaIOMatrix.c ModelicaIOMatrix.h ModelicaIOMatrix.o ModelicaIOMatrix.libs ModelicaIOMatrix.log ModelicaIOMatrix.makefile ModelicaIOMatrix.wasm output.log
+
+loadModel(Modelica, {"4.0.0"}); getErrorString();
+loadFile("ModelicaIOMatrix.mo"); getErrorString();
+simulate(ModelicaIOMatrix, stopTime=1.0); getErrorString();
+val(x, 1.0);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "ModelicaIOMatrix_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ModelicaIOMatrix', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_STDOUT        | info    | ... loading \"M\" from \"ModelicaIOMatrix.mat\"
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 24.0
+// endResult


### PR DESCRIPTION
Mat_VarWrite4 picks the file's endianness tag from a list of platform macros. wasm32-wasip1 defines none of them, so it fell through to the trailing #else and returned MATIO_E_OPERATION_NOT_SUPPORTED before writing a byte - Mat_CreateVer had already created the file, so the model was left with an empty .mat and ModelicaIO's "Cannot write variable" assert.

Only visible since the wasm-jit simulation started using the wasm ModelicaExternalC (#16401); the native library is compiled for x86_64. AixLib.Fluid.Geothermal.Borefields.Examples.Borefields writes its g-function to a MAT v4 file and reads it back, and now runs to completion under --simCodeTarget=wasm-jit. The written file is byte-identical to the C target's.

The new test covers the round trip on both targets.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
