### PR TITLE
Free model data arrays in fmi2FreeInstance

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
@@ -895,80 +895,104 @@ void freeModelDataVars(MODEL_DATA* modelData)
   for(i=0; i < modelData->nVariablesRealArray; i++) {
     freeVarInfo(&modelData->realVarsData[i].info);
   }
-  omc_alloc_interface.free_uncollectable(modelData->realVarsData);
 
   for(i=0; i < modelData->nVariablesIntegerArray; i++) {
     freeVarInfo(&modelData->integerVarsData[i].info);
   }
-  omc_alloc_interface.free_uncollectable(modelData->integerVarsData);
 
   for(i=0; i < modelData->nVariablesBooleanArray; i++) {
     freeVarInfo(&modelData->booleanVarsData[i].info);
   }
-  omc_alloc_interface.free_uncollectable(modelData->booleanVarsData);
 
 #if !defined(OMC_NVAR_STRING) || OMC_NVAR_STRING>0
   for(i=0; i < modelData->nVariablesStringArray; i++) {
     freeVarInfo(&modelData->stringVarsData[i].info);
   }
-  omc_alloc_interface.free_uncollectable(modelData->stringVarsData);
 #endif
 
   // Parameters
   for(i=0; i < modelData->nParametersRealArray; i++) {
     freeVarInfo(&modelData->realParameterData[i].info);
   }
-  omc_alloc_interface.free_uncollectable(modelData->realParameterData);
 
   for(i=0; i < modelData->nParametersIntegerArray; i++) {
     freeVarInfo(&modelData->integerParameterData[i].info);
   }
-  omc_alloc_interface.free_uncollectable(modelData->integerParameterData);
 
   for(i=0; i < modelData->nParametersBooleanArray; i++) {
     freeVarInfo(&modelData->booleanParameterData[i].info);
   }
-  omc_alloc_interface.free_uncollectable(modelData->booleanParameterData);
 
   for(i=0; i < modelData->nParametersStringArray; i++) {
     freeVarInfo(&modelData->stringParameterData[i].info);
   }
-  omc_alloc_interface.free_uncollectable(modelData->stringParameterData);
 
   // Sensitivity
   for(i=0; i < modelData->nSensitivityVars; i++) {
     freeVarInfo(&modelData->realSensitivityData[i].info);
   }
-  omc_alloc_interface.free_uncollectable(modelData->realSensitivityData);
 
   // Alias Variables
   if (modelData->realAlias != NULL) {
     for(i=0; i < modelData->nAliasRealArray; i++) {
       freeVarInfo(&modelData->realAlias[i].info);
     }
-    omc_alloc_interface.free_uncollectable(modelData->realAlias);
   }
 
   if (modelData->integerAlias != NULL) {
     for(i=0; i < modelData->nAliasIntegerArray; i++) {
       freeVarInfo(&modelData->integerAlias[i].info);
     }
-    omc_alloc_interface.free_uncollectable(modelData->integerAlias);
   }
 
   if (modelData->booleanAlias != NULL) {
     for(i=0; i < modelData->nAliasBooleanArray; i++) {
       freeVarInfo(&modelData->booleanAlias[i].info);
     }
-    omc_alloc_interface.free_uncollectable(modelData->booleanAlias);
   }
 
   if (modelData->stringAlias != NULL) {
     for(i=0; i < modelData->nAliasStringArray; i++) {
       freeVarInfo(&modelData->stringAlias[i].info);
     }
-    omc_alloc_interface.free_uncollectable(modelData->stringAlias);
   }
