### PR TITLE
Port covertTextFileToCLiteral and fmilib's DE warnings

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/FMIExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/FMIExt.rs
@@ -32,10 +32,9 @@
 //     `result = false` with NULL/empty outputs; the caller checks
 //     `true := b`. fmilib additionally logs its own diagnostic lines
 //     ("module = FMIXML, log level = ERROR: ...") through the import
-//     logger; those internal lines are not reproduced here, only the
-//     errors FMIImpl.c itself raises.
-//   * `inFMILogLevel` only configures the fmilib logger in C; with no
-//     fmilib here it is unused.
+//     logger; of those only the missing-DefaultExperiment-attribute
+//     warnings are reproduced here.
+//   * `inFMILogLevel` is fmilib's jm_callbacks.log_level.
 
 #![allow(non_snake_case)]
 
@@ -75,6 +74,30 @@ fn add_scripting_error(template: &str, tokens: &[&str]) {
     );
 }
 
+/// FMIImpl.c fills its static jm_callbacks on the first import only, so that
+/// call's loglevel sticks for the rest of the process.
+static JM_LOG_LEVEL: std::sync::OnceLock<i32> = std::sync::OnceLock::new();
+
+/// jm_log_level_warning.
+const JM_LOG_LEVEL_WARNING: i32 = 3;
+
+/// FMIImpl.c's `importlogger`. The tokens read message/level/module because
+/// c_add_message reverses them.
+fn jm_log_warning(module: &str, message: &str) {
+    if JM_LOG_LEVEL_WARNING > *JM_LOG_LEVEL.get().unwrap_or(&JM_LOG_LEVEL_WARNING) {
+        return;
+    }
+    let _ = Error::addMessage(
+        ErrorTypes::Message {
+            id: -1,
+            ty: ErrorTypes::MessageType::SCRIPTING,
+            severity: ErrorTypes::Severity::WARNING,
+            message: arcstr::literal!("module = %s, log level = %s: %s"),
+        },
+        metamodelica::list![ArcStr::from(message), arcstr::literal!("WARNING"), ArcStr::from(module)],
+    );
+}
+
 type InitializeFMIImportResult = (
     bool,                                   // result
     Option<i32>,                            // outFMIContext
@@ -105,11 +128,12 @@ fn failure() -> InitializeFMIImportResult {
 pub fn initializeFMIImport(
     inFileName: ArcStr,
     inWorkingDirectory: ArcStr,
-    _inFMILogLevel: i32,
+    inFMILogLevel: i32,
     inInputConnectors: bool,
     inOutputConnectors: bool,
     inIsModelDescriptionImport: bool,
 ) -> Result<InitializeFMIImportResult> {
+    let _ = JM_LOG_LEVEL.set(inFMILogLevel);
     // `fmi_import_get_fmi_version`: extract the FMU into the working
     // directory, then read the fmiVersion attribute. Every failure mode up
     // to and including "fmiVersion attribute is not 1.0/2.0" maps to the
@@ -402,26 +426,32 @@ fn build_variable(
 /// `<DefaultExperiment>` of either FMI version: startTime (default 0),
 /// stopTime (default 1.0), tolerance (default 1e-4) — fmilib's
 /// FMI{1,2}_DEFAULT_EXPERIMENT_TOLERANCE. Returns `None` on a malformed
-/// number (fmilib parse error).
-fn parse_default_experiment(root: &roxmltree::Node<'_, '_>) -> Option<FMI::ExperimentAnnotation> {
-    let mut start = 0.0;
-    let mut stop = 1.0;
-    let mut tolerance = 1e-4;
-    if let Some(de) = child_element(root, "DefaultExperiment") {
-        if let Some(v) = de.attribute("startTime") {
-            start = v.trim().parse().ok()?;
-        }
-        if let Some(v) = de.attribute("stopTime") {
-            stop = v.trim().parse().ok()?;
-        }
-        if let Some(v) = de.attribute("tolerance") {
-            tolerance = v.trim().parse().ok()?;
+/// number (fmilib parse error). `version` (1 or 2) only names the fmilib
+/// module the missing-attribute warnings come from.
+fn parse_default_experiment(root: &roxmltree::Node<'_, '_>, version: u32) -> Option<FMI::ExperimentAnnotation> {
+    let de = child_element(root, "DefaultExperiment");
+    // Each fmilib getter warns when its attribute was absent; FMIImpl.c reads
+    // them in this order.
+    let mut values = [0.0, 1.0, 1e-4];
+    for (value, (getter, attribute)) in values
+        .iter_mut()
+        .zip([("start", "startTime"), ("stop", "stopTime"), ("tolerance", "tolerance")])
+    {
+        match de.as_ref().and_then(|de| de.attribute(attribute)) {
+            Some(v) => *value = v.trim().parse().ok()?,
+            None => jm_log_warning(
+                &format!("FMI{version}XML"),
+                &format!(
+                    "fmi{version}_xml_get_default_experiment_{getter}: \
+                     returning default value, since no attribute was defined in modelDescription"
+                ),
+            ),
         }
     }
     Some(FMI::ExperimentAnnotation {
-        fmiExperimentStartTime: metamodelica::Real::from(start),
-        fmiExperimentStopTime: metamodelica::Real::from(stop),
-        fmiExperimentTolerance: metamodelica::Real::from(tolerance),
+        fmiExperimentStartTime: metamodelica::Real::from(values[0]),
+        fmiExperimentStopTime: metamodelica::Real::from(values[1]),
+        fmiExperimentTolerance: metamodelica::Real::from(values[2]),
     })
 }
 
@@ -519,7 +549,7 @@ fn parse_fmi2(
     };
 
     let typedefs = parse_type_definitions(root, "SimpleType", true)?;
-    let experiment = parse_default_experiment(root)?;
+    let experiment = parse_default_experiment(root, 2)?;
 
     // Model variables in document order (C uses sortOrder = 0).
     let mut variables: Vec<FMI::ModelVariables> = Vec::new();
@@ -603,7 +633,7 @@ fn parse_fmi1(
     };
 
     let typedefs = parse_type_definitions(root, "Type", false)?;
-    let experiment = parse_default_experiment(root)?;
+    let experiment = parse_default_experiment(root, 1)?;
 
     let mut variables: Vec<FMI::ModelVariables> = Vec::new();
     let mut placements = (60, 60);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
@@ -2511,11 +2511,63 @@ pub fn alarm(seconds: i32) -> i32 {
     0
 }
 
-pub fn covertTextFileToCLiteral(_textFile: ArcStr, _outFile: ArcStr, _target: ArcStr) -> bool {
-    // Reads a text file and writes a C-source file containing the text
-    // as a string literal. The C runtime handles escaping platform-by-
-    // platform; defer until a Susan template needs it.
-    todo!("System.covertTextFileToCLiteral: text-to-C-literal converter not yet ported")
+pub fn covertTextFileToCLiteral(textFile: ArcStr, outFile: ArcStr, target: ArcStr) -> bool {
+    let Ok(bytes) = openmodelica_wasi::fs::read(textFile.as_str()) else {
+        return false;
+    };
+    let mut out: Vec<u8> = Vec::with_capacity(2 * bytes.len() + 2);
+    if target.as_str() == "msvc" {
+        // MSVC caps a string literal at 64k; emit a char array instead,
+        // broken every BUFSIZ input bytes like C does.
+        out.extend_from_slice(b"{\n");
+        for chunk in bytes.chunks(8192) {
+            for &b in chunk {
+                out.push(b'\'');
+                match b {
+                    b'\n' => out.extend_from_slice(b"\\n"),
+                    b'\r' => out.extend_from_slice(b"\\r"),
+                    b'\\' => out.extend_from_slice(b"\\\\"),
+                    b'"' => out.extend_from_slice(b"\\\""),
+                    b'\'' => out.extend_from_slice(b"\\'"),
+                    b => out.push(b),
+                }
+                out.extend_from_slice(b"',");
+            }
+            out.push(b'\n');
+        }
+        // C's do/while emits it once even for an empty file.
+        if bytes.is_empty() {
+            out.push(b'\n');
+        }
+        out.extend_from_slice(b"'\\0'\n}");
+    } else {
+        out.push(b'"');
+        for &b in &bytes {
+            match b {
+                b'\n' => out.extend_from_slice(b"\\n"),
+                b'\r' => out.extend_from_slice(b"\\r"),
+                b'\\' => out.extend_from_slice(b"\\\\"),
+                b'"' => out.extend_from_slice(b"\\\""),
+                b => out.push(b),
+            }
+        }
+        out.push(b'"');
+    }
+    if let Err(e) = openmodelica_wasi::fs::write(outFile.as_str(), &out) {
+        let _ = crate::Error::addMessage(
+            openmodelica_error::ErrorTypes::Message {
+                id: 85,
+                ty: openmodelica_error::ErrorTypes::MessageType::SCRIPTING,
+                severity: openmodelica_error::ErrorTypes::Severity::ERROR,
+                message: literal!(
+                    "SystemImpl__covertTextFileToCLiteral failed: %s. Maybe the total file name is too long."
+                ),
+            },
+            metamodelica::list![ArcStr::from(e.to_string())],
+        );
+        return false;
+    }
+    true
 }
 
 pub fn dladdr<T: Clone + 'static>(_symbol: T) -> (ArcStr, ArcStr, ArcStr) {


### PR DESCRIPTION
Two gaps in the Rust port's FMI support, both hit by tests under openmodelica/fmi.

System.covertTextFileToCLiteral was still a todo!(), so exporting an FMI 1.0 FMU panicked omc: SimCodeMain converts <name>_info.json into sources/<name>_info.c through it (the JavaScript simCodeTarget does the same with <name>_init.xml).  Ported from
SystemImpl__covertTextFileToCLiteral, including the msvc branch that emits a char array because MSVC caps a string literal at 64k.  File I/O goes through openmodelica_wasi::fs so it also works on wasm.

FMIExt reproduced none of fmilib's own log lines, so importing an FMU whose modelDescription.xml has no DefaultExperiment attributes was silent where the C omc warns three times.  Emit those warnings, gated on inFMILogLevel - fmilib's jm_callbacks.log_level, until now ignored by the port.  FMIImpl.c fills its static callbacks struct on the first import only, so the first call's loglevel sticks; that is reproduced. The message/level/module token order matches what c_add_message's token reversal produces.

Fixes, under the default (C) simCodeTarget:

| Test                                    | Was failing on            |
| --------------------------------------- | ------------------------ |
| ModelExchange/1.0/FMI1MEInputOutput      | covertTextFileToCLiteral |
| ModelExchange/1.0/FMI1MEcvodeFlag        | covertTextFileToCLiteral |
| ModelExchange/1.0/FMI1MEfmpy             | covertTextFileToCLiteral |
| ModelExchange/1.0/fmi1_import_boolean    | covertTextFileToCLiteral |
| CoSimulationStandAlone/..._parameters    | missing fmilib warnings  |
| CoSimulationStandAlone/..._setters       | missing fmilib warnings  |

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
