### PR TITLE
wasm FMU: honour buildModelFMU(method=)

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
@@ -1233,21 +1233,45 @@ impl GenCtx {
         feature_for_crate(crate_name)
     }
 
+    /// The message a disabled target crate's stub reports. Names the callee:
+    /// which call wanted the target is not visible in the user's sources.
+    fn gate_message(&self, feature: &str, callee: &str) -> String {
+        let callee = callee.split("::").collect::<Vec<_>>().join(".");
+        format!(
+            "{callee} needs the '{feature}' code generation target, which this \
+             OpenModelica build was compiled without"
+        )
+    }
+
+    /// `sourceInfo!` for the .mo this crate was generated from, falling back to
+    /// the Rust call site when none is known (should not happen for generated code).
+    fn source_info(&self) -> String {
+        if self.source_file.is_empty() {
+            "metamodelica::sourceInfo!()".to_owned()
+        } else {
+            format!("metamodelica::sourceInfo!({:?})", self.source_file)
+        }
+    }
+
+    /// Record the reason, then bail. A `return Err(..)` alone is a plain
+    /// `fail()`, which the caller's `try` swallows into an empty `getErrorString`.
+    fn gate_report(&self, what: &str) -> String {
+        format!(
+            "{{ let _ = ::openmodelica_util::Error::addInternalError(\
+               ::arcstr::literal!({what:?}), {}); return Err({what:?}) }}",
+            self.source_info()
+        )
+    }
+
     /// Wrap a value-producing expression that depends on a gated target crate
     /// so that, when the crate's feature is disabled, evaluating it bails (in a
     /// fallible function) or panics (in an infallible one) instead of referring
     /// to the absent crate. The `#[cfg]`-on-block form below is stable on
     /// edition 2024 and yields the surviving branch's value; `#![allow(warnings)]`
     /// at each generated file's head silences the dead-branch lints.
-    fn gate_value(&self, feature: &str, expr: &str) -> String {
-        let what = format!(
-            "this OpenModelica build was compiled without the '{feature}' code generation target"
-        );
-        let off = if self.current_fn_fallible {
-            format!("return Err({what:?})")
-        } else {
-            format!("panic!({what:?})")
-        };
+    fn gate_value(&self, feature: &str, expr: &str, callee: &str) -> String {
+        let what = self.gate_message(feature, callee);
+        let off = if self.current_fn_fallible { self.gate_report(&what) } else { format!("panic!({what:?})") };
         format!(
             "{{ #[cfg(feature = {feature:?})] {{ {expr} }} #[cfg(not(feature = {feature:?}))] {{ {off} }} }}"
         )
@@ -1262,15 +1286,10 @@ impl GenCtx {
     /// construction (a `!`-typed block) would leave the binding's type
     /// unknowable (E0282). The stub closure bails/panics when *called* instead,
     /// which is the same observable behaviour at the point the target would run.
-    fn gate_fn_value(&self, feature: &str, on_expr: &str, input_tys: &[String], out_ty: &str) -> String {
-        let what = format!(
-            "this OpenModelica build was compiled without the '{feature}' code generation target"
-        );
-        let body = if self.current_fn_fallible {
-            format!("return Err({what:?})")
-        } else {
-            format!("panic!({what:?})")
-        };
+    fn gate_fn_value(&self, feature: &str, on_expr: &str, input_tys: &[String], out_ty: &str, callee: &str) -> String {
+        // A closure returning `Result`, so it bails regardless of the enclosing
+        // function's fallibility.
+        let body = self.gate_report(&self.gate_message(feature, callee));
         let params = (0..input_tys.len())
             .map(|i| format!("_a{i}"))
             .collect::<Vec<_>>()
@@ -8586,8 +8605,10 @@ fn emit_exp<'a>(exp: &TypedExp, is_const: bool, ctx: &mut GenCtx, top_level: &'a
             // to their qualified runtime path before fnptr! wrapping.
             let var_str = remap_shadowed_builtin_path(&var_str, resolved_fn_qname.as_deref());
             // Captured before the `match` below consumes `var_str`: the feature
-            // gating a reference to a gated target crate's function used as a value.
+            // gating a reference to a gated target crate's function used as a
+            // value, plus the path the stub names in its diagnostic.
             let gated_value_feat = ctx.gated_feature_for_path(&var_str);
+            let gated_value_path = if gated_value_feat.is_some() { var_str.clone() } else { String::new() };
             // Clone-elision inputs (see the `copy`/`node_last_use` arms below).
             // `base` is the enclosing binding this reference reads.
             let base = var_base_name(name, segments);
@@ -8960,9 +8981,9 @@ fn emit_exp<'a>(exp: &TypedExp, is_const: bool, ctx: &mut GenCtx, top_level: &'a
                         }
                         // Non-function value of a gated crate (none exist today):
                         // fall back to the diverging form rather than guess a type.
-                        _ => return ctx.gate_value(feat, &emitted),
+                        _ => return ctx.gate_value(feat, &emitted, &gated_value_path),
                     };
-                    ctx.gate_fn_value(feat, &emitted, &input_tys, &out_ty)
+                    ctx.gate_fn_value(feat, &emitted, &input_tys, &out_ty, &gated_value_path)
                 }
                 _ => emitted,
             }
@@ -9601,7 +9622,7 @@ fn emit_exp<'a>(exp: &TypedExp, is_const: bool, ctx: &mut GenCtx, top_level: &'a
             // callee path; its head is the target package. Const calls never
             // reference a target crate, so they pass through unwrapped.
             match ctx.gated_feature_for_path(&func_str) {
-                Some(feat) if !is_const => ctx.gate_value(feat, &result),
+                Some(feat) if !is_const => ctx.gate_value(feat, &result, &func_str),
                 _ => result,
             }
         }