+
+  freeModelDataVarArrays(modelData);
+}
+
+/**
+ * @brief Free the var data arrays allocated by `allocModelDataVars`.
+ *
+ * Leaves the VAR_INFO strings alone. Use this instead of `freeModelDataVars`
+ * when the strings were not allocated by `read_var_info`, e.g. for FMUs, where
+ * `read_input_fmu` points them at string literals in the generated code.
+ *
+ * @param modelData   Pointer to model data.
+ */
+void freeModelDataVarArrays(MODEL_DATA* modelData)
+{
+  // Variables
+  omc_alloc_interface.free_uncollectable(modelData->realVarsData);
+  omc_alloc_interface.free_uncollectable(modelData->integerVarsData);
+  omc_alloc_interface.free_uncollectable(modelData->booleanVarsData);
+#if !defined(OMC_NVAR_STRING) || OMC_NVAR_STRING>0
+  omc_alloc_interface.free_uncollectable(modelData->stringVarsData);
+#endif
+
+  // Parameters
+  omc_alloc_interface.free_uncollectable(modelData->realParameterData);
+  omc_alloc_interface.free_uncollectable(modelData->integerParameterData);
+  omc_alloc_interface.free_uncollectable(modelData->booleanParameterData);
+  omc_alloc_interface.free_uncollectable(modelData->stringParameterData);
+
+  // Sensitivity
+  omc_alloc_interface.free_uncollectable(modelData->realSensitivityData);
+
+  // Alias Variables (not allocated for FMUs, see `allocModelDataVars`)
+  omc_alloc_interface.free_uncollectable(modelData->realAlias);
+  omc_alloc_interface.free_uncollectable(modelData->integerAlias);
+  omc_alloc_interface.free_uncollectable(modelData->booleanAlias);
+  omc_alloc_interface.free_uncollectable(modelData->stringAlias);
 }
 
 /**
@@ -1286,7 +1310,6 @@ void initializeDataStruc(DATA *data, threadData_t *threadData)
 void deInitializeDataStruc(DATA *data)
 {
   size_t i = 0;
-  int needToFree = !data->callback->read_input_fmu;
 
   /* prepare RingBuffer */
   for(i=0; i<SIZERINGBUFFER; i++)
@@ -1301,7 +1324,11 @@ void deInitializeDataStruc(DATA *data)
   omc_alloc_interface.free_uncollectable(data->localData);
   freeRingBuffer(data->simulationData);
 
