### PR TITLE
[C] Cap expression nesting in the C code generator

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -7914,6 +7914,30 @@ algorithm
   end match;
 end isAtomic;
 
+public function isDeeperThan
+  "Whether the expression tree is deeper than inDepth levels."
+  input DAE.Exp inExp;
+  input Integer inDepth;
+  output Boolean outDeeper;
+algorithm
+  outDeeper := match inExp
+    case _ guard inDepth <= 0 then true;
+    case DAE.BINARY() then if isDeeperThan(inExp.exp1, inDepth - 1) then true
+                           else isDeeperThan(inExp.exp2, inDepth - 1);
+    case DAE.LBINARY() then if isDeeperThan(inExp.exp1, inDepth - 1) then true
+                            else isDeeperThan(inExp.exp2, inDepth - 1);
+    case DAE.RELATION() then if isDeeperThan(inExp.exp1, inDepth - 1) then true
+                             else isDeeperThan(inExp.exp2, inDepth - 1);
+    case DAE.IFEXP() then if isDeeperThan(inExp.expCond, inDepth - 1) then true
+                          elseif isDeeperThan(inExp.expThen, inDepth - 1) then true
+                          else isDeeperThan(inExp.expElse, inDepth - 1);
+    case DAE.UNARY() then isDeeperThan(inExp.exp, inDepth - 1);
+    case DAE.LUNARY() then isDeeperThan(inExp.exp, inDepth - 1);
+    case DAE.CAST() then isDeeperThan(inExp.exp, inDepth - 1);
+    else false;
+  end match;
+end isDeeperThan;
+
 public function isImpure "author: lochel
   Returns true if an expression contains an impure function call."
   input DAE.Exp inExp;

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -5920,6 +5920,16 @@ template daeExpCrefIndexSpec(list<Subscript> subs, Context context,
   tmp
 end daeExpCrefIndexSpec;
 
+template daeExpOperand(Exp exp, Text expText, Type ty, Text &preExp, Text &varDecls)
+ "Parenthesizes an operand, or spills it to a temporary when deeply nested."
+::=
+  if Expression.isDeeperThan(exp, 64) then
+    let tmp = tempDecl(expTypeModelica(ty), &varDecls)
+    let &preExp += '<%tmp%> = <%expText%>;<%\n%>'
+    tmp
+  else '(<%expText%>)'
+end daeExpOperand;
+
 template daeExpBinary(Exp exp, Context context, Text &preExp,
                       Text &varDecls, Text &auxFunction)
  "Generates code for a binary expression."
@@ -5934,15 +5944,15 @@ case BINARY(__) then
     let tmpStr = tempDecl("modelica_metatype", &varDecls)
     let &preExp += '<%tmpStr%> = stringAppend(<%e1%>,<%e2%>);<%\n%>'
     tmpStr
-  case ADD(__) then
+  case ADD(ty = ty) then
     if isAtomic(exp2)
       then '<%e1%> + <%e2%>'
-      else '<%e1%> + (<%e2%>)'
-  case SUB(__) then
+      else '<%e1%> + <%daeExpOperand(exp2, e2, ty, &preExp, &varDecls)%>'
+  case SUB(ty = ty) then
     if isAtomic(exp2)
       then '<%e1%> - <%e2%>'
-      else '<%e1%> - (<%e2%>)'
-  case MUL(__) then '(<%e1%>) * (<%e2%>)'
+      else '<%e1%> - <%daeExpOperand(exp2, e2, ty, &preExp, &varDecls)%>'
+  case MUL(ty = ty) then '<%daeExpOperand(exp1, e1, ty, &preExp, &varDecls)%> * <%daeExpOperand(exp2, e2, ty, &preExp, &varDecls)%>'
   case DIV(ty = ty) then
     (match context
       case FUNCTION_CONTEXT(__) then

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -4108,6 +4108,12 @@ package Expression
     output Boolean outBoolean;
   end isAtomic;
 
+  function isDeeperThan
+    input DAE.Exp inExp;
+    input Integer inDepth;
+    output Boolean outDeeper;
+  end isDeeperThan;
+
   function isHalf
     input DAE.Exp inExp;
     output Boolean outBoolean;


### PR DESCRIPTION
`daeExpBinary` ADD parenthesises a non-atomic right operand since 3da99d3404, so the C compiler reads back the tree the code generator built. A right-nested chain of N operands then prints N nested parentheses, and N follows the model: `sum(QA)` over `CocurrentHeatExchangerEquations_N_1280` is 1279 of them. clang parses a right-nested chain recursively and runs out of stack there (`make` reports `Error 139`); only left-nested chains, which print flat, have been surviving.

No constant limit holds when N is the model's, so an operand deeper than 64 levels is now assigned to a temporary and the operator takes that temporary. The tree and its evaluation order are unchanged, so the emitted C keeps its rounding, and left-nested chains still print flat: generated code only moves where it was already past 64 levels.

Assisted-by: Claude Opus 5

### Related Issues

https://github.com/OpenModelica/OpenModelicaLibraryTesting/issues/325

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
