### PR TITLE
Convert string literals from package.encoding

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
@@ -6389,6 +6389,7 @@ version = "0.1.0"
 dependencies = [
  "arcstr",
  "const-str 1.1.0",
+ "encoding_rs",
  "loop_unwrap",
  "metamodelica",
  "openmodelica_error",

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/Cargo.toml
@@ -13,5 +13,7 @@ winnow.workspace = true
 # ParserExt forwards parser diagnostics to the Error subsystem
 # (ErrorExt::addSourceMessage), like the C parser links against errorext.
 openmodelica_error.workspace = true
+# BaseModelica_Lexer.g converts string literals from package.encoding
+encoding_rs.workspace=true
 
 [dev-dependencies]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/src/ParserExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/src/ParserExt.rs
@@ -193,12 +193,6 @@ pub fn parse(
         metamodelica::cancel::PROGRESS_INDETERMINATE,
         metamodelica::cancel::PHASE_PARSE,
     );
-    // The Rust parser operates on UTF-8 `&str` directly.  Anything else
-    // would need transcoding via the `encoding_rs` crate; bail explicitly
-    // rather than silently misinterpreting the bytes.
-    if !encoding.is_empty() && !encoding.eq_ignore_ascii_case("UTF-8") && !encoding.eq_ignore_ascii_case("UTF8") {
-        return Err("ParserExt::parse: only UTF-8 input is supported, got encoding {:?}");
-    }
     let (src, orig_bytes) = read_source_file(filename.as_str())
         .map_err(|_| "ParserExt::parse: cannot read {filename}")?;
     let grammar = select_grammar(acceptedGram, languageStandardInt);
@@ -207,8 +201,12 @@ pub fn parse(
     // cannot write to are flagged read-only in their SOURCEINFO, so the
     // interactive API refuses to modify them.
     let readonly = !regular_file_writable(filename.as_str());
+    // Outside string literals the grammar allows nothing but ASCII, so only
+    // the literals are transcoded from `encoding`.
     parser::set_non_utf8_source_bytes(orig_bytes);
+    parser::set_source_encoding(encoding.as_str());
     let result = run_parse(&src, filename.as_str(), infoFilename.as_str(), grammar, readonly, file_timestamp(filename.as_str()));
+    parser::set_source_encoding("");
     parser::set_non_utf8_source_bytes(None);
     result
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/src/parser/lexer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/src/parser/lexer.rs
@@ -732,22 +732,21 @@ impl<'s> Lexer<'s> {
                 Some(c) => raw.push(c),
             }
         }
-        // Reproduce the C `STRING` rule (BaseModelica_Lexer.g): if the literal's
-        // original bytes are not valid UTF-8, fall back to 7-bit ASCII (high
-        // bytes → '?') and warn. The closing `"` is one byte, so the content
-        // span ends at `self.pos - 1`.
+        // The closing `"` is one byte, so the content span ends here.
         let content_end = self.pos - 1;
-        if let Some(ascii) = super::ascii_fy_string_span_if_invalid(content_start, content_end) {
-            self.warn_non_utf8(&ascii, start_line, start_col);
-            return Ok(TokenKind::Str(ascii.into()));
+        match super::convert_string_literal(&raw, content_start, content_end) {
+            super::StringLiteral::Verbatim => Ok(TokenKind::Str(raw.into())),
+            super::StringLiteral::Converted(s) => Ok(TokenKind::Str(s.into())),
+            super::StringLiteral::AsciiFallback(ascii) => {
+                self.warn_non_utf8(&ascii, start_line, start_col);
+                Ok(TokenKind::Str(ascii.into()))
+            }
         }
-        Ok(TokenKind::Str(raw.into()))
     }
 
-    /// Emit the C `STRING`-rule warning for a string literal that was not valid
-    /// UTF-8. Mirrors the message, truncation (72 chars + "...") and span
-    /// (`[start_col, start_col + len]`) of `BaseModelica_Lexer.g`. `ascii` is
-    /// the already-ASCII-fied content (without the surrounding quotes).
+    /// The C `STRING`-rule warning, with the message, truncation (72 chars +
+    /// "...") and span (`[start_col, start_col + len]`) of
+    /// `BaseModelica_Lexer.g`. `ascii` is the ASCII-fied content, unquoted.
     fn warn_non_utf8(&self, ascii: &str, start_line: u32, start_col: u32) {
         // Every byte is ASCII here, so byte length == display column count.
         let full_len = ascii.len();
@@ -761,8 +760,9 @@ impl<'s> Lexer<'s> {
         if full_len > 75 {
             display.push_str("...");
         }
+        let encoding = super::source_encoding_label();
         let message = format!(
-            "The file was not encoded in UTF-8:\n  \"{display}\".\n  \
+            "The file was not encoded in {encoding}:\n  \"{display}\".\n  \
              Defaulting to 7-bit ASCII with unknown characters replaced by '?'.\n  \
              To change encoding when loading a file: loadFile(encoding=\"ISO-XXXX-YY\").\n  \
              To change it in a package: add a file package.encoding at the top-level.\n  \

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/src/parser/mod.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/src/parser/mod.rs
@@ -162,8 +162,11 @@ thread_local! {
     /// sanitized for the lexer (each invalid byte replaced by `'?'`, preserving
     /// byte offsets). `None` for valid-UTF-8 or string-literal input. The lexer
     /// consults this in `lex_string` to reproduce the C `STRING` rule's
-    /// per-literal UTF-8 check (`SystemImpl__iconv__ascii` + warning).
+    /// per-literal conversion (`SystemImpl__iconv` + warning).
     static SOURCE_ORIG_BYTES: RefCell<Option<std::sync::Arc<[u8]>>> = const { RefCell::new(None) };
+    /// `ModelicaParser_encoding` and the label to name in the warning.
+    static SOURCE_ENCODING: RefCell<(SourceEncoding, ArcStr)> =
+        const { RefCell::new((SourceEncoding::Utf8, literal!("UTF-8"))) };
 }
 
 /// Install (or clear) the original bytes of a non-UTF-8 source for the duration
@@ -173,21 +176,86 @@ pub fn set_non_utf8_source_bytes(bytes: Option<std::sync::Arc<[u8]>>) {
     SOURCE_ORIG_BYTES.with(|b| *b.borrow_mut() = bytes);
 }
 
-/// If the source was non-UTF-8 and the original bytes of `[start, end)` (a
-/// string literal's content span, in byte offsets that line up with the
-/// sanitized source) are not valid UTF-8, return that span ASCII-fied — every
-/// byte with the high bit set replaced by `'?'`, the rest kept — exactly like
-/// the C `SystemImpl__iconv__ascii`. Returns `None` when the span was valid (so
-/// the lexer keeps the string verbatim and emits no warning).
-fn ascii_fy_string_span_if_invalid(start: usize, end: usize) -> Option<String> {
-    SOURCE_ORIG_BYTES.with(|b| {
-        let b = b.borrow();
-        let bytes = b.as_deref()?;
-        let span = bytes.get(start..end)?;
-        if std::str::from_utf8(span).is_ok() {
-            return None;
+enum SourceEncoding {
+    Utf8,
+    /// `encoding_rs` only reaches ISO-8859-1 as an alias of windows-1252,
+    /// while `iconv` decodes it as byte == code point.
+    Latin1,
+    Charset(&'static encoding_rs::Encoding),
+    /// No charset matches the label; `iconv_open` fails in C.
+    Unknown,
+}
+
+pub fn set_source_encoding(label: &str) {
+    let normalized: String =
+        label.chars().filter(|c| *c != '-' && *c != '_').flat_map(char::to_lowercase).collect();
+    let enc = match normalized.as_str() {
+        "" | "utf8" => SourceEncoding::Utf8,
+        "iso88591" | "latin1" | "l1" | "cp819" | "ibm819" => SourceEncoding::Latin1,
+        _ => match encoding_rs::Encoding::for_label(label.as_bytes()) {
+            Some(enc) if enc == encoding_rs::UTF_8 => SourceEncoding::Utf8,
+            Some(enc) => SourceEncoding::Charset(enc),
+            None => SourceEncoding::Unknown,
+        },
+    };
+    let label = if label.is_empty() { literal!("UTF-8") } else { ArcStr::from(label) };
+    SOURCE_ENCODING.with(|e| *e.borrow_mut() = (enc, label));
+}
+
+/// `iconv` rejects the bytes windows-125x and windows-874 leave unassigned,
+/// where the WHATWG index yields the C1 control of the same value instead.
+/// Only the ISO-8859 tables map that range for real.
+fn has_unassigned_c1(enc: &'static encoding_rs::Encoding, decoded: &str) -> bool {
+    enc.is_single_byte()
+        && !enc.name().starts_with("ISO-8859")
+        && decoded.chars().any(|c| ('\u{80}'..='\u{9f}').contains(&c))
+}
+
+fn source_encoding_label() -> ArcStr {
+    SOURCE_ENCODING.with(|e| e.borrow().1.clone())
+}
+
+enum StringLiteral {
+    Verbatim,
+    Converted(String),
+    /// 7-bit ASCII, high bytes replaced by `'?'`; the lexer pairs it with a
+    /// warning.
+    AsciiFallback(String),
+}
+
+/// The `STRING` rule of `Parser/BaseModelica_Lexer.g`. `[start, end)` indexes
+/// the original file bytes, which are only kept when sanitizing changed them,
+/// so the lexed `raw` stands in for the span otherwise.
+fn convert_string_literal(raw: &str, start: usize, end: usize) -> StringLiteral {
+    if raw.is_empty() {
+        return StringLiteral::Verbatim;
+    }
+    let orig = SOURCE_ORIG_BYTES
+        .with(|b| b.borrow().as_deref().and_then(|b| b.get(start..end)).map(<[u8]>::to_vec));
+    let bytes = orig.as_deref().unwrap_or(raw.as_bytes());
+    let ascii_fallback =
+        || StringLiteral::AsciiFallback(bytes.iter().map(|&c| if c & 0x80 != 0 { '?' } else { c as char }).collect());
+
+    SOURCE_ENCODING.with(|e| match e.borrow().0 {
+        SourceEncoding::Utf8 => {
+            if std::str::from_utf8(bytes).is_ok() {
+                StringLiteral::Verbatim
+            } else {
+                ascii_fallback()
+            }
         }
-        Some(span.iter().map(|&c| if c & 0x80 != 0 { '?' } else { c as char }).collect())
+        SourceEncoding::Latin1 => {
+            StringLiteral::Converted(bytes.iter().copied().map(char::from).collect())
+        }
+        SourceEncoding::Charset(enc) => {
+            let (decoded, had_errors) = enc.decode_without_bom_handling(bytes);
+            if had_errors || has_unassigned_c1(enc, &decoded) {
+                ascii_fallback()
+            } else {
+                StringLiteral::Converted(decoded.into_owned())
+            }
+        }
+        SourceEncoding::Unknown => ascii_fallback(),
     })
 }
 

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -2510,9 +2510,9 @@ const char* SystemImpl__iconv__ascii(const char * str)
 static int isUtf8Encoding(const char *str)
 {
 #if defined(_MSC_VER)
-  return _stricmp(str, "UTF-8") || _stricmp(str, "UTF8");
+  return 0 == _stricmp(str, "UTF-8") || 0 == _stricmp(str, "UTF8");
 #else
-  return strcasecmp(str, "UTF-8") || strcasecmp(str, "UTF8");
+  return 0 == strcasecmp(str, "UTF-8") || 0 == strcasecmp(str, "UTF8");
 #endif
 }
 


### PR DESCRIPTION
`ParserExt::parse` rejected every encoding but UTF-8, so a package carrying a `package.encoding` file failed to parse. `ClassLoader` catches that in a `matchcontinue`, leaving only `Failed to load package <name>` behind with no hint of the cause. Physiomodel declares Windows-1250 and could not be loaded at all.

Follow the `STRING` rule of `Parser/BaseModelica_Lexer.g` instead: the grammar allows nothing but ASCII outside string literals, so the file is still lexed as UTF-8 and only the literals are transcoded, falling back to 7-bit ASCII with a warning when their bytes are not valid in the declared charset.

The C compiler was not honouring it either. `strcasecmp` returns 0 on a match, so

    return strcasecmp(str, "UTF-8") || strcasecmp(str, "UTF8");

is true for every string, `SystemImpl__iconv` never reached `iconv_open`, and the encoding only ever acted as a UTF-8 validity check. The two callers passing UTF-8 for both sides -- the parser's file name check and the ZeroMQ reply check -- are unaffected.

`encoding_rs` implements the WHATWG encoding standard, which differs from `iconv` in two places that matter here, so both are pinned to what `iconv` does:

| Input | `iconv` | WHATWG |
| --- | --- | --- |
| unassigned windows-125x byte | rejected | C1 control of the same value | | `ISO-8859-1` | byte == code point | alias of windows-1252 |

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