-  if (needToFree) {
+  if (data->callback->read_input_fmu) {
+    /* FMU: `read_input_fmu` points the VAR_INFO strings at literals in the generated code,
+     * but the arrays were still allocated by `allocModelDataVars` in `fmi2Instantiate`. */
+    freeModelDataVarArrays(data->modelData);
+  } else {
     freeModelDataVars(data->modelData);
   }
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.h
@@ -90,6 +90,7 @@ static inline double numericalJacobianStep(double y, double hyprime, double ewtI
 void allocModelDataVars(MODEL_DATA* modelData, modelica_boolean allocAlias, threadData_t* threadData);
 
 void freeModelDataVars(MODEL_DATA* modelData);
+void freeModelDataVarArrays(MODEL_DATA* modelData);
 
 void scalarAllocArrayAttributes(MODEL_DATA* modelData);
 

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
@@ -1038,6 +1038,7 @@ fmi2Status fmi2Terminate(fmi2Component c)
 fmi2Status fmi2Reset(fmi2Component c)
 {
   ModelInstance* comp = (ModelInstance *)c;
+  modelica_boolean modelDataVarsFreed = FALSE;
   if (invalidState(comp, "fmi2Reset", model_state_instantiated|model_state_initialization_mode|model_state_me_event_mode|model_state_me_continuous_time_mode|model_state_terminated|model_state_error, model_state_instantiated|model_state_initialization_mode|model_state_cs_step_complete|model_state_cs_step_failed|model_state_cs_step_canceled|model_state_terminated|model_state_error))
     return fmi2Error;
   FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2Reset")
@@ -1068,12 +1069,20 @@ fmi2Status fmi2Reset(fmi2Component c)
 #endif
     /* free data struct */
     deInitializeDataStruc(comp->fmuData);
+    modelDataVarsFreed = TRUE;
   }
 
   /* Initialize modelData */
   omc_useStream[OMC_LOG_STDOUT] = 1;
   omc_useStream[OMC_LOG_ASSERT] = 1;
   fmu2_model_interface_setupDataStruc(comp->fmuData, comp->threadData);
+  if (modelDataVarsFreed) {
+    /* deInitializeDataStruc freed the var data arrays; re-allocate them before they are
+     * initialized and filled again, mirroring fmi2Instantiate. */
+    allocModelDataVars(comp->fmuData->modelData, FALSE, comp->threadData);
+    scalarAllocArrayAttributes(comp->fmuData->modelData);
+    calculateAllScalarLength(comp->fmuData->modelData);
+  }
   comp->fmuData->callback->read_simulation_info(comp->fmuData->simulationInfo);
   initializeDataStruc(comp->fmuData, comp->threadData);
 

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu3_model_interface.c
@@ -1083,6 +1083,7 @@ fmi3Status omcTerminate(ModelInstance* c)
 fmi3Status omcReset(ModelInstance* c)
 {
   ModelInstance* comp = (ModelInstance *)c;
+  modelica_boolean modelDataVarsFreed = FALSE;
   if (invalidState(comp, "omcReset", model_state_instantiated|model_state_initialization_mode|model_state_me_event_mode|model_state_me_continuous_time_mode|model_state_terminated|model_state_error, model_state_instantiated|model_state_initialization_mode|model_state_cs_step_complete|model_state_cs_step_failed|model_state_cs_step_canceled|model_state_terminated|model_state_error))
     return fmi3Error;
   FILTERED_LOG(comp, fmi3OK, LOG_FMI3_CALL, "omcReset")
@@ -1113,12 +1114,20 @@ fmi3Status omcReset(ModelInstance* c)
 #endif
     /* free data struct */
     deInitializeDataStruc(comp->fmuData);
+    modelDataVarsFreed = TRUE;
   }
 
   /* Initialize modelData */
   omc_useStream[OMC_LOG_STDOUT] = 1;
   omc_useStream[OMC_LOG_ASSERT] = 1;
   fmu3_model_interface_setupDataStruc(comp->fmuData, comp->threadData);
+  if (modelDataVarsFreed) {
+    /* deInitializeDataStruc freed the var data arrays; re-allocate them before they are
+     * initialized and filled again, mirroring fmi3Instantiate. */
+    allocModelDataVars(comp->fmuData->modelData, FALSE, comp->threadData);
+    scalarAllocArrayAttributes(comp->fmuData->modelData);
+    calculateAllScalarLength(comp->fmuData->modelData);
+  }
   comp->fmuData->callback->read_simulation_info(comp->fmuData->simulationInfo);
   initializeDataStruc(comp->fmuData, comp->threadData);
 


### PR DESCRIPTION
### Related Issues

Fixes #16438 (FMU export: fmi2FreeInstance leaks the model data arrays allocated by fmi2Instantiate).
Regression from #14464 (15d47c31d), first released in 1.27.0. Follow-up to trac #3067, which fixed the
fmi2Reset path and left fmi2Terminate + fmi2FreeInstance open.

### Purpose

`fmi2Instantiate` allocates the `*VarsData` / `*ParameterData` / `realSensitivityData` arrays with
`allocModelDataVars`, but `deInitializeDataStruc` skipped `freeModelDataVars` for FMUs because that
function also frees the `VAR_INFO` strings, which `read_input_fmu` points at string literals in the
generated code. The arrays therefore leaked on every instantiate/free cycle (~190 bytes per model
variable). Tools that instantiate an FMU many times in one process (e.g. CasADi, once per derivative
function) leak several MiB per run and long-running processes eventually run out of memory.

### Approach

* Add `freeModelDataVarArrays(MODEL_DATA*)`, which frees only the arrays allocated by
  `allocModelDataVars` (alias pointers are `NULL` for FMUs; `free(NULL)` is a no-op for both
  `omc_alloc_interface` variants).
* `freeModelDataVars` (XML/simulation path, strings `omc_strdup`'d in `read_var_info`) keeps freeing
  the strings and delegates the arrays to the new helper — no behaviour change for simulations.
* `deInitializeDataStruc` calls `freeModelDataVarArrays` when `read_input_fmu` is set instead of
  skipping all frees.
* `fmi2Reset` / FMI 3 `omcReset` call `deInitializeDataStruc` and then refill the arrays through
  `read_input_fmu` without allocating them — that only worked because the arrays were never freed.
  When `deInitializeDataStruc` ran, they now re-allocate (`allocModelDataVars`,
  `scalarAllocArrayAttributes`, `calculateAllScalarLength`) exactly as the instantiate functions do.
  (The first Jenkins run caught this: `omsimulator.reset.mos` / `reset_omc.mos` failed.)

This restores the behaviour of 1.26.x and earlier (before #14464), whose `FREE_VARS` macro guarded only
`freeVarInfo` with `needToFree` and always freed the arrays.

Verified by rebuilding FMUs from their shipped `sources/` with the patched runtime: a
`fmi2Instantiate`…`fmi2FreeInstance` loop on a 2400-variable model exported by 1.27.0 goes from ~470 KiB
leaked per cycle to 0 (glibc `mallinfo2`; 1.26.0 export of the same model: 0), and valgrind no longer
reports the `allocModelDataVars` blocks. Repeated `fmi2Reset` on a live instance runs valgrind-clean
(0 invalid accesses) with a flat heap.