@@ -10251,7 +10272,7 @@ fn emit_parteval<'a>(
     // same-typed stub-closure form (see [`GenCtx::gate_fn_value`]); a diverging
     // block would make the capture's type unknowable (E0282).
     match ctx.gated_feature_for_path(&func_str) {
-        Some(feat) => ctx.gate_fn_value(feat, &cast, &param_ty_strs, &out_ty_str),
+        Some(feat) => ctx.gate_fn_value(feat, &cast, &param_ty_strs, &out_ty_str, &func_str),
         None => cast,
     }
 }
@@ -11132,13 +11153,7 @@ fn emit_builtin_call<'a>(func: &str, args: &[TypedExp], is_const: bool, ctx: &mu
             // (Error.addInternalError zeroes the position, keeping the file).
             // TODO: carry Absyn.ALGORITHMITEM info through typedexp so the real
             // .mo line can be emitted here.
-            if ctx.source_file.is_empty() {
-                // No source file known (shouldn't happen for generated code);
-                // fall back to the Rust call-site.
-                Ok("metamodelica::sourceInfo!()".to_owned())
-            } else {
-                Ok(format!("metamodelica::sourceInfo!({:?})", ctx.source_file))
-            }
+            Ok(ctx.source_info())
         }
         "list" => {
             if args.is_empty() {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -773,6 +773,12 @@ pub fn fmu_cs_solvers() -> Vec<&'static str> {
         .unwrap_or_default()
 }
 
+/// `CodegenWasmJit.fmuCsSolvers`: [`fmu_cs_solvers`] for the MetaModelica side,
+/// which folds an accepted `method=` into the FMU's `_flags.json`.
+pub fn fmuCsSolvers() -> Arc<List<ArcStr>> {
+    Arc::new(fmu_cs_solvers().into_iter().map(ArcStr::from).collect())
+}
+
 /// The `platforms=` values `buildModelFMU` can serve besides `"wasm"`: those this
 /// omc has a loader library for.
 pub fn fmu_platforms() -> Vec<String> {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/Cargo.lock
@@ -9,10 +9,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
@@ -31,12 +63,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "daskr"
 version = "0.1.0"
 dependencies = [
  "cc",
  "libm",
 ]
+
+[[package]]
+name = "defer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "930c7171c8df9fb1782bdf9b918ed9ed2d33d1d22300abb754f9085bc48bf8e8"
 
 [[package]]
 name = "dlmalloc"
@@ -50,10 +94,111 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-stack"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4713e43e2886ba72b8271aa66c93d722116acf7a75555cce11dcde84388fe8"
+dependencies = [
+ "bytemuck",
+ "dyn-stack-macros",
+]
+
+[[package]]
+name = "dyn-stack-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "equator"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c35da53b5a021d2484a7cc49b2ac7f2d840f8236a286f84202369bd338d761ea"
+dependencies = [
+ "equator-macro 0.2.1",
+]
+
+[[package]]
+name = "equator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02da895aab06bbebefb6b2595f6d637b18c9ff629b4cd840965bb3164e4194b0"
+dependencies = [
+ "equator-macro 0.6.0",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b14b339eb76d07f052cdbad76ca7c1310e56173a138095d3bf42a23c06ef5d8"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "faer"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab6df3dd147fe8d702a288b95bcd8fcc499ab572fc80da6828f60cd4d524d67"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "equator 0.6.0",
+ "faer-traits",
+ "gemm",
+ "generativity",
+ "libm",
+ "nano-gemm",
+ "num-complex",
+ "num-traits",
+ "private-gemm-x86",
+ "pulp",
+ "reborrow",
+]
+
+[[package]]
+name = "faer-traits"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87d23ed7ab1f26c0cba0e5b9e061a796fbb7dc170fa8bee6970055a1308bb0f"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "generativity",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "pulp",
+ "qd",
+ "reborrow",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -66,6 +211,142 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "gemm"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa0673db364b12263d103b68337a68fbecc541d6f6b61ba72fe438654709eacb"
+dependencies = [
+ "dyn-stack",
+ "gemm-c32",
+ "gemm-c64",
+ "gemm-common",
+ "gemm-f16",
+ "gemm-f32",
+ "gemm-f64",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "086936dbdcb99e37aad81d320f98f670e53c1e55a98bee70573e83f95beb128c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c8aeeeec425959bda4d9827664029ba1501a90a0d1e6228e48bef741db3a3f"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88027625910cc9b1085aaaa1c4bc46bb3a36aad323452b33c25b5e4e7c8e2a3e"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "half",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp",
+ "raw-cpuid",
+ "seq-macro",
+ "sysctl",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3df7a55202e6cd6739d82ae3399c8e0c7e1402859b30e4cb780e61525d9486e"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "gemm-f32",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0b8c9da1fbec6e3e3ab2ce6bc259ef18eb5f6f0d3e4edf54b75f9fd41a81c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056131e8f2a521bfab322f804ccd652520c79700d81209e9d9275bbdecaadc6a"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "generativity"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c81fb5260e37854d09d5c87183309fd8c555b75289427884b25660bc87a85e"
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -89,6 +370,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +391,17 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "interpol"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb58032ba748f4010d15912a1855a8a0b1ba9eaad3395b0c171c09b3b356ae50"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -150,6 +448,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "nano-gemm"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e04345dc84b498ff89fe0d38543d1f170da9e43a2c2bcee73a0f9069f72d081"
+dependencies = [
+ "equator 0.2.2",
+ "nano-gemm-c32",
+ "nano-gemm-c64",
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+ "nano-gemm-f32",
+ "nano-gemm-f64",
+ "num-complex",
+]
+
+[[package]]
+name = "nano-gemm-c32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0775b1e2520e64deee8fc78b7732e3091fb7585017c0b0f9f4b451757bbbc562"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+ "num-complex",
+]
+
+[[package]]
+name = "nano-gemm-c64"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af49a20d58816e6b5ee65f64142e50edb5eba152678d4bb7377fcbf63f8437a"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+ "num-complex",
+]
+
+[[package]]
+name = "nano-gemm-codegen"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cc8d495c791627779477a2cf5df60049f5b165342610eb0d76bee5ff5c5d74c"
+
+[[package]]
+name = "nano-gemm-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d998dfa644de87a0f8660e5ea511d7cb5c33b5a2d9847b7af57a2565105089f0"
+
+[[package]]
+name = "nano-gemm-f32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879d962e79bc8952e4ad21ca4845a21132540ed3f5e01184b2ff7f720e666523"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+]
+
+[[package]]
+name = "nano-gemm-f64"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9a513473dce7dc00c7e7c318481ca4494034e76997218d8dad51bd9f007a815"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "bytemuck",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "openmodelica_codegen_wasm_jit_runtime"
 version = "0.1.0"
 dependencies = [
@@ -173,6 +577,7 @@ dependencies = [
 name = "openmodelica_lapack"
 version = "0.1.0"
 dependencies = [
+ "faer",
  "libm",
 ]
 
@@ -186,6 +591,7 @@ version = "0.1.0"
 dependencies = [
  "daskr",
  "libm",
+ "openmodelica_lapack",
  "openmodelica_mat_writer",
  "openmodelica_solvers",
 ]
@@ -199,13 +605,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "private-gemm-x86"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0af8c3e5087969c323f667ccb4b789fa0954f5aa650550e38e81cf9108be21b5"
+dependencies = [
+ "defer",
+ "interpol",
+ "num_cpus",
+ "raw-cpuid",
 ]
 
 [[package]]
@@ -218,6 +642,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulp"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
+
+[[package]]
+name = "qd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f1304a5aecdcfe9ee72fbba90aa37b3aa067a69d14cb7f3d9deada0be7c07c"
+dependencies = [
+ "bytemuck",
+ "libm",
+ "num-traits",
+ "pulp",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,10 +686,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -258,7 +747,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -282,6 +771,17 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
@@ -289,6 +789,51 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -302,6 +847,22 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasm-encoder"
@@ -335,6 +896,15 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -392,7 +962,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.118",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -408,7 +978,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -448,6 +1018,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/index.html
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/index.html
@@ -295,6 +295,17 @@ renderTol();
 
 function setStatus(text, cls='') { statusEl.textContent = text; statusEl.className = 'status ' + cls; }
 function num(v, d) { const n = parseFloat(v); return isFinite(n) ? n : d; }
+const dur = (ms) => ms >= 10000 ? (ms / 1000).toFixed(1) + ' s' : Math.round(ms) + ' ms';
+
+// What the page is doing, so `fail` can name it and say how long it took.
+let opStart = null, opLabel = 'Failed';
+function beginOp(label) { opLabel = label; return (opStart = performance.now()); }
+
+function showEmpty(text, isErr = false) {
+  chartsEmpty.textContent = text;
+  chartsEmpty.className = 'charts-empty' + (isErr ? ' err' : '');
+  chartsEmpty.style.display = '';
+}
 
 // --- logging ---------------------------------------------------------------
 const DEBUG = true;
@@ -525,7 +536,7 @@ async function run(kind) {                       // 'full' | 'resim'
     return;
   }
   running = true; runningKind = kind; setRunUI(true);
-  const tRun = performance.now();
+  const tRun = beginOp(kind === 'resim' ? 'Re-simulation failed' : 'Simulation failed');
   let runMs = 0;
   log('run', kind, 'mode', mode);
   setStatus(kind === 'resim' ? 'Re-simulating…' : 'Compiling & simulating…', 'busy');
@@ -628,12 +639,13 @@ function showBuilding() {
   icGrid.replaceChildren(); icValues.clear(); icBaseline.clear();
   icEmpty.style.display = ''; icEmpty.textContent = 'Simulating…';
   charts.clear(chartsEmpty);
-  chartsEmpty.style.display = ''; chartsEmpty.textContent = 'Simulating…';
+  showEmpty('Simulating…');
   docBody.className = 'doc-body empty'; docBody.textContent = '…';
   if (animView) animView.hide();
 }
 
 async function selectExample(ex) {
+  beginOp('Loading the example failed');
   currentExample = ex;
   builtModel = null; builtWorker = null; lastText = null; preloaded = null; freshModel = true;
   showBuilding();
@@ -692,10 +704,15 @@ async function loadConfig() {
   }
 }
 
+// The status bar is one truncated line, so it keeps the verdict and the charts
+// box — the only panel big enough — carries the diagnostic itself.
 function fail(msg) {
   log('FAIL', msg);
-  setStatus(msg, 'err'); modelFigures = null;
-  charts.clear(chartsEmpty); chartsEmpty.style.display = ''; chartsEmpty.textContent = 'Simulation failed — see the status bar.';
+  const took = opStart === null ? '' : ' after ' + dur(performance.now() - opStart);
+  setStatus(`${opLabel}${took} — see the message below.`, 'err');
+  modelFigures = null;
+  charts.clear(chartsEmpty);
+  showEmpty(('' + msg).trim() || 'Failed without a message.', true);
 }
 
 // --- editable initial conditions -------------------------------------------
@@ -782,8 +799,7 @@ function renderCharts() {
   const useFigs = haveFigs && viewMode !== 'all';
   toggleBtn.textContent = useFigs ? 'All variables' : 'Figures';
   if (useFigs) renderFigures(); else renderAllVariables();
-  if (!charts.list.length) { chartsEl.appendChild(chartsEmpty); chartsEmpty.style.display = '';
-    chartsEmpty.textContent = 'No variables to plot.'; }
+  if (!charts.list.length) { chartsEl.appendChild(chartsEmpty); showEmpty('No variables to plot.'); }
 }
 
 function renderAllVariables() {
@@ -935,6 +951,7 @@ async function exportFmu({ fmuType, method, platforms }) {
   const text = srcEl.value;
   if (touchesModelica(text)) return fail('Refusing to modify the Modelica library — rename the class or remove any "within Modelica" clause.');
   exporting = true;
+  beginOp('FMU export failed');
   exportBtn.textContent = 'Cancel';         // the button cancels the running export
   setStatus('Exporting FMU…', 'busy');
   try {

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/omc-worker.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/omc-worker.js
@@ -447,7 +447,7 @@ self.onmessage = async (ev) => {
           `buildModelFMU(${a.name}, version="3.0", fmuType="${fmuType}", platforms={${platforms}}${method})`, status)).trim();
         const path = unquote(res);
         if (!path || !path.endsWith('.fmu')) {
-          const err = omc_eval('getErrorString()');
+          const err = unquote(omc_eval('getErrorString()'));
           if (cancelFlag && Atomics.load(cancelFlag, 0)) { clearCancel(); return reply({ ok: false, cancelled: true }); }
           return reply({ ok: false, error: err.trim() || 'FMU export failed.' });
         }

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/theme.css
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/theme.css
@@ -67,6 +67,10 @@ input, select {
 .charts { flex:1 1 auto; overflow-y:auto; padding:8px 10px; display:flex; flex-direction:column; gap:8px; }
 .charts[hidden] { display:none; }
 .charts-empty { margin:auto; color:var(--muted); text-align:center; padding:20px; }
+/* Carrying a compiler diagnostic: fills the area from the top and scrolls. */
+.charts-empty.err { margin:0; align-self:stretch; text-align:left; padding:12px 14px;
+  color:var(--err); white-space:pre-wrap; overflow-wrap:anywhere;
+  font:12.5px/1.5 ui-monospace,Menlo,Consolas,monospace; }
 .fig-head { color:var(--teal); font-weight:650; font-size:14px; margin:2px 2px -2px; }
 .chart-card { flex:0 0 auto; border:1px solid var(--border); border-radius:6px; background:var(--panel); padding:6px 8px 8px; }
 .chart-card.solo { flex:1 1 auto; display:flex; flex-direction:column; min-height:0; }

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -1270,8 +1270,7 @@ algorithm
     case ("buildModelFMU", Values.CODE(Absyn.C_TYPENAME(className))::Values.STRING(str1)::Values.STRING(str2)::Values.STRING(filenameprefix)::Values.ARRAY(valueLst=cvars)::Values.BOOL(_)::Values.STRING(str3)::_)
       algorithm
         simSettings := fmuSimulationSettings(className, filenameprefix, str3);
-        fmuMethodToSimulationFlag(str3);
-        (outCache, ret_val) := buildModelFMU(outCache, inEnv, className, str1, str2, filenameprefix, true, list(ValuesUtil.extractValueString(vv) for vv in cvars), SOME(simSettings));
+        (outCache, ret_val) := buildModelFMU(outCache, inEnv, className, str1, str2, filenameprefix, true, list(ValuesUtil.extractValueString(vv) for vv in cvars), SOME(simSettings), str3);
       then
         ret_val;
 
@@ -4648,14 +4647,17 @@ protected function fmuMethodToSimulationFlag
    `--fmiFlags` writes. So fold an explicit method in there, unless the caller
    already said `s:`.
 
-   Only `euler` and `cvode`: those are the values an FMU's `s` flag accepts, and a
-   model's own `dassl` default must not become an `s:dassl` the FMU rejects at
-   instantiation. `buildModelFMU` restores the flag store afterwards."
+   Only a method the FMU can integrate with: C's `FMI2CS_initializeSolverData`
+   takes `euler`/`cvode` and rejects the rest at instantiation (so a model's own
+   `dassl` default must not become `s:dassl`); a wasm FMU serves the whole
+   wasm-jit driver set. An unaccepted method is left out — the FMU keeps euler."
   input String method;
+  input Boolean isWasmFMU;
 protected
   list<String> fmiFlags;
+  list<String> accepted = if isWasmFMU then CodegenWasmJit.fmuCsSolvers() else {"euler", "cvode"};
 algorithm
-  if method == "<default>" or not (method == "euler" or method == "cvode") then
+  if method == "<default>" or not listMember(method, accepted) then
     return;
   end if;
   fmiFlags := Flags.getConfigStringList(Flags.FMI_FLAGS);
@@ -4722,10 +4724,12 @@ protected function buildModelFMU
   input Boolean addDummy "if true, add a dummy state";
   input list<String> platforms = {"static"};
   input Option<SimCode.SimulationSettings> inSimSettings = NONE();
+  input String method = "<default>" "`buildModelFMU(method=)`, folded into --fmiFlags where the FMU accepts it";
   output FCore.Cache cache;
   output Values.Value outValue;
 protected
   Flags.Flag flags;
+  list<String> fmiFlags;
 algorithm
   if isProtectedContentAccess(className) then
     // if AST contains encrypted class show nothing
@@ -4733,12 +4737,19 @@ algorithm
     outValue := Values.STRING("");
   else
     flags := loadCommandLineOptionsFromModel(className);
+    // `method=` reaches the FMU only through --fmiFlags, a global: restore it by
+    // hand so one export does not pick the solver for the next. `saveFlags` will
+    // not — without __OpenModelica_commandLineOptions `flags` aliases the store.
+    fmiFlags := Flags.getConfigStringList(Flags.FMI_FLAGS);
+    fmuMethodToSimulationFlag(method, isWasmFMUExport(FMUVersion, platforms));
 
     try
       (cache, outValue) := callBuildModelFMU(inCache,inEnv,className,FMUVersion,inFMUType,inFileNamePrefix,addDummy,platforms,inSimSettings);
       // reset to the original flags
+      FlagsUtil.setConfigStringList(Flags.FMI_FLAGS, fmiFlags);
       FlagsUtil.saveFlags(flags);
     else
+      FlagsUtil.setConfigStringList(Flags.FMI_FLAGS, fmiFlags);
       FlagsUtil.saveFlags(flags);
       fail();
     end try;
@@ -4774,7 +4785,7 @@ protected
   // is the C export's business even under the wasm simCodeTarget.
   Boolean wasmRequested = listMember("wasm", platforms);
   Boolean wasmTarget = Config.simCodeTarget() == "wasm-jit" or Config.simCodeTarget() == "wasm";
-  Boolean isWasmFMU = (wasmRequested or wasmTarget) and FMUVersion <> "1.0";
+  Boolean isWasmFMU = isWasmFMUExport(FMUVersion, platforms);
   // Reached through the target, the caller still wants an FMU the ordinary
   // tooling can load, so it gets this machine's platform too.
   list<String> nativePlatforms = if wasmRequested then List.select(platforms, isNotWasmPlatform) else {"native"};
@@ -4963,6 +4974,17 @@ algorithm
     end if;
   end if;
 end callBuildModelFMU;
+
+protected function isWasmFMUExport
+  "Whether `buildModelFMU` takes the wasm (fmi-ls-wasm) route: the `wasm` platform
+   was asked for, or the simCodeTarget is already a wasm one. FMI 1.0 never does."
+  input String FMUVersion;
+  input list<String> platforms;
+  output Boolean isWasm;
+algorithm
+  isWasm := (listMember("wasm", platforms) or Config.simCodeTarget() == "wasm-jit"
+             or Config.simCodeTarget() == "wasm") and FMUVersion <> "1.0";
+end isWasmFMUExport;
 
 protected function isNotWasmPlatform
   "\"static\"/\"dynamic\" are the C target's own platform names, meaningless once

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -71,6 +71,7 @@ import CodegenEmbeddedC;
 import CodegenFMU;
 import CodegenFMU2;
 import CodegenFMU3;
+import CodegenFMUCommon;
 import CodegenFMUCpp;
 import CodegenOMSICpp;
 import CodegenFMUCppHpcom;
@@ -896,7 +897,7 @@ algorithm
             String path;
           case SOME(SimCode.FMI_SIMULATION_FLAGS_FILE(path=path)) then System.readFile(path);
           case SOME(flags as SimCode.FMI_SIMULATION_FLAGS()) then
-            Tpl.textString(CodegenFMU.fmuSimulationFlagsFile(Tpl.emptyTxt, flags));
+            Tpl.textString(CodegenFMUCommon.fmuSimulationFlagsFile(Tpl.emptyTxt, flags));
           else "";
         end match;
         if FMI.isFMIMEType(FMUType) and FMI.isFMICSType(FMUType) then

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -13738,7 +13738,10 @@ algorithm
 
       // Save value
       if stringEqual(tmpName, "s") then
-        if not stringEqual(tmpValue, "euler") and not stringEqual(tmpValue, "cvode") then
+        // euler/cvode is what C's FMI2CS_initializeSolverData accepts; another
+        // target links its own driver and validates against its own solver set.
+        if Config.simCodeTarget() == "C"
+           and not stringEqual(tmpValue, "euler") and not stringEqual(tmpValue, "cvode") then
           if printWarning then
             msg := "Unknown value \"" + tmpValue + "\" for flag \"s\".";
             Error.addCompilerWarning(msg);

--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -250,21 +250,6 @@ case SIMCODE(__) then
   >>
 end fmuModelDescriptionFile;
 
-template fmuSimulationFlagsFile(FmiSimulationFlags fmiSimulationFlags)
-  "Generates <fmiPrefix>_flags.json file for FMUs with custom simulation flags."
- ::=
-  match fmiSimulationFlags
-  case flags as FMI_SIMULATION_FLAGS(__) then
-  let fileContent = (flags.nameValueTuples |> (name, value) =>
-      '"<%name%>" : "<%value%>"'
-      ;separator=",\n")
-    <<
-    {
-      <%fileContent%>
-    }
-    >>
-end fmuSimulationFlagsFile;
-
 template VendorAnnotations(SimCode simCode)
  "Generates code for VendorAnnotations file for FMU target."
 ::=

--- a/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
@@ -888,6 +888,23 @@ match simulationSettings
     >>
 end DefaultExperimentAttribute;
 
+template fmuSimulationFlagsFile(FmiSimulationFlags fmiSimulationFlags)
+  "Generates <fmiPrefix>_flags.json file for FMUs with custom simulation flags.
+   Lives in the codegen_fmu tier: the wasm export ships the same file and reads
+   its solver back out of it, so it must not depend on the C target."
+ ::=
+  match fmiSimulationFlags
+  case flags as FMI_SIMULATION_FLAGS(__) then
+  let fileContent = (flags.nameValueTuples |> (name, value) =>
+      '"<%name%>" : "<%value%>"'
+      ;separator=",\n")
+    <<
+    {
+      <%fileContent%>
+    }
+    >>
+end fmuSimulationFlagsFile;
+
 annotation(__OpenModelica_Interface="codegen_fmu");
 end CodegenFMUCommon;
 

--- a/OMCompiler/Compiler/Template/CodegenWasmJit.mo
+++ b/OMCompiler/Compiler/Template/CodegenWasmJit.mo
@@ -160,5 +160,15 @@ algorithm
   status := 0;
 end runSimulationWasmtime;
 
+function fmuCsSolvers
+  " The `method=` values a Co-Simulation wasm FMU can integrate with: the solvers
+    the driver linked into the component carries. `buildModelFMU` folds an accepted
+    method into the FMU's `resources/<prefix>_flags.json`, the only channel the
+    component reads its solver from. Empty without the Rust export. Implemented in Rust. "
+  output list<String> methods;
+algorithm
+  methods := {};
+end fmuCsSolvers;
+
 annotation(__OpenModelica_Interface="codegen_wasm_jit");
 end CodegenWasmJit;


### PR DESCRIPTION
Exporting a Co-Simulation FMU with `method="cvode"` failed in the web build and reported nothing: `buildModelFMU` returned `""` while `getErrorString()` held only the model's pre-existing alias warning.

A CS FMU learns its solver from `resources/<prefix>_flags.json` alone, and that file is the only thing `method=` feeds. Four defects met there.

**The generator sat in the wrong interface tier.** `cvode` is the only value that writes the file, so it was the only export reaching `CodegenFMU.fmuSimulationFlagsFile` — `codegen_fmu_c`, a code generator the web build deliberately drops. It moves to `CodegenFMUCommon` (`codegen_fmu`), which the wasm export already uses for `modelDescription.xml`. The generated function is unchanged, and `CodegenFMU` still reaches it through its unqualified import.

**A dropped target failed silently.** mmtorust's gating stub was a bare `return Err(..)`, which is a plain `fail()` the caller's `try` swallows, leaving an empty error buffer. It now records the reason first and names the callee:

    Internal error CodegenC.translateModel needs the 'codegen_c' code
    generation target, which this build was compiled without

**Only C's two solvers were forwarded.** `euler`/`cvode` is what C's `FMI2CS_initializeSolverData` accepts, so `fmuMethodToSimulationFlag` dropped every other method — and a wasm FMU, which links the wasm-jit driver and serves the whole set, then integrated with euler without saying so. It now asks `CodegenWasmJit.fmuCsSolvers()` for a wasm export. `createFMISimulationFlags`'s "Unknown value for flag s" warning is C-only for the same reason.

| method | before (wasm) | after |
| --- | --- | --- |
| `euler` | euler | euler |
| `cvode` | export fails | cvode |
| `dassl`, `ida`, `gbode`, `rungekutta` | euler | as named |

**`--fmiFlags` leaked between exports.** The fold ran outside the flag-restoring wrapper, and `loadCommandLineOptionsFromModel` copies the flag store only for a model carrying `__OpenModelica_commandLineOptions` — otherwise it hands back the live one, so `saveFlags` reverts nothing. `method=` moves into `buildModelFMU`, which restores `FMI_FLAGS` on both exits. One omc serves every export on the simulator page, so a single cvode export used to make the rest of the session cvode too.

FullRobot now exports as me, me_cs and cs with any of those methods, on the web and native builds; the C export is unchanged.

The simulator page also stops hiding the message it just produced. The status bar keeps the verdict and how long the attempt took, and the charts box carries the diagnostic itself rather than "see the status bar", where it never fit. The export error skipped `unquote`, so it also arrived wrapped in its Modelica string-literal quotes.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
