### PR TITLE
Simulate a wasm FMU three ways from one export

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -147,7 +147,9 @@ openmodelica_codegen_fmu_omsi/Cargo.toml
 openmodelica_codegen_graphml/Cargo.toml
 openmodelica_codegen_wasm_jit/Cargo.toml
 openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+openmodelica_codegen_wasm_jit/src/CodegenWasmJit/artifact.rs
 openmodelica_codegen_wasm_jit/src/CodegenWasmJit/datarecon.rs
+openmodelica_codegen_wasm_jit/src/CodegenWasmJit/dylink_fmi.rs
 openmodelica_codegen_wasm_jit/src/CodegenWasmJit/linearize.rs
 openmodelica_codegen_wasm_jit/src/CodegenWasmJit/native_fmu.rs
 openmodelica_codegen_wasm_jit/src/CodegenWasmJit/optimization.rs
@@ -240,7 +242,10 @@ openmodelica_fmi/src/platform.rs
 openmodelica_fmi/tests/model_description.rs
 openmodelica_fmi3_wasm/Cargo.lock
 openmodelica_fmi3_wasm/Cargo.toml
+openmodelica_fmi3_wasm/src/capi.rs
 openmodelica_fmi3_wasm/src/lib.rs
+openmodelica_fmi3_wasm/src/sim_run.rs
+openmodelica_fmi3_wasm/wit/deps/om-sim/simulation.wit
 openmodelica_fmi3_wasm/wit/fmi3-callbacks.wit
 openmodelica_fmi3_wasm/wit/fmi3-co-simulation.wit
 openmodelica_fmi3_wasm/wit/fmi3-common.wit
@@ -253,6 +258,7 @@ openmodelica_fmi_driver/examples/fmuprobe.rs
 openmodelica_fmi_driver/examples/fmusim.rs
 openmodelica_fmi_driver/src/api.rs
 openmodelica_fmi_driver/src/common.rs
+openmodelica_fmi_driver/src/component.rs
 openmodelica_fmi_driver/src/cs.rs
 openmodelica_fmi_driver/src/expr.rs
 openmodelica_fmi_driver/src/ffi.rs

--- a/OMCompiler/Compiler/Global/Global.mo
+++ b/OMCompiler/Compiler/Global/Global.mo
@@ -77,6 +77,16 @@ constant Integer packageIndexCacheIndex = 29;
 constant Integer sharedLibraryCacheIndex = 30;
 constant Integer backendInterface = 31;
 constant Integer backendCevalInterface = 32;
+// The FMI index -> value reference map an FMI 3.0 <ModelStructure> is written
+// through (SimCodeUtil.cacheFMI3ValueReferences); live only while one is.
+constant Integer fmi3ValueReferenceCache = 33;
+// The value reference -> nested <Alias> members map an FMI 3.0 <ModelVariables>
+// is written through (SimCodeUtil.cacheFMI3VariableAliases); same lifetime.
+constant Integer fmi3VariableAliasCache = 34;
+// The FMU-grade translation translateModelFMU kept, which the buildModelFMU that
+// follows exports instead of translating the model again:
+// SOME((simCode, FMUVersion, FMUType)). Lives until the next translation.
+constant Integer fmuTranslation = 35;
 
 // indexes in System.tick
 // ----------------------
@@ -113,6 +123,9 @@ algorithm
   setGlobalRoot(instNFNodeCacheIndex, {});
   setGlobalRoot(instNFLookupCacheIndex, {});
   setGlobalRoot(sharedLibraryCacheIndex, {});
+  setGlobalRoot(fmi3ValueReferenceCache, NONE());
+  setGlobalRoot(fmi3VariableAliasCache, NONE());
+  setGlobalRoot(fmuTranslation, NONE());
 end initialize;
 
 annotation(__OpenModelica_Interface="util");

--- a/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
@@ -89,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android-activity"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +998,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "cap-fs-ext"
+version = "3.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "476f0d0003a760918ed4b1e039a59e11769030416f79c8222551d22785f7f70d"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "cap-net-ext"
+version = "3.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150941cefd3df4de2fea24604ba4949371576f62e527410298333f7d431a1bc6"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "rustix 1.1.4",
+ "smallvec",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "3.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e0bf07d379916947be6c4a07f43684153d710a2896c31f9e97781362895596c"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "maybe-owned",
+ "rustix 1.1.4",
+ "rustix-linux-procfs",
+ "windows-sys 0.59.0",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "3.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a59e59fa26472d29680ece6a9f8ee8b0551a719a33df2f5240bde065ecbddfd7"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "cap-time-ext"
+version = "3.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b54c289326c70f1c697ebf0a31842a480932e5942b5fac92fcc46e87286b48e2"
+dependencies = [
+ "ambient-authority",
+ "cap-primitives",
+ "iana-time-zone",
+ "once_cell",
+ "rustix 1.1.4",
+ "winx",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,6 +1132,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3322,6 +3407,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3744,6 +3840,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -4391,6 +4488,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4650,6 +4771,22 @@ checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "io-extras"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
+dependencies = [
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "ipnet"
@@ -5366,6 +5503,12 @@ dependencies = [
  "autocfg",
  "rawpointer",
 ]
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "maybe-rayon"
@@ -6823,6 +6966,8 @@ dependencies = [
  "openmodelica_backend",
  "openmodelica_backend_types",
  "openmodelica_error",
+ "openmodelica_fmi",
+ "openmodelica_fmi_driver",
  "openmodelica_frontend_base",
  "openmodelica_frontend_dump",
  "openmodelica_frontend_types",
@@ -6908,6 +7053,8 @@ dependencies = [
  "openmodelica_fmi",
  "openmodelica_mat_writer",
  "openmodelica_solvers",
+ "wasmtime",
+ "wasmtime-wasi",
 ]
 
 [[package]]
@@ -8243,6 +8390,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8298,6 +8456,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_hc"
@@ -8780,6 +8944,16 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -11325,6 +11499,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-wasi"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e92a304eaafd672718011c69084041db74fa0fcc3532c5920f492c557b721"
+dependencies = [
+ "async-trait",
+ "bitflags 2.13.0",
+ "bytes",
+ "cap-fs-ext",
+ "cap-net-ext",
+ "cap-std",
+ "cap-time-ext",
+ "cfg-if",
+ "fs-set-times",
+ "futures",
+ "io-extras",
+ "io-lifetimes",
+ "rand 0.10.2",
+ "rustix 1.1.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtime",
+ "wasmtime-wasi-io",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-wasi-io"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e0013e1f37d2e0e1b030fa186972f6f5819f69814bb07d3b6d3cab0c40b50e2"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "tracing",
+ "wasmtime",
+]
+
+[[package]]
 name = "wast"
 version = "252.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12621,6 +12837,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.13.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
@@ -12230,7 +12230,9 @@ fn global_root_var_path(grc: &GlobalRootConst, ctx: &GenCtx) -> String {
         // lives in openmodelica_simcode_types, but the root accessor stays in
         // openmodelica_backend (which depends on simcode_types): the types crate
         // is datatype-only and must not own mutable global state.
-        "symbolTable" | "rewriteRulesIndex" | "optionSimCode" => {
+        // fmi3VariableAliasCache holds SimCodeVar.SimVar lists; same reasoning as
+        // optionSimCode — the types crate must not own mutable global state.
+        "symbolTable" | "rewriteRulesIndex" | "optionSimCode" | "fmi3VariableAliasCache" => {
             Some("openmodelica_backend")
         }
         // openmodelica_backend_main — the interactive cache holds a tuple
@@ -12239,7 +12241,9 @@ fn global_root_var_path(grc: &GlobalRootConst, ctx: &GenCtx) -> String {
         // root cannot be declared in openmodelica_backend (which does not, and
         // must not, depend on backend_main); its only accessor is also in
         // backend_main, so place the thread_local there.
-        "interactiveCache" => Some("openmodelica_backend_main"),
+        // fmuTranslation holds a SimCodeMain.FmuTranslation, a uniontype defined
+        // in SimCode/SimCodeMain.mo, which is in this crate.
+        "interactiveCache" | "fmuTranslation" => Some("openmodelica_backend_main"),
         _ => None,
     };
     let pkg_top = grc.pkg.split('.').next().unwrap_or(&grc.pkg);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend/src/Globals.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend/src/Globals.rs
@@ -42,6 +42,15 @@ thread_local! {
     pub static optionSimCode: RefCell<Option<openmodelica_simcode_types::SimCode::SimCode>> =
         const { RefCell::new(None) };
 
+    // Index 34 — fmi3VariableAliasCache
+    //
+    // Value reference -> the FMI 3.0 <Alias> members nested under the variable
+    // with that value reference. Live only while one modelDescription.xml is
+    // being written; source: SimCodeUtil.cacheFMI3VariableAliases.
+    pub static fmi3VariableAliasCache: RefCell<
+        Option<metamodelica::Array<Arc<metamodelica::List<openmodelica_simcode_types::SimCodeVar::SimVar>>>>,
+    > = const { RefCell::new(None) };
+
     // Index 26 — interactiveCache
     //
     // Declared in `openmodelica_backend_main/src/Globals.rs`: its value type

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_main/src/Globals.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_main/src/Globals.rs
@@ -32,6 +32,14 @@ thread_local! {
         crate::Interactive::GraphicEnvCache,
     )>>>> = const { RefCell::new(None) };
 
+    // Index 35 — fmuTranslation
+    //
+    // The FMU-grade translation translateModelFMU kept, which the buildModelFMU
+    // that follows exports instead of translating the model again. Its type is
+    // SimCodeMain.FmuTranslation, defined in this crate.
+    pub static fmuTranslation: RefCell<Option<crate::SimCodeMain::FmuTranslation>> =
+        const { RefCell::new(None) };
+
     // Index 10 — instNFInstCacheIndex
     //
     // NF instantiation cache (instance path → SCode elements, name, InstNode).

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/Cargo.toml
@@ -50,7 +50,7 @@ miniz_oxide = "0.8"
 # simulation target). Default on. Built without it, the crate still *emits* wasm
 # modules but cannot execute them (the entry points report the engine absent),
 # and neither wasmtime nor wasmer is pulled in.
-default = ["jit", "sundials", "fmu-native"]
+default = ["jit", "sundials", "fmu-native", "artifact"]
 # `jit` pulls the native default engine (wasmtime); on wasm32 the wasmtime dep
 # is target-absent and wasmer-js is used instead (requires `engine-wasmer`).
 jit = ["dep:wasmtime", "openmodelica_wasm_jit/jit"]
@@ -68,6 +68,10 @@ engine-wasmer = ["jit", "dep:wasmer", "openmodelica_wasm_jit/engine-wasmer"]
 # on this platform"). Verified in a browser. Until cranelift can be built without
 # it, a browser omc reports the platform as unavailable rather than trapping.
 fmu-native = ["dep:wasmtime"]
+# Simulate an exported wasm artifact (`resimulateExecutable="M.fmu"`): the FMI
+# masters and the wasmtime component backend, so an artifact runs here without a
+# loader library. Native-only, and implies `fmu-native`'s wasmtime.
+artifact = ["fmu-native", "dep:openmodelica_fmi", "dep:openmodelica_fmi_driver"]
 # SUNDIALS/KLU sparse solver for the wasm-jit runtimes (FMI/web).
 # CMake sets this via --features when RUST_OMC_ENABLE_SUNDIALS is ON; the
 # runtime's build.rs then links the precompiled wasm32-wasip1 archives.
@@ -76,6 +80,9 @@ sundials = []
 # The wasm engine and the FMU cross-compiler, both native-only; the wasm build of
 # omc runs models through wasmer-js instead.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# Reading an exported FMU and driving its component with the FMI masters.
+openmodelica_fmi = { path = "../openmodelica_fmi", optional = true }
+openmodelica_fmi_driver = { path = "../openmodelica_fmi_driver", optional = true, features = ["component"] }
 wasmtime = { workspace = true, optional = true, features = [
   "cranelift", "all-arch", "component-model", "anyhow", "gc", "gc-null", "gc-drc",
 ] }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -110,6 +110,14 @@ pub(crate) mod optimization;
 #[path = "CodegenWasmJit/datarecon.rs"]
 pub(crate) mod datarecon;
 
+#[cfg(all(feature = "artifact", not(target_arch = "wasm32")))]
+#[path = "CodegenWasmJit/artifact.rs"]
+pub(crate) mod artifact;
+
+#[cfg(all(feature = "artifact", feature = "jit", not(target_arch = "wasm32")))]
+#[path = "CodegenWasmJit/dylink_fmi.rs"]
+pub(crate) mod dylink_fmi;
+
 /// Iterate a MetaModelica `List` (which is `IntoIterator` by reference, not via
 /// an `.iter()` method).
 pub(crate) fn lst<T: Clone>(l: &Arc<List<T>>) -> impl Iterator<Item = &T> {
@@ -286,6 +294,21 @@ fn sys_stats_section(s: &SolveStats, nonlinear: bool) -> String {
 fn sim_models() -> &'static Mutex<HashMap<String, Arc<SimModel>>> {
     static MODELS: OnceLock<Mutex<HashMap<String, Arc<SimModel>>>> = OnceLock::new();
     MODELS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// A model kernel a wasm FMU can be built around. Only kernels an export can
+/// actually use are kept, so finding one is the whole test.
+struct FmuKernel {
+    model: Arc<SimModel>,
+    /// Reaches the kernel's embedded metadata, so a different one cannot reuse it.
+    method: String,
+}
+
+/// Kept by [`translateFmu`] so the export that follows links this kernel rather
+/// than lowering it again. Keyed by file-name prefix.
+fn fmu_kernels() -> &'static Mutex<HashMap<String, Arc<FmuKernel>>> {
+    static KERNELS: OnceLock<Mutex<HashMap<String, Arc<FmuKernel>>>> = OnceLock::new();
+    KERNELS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 /// One captured result signal: its name/description and the resolved value over
@@ -542,6 +565,13 @@ fn init_success_line() -> String {
 const RUN_CHECKPOINT: ArcStr = arcstr::literal!("wasm-jit simulation run");
 
 pub fn runSimulation(fileNamePrefix: ArcStr, resultFile: ArcStr, simflags: ArcStr) -> i32 {
+    // `resimulateExecutable` may name an exported wasm artifact instead of a model
+    // this session translated; then the run happens inside it (or through its FMI
+    // interfaces) rather than in the JIT engine.
+    #[cfg(all(feature = "artifact", not(target_arch = "wasm32")))]
+    if let Some(path) = artifact::locate(&fileNamePrefix) {
+        return run_artifact(&path, &fileNamePrefix, &resultFile, &simflags);
+    }
     openmodelica_error::ErrorExt::setCheckpoint(RUN_CHECKPOINT);
     let (res, init_output, sim_output, post_output) = run_simulation_inner(&fileNamePrefix, &resultFile, &simflags);
     openmodelica_error::ErrorExt::rollBack(RUN_CHECKPOINT);
@@ -584,6 +614,27 @@ pub fn runSimulation(fileNamePrefix: ArcStr, resultFile: ArcStr, simflags: ArcSt
         Ok(()) => 0,
         Err(_) => 1,
     }
+}
+
+/// Simulate an exported wasm artifact. The three faces (`-s fmi3:me[:solver]`,
+/// `-s fmi3:cs`, and the artifact's own simulation runtime otherwise) all report
+/// themselves through `<prefix>.log`, as a run of a translated model does.
+#[cfg(all(feature = "artifact", not(target_arch = "wasm32")))]
+fn run_artifact(path: &std::path::Path, prefix: &str, result_file: &str, simflags: &str) -> i32 {
+    let (face, rest) = match artifact::select_face(simflags) {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = write_output(&format!("{prefix}.log"), format!("LOG_ERROR         | error   | {e}\n").as_bytes());
+            return 1;
+        }
+    };
+    let (res, mut log) = artifact::run(path, face, result_file, &rest);
+    match &res {
+        Ok(()) => log.push_str("LOG_SUCCESS       | info    | The simulation finished successfully.\n"),
+        Err(e) => log.push_str(&format!("LOG_ERROR         | error   | {e}\n")),
+    }
+    let _ = write_output(&format!("{prefix}.log"), log.as_bytes());
+    if res.is_ok() { 0 } else { 1 }
 }
 
 /// `CodegenWasmJit.finishCompile`: force the model's wasm modules to finish
@@ -2420,6 +2471,32 @@ fn add_resource(entries: &mut Vec<(String, Vec<u8>)>, path: &str) {
 
 /// A ZIP assembled in-process rather than by an external `zip`, deflated unless
 /// that would grow the entry.
+/// `--fmuDirectory`: the same entries as files under `path`, which then names a
+/// directory rather than a zip. A stale export of the same name is removed first,
+/// so what is there is what this run wrote.
+fn write_directory(path: &str, entries: &[(String, Vec<u8>)]) -> Result<()> {
+    let root = std::path::Path::new(path);
+    if root.is_dir() {
+        let _ = std::fs::remove_dir_all(root);
+    } else {
+        let _ = std::fs::remove_file(root);
+    }
+    for (name, bytes) in entries {
+        let out = root.join(name);
+        if let Some(parent) = out.parent()
+            && std::fs::create_dir_all(parent).is_err()
+        {
+            record_error(format!("CodegenWasmJit: cannot create {}", parent.display()));
+            return Err("CodegenWasmJit: cannot write the FMU directory");
+        }
+        if write_output(&out.to_string_lossy(), bytes).is_err() {
+            record_error(format!("CodegenWasmJit: cannot write {}", out.display()));
+            return Err("CodegenWasmJit: cannot write the FMU directory");
+        }
+    }
+    Ok(())
+}
+
 fn zip_archive(entries: &[(String, Vec<u8>)]) -> Vec<u8> {
     let mut out = Vec::new();
     let mut central = Vec::new();
@@ -2557,6 +2634,39 @@ fn fmi_version() -> String {
     if v.is_empty() { "3.0".to_string() } else { v.to_string() }
 }
 
+/// Where an unzipped export keeps the model kernel. Not `binaries/wasm32-wasip2/`,
+/// which fmi-ls-wasm defines as a *component*: this is a dylink library, and only
+/// a host that links it against the adapter can run it.
+pub(crate) const DYLINK_DIR: &str = "binaries/wasm32-om-dylink";
+
+/// What the host has to load beside the model kernel, decided here because this
+/// is where the model's `external "C"` libraries were resolved. A tiny JSON, read
+/// by `CodegenWasmJit::artifact`.
+fn artifact_manifest(model: &SimModel, sundials: bool) -> String {
+    let ext = first_external_import(&model.wasm).is_some();
+    let mut out = String::from("{\n");
+    out.push_str(&format!("  \"externalC\": {ext},\n"));
+    out.push_str(&format!("  \"lapack\": {},\n", needs_lapack(&model.wasm, &model.ext_libs)));
+    out.push_str(&format!("  \"sundials\": {sundials},\n"));
+    out.push_str(&format!("  \"extLibraries\": {}\n", model.ext_libs.len()));
+    out.push_str("}\n");
+    out
+}
+
+/// `--fmuDirectory`: write the export as an unzipped directory holding only what
+/// an OpenModelica importer reads, rather than a portable FMU in a zip.
+fn fmu_directory() -> bool {
+    openmodelica_util::Flags::getConfigBool(openmodelica_util::Flags::FMU_DIRECTORY.clone())
+        .unwrap_or(false)
+}
+
+/// A `-d=execstat` phase, beside the `FMU modelDescription.xml` ones the
+/// MetaModelica side emits. Not a compiler notification: those reach
+/// `getErrorString()`, where a timing makes every FMU test depend on the clock.
+fn export_phase(name: &str) {
+    let _ = openmodelica_util::ExecStat::execStat(ArcStr::from(name));
+}
+
 /// The platforms `platforms={...}` named besides `"wasm"`.
 fn requested_native_platforms() -> Vec<String> {
     openmodelica_util::Flags::getConfigString(openmodelica_util::Flags::FMU_NATIVE_PLATFORMS.clone())
@@ -2571,12 +2681,79 @@ fn requested_native_platforms() -> Vec<String> {
 /// Per platform named in `platforms={...}` besides `"wasm"`: the component
 /// compiled ahead of time for it, plus the loader that serves the FMI C API from
 /// that artifact. The FMU then works with a WebAssembly-unaware importer.
+/// Compile the component for this machine and keep it, so the runs that follow
+/// the export in this session neither serialize it nor read it back.
+///
+/// An unzipped export is for this omc, so it is always compiled — and then the
+/// `.cwasm` need not be written at all unless `platforms` asked for one. A zipped
+/// export is only compiled here if it is going to carry this machine's artifact
+/// anyway. `None` if the engine refuses it; the caller then falls back to
+/// [`native_fmu::precompile`].
+#[cfg(all(feature = "artifact", not(target_arch = "wasm32")))]
+fn compile_for_host(
+    component: &[u8],
+    fmu_path: &str,
+    linked: bool,
+) -> Option<std::sync::Arc<openmodelica_fmi_driver::component::WasmArtifact>> {
+    // The unzipped form is not a component at all — the host links the model
+    // kernel against the adapter it has already compiled — so there is nothing
+    // here to compile ahead of time.
+    if linked {
+        return None;
+    }
+    let host = native_fmu::host_platform()?;
+    if !requested_native_platforms().iter().any(|n| native_fmu::lookup(n).is_some_and(|p| p.fmi == host.fmi)) {
+        return None;
+    }
+    // The resources it reads through are written after this, so the caller points
+    // it at them ([`WasmArtifact::use_resources`]) and remembers it then.
+    let _ = fmu_path;
+    Some(std::sync::Arc::new(
+        openmodelica_fmi_driver::component::WasmArtifact::compile(component, None).ok()?,
+    ))
+}
+
+#[cfg(not(all(feature = "artifact", not(target_arch = "wasm32"))))]
+fn compile_for_host(_component: &[u8], _fmu_path: &str, _linked: bool) -> Option<()> {
+    None
+}
+
+/// The `.cwasm` for `platform`: serialized out of what [`compile_for_host`] just
+/// compiled when it is this machine's, and a cross-compile otherwise.
+#[cfg(all(feature = "artifact", not(target_arch = "wasm32")))]
+fn host_cwasm(
+    host: Option<&std::sync::Arc<openmodelica_fmi_driver::component::WasmArtifact>>,
+    platform: &native_fmu::Platform,
+    component: &[u8],
+) -> Result<Vec<u8>> {
+    match host.filter(|_| native_fmu::host_platform().is_some_and(|h| h.fmi == platform.fmi)) {
+        Some(a) => a.serialize().map_err(|e| {
+            record_error(format!("CodegenWasmJit: serializing the artifact for {}: {e}", platform.fmi));
+            "CodegenWasmJit: cannot serialize the compiled artifact"
+        }),
+        None => native_fmu::precompile(component, platform),
+    }
+}
+
+#[cfg(not(all(feature = "artifact", not(target_arch = "wasm32"))))]
+fn host_cwasm(_host: Option<&()>, platform: &native_fmu::Platform, component: &[u8]) -> Result<Vec<u8>> {
+    native_fmu::precompile(component, platform)
+}
+
 fn add_native_platforms(
     entries: &mut Vec<(String, Vec<u8>)>,
     component: &[u8],
     model_id: &str,
     version: &str,
+    linked: bool,
+    #[cfg(all(feature = "artifact", not(target_arch = "wasm32")))]
+    host: Option<&std::sync::Arc<openmodelica_fmi_driver::component::WasmArtifact>>,
+    #[cfg(not(all(feature = "artifact", not(target_arch = "wasm32"))))] host: Option<&()>,
 ) -> Result<()> {
+    if linked {
+        // Nothing to precompile: see `compile_for_host`.
+        return Ok(());
+    }
     for name in requested_native_platforms() {
         let Some(platform) = native_fmu::lookup(&name) else {
             record_error(format!(
@@ -2598,7 +2775,7 @@ fn add_native_platforms(
             ));
             return Err("CodegenWasmJit: no FMU loader for the requested platform");
         };
-        let cwasm = native_fmu::precompile(component, platform)?;
+        let cwasm = host_cwasm(host, platform, component)?;
         entries.push((
             format!("binaries/{dir}/{}", native_fmu::loader_file_name(platform, model_id)),
             loader,
@@ -2655,6 +2832,133 @@ fn cad_basename(uri: &str) -> &str {
     uri.rsplit(['/', '\\']).next().unwrap_or(uri)
 }
 
+/// The integration method the export settles on, onto the settings the lowering
+/// reads. C's FMU reads `-s` from `_flags.json` at run time; this one is linked
+/// against one solver, so the flag has to reach the export.
+fn settle_fmu_method(sim_code: &mut SimCode::SimCode, simulation_flags_json: &str, kind: &str) {
+    let Some(settings) = sim_code.simulationSettingsOpt.as_mut() else { return };
+    match fmi_flag(simulation_flags_json, "s") {
+        Some(s) => settings.method = ArcStr::from(s.as_str()),
+        // A wasm FMU's embedded driver has the solvers a simulation has, so a
+        // Co-Simulation export keeps the model's own method and falls back to
+        // DASKR for one the driver cannot step to a communication point. C
+        // defaults to euler only because `fmu_read_flags.c` knows no other.
+        None if kind != "ME" && !fmu_cs_solvers().contains(&settings.method.as_str()) => {
+            settings.method = ArcStr::from("dassl")
+        }
+        None => {}
+    }
+}
+
+/// Lower the model kernel a wasm FMU is built around, and check that this omc and
+/// this `kind` can serve it. Shared linear memory across model + runtime +
+/// ModelicaExternalC, so `external "C"` calls pass real pointers rather than
+/// runtime handles — which is also why the simulation path cannot bind it.
+fn lower_fmu_kernel(sim_code: &SimCode::SimCode, kind: &str) -> Result<SimModel> {
+    let model = crate::CodegenWasmJitFunctions::with_shared_externals(|| build_sim_model(sim_code, true, ExtHost::Wasm))?;
+    if let Some(func) = first_external_import(&model.wasm) {
+        if !external_c_available() {
+            record_error(format!(
+                "CodegenWasmJit: model `{}` uses the external C function `{func}`, but this omc \
+                 was built without the PIC wasi-libc needed for external \"C\" in a host-free \
+                 wasm FMU. Rebuild with a PIC wasi-libc (set OMC_WASI_PIC_SYSROOT), or simulate \
+                 the model in the browser (`--simCodeTarget=wasm-jit`) instead.", model.model_name));
+            return Err("CodegenWasmJit: external \"C\" support not built into this omc");
+        }
+    }
+    check_fmu_method(&model, kind)?;
+    Ok(model)
+}
+
+/// A CS FMU integrates itself, so an unservable method has to fail at export
+/// rather than at the importer's first do-step. Empty is the dassl default.
+fn check_fmu_method(model: &SimModel, kind: &str) -> Result<()> {
+    if kind != "ME" && !model.method.is_empty() && !fmu_cs_solvers().contains(&model.method.as_str()) {
+        record_error(format!(
+            "CodegenWasmJit: a Co-Simulation wasm FMU cannot integrate with method=\"{}\". \
+             Available: {}.",
+            model.method,
+            fmu_cs_solvers().join(", ")
+        ));
+        return Err("CodegenWasmJit: unusable Co-Simulation integration method");
+    }
+    Ok(())
+}
+
+/// The kernel to build this FMU around: the one [`translateFmu`] left behind if it
+/// was lowered the way this export needs, and a fresh lowering otherwise.
+fn fmu_kernel(sim_code: &SimCode::SimCode, kind: &str) -> Result<Arc<SimModel>> {
+    let prefix = sim_code.fileNamePrefix.to_string();
+    let method = settled_method(sim_code);
+    let cached = fmu_kernels().lock().unwrap_or_else(|e| e.into_inner()).get(&prefix).cloned();
+    if let Some(k) = cached.filter(|k| k.method == method) {
+        check_fmu_method(&k.model, kind)?;
+        return Ok(k.model.clone());
+    }
+    let model = Arc::new(lower_fmu_kernel(sim_code, kind)?);
+    keep_fmu_kernel(&prefix, &model);
+    Ok(model)
+}
+
+/// What [`settle_fmu_method`] left on the settings.
+fn settled_method(sim_code: &SimCode::SimCode) -> String {
+    sim_code.simulationSettingsOpt.as_ref().map(|s| s.method.to_string()).unwrap_or_default()
+}
+
+fn keep_fmu_kernel(prefix: &str, model: &Arc<SimModel>) {
+    fmu_kernels().lock().unwrap_or_else(|e| e.into_inner()).insert(
+        prefix.to_string(),
+        Arc::new(FmuKernel { model: model.clone(), method: model.method.clone() }),
+    );
+}
+
+/// `CodegenWasmJit.translateFmu`: the wasm counterpart of the C target generating
+/// the FMU sources without building them. Lower the model once and keep it, both
+/// for the `buildModelFMU` that follows and as the prepared simulation model, so a
+/// run and an export share one kernel.
+pub fn translateFmu(sim_code: SimCode::SimCode, fmu_type: ArcStr, simulation_flags_json: ArcStr) -> Result<()> {
+    sync_engine_threading()?;
+    sim_runtime::start_runtime_compile();
+    let kind = fmu_kind(&fmu_type);
+    let mut sim_code = sim_code;
+    settle_fmu_method(&mut sim_code, &simulation_flags_json, kind);
+    let prefix = sim_code.fileNamePrefix.to_string();
+    let _ = openmodelica_wasi::fs::remove_file(&format!("{prefix}.wasm"));
+    let errs_before = openmodelica_util::Error::getNumErrorMessages();
+    let outcome = (|| -> Result<()> {
+        // Lowered the way the simulation path binds it, since that is what runs it.
+        // With no `external "C"` this is the FMU kernel too: shared externals
+        // change the lowering only where there are `ext` imports.
+        let model = Arc::new(build_sim_model(&sim_code, true, ExtHost::SIM)?);
+        check_fmu_method(&model, kind)?;
+        write_output(&format!("{prefix}.wasm"), &model.wasm).map_err(|_| "CodegenWasmJit: write failed")?;
+        sim_models().lock().unwrap_or_else(|e| e.into_inner()).insert(prefix.clone(), model.clone());
+        // With `external "C"` the two differ, and the export lowers its own.
+        if first_external_import(&model.wasm).is_none() {
+            keep_fmu_kernel(&prefix, &model);
+        }
+        Ok(())
+    })();
+    if let Err(e) = &outcome {
+        if openmodelica_util::Error::getNumErrorMessages() == errs_before {
+            record_error(format!(
+                "CodegenWasmJit: cannot build the FMU model kernel for `{prefix}`: {}",
+                with_engine_detail(e)
+            ));
+        }
+    }
+    outcome
+}
+
+/// `emit_fmu`'s `kind` for a `buildModelFMU(fmuType=)`.
+fn fmu_kind(fmu_type: &str) -> &'static str {
+    match fmu_type {
+        "me" => "ME",
+        "cs" => "CS",
+        _ => "me_cs",
+    }
+}
+
 /// `adapter` is `(plain, with-SUNDIALS)`; the second is picked for a method that needs
 /// CVODE/IDA and is empty for Model Exchange.
 fn emit_fmu(
@@ -2668,19 +2972,8 @@ fn emit_fmu(
 ) -> Result<()> {
     sync_engine_threading()?;
     sim_runtime::start_runtime_compile();
-    // C's FMU reads `-s` from _flags.json at run time; this one is linked against
-    // one solver, so the flag has to reach the export. On the settings it reaches
-    // both the adapter choice and the metadata the driver reads.
     let mut sim_code = sim_code;
-    if let Some(settings) = sim_code.simulationSettingsOpt.as_mut() {
-        match fmi_flag(&simulation_flags_json, "s") {
-            Some(s) => settings.method = ArcStr::from(s.as_str()),
-            // C's `FMI2CS_initializeSolverData` default. The method the model was
-            // translated with is the standalone simulation's, not the FMU's.
-            None if kind != "ME" => settings.method = ArcStr::from("euler"),
-            None => {}
-        }
-    }
+    settle_fmu_method(&mut sim_code, &simulation_flags_json, kind);
     // Emitting the model takes seconds; a host that compiles the native platforms
     // out of process can spend them loading its compiler.
     if !requested_native_platforms().is_empty() {
@@ -2688,34 +2981,29 @@ fn emit_fmu(
     }
     let errs_before = openmodelica_util::Error::getNumErrorMessages();
     let outcome = (|| -> Result<()> {
-        // Shared linear memory across model + runtime + ModelicaExternalC, so
-        // `external "C"` calls pass real pointers, not handles.
-        let model = crate::CodegenWasmJitFunctions::with_shared_externals(|| build_sim_model(&sim_code, true, ExtHost::Wasm))?;
-        if let Some(func) = first_external_import(&model.wasm) {
-            if !external_c_available() {
-                record_error(format!(
-                    "CodegenWasmJit: model `{}` uses the external C function `{func}`, but this omc \
-                     was built without the PIC wasi-libc needed for external \"C\" in a host-free \
-                     wasm FMU. Rebuild with a PIC wasi-libc (set OMC_WASI_PIC_SYSROOT), or simulate \
-                     the model in the browser (`--simCodeTarget=wasm-jit`) instead.", model.model_name));
-                return Err("CodegenWasmJit: external \"C\" support not built into this omc");
-            }
-        }
-        // A CS FMU integrates itself, so an unservable method must fail here rather
-        // than at the importer's first do-step. Empty is the dassl default.
+        let model = fmu_kernel(&sim_code, kind)?;
+        export_phase("FMU model kernel");
         let cs = kind != "ME";
-        if cs && !model.method.is_empty() && !fmu_cs_solvers().contains(&model.method.as_str()) {
-            record_error(format!(
-                "CodegenWasmJit: a Co-Simulation wasm FMU cannot integrate with method=\"{}\". \
-                 Available: {}.",
-                model.method,
-                fmu_cs_solvers().join(", ")
-            ));
-            return Err("CodegenWasmJit: unusable Co-Simulation integration method");
-        }
         let sundials = cs && fmu_needs_sundials(&model.method);
-        let component =
-            link_fmu_component(&model.wasm, if sundials { adapter.1 } else { adapter.0 }, sundials, &model.ext_libs)?;
+        // An unzipped export is for an OpenModelica importer: it holds the model
+        // description and the model kernel and nothing else, and the host links
+        // that kernel against an adapter it compiled once into
+        // `~/.openmodelica/cache`. A component would carry that megabyte itself
+        // and be compiled with it, which is nearly all of what exporting a small
+        // model used to cost. `OMC_WASM_LINKED_ARTIFACT=0` asks for one anyway.
+        let bare = fmu_directory();
+        let linked = bare && std::env::var("OMC_WASM_LINKED_ARTIFACT").as_deref() != Ok("0");
+        let component = if linked {
+            // The model kernel exactly as the ordinary simulation path runs it —
+            // not a dylink library. PIC would put its every data access behind
+            // `__memory_base` and its calls through the indirect table, in the
+            // loop that dominates a run; only the *adapter* has to be relocatable,
+            // because only the adapter is shared between models.
+            model.wasm.clone()
+        } else {
+            link_fmu_component(&model.wasm, if sundials { adapter.1 } else { adapter.0 }, sundials, &model.ext_libs)?
+        };
+        export_phase("FMU component link");
         // The modelIdentifier modelDescription.xml declares, not the class name:
         // an importer resolves `binaries/<platform>/<modelIdentifier>`.
         let model_id = model_name_prefix(&sim_code);
@@ -2723,8 +3011,10 @@ fn emit_fmu(
             ("modelDescription.xml".to_string(), announce_directional_derivatives(&model_description, &model).into_bytes()),
         ];
         // terminalsAndIcons/, documentation/ — whatever the caller rendered.
-        for (name, content) in lst(&extra_files) {
-            entries.push((name.to_string(), content.as_bytes().to_vec()));
+        if !bare {
+            for (name, content) in lst(&extra_files) {
+                entries.push((name.to_string(), content.as_bytes().to_vec()));
+            }
         }
         // What the FMU was built with, where C's carries what its runtime reads.
         if !simulation_flags_json.is_empty() {
@@ -2734,7 +3024,11 @@ fn emit_fmu(
             ));
         }
         let version = fmi_version();
-        add_native_platforms(&mut entries, &component, &model_id, &version)?;
+        // This machine's artifact, compiled once: the runs that follow in this
+        // session get the live component and never read a `.cwasm` back.
+        let host = compile_for_host(&component, &fmu_path, linked);
+        add_native_platforms(&mut entries, &component, &model_id, &version, linked, host.as_ref())?;
+        export_phase("FMU precompile");
         if version == "2.0" {
             if requested_native_platforms().is_empty() {
                 record_error(format!(
@@ -2749,6 +3043,14 @@ fn emit_fmu(
             // Not in binaries/: an FMI 2.0 FMU is not an fmi-ls-wasm one. Here so
             // a platform can still be added to it later, as the browser page does.
             entries.push((format!("resources/{model_id}.wasm"), component));
+        } else if linked {
+            // Not a component: the model kernel as a dylink library, which the host
+            // links against the adapter and libc it has already compiled.
+            entries.push((format!("{DYLINK_DIR}/{model_id}.wasm"), component));
+            entries.push(("resources/artifact.json".to_string(), artifact_manifest(&model, sundials).into_bytes()));
+            for (i, lib) in model.ext_libs.iter().enumerate() {
+                entries.push((format!("resources/ext/{i:02}.wasm"), lib.bytes.clone()));
+            }
         } else {
             entries.push((format!("binaries/wasm32-wasip2/{model_id}.wasm"), component));
         }
@@ -2775,8 +3077,27 @@ fn emit_fmu(
                 }
             }
         }
-        let fmu = zip_archive(&entries);
-        write_output(&fmu_path, &fmu).map_err(|_| "CodegenWasmJit: cannot write .fmu")?;
+        let (packed, how) = if bare {
+            write_directory(&fmu_path, &entries)?;
+            (entries.iter().map(|(_, b)| b.len()).sum::<usize>(), "unzipped")
+        } else {
+            let fmu = zip_archive(&entries);
+            let n = fmu.len();
+            write_output(&fmu_path, &fmu).map_err(|_| "CodegenWasmJit: cannot write .fmu")?;
+            (n, "zipped")
+        };
+        // Now that the files are there, hand the compiled component to the runs
+        // that follow, pointed at the resources they read through.
+        #[cfg(all(feature = "artifact", not(target_arch = "wasm32")))]
+        if let Some(a) = &host {
+            let path = std::path::Path::new(&*fmu_path);
+            let resources = path.join("resources");
+            if bare && resources.is_dir() {
+                a.use_resources(&resources);
+            }
+            artifact::remember(path, a.clone());
+        }
+        export_phase(&format!("FMU write ({} MB {how})", (packed as f64 / 1.0e6 * 10.0).round() / 10.0));
         Ok(())
     })();
     if let Err(e) = &outcome {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/artifact.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/artifact.rs
@@ -1,0 +1,600 @@
+//! Simulating a **wasm artifact**: what one wasm FMU export produces and three
+//! ways of running it.
+//!
+//! `buildModelFMU(M, fmuType="me_cs", version="3.0")` under
+//! `--simCodeTarget=wasm-jit` writes `M.fmu`; `simulate(M,
+//! resimulateExecutable="M.fmu", simflags=…)` runs it here, without translating
+//! the model again:
+//!
+//! | `-s` | what runs |
+//! | --- | --- |
+//! | absent, or an ordinary solver | the artifact's own simulation runtime, in wasm |
+//! | `fmi3:me[:solver]` | Model Exchange, this process integrating (DASKR by default) |
+//! | `fmi3:cs` | Co-Simulation, the artifact integrating itself |
+//!
+//! The export takes one of two forms. `--fmuDirectory` writes the model kernel
+//! alone, unzipped, and the host links it against an adapter it compiled once
+//! ([`super::dylink_fmi`]) — what the library testing uses. Otherwise it is an
+//! fmi-ls-wasm component, which any FMI tool can also open. Every phase is timed
+//! and reported in the run's log; `HANDOFF-wasm-artifact.md` has the numbers.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::Instant;
+
+use openmodelica_fmi::{Fmu, InterfaceKind};
+use openmodelica_fmi_driver::api::Fmi3;
+use openmodelica_fmi_driver::component::WasmArtifact;
+use openmodelica_fmi_driver::{cs, me, Options, Solver};
+use openmodelica_wasm_jit::sim_runtime::ArtifactLib;
+
+use super::dylink_fmi::DylinkInstance;
+
+use super::{split_simflags, write_output};
+
+/// Artifacts this omc has already compiled, by where they were written.
+///
+/// The export compiles the component to machine code; a run in the same session
+/// would otherwise write that out, read it back and relocate it for nothing.
+/// Keyed by path, so a re-export of the same name replaces it.
+static COMPILED: LazyLock<Mutex<HashMap<PathBuf, Arc<WasmArtifact>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// An absolute key for `path`, resolvable *before* it exists: the export
+/// remembers what it compiled under the name it is about to write, and the run
+/// that follows looks it up under the name it now finds.
+fn canonical(path: &Path) -> PathBuf {
+    let Some(name) = path.file_name() else { return path.to_path_buf() };
+    let parent = match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
+        _ => PathBuf::from("."),
+    };
+    std::fs::canonicalize(parent).map(|d| d.join(name)).unwrap_or_else(|_| path.to_path_buf())
+}
+
+pub fn remember(path: &Path, artifact: Arc<WasmArtifact>) {
+    COMPILED.lock().unwrap_or_else(|e| e.into_inner()).insert(canonical(path), artifact);
+}
+
+fn recall(path: &Path) -> Option<Arc<WasmArtifact>> {
+    COMPILED.lock().unwrap_or_else(|e| e.into_inner()).get(&canonical(path)).cloned()
+}
+
+/// Which of the artifact's three faces a run asked for.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Face {
+    Simulation,
+    ModelExchange(Solver),
+    CoSimulation,
+}
+
+/// Read `-s fmi3:…` out of the flag list. Returns the face and the flags with
+/// the selector removed, since `simflags::parse` knows nothing about it.
+///
+/// Both spellings C accepts are: `-s=<v>` and `-s <v>`.
+pub fn select_face(simflags: &str) -> std::result::Result<(Face, String), String> {
+    let args = split_simflags(simflags);
+    let mut out: Vec<String> = Vec::with_capacity(args.len());
+    let mut face = Face::Simulation;
+    let mut i = 0;
+    while i < args.len() {
+        let a = &args[i];
+        let value = if let Some(v) = a.strip_prefix("-s=") {
+            Some(v.to_string())
+        } else if a == "-s" && i + 1 < args.len() {
+            Some(args[i + 1].clone())
+        } else {
+            None
+        };
+        match value {
+            Some(v) if v.starts_with("fmi3:") => {
+                face = parse_face(&v)?;
+                i += if a == "-s" { 2 } else { 1 };
+                continue;
+            }
+            _ => {}
+        }
+        out.push(a.clone());
+        i += 1;
+    }
+    Ok((face, out.join(" ")))
+}
+
+fn parse_face(v: &str) -> std::result::Result<Face, String> {
+    let mut parts = v.split(':');
+    parts.next(); // "fmi3"
+    let kind = parts.next().unwrap_or("");
+    let solver = parts.next().unwrap_or("");
+    let unknown = |what: &str, name: &str| {
+        format!(
+            "wasm artifact: `-s {v}` names no interface this artifact serves: {what} `{name}`. \
+             Use `fmi3:me[:<solver>]`, `fmi3:cs`, or a plain `-s=<solver>` for the artifact's own \
+             simulation runtime."
+        )
+    };
+    match kind {
+        "me" => {
+            let s = match solver {
+                // DASKR is the BDF integrator behind `-s=dassl`; both names reach it.
+                "" | "daskr" | "dassl" => Solver::Dassl,
+                name => Solver::parse(name).ok_or_else(|| unknown("solver", name))?,
+            };
+            Ok(Face::ModelExchange(s))
+        }
+        // The FMU's own integrator is chosen when it is exported (`--fmiFlags=s:…`),
+        // not here; naming it is allowed so the two spellings read alike.
+        "cs" => Ok(Face::CoSimulation),
+        name => Err(unknown("interface", name)),
+    }
+}
+
+/// The artifact `resimulateExecutable` names, if it names one: a `.fmu`, zipped
+/// or (`--fmuDirectory`) unzipped. It has to say `.fmu` outright — a bare prefix
+/// is a model this session translated, and a leftover export of the same name
+/// must not take a run away from it.
+pub fn locate(prefix: &str) -> Option<PathBuf> {
+    let path = Path::new(prefix);
+    (path.extension().is_some_and(|e| e == "fmu") && path.exists()).then(|| path.to_path_buf())
+}
+
+/// Where the result goes: `-r=` outright, else what `simulate` derived — with the
+/// artifact's own extension taken out of it, since the caller built the name from
+/// `resimulateExecutable` (`M.fmu_res.mat`).
+fn result_path(flags: &openmodelica_sim_meta::simflags::SimFlags, derived: &str) -> String {
+    if let Some(r) = &flags.result_file {
+        return r.clone();
+    }
+    let cleaned = derived.replace(".fmu_res.", "_res.");
+    match &flags.output_path {
+        Some(dir) => format!("{dir}/{}", Path::new(&cleaned).file_name().unwrap_or_default().to_string_lossy()),
+        None => cleaned,
+    }
+}
+
+/// Which form the export took: a component this omc instantiates, or a model
+/// kernel it links against the adapter itself.
+enum Form {
+    Component(Arc<WasmArtifact>),
+    Dylink { model: Vec<u8>, ext: Vec<ArtifactLib>, external_c: bool, lapack: bool },
+}
+
+struct Loaded {
+    /// Where the artifact's files are: itself when it was exported unzipped, the
+    /// directory it was unpacked into otherwise.
+    dir: PathBuf,
+    form: Form,
+    how: String,
+    load_ms: f64,
+}
+
+thread_local! {
+    /// The linked artifact this omc has standing, and where it came from.
+    ///
+    /// Linking is a relocation pass over the adapter and the model's libraries,
+    /// proportional to their size — 75 ms for the adapter alone, 660 ms with
+    /// `Modelica.Utilities`' tables. The three runs of one artifact are three
+    /// `simulate` calls in one omc, so they share it: the FMI instance is freed
+    /// and made again between them, which is what `fmi3FreeInstance` is for.
+    static LINKED: std::cell::RefCell<Option<(PathBuf, DylinkInstance)>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+impl Loaded {
+        fn resources(&self) -> String {
+        let r = self.dir.join("resources");
+        if r.is_dir() { r.to_string_lossy().into_owned() } else { "/".to_string() }
+    }
+
+    /// Run `f` against the linked artifact, standing or newly linked. The adapter
+    /// it links against is a fixed library, so linking compiles only the model.
+    fn with_dylink<R>(
+        &self,
+        f: impl FnOnce(&mut DylinkInstance) -> std::result::Result<R, String>,
+    ) -> std::result::Result<R, String> {
+        let Form::Dylink { model, ext, external_c, lapack } = &self.form else {
+            return Err("wasm artifact: not a linkable artifact".to_string());
+        };
+        let standing = LINKED.with(|c| {
+            let mut c = c.borrow_mut();
+            match &*c {
+                Some((p, _)) if *p == self.dir => c.take().map(|(_, i)| i),
+                _ => None,
+            }
+        });
+        let mut inst = match standing {
+            Some(mut i) => {
+                // A run of its own: the previous one's FMI instance goes first.
+                i.free_instance();
+                i
+            }
+            None => DylinkInstance::load(model, ext, *external_c, *lapack, &self.resources())
+                .map_err(|e| e.to_string())?,
+        };
+        let out = f(&mut inst);
+        LINKED.with(|c| *c.borrow_mut() = Some((self.dir.clone(), inst)));
+        out
+    }
+}
+
+impl Loaded {
+    /// The model description, which only the FMI interfaces need — and which is
+    /// megabytes of XML for a big model, so the artifact's own runtime never
+    /// parses it.
+    fn model_description(&self) -> std::result::Result<Fmu, String> {
+        Fmu::from_dir(&self.dir).map_err(|e| format!("wasm artifact {}: {e}", self.dir.display()))
+    }
+}
+
+/// The FMI platform tuple naming the `.cwasm` this machine can deserialize.
+fn platform() -> Option<&'static str> {
+    super::native_fmu::host_platform().map(|p| p.fmi)
+}
+
+/// Load the artifact out of a directory of files.
+///
+/// That is what makes a run cheap: `Component::deserialize_file` **maps** the
+/// `.cwasm` instead of reading it, and nothing is inflated. An export written
+/// with `--fmuDirectory` already is such a directory and is used where it lies;
+/// a zipped one is unpacked beside itself once, since inflating a ten-megabyte
+/// `.cwasm` per run is most of what a short simulation would otherwise cost.
+fn load(path: &Path) -> std::result::Result<Loaded, String> {
+    let t = Instant::now();
+    if let Some(artifact) = recall(path) {
+        let dir = if path.is_dir() { path.to_path_buf() } else { unpacked_dir(path) };
+        return Ok(Loaded {
+            dir,
+            form: Form::Component(artifact),
+            how: "compiled by this omc".to_string(),
+            load_ms: ms(t),
+        });
+    }
+    let (dir, unpacked) = if path.is_dir() {
+        (path.to_path_buf(), false)
+    } else {
+        let dir = unpacked_dir(path);
+        let unpacked = unpack(path, &dir)?;
+        (dir, unpacked)
+    };
+    // The linkable form: the model kernel alone, which this omc links against the
+    // adapter it has already compiled. Nothing here is compiled but the model.
+    if let Some(model) = dylink_model(&dir) {
+        let manifest = std::fs::read_to_string(dir.join("resources/artifact.json")).unwrap_or_default();
+        let flag = |k: &str| manifest.contains(&format!("\"{k}\": true"));
+        let mut ext = Vec::new();
+        if let Ok(rd) = std::fs::read_dir(dir.join("resources/ext")) {
+            let mut paths: Vec<PathBuf> = rd.flatten().map(|e| e.path()).collect();
+            paths.sort();
+            for p in paths {
+                let name = p.file_stem().map(|s| s.to_string_lossy().into_owned()).unwrap_or_default();
+                if let Ok(bytes) = std::fs::read(&p) {
+                    ext.push(ArtifactLib { name, bytes });
+                }
+            }
+        }
+        let size = model.len();
+        return Ok(Loaded {
+            dir,
+            form: Form::Dylink { model, ext, external_c: flag("externalC"), lapack: flag("lapack") },
+            how: format!(
+                "model kernel {:.1} MB linked against the cached adapter{}",
+                size as f64 / 1.0e6,
+                if unpacked { ", unpacked here" } else { "" }
+            ),
+            load_ms: ms(t),
+        });
+    }
+    // What `Modelica.Utilities.Files.loadResource` and a file-backed table read
+    // through: the component sees this directory as its own root.
+    let resources = dir.join("resources");
+    let resources = resources.is_dir().then_some(resources);
+    let cwasm = platform().map(|p| dir.join(format!("resources/{p}.cwasm"))).filter(|p| p.is_file());
+    // A `.cwasm` is tied to one wasmtime build and one engine configuration; if
+    // this omc is not the one that wrote it, compiling the component still works.
+    if let Some(cwasm) = &cwasm {
+        // Safety: the artifact was written by an OpenModelica export; a mismatch is
+        // rejected by wasmtime rather than trusted.
+        if let Ok(artifact) = unsafe { WasmArtifact::from_cwasm_file(cwasm, resources.as_deref()) } {
+            let size = std::fs::metadata(cwasm).map(|m| m.len()).unwrap_or(0);
+            return Ok(Loaded {
+                form: Form::Component(Arc::new(artifact)),
+                how: format!(
+                    "{}.cwasm, {:.1} MB, mapped{}",
+                    platform().unwrap_or("?"),
+                    size as f64 / 1.0e6,
+                    if unpacked { ", unpacked here" } else { "" }
+                ),
+                load_ms: ms(t),
+                dir,
+            });
+        }
+    }
+    let fmu = Fmu::from_dir(&dir).map_err(|e| format!("wasm artifact {}: {e}", dir.display()))?;
+    let component = component_bytes(&fmu).ok_or_else(|| {
+        format!(
+            "wasm artifact {}: no artifact this omc can load. It carries no {} and no wasm \
+             component to compile one from; export it again with this omc.",
+            path.display(),
+            cwasm.map(|p| p.display().to_string()).unwrap_or_else(|| "*.cwasm".to_string())
+        )
+    })?;
+    let artifact = WasmArtifact::compile(&component, resources.as_deref())
+        .map_err(|e| format!("wasm artifact {}: {e}", path.display()))?;
+    Ok(Loaded {
+        form: Form::Component(Arc::new(artifact)),
+        how: format!("compiled from the component, {:.1} MB", component.len() as f64 / 1.0e6),
+        load_ms: ms(t),
+        dir,
+    })
+}
+
+fn dylink_model(dir: &Path) -> Option<Vec<u8>> {
+    let d = dir.join(super::DYLINK_DIR);
+    let entry = std::fs::read_dir(d).ok()?.flatten().map(|e| e.path()).find(|p| p.extension().is_some_and(|e| e == "wasm"))?;
+    std::fs::read(entry).ok()
+}
+
+/// Where the artifact is unpacked, beside itself so a second run finds it there.
+fn unpacked_dir(path: &Path) -> PathBuf {
+    let stem = path.file_stem().map(|s| s.to_string_lossy().into_owned()).unwrap_or_default();
+    path.with_file_name(format!("{stem}_artifact"))
+}
+
+/// Unpack the archive into `dir` unless a previous run already did. Returns
+/// whether this call was the one that unpacked it.
+fn unpack(path: &Path, dir: &Path) -> std::result::Result<bool, String> {
+    let stamp = dir.join(".unpacked");
+    let exported = std::fs::metadata(path).and_then(|m| m.modified()).ok();
+    let ours = std::fs::metadata(&stamp).and_then(|m| m.modified()).ok();
+    if let (Some(exported), Some(ours)) = (exported, ours)
+        && ours >= exported
+    {
+        return Ok(false);
+    }
+    let fmu = Fmu::from_path(path).map_err(|e| format!("wasm artifact {}: {e}", path.display()))?;
+    let io = |e: std::io::Error| format!("wasm artifact {}: {e}", dir.display());
+    for name in fmu.names().to_vec() {
+        let Some(data) = fmu.read(&name) else { continue };
+        let out = dir.join(&name);
+        if let Some(parent) = out.parent() {
+            std::fs::create_dir_all(parent).map_err(io)?;
+        }
+        std::fs::write(&out, &*data).map_err(io)?;
+    }
+    std::fs::write(&stamp, b"").map_err(io)?;
+    Ok(true)
+}
+
+fn component_bytes(fmu: &Fmu) -> Option<Vec<u8>> {
+    let name = fmu
+        .names()
+        .iter()
+        .find(|n| n.starts_with("binaries/wasm32-wasip2/") && n.ends_with(".wasm"))
+        .or_else(|| fmu.names().iter().find(|n| n.starts_with("resources/") && n.ends_with(".wasm")))?
+        .clone();
+    fmu.read(&name).map(|b| b.into_owned())
+}
+
+fn ms(t: Instant) -> f64 {
+    t.elapsed().as_secs_f64() * 1.0e3
+}
+
+/// Run `path` the way `face` says, writing the result file and returning the log
+/// the caller puts in `<prefix>.log`.
+pub fn run(
+    path: &Path,
+    face: Face,
+    result_file: &str,
+    simflags: &str,
+) -> (std::result::Result<(), String>, String) {
+    let mut log = String::new();
+    let loaded = match load(path) {
+        Ok(l) => l,
+        Err(e) => return (Err(e), log),
+    };
+    log.push_str(&format!(
+        "LOG_STDOUT        | info    | wasm artifact loaded in {:.1} ms ({})\n",
+        loaded.load_ms, loaded.how
+    ));
+    let flags = match super::install_sim_flags(simflags) {
+        Ok(f) => f,
+        Err(e) => return (Err(e), log),
+    };
+    let out = result_path(&flags, result_file);
+    let res = match face {
+        Face::Simulation => run_simulation(&loaded, &flags, &out, simflags, &mut log),
+        Face::ModelExchange(solver) => run_fmi(&loaded, &flags, &out, Some(solver), &mut log),
+        Face::CoSimulation => run_fmi(&loaded, &flags, &out, None, &mut log),
+    };
+    (res, log)
+}
+
+/// The artifact's own simulation runtime.
+fn run_simulation(
+    loaded: &Loaded,
+    flags: &openmodelica_sim_meta::simflags::SimFlags,
+    out: &str,
+    simflags: &str,
+    log: &mut String,
+) -> std::result::Result<(), String> {
+    let args = split_simflags(simflags);
+    let t = Instant::now();
+    let run = match &loaded.form {
+        Form::Component(a) => {
+            let r = a.run_simulation(&args).map_err(|e| e.to_string())?;
+            log.push_str(&r.output);
+            for (_, category, message) in &r.log {
+                log.push_str(&format!("LOG_STDOUT        | info    | {category}: {message}\n"));
+            }
+            super::dylink_fmi::SimRun { file: r.file, linear_file: r.linear_file, rows: r.rows, solver: r.solver }
+        }
+        Form::Dylink { .. } => {
+            loaded.with_dylink(|i| i.run_simulation(&args).map_err(|e| e.to_string()))?
+        }
+    };
+    let elapsed = ms(t);
+    log.push_str(&format!(
+        "LOG_STDOUT        | info    | in-wasm simulation ({}) wrote {} rows in {:.1} ms\n",
+        run.solver, run.rows, elapsed
+    ));
+    if let Some((name, content)) = &run.linear_file {
+        let path = match &flags.output_path {
+            Some(dir) => format!("{dir}/{name}"),
+            None => name.clone(),
+        };
+        write_output(&path, content.as_bytes()).map_err(|e| format!("cannot write {path}: {e}"))?;
+    }
+    if run.file.is_empty() {
+        return Ok(());
+    }
+    write_output(out, &run.file).map_err(|e| format!("cannot write {out}: {e}"))
+}
+
+/// Model Exchange (this process integrates) or Co-Simulation (the FMU does).
+fn run_fmi(
+    loaded: &Loaded,
+    flags: &openmodelica_sim_meta::simflags::SimFlags,
+    out: &str,
+    me_solver: Option<Solver>,
+    log: &mut String,
+) -> std::result::Result<(), String> {
+    let fmu = loaded.model_description()?;
+    let md = &fmu.model_description;
+    let kind =
+        if me_solver.is_some() { InterfaceKind::ModelExchange } else { InterfaceKind::CoSimulation };
+    if md.interface(kind).is_none() {
+        return Err(format!(
+            "wasm artifact: it has no {} interface; export it with fmuType=\"me_cs\"",
+            kind.as_str()
+        ));
+    }
+    let mut opts = Options::from_model_description(md);
+    // C's `read_experiment`: the run's flags win over what the export baked in.
+    if let Some(v) = flags.start_time {
+        opts.start_time = v;
+    }
+    if let Some(v) = flags.stop_time {
+        opts.stop_time = v;
+    }
+    if let Some(v) = flags.tolerance {
+        opts.tolerance = Some(v);
+    }
+    if let Some(v) = flags.step_size.filter(|h| *h > 0.0) {
+        opts.step_size = v;
+    }
+    // The FMU's own `FILTERED_LOG` categories, which are not the `-lv` streams:
+    // `-lv=LOG_STATS` asks the *runtime* for a block, not the FMU for a trace of
+    // every event, so it alone leaves the FMI logger off.
+    opts.logging_on = flags.has_log("LOG_EVENTS") || flags.has_log("LOG_NLS") || flags.has_log("LOG_DSS");
+    if let Some(s) = me_solver {
+        opts.solver = s;
+    }
+    // C's `doOverride`, as far as FMI reaches: a parameter is settable in
+    // Initialization Mode and nothing else is.
+    for (name, value) in &flags.overrides {
+        if matches!(name.as_str(), "startTime" | "stopTime" | "stepSize" | "tolerance") {
+            continue;
+        }
+        let Some(v) = md.variables.iter().find(|v| v.name == *name) else {
+            return Err(format!("wasm artifact: -override names no variable `{name}`"));
+        };
+        let Ok(value) = value.parse::<f64>() else {
+            return Err(format!("wasm artifact: -override={name}={value} is not a number"));
+        };
+        opts.parameters.push(openmodelica_fmi_driver::Parameter {
+            value_reference: v.value_reference,
+            ty: v.ty,
+            value,
+        });
+    }
+
+    let t = Instant::now();
+    let (recorder, summary, elapsed) = match &loaded.form {
+        Form::Component(a) => {
+            let mut inst = match kind {
+                InterfaceKind::ModelExchange => a.model_exchange(&instance_name(md), opts.logging_on),
+                _ => a.co_simulation(&instance_name(md), opts.logging_on, opts.event_mode),
+            }
+            .map_err(|e| e.to_string())?;
+            log.push_str(&format!(
+                "LOG_STDOUT        | info    | {} instantiated in {:.1} ms\n",
+                kind.as_str(),
+                ms(t)
+            ));
+            let t = Instant::now();
+            let (r, s) = drive(&mut inst, kind, md, &opts)?;
+            let elapsed = ms(t);
+            log.push_str(&inst.output());
+            for (_, category, message) in inst.take_log() {
+                log.push_str(&format!("LOG_STDOUT        | info    | {category}: {message}\n"));
+            }
+            (r, s, elapsed)
+        }
+        Form::Dylink { .. } => {
+            let mut linked_ms = 0.0;
+            let (r, s, e) = loaded.with_dylink(|inst| {
+                match kind {
+                    InterfaceKind::ModelExchange => inst.instantiate_me(&instance_name(md), opts.logging_on),
+                    _ => inst.instantiate_cs(&instance_name(md), opts.logging_on, opts.event_mode),
+                }
+                .map_err(|e| e.to_string())?;
+                linked_ms = ms(t);
+                let t = Instant::now();
+                let (r, s) = drive(inst, kind, md, &opts)?;
+                Ok((r, s, ms(t)))
+            })?;
+            log.push_str(&format!(
+                "LOG_STDOUT        | info    | {} instantiated in {:.1} ms\n",
+                kind.as_str(),
+                linked_ms
+            ));
+            (r, s, e)
+        }
+    };
+    log.push_str(&format!(
+        "LOG_STDOUT        | info    | {} run: {summary}, {} samples in {:.1} ms\n",
+        kind.as_str(),
+        recorder.len(),
+        elapsed
+    ));
+    if flags.noemit || flags.output_format.as_deref() == Some("empty") {
+        return Ok(());
+    }
+    recorder
+        .write_mat(Path::new(out), opts.start_time, opts.stop_time)
+        .map_err(|e| format!("cannot write {out}: {e}"))
+}
+
+/// Run one of the two FMI interfaces to the end, whichever backend serves it.
+fn drive<T>(
+    inst: &mut T,
+    kind: InterfaceKind,
+    md: &openmodelica_fmi::ModelDescription,
+    opts: &Options,
+) -> std::result::Result<(openmodelica_fmi_driver::record::Recorder, String), String>
+where
+    T: openmodelica_fmi_driver::api::Fmi3ModelExchange + openmodelica_fmi_driver::api::Fmi3CoSimulation,
+{
+    match kind {
+        InterfaceKind::ModelExchange => {
+            let run = me::simulate(inst, md, opts).map_err(|e| e.to_string())?;
+            let s = format!(
+                "{} steps, {} evaluations, {} Jacobians, {} state events, {} time events",
+                run.steps, run.calls, run.jacobians, run.state_events, run.time_events
+            );
+            Ok((run.recorder, s))
+        }
+        _ => {
+            let run = cs::simulate(inst, md, opts).map_err(|e| e.to_string())?;
+            let s = format!(
+                "{} communication steps, {} events, {} early returns",
+                run.steps, run.events, run.early_returns
+            );
+            Ok((run.recorder, s))
+        }
+    }
+}
+
+fn instance_name(md: &openmodelica_fmi::ModelDescription) -> String {
+    if md.model_name.is_empty() { "model".to_string() } else { md.model_name.clone() }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/dylink_fmi.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/dylink_fmi.rs
@@ -1,0 +1,495 @@
+//! The FMI 3.0 masters over an artifact the host links itself.
+//!
+//! [`super::artifact`]'s other backend instantiates a component; this one loads
+//! the model kernel and the FMI3 adapter as dylink libraries sharing one linear
+//! memory, and calls the adapter's `om_fmi3*` core exports. The adapter is then a
+//! *fixed* library, compiled once into `~/.openmodelica/cache` instead of into
+//! every model's component — which is what a small model's export was spending
+//! almost all of its time on.
+//!
+//! Every array crosses through scratch this side allocates in the shared memory
+//! (`rt_alloc`), which is what the FMI 3.0 C API's pointers are here.
+
+use openmodelica_fmi_driver::api::{
+    CompletedStep, DiscreteStates, DoStep, Fmi3, Fmi3CoSimulation, Fmi3ModelExchange,
+};
+use openmodelica_fmi_driver::{Error, Result};
+use openmodelica_fmi::VarType;
+use openmodelica_wasm_jit::sim_runtime::{ArtifactLib, DylinkFmu};
+use wasmtime::Val;
+
+/// What the artifact's own simulation runtime returned (`om_sim_run`).
+pub struct SimRun {
+    pub file: Vec<u8>,
+    pub linear_file: Option<(String, String)>,
+    pub rows: u32,
+    pub solver: String,
+}
+
+pub struct DylinkInstance {
+    fmu: DylinkFmu,
+    /// Scratch big enough for the widest array a call passes, grown as needed.
+    scratch: (u32, u32),
+}
+
+fn err(call: &'static str, e: String) -> Error {
+    Error::Load(format!("{call}: {e}"))
+}
+
+fn status(call: &'static str, raw: i32) -> Result<()> {
+    openmodelica_fmi_driver::api::check(call, raw)
+}
+
+impl DylinkInstance {
+    pub fn load(
+        model: &[u8],
+        ext: &[ArtifactLib],
+        external_c: bool,
+        lapack: bool,
+        resources: &str,
+    ) -> Result<DylinkInstance> {
+        let fmu = DylinkFmu::load(
+            openmodelica_wasm_jit::FMI3_MECS_CAPI_ADAPTER,
+            model,
+            ext,
+            external_c,
+            lapack,
+            resources,
+        )
+        .map_err(|e| Error::Load(e))?;
+        Ok(DylinkInstance { fmu, scratch: (0, 0) })
+    }
+
+    /// Scratch of at least `bytes`, reused between calls.
+    fn scratch(&mut self, bytes: u32) -> Result<u32> {
+        if self.scratch.1 < bytes {
+            let p = self.fmu.alloc(bytes.max(256)).map_err(|e| err("rt_alloc", e))?;
+            self.scratch = (p, bytes.max(256));
+        }
+        Ok(self.scratch.0)
+    }
+
+    /// `vrs` and a values buffer, back to back in one scratch block.
+    fn vrs_and_values(&mut self, vrs: &[u32], value_bytes: usize) -> Result<(u32, u32)> {
+        let vr_bytes = vrs.len() * 4;
+        let base = self.scratch((vr_bytes + value_bytes) as u32 + 16)?;
+        let mut buf = Vec::with_capacity(vr_bytes);
+        for v in vrs {
+            buf.extend_from_slice(&v.to_le_bytes());
+        }
+        self.fmu.write(base, &buf).map_err(|e| err("artifact", e))?;
+        Ok((base, base + vr_bytes as u32))
+    }
+
+    /// Drop the FMI instance, so the next `instantiate` starts from a clean model
+    /// the way `fmi3FreeInstance` promises.
+    pub fn free_instance(&mut self) {
+        let _ = self.fmu.call_void("om_fmi3FreeInstance", &[]);
+    }
+
+    pub fn instantiate_me(&mut self, name: &str, logging_on: bool) -> Result<()> {
+        let (p, n) = self.write_str(name)?;
+        let ok = self
+            .fmu
+            .call("om_fmi3InstantiateModelExchange", &[Val::I32(p as i32), Val::I32(n as i32), Val::I32(logging_on as i32)])
+            .map_err(|e| err("fmi3InstantiateModelExchange", e))?;
+        if ok == 0 {
+            return Err(Error::Instantiate { call: "fmi3InstantiateModelExchange", log: Vec::new() });
+        }
+        Ok(())
+    }
+
+    pub fn instantiate_cs(&mut self, name: &str, logging_on: bool, event_mode: bool) -> Result<()> {
+        let (p, n) = self.write_str(name)?;
+        let ok = self
+            .fmu
+            .call(
+                "om_fmi3InstantiateCoSimulation",
+                &[Val::I32(p as i32), Val::I32(n as i32), Val::I32(logging_on as i32), Val::I32(event_mode as i32)],
+            )
+            .map_err(|e| err("fmi3InstantiateCoSimulation", e))?;
+        if ok == 0 {
+            return Err(Error::Instantiate { call: "fmi3InstantiateCoSimulation", log: Vec::new() });
+        }
+        Ok(())
+    }
+
+    fn write_str(&mut self, s: &str) -> Result<(u32, u32)> {
+        let p = self.scratch(s.len() as u32 + 16)?;
+        self.fmu.write(p, s.as_bytes()).map_err(|e| err("artifact", e))?;
+        Ok((p, s.len() as u32))
+    }
+
+    /// The artifact's own simulation runtime, the third face.
+    pub fn run_simulation(&mut self, args: &[String]) -> Result<SimRun> {
+        let mut blob = Vec::new();
+        for a in args {
+            blob.extend_from_slice(a.as_bytes());
+            blob.push(0);
+        }
+        let p = self.scratch(blob.len() as u32 + 16)?;
+        self.fmu.write(p, &blob).map_err(|e| err("artifact", e))?;
+        let out = self
+            .fmu
+            .call("om_sim_run", &[Val::I32(p as i32), Val::I32(blob.len() as i32)])
+            .map_err(|e| err("om_sim_run", e))? as u32;
+        // The header is ten words: status, then (pointer, length) for the result
+        // file, the linearized model's name and content, the row count, and the
+        // solver's name.
+        let read = (|| -> std::result::Result<SimRun, String> {
+            let mut head = [0u32; 10];
+            for (i, w) in head.iter_mut().enumerate() {
+                *w = self.fmu.read_u32(out + i as u32 * 4)?;
+            }
+            let mut bytes = |ptr: u32, len: u32| -> std::result::Result<Vec<u8>, String> {
+                let mut v = vec![0u8; len as usize];
+                if len > 0 {
+                    self.fmu.read(ptr, &mut v)?;
+                }
+                Ok(v)
+            };
+            let file = bytes(head[1], head[2])?;
+            if head[0] != 0 {
+                return Err(String::from_utf8_lossy(&file).into_owned());
+            }
+            let name = bytes(head[3], head[4])?;
+            let content = bytes(head[5], head[6])?;
+            let solver = bytes(head[8], head[9])?;
+            Ok(SimRun {
+                file,
+                linear_file: (!name.is_empty()).then(|| {
+                    (String::from_utf8_lossy(&name).into_owned(), String::from_utf8_lossy(&content).into_owned())
+                }),
+                rows: head[7],
+                solver: String::from_utf8_lossy(&solver).into_owned(),
+            })
+        })();
+        read.map_err(Error::Simulation)
+    }
+}
+
+/// The `om_fmi3Get*`/`Set*` entry point for a base type, and how wide one value is.
+fn numeric_call(ty: VarType, get: bool) -> Option<(&'static str, usize)> {
+    Some(match (ty, get) {
+        (VarType::Float64, true) => ("om_fmi3GetFloat64", 8),
+        (VarType::Float64, false) => ("om_fmi3SetFloat64", 8),
+        (VarType::Float32, true) => ("om_fmi3GetFloat32", 4),
+        (VarType::Float32, false) => ("om_fmi3SetFloat32", 4),
+        (VarType::Int8, true) => ("om_fmi3GetInt8", 1),
+        (VarType::Int8, false) => ("om_fmi3SetInt8", 1),
+        (VarType::UInt8, true) => ("om_fmi3GetUInt8", 1),
+        (VarType::UInt8, false) => ("om_fmi3SetUInt8", 1),
+        (VarType::Int16, true) => ("om_fmi3GetInt16", 2),
+        (VarType::Int16, false) => ("om_fmi3SetInt16", 2),
+        (VarType::UInt16, true) => ("om_fmi3GetUInt16", 2),
+        (VarType::UInt16, false) => ("om_fmi3SetUInt16", 2),
+        (VarType::Int32, true) => ("om_fmi3GetInt32", 4),
+        (VarType::Int32, false) => ("om_fmi3SetInt32", 4),
+        (VarType::UInt32, true) => ("om_fmi3GetUInt32", 4),
+        (VarType::UInt32, false) => ("om_fmi3SetUInt32", 4),
+        (VarType::Int64, true) => ("om_fmi3GetInt64", 8),
+        (VarType::Int64, false) => ("om_fmi3SetInt64", 8),
+        (VarType::UInt64, true) => ("om_fmi3GetUInt64", 8),
+        (VarType::UInt64, false) => ("om_fmi3SetUInt64", 8),
+        // The adapter takes and gives a boolean as an i32: wasm has nothing narrower.
+        (VarType::Boolean, true) => ("om_fmi3GetBoolean", 4),
+        (VarType::Boolean, false) => ("om_fmi3SetBoolean", 4),
+        _ => return None,
+    })
+}
+
+/// Decode `n` values of `ty` out of the bytes the adapter wrote.
+fn decode(ty: VarType, width: usize, raw: &[u8], out: &mut [f64]) {
+    for (i, o) in out.iter_mut().enumerate() {
+        let b = &raw[i * width..(i + 1) * width];
+        *o = match (ty, width) {
+            (VarType::Float64, _) => f64::from_le_bytes(b.try_into().unwrap()),
+            (VarType::Float32, _) => f32::from_le_bytes(b.try_into().unwrap()) as f64,
+            (VarType::Boolean, _) => (i32::from_le_bytes(b.try_into().unwrap()) != 0) as u8 as f64,
+            (VarType::Int8, _) => b[0] as i8 as f64,
+            (VarType::UInt8, _) => b[0] as f64,
+            (VarType::Int16, _) => i16::from_le_bytes(b.try_into().unwrap()) as f64,
+            (VarType::UInt16, _) => u16::from_le_bytes(b.try_into().unwrap()) as f64,
+            (VarType::Int32, _) => i32::from_le_bytes(b.try_into().unwrap()) as f64,
+            (VarType::UInt32, _) => u32::from_le_bytes(b.try_into().unwrap()) as f64,
+            (VarType::Int64, _) => i64::from_le_bytes(b.try_into().unwrap()) as f64,
+            (VarType::UInt64, _) => u64::from_le_bytes(b.try_into().unwrap()) as f64,
+            _ => 0.0,
+        };
+    }
+}
+
+fn encode(ty: VarType, width: usize, values: &[f64], raw: &mut Vec<u8>) {
+    for v in values {
+        match (ty, width) {
+            (VarType::Float64, _) => raw.extend_from_slice(&v.to_le_bytes()),
+            (VarType::Float32, _) => raw.extend_from_slice(&(*v as f32).to_le_bytes()),
+            (VarType::Boolean, _) => raw.extend_from_slice(&((*v != 0.0) as i32).to_le_bytes()),
+            (VarType::Int8, _) => raw.push(*v as i8 as u8),
+            (VarType::UInt8, _) => raw.push(*v as u8),
+            (VarType::Int16, _) => raw.extend_from_slice(&(*v as i16).to_le_bytes()),
+            (VarType::UInt16, _) => raw.extend_from_slice(&(*v as u16).to_le_bytes()),
+            (VarType::Int32, _) => raw.extend_from_slice(&(*v as i32).to_le_bytes()),
+            (VarType::UInt32, _) => raw.extend_from_slice(&(*v as u32).to_le_bytes()),
+            (VarType::Int64, _) => raw.extend_from_slice(&(*v as i64).to_le_bytes()),
+            (VarType::UInt64, _) => raw.extend_from_slice(&(*v as u64).to_le_bytes()),
+            _ => {}
+        }
+    }
+}
+
+/// An array of `f64` out of one of the Model Exchange getters.
+fn get_vector(inst: &mut DylinkInstance, call: &'static str, out: &mut [f64]) -> Result<()> {
+    let p = inst.scratch(out.len() as u32 * 8 + 16)?;
+    let raw = inst
+        .fmu
+        .call(call, &[Val::I32(p as i32), Val::I32(out.len() as i32)])
+        .map_err(|e| err(call, e))?;
+    status(call, raw)?;
+    for (i, o) in out.iter_mut().enumerate() {
+        *o = inst.fmu.read_f64(p + i as u32 * 8).map_err(|e| err(call, e))?;
+    }
+    Ok(())
+}
+
+impl Fmi3 for DylinkInstance {
+    fn get_version(&mut self) -> String {
+        "3.0".to_string()
+    }
+
+    fn enter_initialization_mode(
+        &mut self,
+        tolerance: Option<f64>,
+        start_time: f64,
+        stop_time: Option<f64>,
+    ) -> Result<()> {
+        let raw = self
+            .fmu
+            .call(
+                "om_fmi3EnterInitializationMode",
+                &[
+                    Val::I32(tolerance.is_some() as i32),
+                    Val::F64(tolerance.unwrap_or(0.0).to_bits()),
+                    Val::F64(start_time.to_bits()),
+                    Val::I32(stop_time.is_some() as i32),
+                    Val::F64(stop_time.unwrap_or(0.0).to_bits()),
+                ],
+            )
+            .map_err(|e| err("fmi3EnterInitializationMode", e))?;
+        status("fmi3EnterInitializationMode", raw)
+    }
+
+    fn exit_initialization_mode(&mut self) -> Result<()> {
+        let raw = self.fmu.call("om_fmi3ExitInitializationMode", &[]).map_err(|e| err("fmi3ExitInitializationMode", e))?;
+        status("fmi3ExitInitializationMode", raw)
+    }
+
+    fn enter_event_mode(&mut self) -> Result<()> {
+        let raw = self.fmu.call("om_fmi3EnterEventMode", &[]).map_err(|e| err("fmi3EnterEventMode", e))?;
+        status("fmi3EnterEventMode", raw)
+    }
+
+    fn update_discrete_states(&mut self) -> Result<DiscreteStates> {
+        let p = self.scratch(64)?;
+        let raw = self
+            .fmu
+            .call("om_fmi3UpdateDiscreteStates", &[Val::I32(p as i32)])
+            .map_err(|e| err("fmi3UpdateDiscreteStates", e))?;
+        status("fmi3UpdateDiscreteStates", raw)?;
+        let f = |s: &mut Self, i: u32| s.fmu.read_u32(p + i * 4).map_err(|e| err("fmi3UpdateDiscreteStates", e));
+        let need_update = f(self, 0)? != 0;
+        let terminate = f(self, 1)? != 0;
+        let nominals_changed = f(self, 2)? != 0;
+        let states_changed = f(self, 3)? != 0;
+        let defined = f(self, 4)? != 0;
+        let time = self.fmu.read_f64(p + 24).map_err(|e| err("fmi3UpdateDiscreteStates", e))?;
+        Ok(DiscreteStates {
+            need_update,
+            terminate,
+            nominals_changed,
+            states_changed,
+            next_event_time: defined.then_some(time),
+        })
+    }
+
+    fn terminate(&mut self) -> Result<()> {
+        let raw = self.fmu.call("om_fmi3Terminate", &[]).map_err(|e| err("fmi3Terminate", e))?;
+        status("fmi3Terminate", raw)
+    }
+
+    fn get_numeric(&mut self, ty: VarType, vrs: &[u32], values: &mut [f64]) -> Result<()> {
+        let (call, width) = numeric_call(ty.wire(), true)
+            .ok_or_else(|| Error::Unsupported(format!("reading a {} as a number", ty.as_str())))?;
+        let (vp, valp) = self.vrs_and_values(vrs, values.len() * width)?;
+        let raw = self
+            .fmu
+            .call(call, &[Val::I32(vp as i32), Val::I32(vrs.len() as i32), Val::I32(valp as i32), Val::I32(values.len() as i32)])
+            .map_err(|e| err(call, e))?;
+        status(call, raw)?;
+        let mut buf = vec![0u8; values.len() * width];
+        self.fmu.read(valp, &mut buf).map_err(|e| err(call, e))?;
+        decode(ty.wire(), width, &buf, values);
+        Ok(())
+    }
+
+    fn set_numeric(&mut self, ty: VarType, vrs: &[u32], values: &[f64]) -> Result<()> {
+        let (call, width) = numeric_call(ty.wire(), false)
+            .ok_or_else(|| Error::Unsupported(format!("writing a {} as a number", ty.as_str())))?;
+        let (vp, valp) = self.vrs_and_values(vrs, values.len() * width)?;
+        let mut buf = Vec::with_capacity(values.len() * width);
+        encode(ty.wire(), width, values, &mut buf);
+        self.fmu.write(valp, &buf).map_err(|e| err(call, e))?;
+        let raw = self
+            .fmu
+            .call(call, &[Val::I32(vp as i32), Val::I32(vrs.len() as i32), Val::I32(valp as i32), Val::I32(values.len() as i32)])
+            .map_err(|e| err(call, e))?;
+        status(call, raw)
+    }
+}
+
+impl Fmi3ModelExchange for DylinkInstance {
+    fn enter_continuous_time_mode(&mut self) -> Result<()> {
+        let raw =
+            self.fmu.call("om_fmi3EnterContinuousTimeMode", &[]).map_err(|e| err("fmi3EnterContinuousTimeMode", e))?;
+        status("fmi3EnterContinuousTimeMode", raw)
+    }
+
+    fn set_time(&mut self, time: f64) -> Result<()> {
+        let raw = self.fmu.call("om_fmi3SetTime", &[Val::F64(time.to_bits())]).map_err(|e| err("fmi3SetTime", e))?;
+        status("fmi3SetTime", raw)
+    }
+
+    fn set_continuous_states(&mut self, states: &[f64]) -> Result<()> {
+        let p = self.scratch(states.len() as u32 * 8 + 16)?;
+        let mut buf = Vec::with_capacity(states.len() * 8);
+        for v in states {
+            buf.extend_from_slice(&v.to_le_bytes());
+        }
+        self.fmu.write(p, &buf).map_err(|e| err("fmi3SetContinuousStates", e))?;
+        let raw = self
+            .fmu
+            .call("om_fmi3SetContinuousStates", &[Val::I32(p as i32), Val::I32(states.len() as i32)])
+            .map_err(|e| err("fmi3SetContinuousStates", e))?;
+        status("fmi3SetContinuousStates", raw)
+    }
+
+    fn get_continuous_states(&mut self, states: &mut [f64]) -> Result<()> {
+        get_vector(self, "om_fmi3GetContinuousStates", states)
+    }
+
+    fn get_continuous_state_derivatives(&mut self, ders: &mut [f64]) -> Result<()> {
+        get_vector(self, "om_fmi3GetContinuousStateDerivatives", ders)
+    }
+
+    fn get_event_indicators(&mut self, indicators: &mut [f64]) -> Result<()> {
+        get_vector(self, "om_fmi3GetEventIndicators", indicators)
+    }
+
+    fn get_nominals_of_continuous_states(&mut self, nominals: &mut [f64]) -> Result<()> {
+        get_vector(self, "om_fmi3GetNominalsOfContinuousStates", nominals)
+    }
+
+    fn completed_integrator_step(&mut self, no_set_state_prior: bool) -> Result<CompletedStep> {
+        let p = self.scratch(16)?;
+        let raw = self
+            .fmu
+            .call("om_fmi3CompletedIntegratorStep", &[Val::I32(no_set_state_prior as i32), Val::I32(p as i32)])
+            .map_err(|e| err("fmi3CompletedIntegratorStep", e))?;
+        status("fmi3CompletedIntegratorStep", raw)?;
+        let enter = self.fmu.read_u32(p).map_err(|e| err("fmi3CompletedIntegratorStep", e))? != 0;
+        let terminate = self.fmu.read_u32(p + 4).map_err(|e| err("fmi3CompletedIntegratorStep", e))? != 0;
+        Ok(CompletedStep { enter_event_mode: enter, terminate })
+    }
+
+    fn get_directional_derivative(
+        &mut self,
+        unknowns: &[u32],
+        knowns: &[u32],
+        seed: &[f64],
+        sensitivity: &mut [f64],
+    ) -> Result<()> {
+        let call = "om_fmi3GetDirectionalDerivative";
+        let bytes = unknowns.len() * 4 + knowns.len() * 4 + seed.len() * 8 + sensitivity.len() * 8;
+        let base = self.scratch(bytes as u32 + 32)?;
+        let (up, kp) = (base, base + (unknowns.len() * 4) as u32);
+        let sp = kp + (knowns.len() * 4) as u32;
+        let op = sp + (seed.len() * 8) as u32;
+        let mut buf = Vec::with_capacity(bytes);
+        for v in unknowns {
+            buf.extend_from_slice(&v.to_le_bytes());
+        }
+        for v in knowns {
+            buf.extend_from_slice(&v.to_le_bytes());
+        }
+        for v in seed {
+            buf.extend_from_slice(&v.to_le_bytes());
+        }
+        self.fmu.write(base, &buf).map_err(|e| err(call, e))?;
+        let raw = self
+            .fmu
+            .call(
+                call,
+                &[
+                    Val::I32(up as i32),
+                    Val::I32(unknowns.len() as i32),
+                    Val::I32(kp as i32),
+                    Val::I32(knowns.len() as i32),
+                    Val::I32(sp as i32),
+                    Val::I32(seed.len() as i32),
+                    Val::I32(op as i32),
+                    Val::I32(sensitivity.len() as i32),
+                ],
+            )
+            .map_err(|e| err(call, e))?;
+        status(call, raw)?;
+        for (i, o) in sensitivity.iter_mut().enumerate() {
+            *o = self.fmu.read_f64(op + i as u32 * 8).map_err(|e| err(call, e))?;
+        }
+        Ok(())
+    }
+
+    fn get_number_of_continuous_states(&mut self) -> Result<usize> {
+        let p = self.scratch(16)?;
+        let raw = self
+            .fmu
+            .call("om_fmi3GetNumberOfContinuousStates", &[Val::I32(p as i32)])
+            .map_err(|e| err("fmi3GetNumberOfContinuousStates", e))?;
+        status("fmi3GetNumberOfContinuousStates", raw)?;
+        Ok(self.fmu.read_u32(p).map_err(|e| err("fmi3GetNumberOfContinuousStates", e))? as usize)
+    }
+
+    fn get_number_of_event_indicators(&mut self) -> Result<usize> {
+        let p = self.scratch(16)?;
+        let raw = self
+            .fmu
+            .call("om_fmi3GetNumberOfEventIndicators", &[Val::I32(p as i32)])
+            .map_err(|e| err("fmi3GetNumberOfEventIndicators", e))?;
+        status("fmi3GetNumberOfEventIndicators", raw)?;
+        Ok(self.fmu.read_u32(p).map_err(|e| err("fmi3GetNumberOfEventIndicators", e))? as usize)
+    }
+}
+
+impl Fmi3CoSimulation for DylinkInstance {
+    fn enter_step_mode(&mut self) -> Result<()> {
+        let raw = self.fmu.call("om_fmi3EnterStepMode", &[]).map_err(|e| err("fmi3EnterStepMode", e))?;
+        status("fmi3EnterStepMode", raw)
+    }
+
+    fn do_step(&mut self, point: f64, size: f64, no_set_state_prior: bool) -> Result<DoStep> {
+        let p = self.scratch(32)?;
+        let raw = self
+            .fmu
+            .call(
+                "om_fmi3DoStep",
+                &[Val::F64(point.to_bits()), Val::F64(size.to_bits()), Val::I32(no_set_state_prior as i32), Val::I32(p as i32)],
+            )
+            .map_err(|e| err("fmi3DoStep", e))?;
+        status("fmi3DoStep", raw)?;
+        let f = |s: &mut Self, i: u32| s.fmu.read_u32(p + i * 4).map_err(|e| err("fmi3DoStep", e));
+        let event = f(self, 0)? != 0;
+        let terminate = f(self, 1)? != 0;
+        let early = f(self, 2)? != 0;
+        let last = self.fmu.read_f64(p + 16).map_err(|e| err("fmi3DoStep", e))?;
+        Ok(DoStep { event_handling_needed: event, terminate, early_return: early, last_successful_time: last })
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -57,6 +57,26 @@ mod sundials;
 #[cfg(sundials)]
 mod lis;
 
+pub use sysstats::enable as enable_sys_stats;
+
+/// Install a run's solver selectors, Newton tuning and homotopy settings from
+/// parsed simulation flags. The `rt_set_*` exports are how a *host* driver says
+/// this; a caller that drives the model from inside the module (the FMI3
+/// adapter's simulation interface) has the parsed flags instead.
+pub fn apply_sim_flags(f: &openmodelica_sim_meta::simflags::SimFlags) {
+    solvers::apply_flags(f);
+}
+
+/// What this runtime build can serve, for `simflags::check`.
+pub fn sim_capabilities() -> openmodelica_sim_meta::simflags::Capabilities {
+    sundials::capabilities()
+}
+
+/// The iteration-variable names `-lv=LOG_NLS` prints, which only the metadata has.
+pub fn set_nls_var_names(set: alloc::vec::Vec<(u32, alloc::vec::Vec<String>)>) {
+    nls::set_var_names(set);
+}
+
 use alloc::format;
 use alloc::string::String;
 use core::alloc::{GlobalAlloc, Layout};

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/solvers.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/solvers.rs
@@ -213,7 +213,6 @@ pub(crate) fn nls_use_sparse(size: usize, nnz: usize) -> bool {
         || size > NLSS_MIN_SIZE.load(Ordering::Relaxed) as usize
 }
 
-#[cfg(any(feature = "session", feature = "standalone"))]
 pub(crate) fn apply_flags(f: &openmodelica_sim_meta::simflags::SimFlags) {
     let (nls, nls_ls, ls, lss) = f.solver_codes();
     rt_set_solvers(nls, nls_ls, ls, lss);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
@@ -11,7 +11,6 @@ pub extern "C" fn rt_sundials_available() -> i32 {
 }
 
 /// What this build can serve, for `simflags::check`.
-#[cfg(any(feature = "session", feature = "standalone"))]
 pub fn capabilities() -> openmodelica_sim_meta::simflags::Capabilities {
     openmodelica_sim_meta::simflags::Capabilities {
         klu: cfg!(sundials),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/Cargo.lock
@@ -569,6 +569,8 @@ name = "openmodelica_fmi3_wasm"
 version = "0.1.0"
 dependencies = [
  "openmodelica_codegen_wasm_jit_runtime",
+ "openmodelica_mat_writer",
+ "openmodelica_plt_writer",
  "openmodelica_sim_meta",
  "wit-bindgen",
 ]
@@ -584,6 +586,13 @@ dependencies = [
 [[package]]
 name = "openmodelica_mat_writer"
 version = "0.1.0"
+
+[[package]]
+name = "openmodelica_plt_writer"
+version = "0.1.0"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "openmodelica_sim_meta"

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/Cargo.toml
@@ -28,6 +28,10 @@ crate-type = ["cdylib"]
 wit-bindgen = { version = "0.43", default-features = false, features = ["macros"] }
 openmodelica_codegen_wasm_jit_runtime = { path = "../openmodelica_codegen_wasm_jit_runtime", default-features = false }
 openmodelica_sim_meta = { path = "../openmodelica_sim_meta", default-features = false }
+# The result-file serializers, for the `om:sim/simulation` export: the same
+# writers the standalone export and the host use, so the three cannot drift.
+openmodelica_mat_writer = { path = "../openmodelica_mat_writer" }
+openmodelica_plt_writer = { path = "../openmodelica_plt_writer" }
 
 [profile.release]
 opt-level = "s"
@@ -46,6 +50,11 @@ strip = true
 default = ["me"]
 me = []
 cs = []
+# Export the FMI 3.0 C API from the core module (src/capi.rs) beside the
+# component's WIT exports, for a host that links this module as a dylink library
+# instead of composing it into a per-model component — and can then compile it
+# once and keep the `.cwasm`, as it already does for the simulation runtime.
+capi = []
 # CVODE/IDA for the embedded driver, as imports the SUNDIALS side module resolves. A
 # second `cs`/`me_cs` blob is built with it, so an FMU that does not ask for those
 # solvers links neither the calls nor the module.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/capi.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/capi.rs
@@ -1,0 +1,536 @@
+//! The FMI 3.0 interface as **core exports**, for a host that links this module
+//! rather than instantiating a component.
+//!
+//! A component is compiled as one artifact, so the ~1 MB of adapter, libc and
+//! runtime inside it is compiled again for every model — 0.3 s of a small
+//! model's 0.4 s export. Linked as a dylink library instead, the adapter is
+//! *fixed*: the host compiles it once and keeps the `.cwasm` under
+//! `~/.openmodelica/cache`, as it already does for the simulation runtime and the
+//! `external "C"` libraries.
+//!
+//! The entry points follow the standard's names and argument order under an
+//! `om_` prefix, with every pointer an offset into this module's linear memory —
+//! which is the host's too, since the model, the adapter and the runtime share
+//! one. There is no `fmi3Instance` argument and no callbacks: a host links this
+//! module per run, and the log goes to stdout, where the `-lv` streams already go
+//! and where the host already reads them.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+// The lifecycle and variable access are declared on both resources and given one
+// body by `shared_instance_methods!`, so a call has to name which trait it goes
+// through; either resolves to the same code.
+use crate::exports::fmi::fmi3::co_simulation::GuestCoSimulationInstance;
+use crate::exports::fmi::fmi3::model_exchange::GuestModelExchangeInstance;
+use crate::{Instance, Status};
+
+// ── The instance ────────────────────────────────────────────────────────────
+
+static mut INSTANCE: Option<Instance> = None;
+
+fn instance() -> Option<&'static Instance> {
+    unsafe { (*core::ptr::addr_of!(INSTANCE)).as_ref() }
+}
+
+const OK: i32 = 0;
+const ERROR: i32 = 3;
+
+fn status(s: Status) -> i32 {
+    match s {
+        Status::Ok => 0,
+        Status::Warning => 1,
+        Status::Discard => 2,
+        Status::Error => 3,
+        Status::Fatal => 4,
+    }
+}
+
+/// The status of a call on an instance that was never created.
+fn with<R>(f: impl FnOnce(&Instance) -> R, absent: R) -> R {
+    match instance() {
+        Some(i) => f(i),
+        None => absent,
+    }
+}
+
+unsafe fn slice_u32<'a>(p: u32, n: u32) -> &'a [u32] {
+    if n == 0 { &[] } else { unsafe { core::slice::from_raw_parts(p as *const u32, n as usize) } }
+}
+
+unsafe fn slice_f64<'a>(p: u32, n: u32) -> &'a [f64] {
+    if n == 0 { &[] } else { unsafe { core::slice::from_raw_parts(p as *const f64, n as usize) } }
+}
+
+/// Copy `values` out to the caller's buffer, refusing a short one as the standard
+/// requires (`nValues` must match what the variables need).
+fn write_f64(p: u32, n: u32, values: &[f64]) -> i32 {
+    if values.len() != n as usize {
+        return ERROR;
+    }
+    unsafe { core::ptr::copy_nonoverlapping(values.as_ptr(), p as *mut f64, values.len()) };
+    OK
+}
+
+fn write_i32(p: u32, n: u32, values: &[i32]) -> i32 {
+    if values.len() != n as usize {
+        return ERROR;
+    }
+    unsafe { core::ptr::copy_nonoverlapping(values.as_ptr(), p as *mut i32, values.len()) };
+    OK
+}
+
+// ── Lifecycle ───────────────────────────────────────────────────────────────
+
+/// `fmi3InstantiateModelExchange`. The name is a UTF-8 pointer/length pair
+/// rather than a C string: the host has the length and this module has no
+/// `strlen` of its own.
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3InstantiateModelExchange(name: u32, name_len: u32, logging_on: i32) -> u32 {
+    // The guest's own `instantiate_model_exchange` wraps the state in a component
+    // resource, which would drag the resource intrinsics into a module nothing
+    // instantiates as a component. Same steps, no wrapper.
+    let name = read_str(name, name_len);
+    crate::init_logging(name, logging_on != 0);
+    openmodelica_codegen_wasm_jit_runtime::set_resources_dir("/");
+    match crate::new_state() {
+        Some(st) => {
+            unsafe { INSTANCE = Some(Instance { st: core::cell::RefCell::new(st) }) };
+            1
+        }
+        None => 0,
+    }
+}
+
+/// `fmi3InstantiateCoSimulation`, with `eventModeUsed` and `earlyReturnAllowed`
+/// both following `event_mode`: the master that drives one drives the other.
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3InstantiateCoSimulation(
+    name: u32,
+    name_len: u32,
+    logging_on: i32,
+    event_mode: i32,
+) -> u32 {
+    let name = read_str(name, name_len);
+    crate::init_logging(name, logging_on != 0);
+    openmodelica_codegen_wasm_jit_runtime::set_resources_dir("/");
+    match crate::new_state() {
+        Some(mut st) => {
+            st.defer = if event_mode != 0 {
+                openmodelica_sim_meta::driver::CsDefer::Any
+            } else {
+                openmodelica_sim_meta::driver::CsDefer::None
+            };
+            // C's `fmi2Instantiate` sets the internal solver up here, CS only.
+            openmodelica_sim_meta::driver::log_cs_solver_setup(&st.meta, st.defer);
+            unsafe { INSTANCE = Some(Instance { st: core::cell::RefCell::new(st) }) };
+            1
+        }
+        None => 0,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3FreeInstance() {
+    unsafe { INSTANCE = None };
+}
+
+fn read_str(p: u32, len: u32) -> String {
+    if len == 0 {
+        return String::new();
+    }
+    let bytes = unsafe { core::slice::from_raw_parts(p as *const u8, len as usize) };
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3EnterInitializationMode(
+    tolerance_defined: i32,
+    tolerance: f64,
+    start_time: f64,
+    stop_time_defined: i32,
+    stop_time: f64,
+) -> i32 {
+    with(
+        |i| {
+            status(GuestModelExchangeInstance::enter_initialization_mode(i, 
+                (tolerance_defined != 0).then_some(tolerance),
+                start_time,
+                (stop_time_defined != 0).then_some(stop_time),
+            ))
+        },
+        ERROR,
+    )
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3ExitInitializationMode() -> i32 {
+    with(|i| status(GuestModelExchangeInstance::exit_initialization_mode(i, )), ERROR)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3EnterEventMode() -> i32 {
+    with(|i| status(GuestModelExchangeInstance::enter_event_mode(i, )), ERROR)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3EnterContinuousTimeMode() -> i32 {
+    with(|i| status(i.enter_continuous_time_mode()), ERROR)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3EnterStepMode() -> i32 {
+    with(|i| status(GuestCoSimulationInstance::enter_step_mode(i)), ERROR)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3Terminate() -> i32 {
+    with(|i| status(GuestModelExchangeInstance::terminate(i, )), ERROR)
+}
+
+/// `fmi3UpdateDiscreteStates`. The five flags and the next event time are written
+/// to `out`: `[needUpdate, terminate, nominalsChanged, statesChanged,
+/// nextEventTimeDefined]` as `i32`, then the time as an `f64` at `out + 24`.
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3UpdateDiscreteStates(out: u32) -> i32 {
+    with(
+        |i| match GuestModelExchangeInstance::update_discrete_states(i, ) {
+            Ok(d) => {
+                let flags = [
+                    d.new_discrete_states_needed as i32,
+                    d.terminate_simulation as i32,
+                    d.nominals_of_continuous_states_changed as i32,
+                    d.values_of_continuous_states_changed as i32,
+                    d.next_event_time_defined as i32,
+                ];
+                unsafe {
+                    core::ptr::copy_nonoverlapping(flags.as_ptr(), out as *mut i32, flags.len());
+                    core::ptr::write_unaligned((out + 24) as *mut f64, d.next_event_time);
+                }
+                OK
+            }
+            Err(s) => status(s),
+        },
+        ERROR,
+    )
+}
+
+// ── Model Exchange ──────────────────────────────────────────────────────────
+
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3SetTime(time: f64) -> i32 {
+    with(|i| status(i.set_time(time)), ERROR)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3SetContinuousStates(states: u32, n: u32) -> i32 {
+    with(|i| status(i.set_continuous_states(unsafe { slice_f64(states, n) }.to_vec())), ERROR)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3GetContinuousStates(states: u32, n: u32) -> i32 {
+    with(
+        |i| match i.get_continuous_states() {
+            Ok(v) => write_f64(states, n, &v),
+            Err(s) => status(s),
+        },
+        ERROR,
+    )
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3GetContinuousStateDerivatives(ders: u32, n: u32) -> i32 {
+    with(
+        |i| match i.get_continuous_state_derivatives() {
+            Ok(v) => write_f64(ders, n, &v),
+            Err(s) => status(s),
+        },
+        ERROR,
+    )
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3GetEventIndicators(z: u32, n: u32) -> i32 {
+    with(
+        |i| match i.get_event_indicators() {
+            Ok(v) => write_f64(z, n, &v),
+            Err(s) => status(s),
+        },
+        ERROR,
+    )
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3GetNominalsOfContinuousStates(nominals: u32, n: u32) -> i32 {
+    with(
+        |i| match i.get_nominals_of_continuous_states() {
+            Ok(v) => write_f64(nominals, n, &v),
+            Err(s) => status(s),
+        },
+        ERROR,
+    )
+}
+
+/// `[enterEventMode, terminateSimulation]` as `i32` at `out`.
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3CompletedIntegratorStep(no_set_state_prior: i32, out: u32) -> i32 {
+    with(
+        |i| match i.completed_integrator_step(no_set_state_prior != 0) {
+            Ok(r) => write_i32(out, 2, &[r.enter_event_mode as i32, r.terminate_simulation as i32]),
+            Err(s) => status(s),
+        },
+        ERROR,
+    )
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3GetNumberOfContinuousStates(out: u32) -> i32 {
+    with(
+        |i| match i.get_number_of_continuous_states() {
+            Ok(n) => write_i32(out, 1, &[n as i32]),
+            Err(s) => status(s),
+        },
+        ERROR,
+    )
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3GetNumberOfEventIndicators(out: u32) -> i32 {
+    with(
+        |i| match i.get_number_of_event_indicators() {
+            Ok(n) => write_i32(out, 1, &[n as i32]),
+            Err(s) => status(s),
+        },
+        ERROR,
+    )
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3GetDirectionalDerivative(
+    unknowns: u32,
+    n_unknowns: u32,
+    knowns: u32,
+    n_knowns: u32,
+    seed: u32,
+    n_seed: u32,
+    sensitivity: u32,
+    n_sensitivity: u32,
+) -> i32 {
+    with(
+        |i| {
+            let (u, k, s) = unsafe {
+                (slice_u32(unknowns, n_unknowns).to_vec(), slice_u32(knowns, n_knowns).to_vec(), slice_f64(seed, n_seed).to_vec())
+            };
+            match GuestModelExchangeInstance::get_directional_derivative(i, u, k, s) {
+                Ok(v) => write_f64(sensitivity, n_sensitivity, &v),
+                Err(st) => status(st),
+            }
+        },
+        ERROR,
+    )
+}
+
+// ── Co-Simulation ───────────────────────────────────────────────────────────
+
+/// `fmi3DoStep`. `[eventHandlingNeeded, terminate, earlyReturn]` as `i32` at
+/// `out`, then `lastSuccessfulTime` as an `f64` at `out + 16`.
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3DoStep(point: f64, size: f64, no_set_state_prior: i32, out: u32) -> i32 {
+    with(
+        |i| match i.do_step(point, size, no_set_state_prior != 0) {
+            Ok(r) => {
+                let flags =
+                    [r.event_handling_needed as i32, r.terminate_simulation as i32, r.early_return as i32];
+                unsafe {
+                    core::ptr::copy_nonoverlapping(flags.as_ptr(), out as *mut i32, flags.len());
+                    core::ptr::write_unaligned((out + 16) as *mut f64, r.last_successful_time);
+                }
+                OK
+            }
+            Err(s) => status(s),
+        },
+        ERROR,
+    )
+}
+
+// ── Variable access ─────────────────────────────────────────────────────────
+// One entry point per base type, as the standard has: the master reads and
+// writes in the type the variable is declared with.
+
+macro_rules! getter {
+    ($name:ident, $call:ident, $ty:ty, $out:ty) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn $name(vrs: u32, n_vrs: u32, values: u32, n_values: u32) -> i32 {
+            with(
+                |i| match GuestModelExchangeInstance::$call(i, unsafe { slice_u32(vrs, n_vrs) }.to_vec()) {
+                    Ok(v) => {
+                        if v.len() != n_values as usize {
+                            return ERROR;
+                        }
+                        let buf: Vec<$out> = v.into_iter().map(|x| x as $out).collect();
+                        unsafe {
+                            core::ptr::copy_nonoverlapping(buf.as_ptr(), values as *mut $out, buf.len())
+                        };
+                        OK
+                    }
+                    Err(s) => status(s),
+                },
+                ERROR,
+            )
+        }
+    };
+}
+
+macro_rules! setter {
+    ($name:ident, $call:ident, $ty:ty, $wire:ty) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn $name(vrs: u32, n_vrs: u32, values: u32, n_values: u32) -> i32 {
+            with(
+                |i| {
+                    let vrs = unsafe { slice_u32(vrs, n_vrs) }.to_vec();
+                    let src = if n_values == 0 {
+                        &[][..]
+                    } else {
+                        unsafe { core::slice::from_raw_parts(values as *const $wire, n_values as usize) }
+                    };
+                    let v: Vec<$ty> = src.iter().map(|x| *x as $ty).collect();
+                    status(GuestModelExchangeInstance::$call(i, vrs, v))
+                },
+                ERROR,
+            )
+        }
+    };
+}
+
+getter!(om_fmi3GetFloat64, get_float64, f64, f64);
+getter!(om_fmi3GetFloat32, get_float32, f32, f32);
+getter!(om_fmi3GetInt8, get_int8, i8, i8);
+getter!(om_fmi3GetUInt8, get_uint8, u8, u8);
+getter!(om_fmi3GetInt16, get_int16, i16, i16);
+getter!(om_fmi3GetUInt16, get_uint16, u16, u16);
+getter!(om_fmi3GetInt32, get_int32, i32, i32);
+getter!(om_fmi3GetUInt32, get_uint32, u32, u32);
+getter!(om_fmi3GetInt64, get_int64, i64, i64);
+getter!(om_fmi3GetUInt64, get_uint64, u64, u64);
+
+setter!(om_fmi3SetFloat64, set_float64, f64, f64);
+setter!(om_fmi3SetFloat32, set_float32, f32, f32);
+setter!(om_fmi3SetInt8, set_int8, i8, i8);
+setter!(om_fmi3SetUInt8, set_uint8, u8, u8);
+setter!(om_fmi3SetInt16, set_int16, i16, i16);
+setter!(om_fmi3SetUInt16, set_uint16, u16, u16);
+setter!(om_fmi3SetInt32, set_int32, i32, i32);
+setter!(om_fmi3SetUInt32, set_uint32, u32, u32);
+setter!(om_fmi3SetInt64, set_int64, i64, i64);
+setter!(om_fmi3SetUInt64, set_uint64, u64, u64);
+
+/// Booleans cross as `i32`, since wasm has no narrower value type and the host
+/// writes what the standard's `fmi3Boolean` is on this side.
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3GetBoolean(vrs: u32, n_vrs: u32, values: u32, n_values: u32) -> i32 {
+    with(
+        |i| match GuestModelExchangeInstance::get_boolean(i, unsafe { slice_u32(vrs, n_vrs) }.to_vec()) {
+            Ok(v) => {
+                let buf: Vec<i32> = v.into_iter().map(|b| b as i32).collect();
+                write_i32(values, n_values, &buf)
+            }
+            Err(s) => status(s),
+        },
+        ERROR,
+    )
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3SetBoolean(vrs: u32, n_vrs: u32, values: u32, n_values: u32) -> i32 {
+    with(
+        |i| {
+            let vrs = unsafe { slice_u32(vrs, n_vrs) }.to_vec();
+            let src = if n_values == 0 {
+                &[][..]
+            } else {
+                unsafe { core::slice::from_raw_parts(values as *const i32, n_values as usize) }
+            };
+            status(GuestModelExchangeInstance::set_boolean(i, vrs, src.iter().map(|b| *b != 0).collect()))
+        },
+        ERROR,
+    )
+}
+
+// ── The model's own simulation runtime ───────────────────────────────────────
+
+/// What [`om_sim_run`] hands back, in this module's memory. The host reads the
+/// fields it wants and the buffers stay alive until the next call.
+#[repr(C)]
+#[derive(Default)]
+struct RunOut {
+    /// 0 on success; 1 with `file` holding the failure text.
+    status: u32,
+    file: u32,
+    file_len: u32,
+    lin_name: u32,
+    lin_name_len: u32,
+    lin_content: u32,
+    lin_content_len: u32,
+    rows: u32,
+    solver: u32,
+    solver_len: u32,
+}
+
+static mut RUN_OUT: RunOut = RunOut {
+    status: 0,
+    file: 0,
+    file_len: 0,
+    lin_name: 0,
+    lin_name_len: 0,
+    lin_content: 0,
+    lin_content_len: 0,
+    rows: 0,
+    solver: 0,
+    solver_len: 0,
+};
+static mut RUN_KEEP: Option<(Vec<u8>, String, String, String)> = None;
+
+/// Run the whole simulation in-wasm, as `om:sim/simulation.run` does for a
+/// component. `args` is the flag list as NUL-separated UTF-8, without the program
+/// name. Returns a pointer to a [`RunOut`].
+#[unsafe(no_mangle)]
+pub extern "C" fn om_sim_run(args: u32, args_len: u32) -> u32 {
+    let blob = if args_len == 0 {
+        &[][..]
+    } else {
+        unsafe { core::slice::from_raw_parts(args as *const u8, args_len as usize) }
+    };
+    let argv: Vec<String> = blob
+        .split(|b| *b == 0)
+        .filter(|s| !s.is_empty())
+        .map(|s| String::from_utf8_lossy(s).into_owned())
+        .collect();
+    let (out, keep) = match crate::sim_run::run(argv) {
+        Ok(r) => {
+            let (name, content) = r.linear_file.unwrap_or_default();
+            let keep = (r.file, name, content, r.solver);
+            let mut out = RunOut { status: 0, rows: r.rows, ..RunOut::default() };
+            out.file = keep.0.as_ptr() as u32;
+            out.file_len = keep.0.len() as u32;
+            out.lin_name = keep.1.as_ptr() as u32;
+            out.lin_name_len = keep.1.len() as u32;
+            out.lin_content = keep.2.as_ptr() as u32;
+            out.lin_content_len = keep.2.len() as u32;
+            out.solver = keep.3.as_ptr() as u32;
+            out.solver_len = keep.3.len() as u32;
+            (out, keep)
+        }
+        Err(e) => {
+            let keep = (e.into_bytes(), String::new(), String::new(), String::new());
+            let mut out = RunOut { status: 1, ..RunOut::default() };
+            out.file = keep.0.as_ptr() as u32;
+            out.file_len = keep.0.len() as u32;
+            (out, keep)
+        }
+    };
+    unsafe {
+        RUN_KEEP = Some(keep);
+        RUN_OUT = out;
+        core::ptr::addr_of!(RUN_OUT) as u32
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -70,6 +70,19 @@ unsafe extern "C" {
     fn om_meta_len() -> u32;
 }
 
+// The rest of the driver's entry points, imported only by the me_cs build, which
+// also carries the model's own simulation runtime (`om:sim/simulation`). The
+// emitter exports all of them from every model, so the link resolves regardless.
+#[cfg(all(feature = "me", feature = "cs"))]
+#[link(wasm_import_module = "env")]
+unsafe extern "C" {
+    fn simulate(sim_data: u32, start: f64, stop: f64, n_steps: u32) -> u32;
+    fn linearJacA(sim_data: u32);
+    fn linearJacB(sim_data: u32);
+    fn linearJacC(sim_data: u32);
+    fn linearJacD(sim_data: u32);
+}
+
 // ── Messages ─────────────────────────────────────────────────────────────────
 // Two channels, as C's FMU has: `messageText` prints the `-lv` streams to stdout,
 // and the `log-message` callback (`fmi3LogMessage`) carries what
@@ -152,9 +165,22 @@ fn logger() -> &'static mut Logger {
     unsafe { &mut *core::ptr::addr_of_mut!(LOGGER) }
 }
 
+#[cfg(not(feature = "capi"))]
 fn log_raw(status: Status, cat: u32, msg: &str) {
     let l = logger();
     fmi::fmi3::callbacks::log_message(&l.name, status, CATEGORIES[cat as usize], msg.trim_end_matches('\n'));
+}
+
+/// Linked as a core module there is no importer to call back into, so what the
+/// component sends through `fmi3LogMessage` goes where its `-lv` streams already
+/// go: the FMU's stdout, which the host captures.
+#[cfg(feature = "capi")]
+fn log_raw(status: Status, cat: u32, msg: &str) {
+    let _ = status;
+    let l = logger();
+    stdio::print(
+        alloc::format!("{}: {}: {}\n", l.name, CATEGORIES[cat as usize], msg.trim_end_matches('\n')).as_bytes(),
+    );
 }
 
 /// [`Engine::call1`] was asked for a model function this adapter does not import.
@@ -311,6 +337,14 @@ impl SimEngine for Engine {
                 "functionInitSynchronous" => functionInitSynchronous(arg),
                 "callExternalObjectDestructors" => callExternalObjectDestructors(arg),
                 "symbolicInlineSystem" => symbolicInlineSystem(arg),
+                #[cfg(all(feature = "me", feature = "cs"))]
+                "linearJacA" => linearJacA(arg),
+                #[cfg(all(feature = "me", feature = "cs"))]
+                "linearJacB" => linearJacB(arg),
+                #[cfg(all(feature = "me", feature = "cs"))]
+                "linearJacC" => linearJacC(arg),
+                #[cfg(all(feature = "me", feature = "cs"))]
+                "linearJacD" => linearJacD(arg),
                 _ => return Err(UNKNOWN_MODEL_FN),
             }
         }
@@ -336,6 +370,13 @@ impl SimEngine for Engine {
             r => r,
         }
     }
+    #[cfg(all(feature = "me", feature = "cs"))]
+    fn call_simulate(&mut self, s: u32, a: f64, b: f64, n: u32) -> driver::Result<u32> {
+        Ok(unsafe { simulate(s, a, b, n) })
+    }
+    /// The FMI interfaces step the model themselves; only the simulation runtime
+    /// the me_cs build carries takes the emitted `simulate` loop.
+    #[cfg(not(all(feature = "me", feature = "cs")))]
     fn call_simulate(&mut self, _s: u32, _a: f64, _b: f64, _n: u32) -> driver::Result<u32> {
         Err("fmi3-me: simulate not used")
     }
@@ -578,6 +619,9 @@ wit_bindgen::generate!({
     world: "model-exchange-and-co-simulation-fmu",
     path: "wit",
     std_feature,
+    // The OpenModelica simulation interface is ours; the FMI ones come from the
+    // world's own package.
+    with: { "om:sim/simulation@0.1.0": generate },
 });
 
 use exports::fmi::fmi3::common::Guest as CommonGuest;
@@ -1432,4 +1476,17 @@ impl CsGuest for Fmu {
     type CoSimulationInstance = Instance;
 }
 
+/// The model's own simulation runtime, exported alongside the FMI interfaces by
+/// the me_cs build (the world that declares `om:sim/simulation`).
+#[cfg(all(feature = "me", feature = "cs"))]
+mod sim_run;
+
+/// The same adapter reached as a core module rather than a component, so a host
+/// can compile it once and keep the artifact.
+#[cfg(feature = "capi")]
+mod capi;
+
+// The component's exports, which is what pulls in the resource intrinsics: the
+// C-API build is linked as a core module and needs none of them.
+#[cfg(not(feature = "capi"))]
 export!(Fmu);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/sim_run.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/sim_run.rs
@@ -1,0 +1,178 @@
+//! The `om:sim/simulation` export: the model's own simulation runtime, inside
+//! the same component that serves the FMI 3.0 interfaces.
+//!
+//! It runs `openmodelica_sim_meta::driver` — the driver a wasm-jit simulation
+//! runs — over the adapter's [`Engine`](super::Engine), so an artifact can be
+//! simulated the ordinary way without being translated a second time. The
+//! result file is serialized here and handed back to the caller; the log goes
+//! to the component's stdout, where the FMI interfaces' log goes.
+
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
+
+use openmodelica_mat_writer::{MatVar, Precision};
+use openmodelica_sim_meta::driver;
+use openmodelica_sim_meta::simflags;
+use openmodelica_sim_meta::{self as meta, MetaKind};
+
+use crate::exports::om::sim::simulation::{Guest as SimGuest, RunResult};
+use crate::{log_sink, read_meta, Engine, Fmu};
+
+impl SimGuest for Fmu {
+    fn run(args: Vec<String>) -> Result<RunResult, String> {
+        run(args)
+    }
+}
+
+/// WASI's monotonic clock, in ms since the first reading. The driver's per-step
+/// deadline (`-alarm`) and the `LOG_STATS` timings need one; the component gets
+/// it from the same preview1 adapter its stdout comes from.
+mod clock {
+    #[link(wasm_import_module = "wasi_snapshot_preview1")]
+    unsafe extern "C" {
+        #[link_name = "clock_time_get"]
+        fn clock_time_get(id: u32, precision: u64, out: *mut u64) -> i32;
+    }
+
+    const MONOTONIC: u32 = 1;
+
+    fn now_ns() -> u64 {
+        let mut t = 0u64;
+        if unsafe { clock_time_get(MONOTONIC, 1_000, &mut t) } != 0 {
+            return 0;
+        }
+        t
+    }
+
+    pub fn now_ms() -> f64 {
+        static mut START: u64 = 0;
+        let now = now_ns();
+        let start = unsafe {
+            if START == 0 {
+                START = now;
+            }
+            START
+        };
+        now.saturating_sub(start) as f64 / 1.0e6
+    }
+}
+
+pub(crate) fn run(args: Vec<String>) -> Result<RunResult, String> {
+    // `parse` takes an argv, program name first, as a simulation executable's.
+    let mut argv: Vec<String> = vec!["model".to_string()];
+    argv.extend(args);
+    let flags = simflags::parse(&argv)?;
+    simflags::check(&flags, openmodelica_codegen_wasm_jit_runtime::sim_capabilities())?;
+    openmodelica_codegen_wasm_jit_runtime::apply_sim_flags(&flags);
+    // Installs the `-lv` log mask too, so the notices below are already filtered.
+    simflags::set_flags(flags);
+
+    let mut m = read_meta();
+    if m.layout.total == 0 {
+        return Err("wasm-jit: the artifact carries no model metadata".to_string());
+    }
+    driver::set_log_sink(log_sink);
+    // What `OpenModelica_fmuLoadResource` resolves against, as at instantiation:
+    // the host preopens the artifact's resources as this component's root.
+    openmodelica_codegen_wasm_jit_runtime::set_resources_dir("/");
+    simflags::with_flags(|f| {
+        simflags::print_notices(f);
+        m.apply_flags(f);
+    });
+
+    openmodelica_codegen_wasm_jit_runtime::rt_set_step_size(m.step_size());
+    openmodelica_codegen_wasm_jit_runtime::set_nls_var_names(
+        if meta::omclog::active(meta::omclog::NLS) {
+            m.nls_vars.iter().map(|s| (s.eq_index, s.names.clone())).collect()
+        } else {
+            Vec::new()
+        },
+    );
+    openmodelica_codegen_wasm_jit_runtime::enable_sys_stats(meta::omclog::active(meta::omclog::STATS_V));
+    driver::set_clock(clock::now_ms);
+
+    let sim_data = openmodelica_codegen_wasm_jit_runtime::rt_alloc(m.layout.total);
+    unsafe { core::ptr::write_bytes(sim_data as *mut u8, 0, m.layout.total as usize) };
+    let mut engine = Engine;
+    let (result, label) = driver::drive(&mut engine, &m, sim_data, m.method.as_str(), false, false)
+        .map_err(|e| e.to_string())?;
+
+    let rows = if result.n_reals == 0 { 0 } else { result.rows.len() / result.n_reals as usize };
+    let bytes = write_result_file(&m, &result);
+    Ok(RunResult {
+        file: bytes,
+        linear_file: result.lin.as_ref().map(|f| (f.name.clone(), f.content.clone())),
+        rows: rows as u32,
+        solver: label.to_string(),
+    })
+}
+
+/// The `.mat` / `.plt` bytes, exactly as the standalone export serializes them
+/// (one writer, so the two cannot drift). `"empty"` writes nothing: the run was
+/// only asked for its integration.
+fn write_result_file(m: &meta::SimMeta, result: &driver::RunResult) -> Vec<u8> {
+    if m.output_format != "mat" && m.output_format != "plt" {
+        return Vec::new();
+    }
+    let keep = m.output_keep(None);
+    // `params` is positional over the unfiltered `Param` signals; only the kept
+    // ones are collected, in signal order, for the writer.
+    let mut kept_params: Vec<f64> = Vec::new();
+    let mut param_idx = 0usize;
+    if m.output_format == "mat" {
+        let mut matvars: Vec<MatVar> = Vec::new();
+        for (v, &keep) in m.vars.iter().zip(&keep) {
+            let is_param = matches!(v.kind, MetaKind::Param { .. });
+            if is_param && keep {
+                kept_params.push(result.params.get(param_idx).copied().unwrap_or(0.0));
+            }
+            param_idx += is_param as usize;
+            if !keep {
+                continue;
+            }
+            matvars.push(MatVar { name: &v.name, comment: &v.comment, kind: v.kind.mat() });
+        }
+        let precision = simflags::with_flags(|f| {
+            if f.single_precision { Precision::Single } else { Precision::Double }
+        });
+        openmodelica_mat_writer::write_mat4(
+            &matvars,
+            m.start_time,
+            m.stop_time,
+            &result.rows,
+            result.n_reals,
+            &kept_params,
+            precision,
+        )
+    } else {
+        use openmodelica_plt_writer::{Neg as PltNeg, PltKind, PltVar};
+        let neg = |n: &meta::Neg| match n {
+            meta::Neg::None => PltNeg::None,
+            meta::Neg::Arith => PltNeg::Arith,
+            meta::Neg::Not => PltNeg::Not,
+        };
+        let to_plt = |k: &MetaKind| match k {
+            MetaKind::Time => PltKind::Time,
+            MetaKind::Column { col, negate } => PltKind::Column { col: *col, negate: neg(negate) },
+            MetaKind::Param { negate, .. } => PltKind::Param { negate: neg(negate) },
+            MetaKind::Const { value } => PltKind::Const { value: *value },
+        };
+        let mut signals: Vec<PltVar> = Vec::new();
+        for (v, &keep) in m.vars.iter().zip(&keep) {
+            let is_param = matches!(v.kind, MetaKind::Param { .. });
+            // C's plt writer omits integer/boolean parameters (`nParameters*`).
+            let is_int_bool_param = matches!(v.kind, MetaKind::Param { wty: meta::WTy::I32, .. });
+            let emit = keep && !is_int_bool_param;
+            if is_param && emit {
+                kept_params.push(result.params.get(param_idx).copied().unwrap_or(0.0));
+            }
+            param_idx += is_param as usize;
+            if !emit {
+                continue;
+            }
+            signals.push(PltVar { name: &v.name, kind: to_plt(&v.kind) });
+        }
+        openmodelica_plt_writer::write_plt(&signals, &result.rows, result.n_reals, &kept_params)
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/wit/deps/om-sim/simulation.wit
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/wit/deps/om-sim/simulation.wit
@@ -1,0 +1,26 @@
+package om:sim@0.1.0;
+
+// An OpenModelica extension, not part of fmi-ls-wasm: the same component that
+// serves the FMI 3.0 interfaces also carries the model's own simulation
+// runtime, so one artifact can be run as a plain simulation, as Model Exchange
+// and as Co-Simulation without being translated three times.
+interface simulation {
+  record run-result {
+    /// The result file (`.mat` / `.plt`); empty for `-noemit` and
+    /// `outputFormat="empty"`.
+    file: list<u8>,
+    /// `-l`'s linearized model: the file name and its content.
+    linear-file: option<tuple<string, string>>,
+    /// Output rows written.
+    rows: u32,
+    /// The integration method the run actually used.
+    solver: string,
+  }
+
+  /// Run the whole simulation in-wasm, with the driver a wasm-jit simulation
+  /// uses. `args` is the runtime flag list a simulation executable would be
+  /// given (`-s=dassl`, `-lv=LOG_STATS`, …), without the program name; the log
+  /// goes to stdout, as an FMU's does. The result file is returned rather than
+  /// written, so the caller decides where it lands.
+  run: func(args: list<string>) -> result<run-result, string>;
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/wit/world.wit
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/wit/world.wit
@@ -81,6 +81,9 @@ world model-exchange-and-co-simulation-fmu {
   export common;
   export model-exchange;
   export co-simulation;
+
+  /// The model's own simulation runtime (OpenModelica extension).
+  export om:sim/simulation@0.1.0;
 }
 
 // ── Scheduled Execution FMU ───────────────────────────────────────────────────

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/Cargo.toml
@@ -15,6 +15,10 @@ default = ["ffi"]
 # Load a native FMU binary and call the FMI 3.0 C API through it (`dlopen`).
 # Not available on wasm, where there is nothing to dlopen.
 ffi = ["dep:libloading"]
+# Drive an fmi-ls-wasm component in this process: wasmtime instantiates it and
+# the masters reach the FMU through its exports. What lets omc simulate the
+# artifact it exported without a loader library in between.
+component = ["dep:wasmtime", "dep:wasmtime-wasi"]
 
 [dependencies]
 openmodelica_fmi = { path = "../openmodelica_fmi" }
@@ -25,3 +29,8 @@ openmodelica_mat_writer = { path = "../openmodelica_mat_writer" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libloading = { version = "0.8", optional = true }
+# The same wasmtime the wasm-jit engine and the FMU exporter use: a `.cwasm` is
+# tied to one build and one configuration, so there can only be one.
+wasmtime = { workspace = true, optional = true, features = ["component-model", "gc", "gc-null", "gc-drc"] }
+# An FMU whose model has `external "C"` reaches libc, and libc imports WASI.
+wasmtime-wasi = { version = "45", default-features = false, optional = true, features = ["p2"] }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/component.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/component.rs
@@ -1,0 +1,638 @@
+//! The FMI 3.0 API over an fmi-ls-wasm **component**, in this process.
+//!
+//! The same thing `openmodelica_fmi_ls_wasm_to_native` does for an importer that
+//! wants a shared library, done for a caller that is already Rust: wasmtime
+//! instantiates the component and the [`api`](crate::api) traits are served from
+//! its exports, so [`me::simulate`](crate::me::simulate) and
+//! [`cs::simulate`](crate::cs::simulate) drive it exactly as they drive a native
+//! FMU.
+//!
+//! The world bound here is OpenModelica's `me_cs` one, which also carries the
+//! model's own simulation runtime (`om:sim/simulation`) — so one artifact, one
+//! compilation, three ways to run it.
+//!
+//! A `.cwasm` is tied to the exact wasmtime version *and* [`engine`]
+//! configuration that produced it; the exporter uses this same configuration.
+
+use std::path::Path;
+
+use wasmtime::component::{Component, Linker, ResourceAny};
+use wasmtime::{Config, Engine, Store};
+
+use crate::api::{CompletedStep, DiscreteStates, DoStep, Fmi3, Fmi3CoSimulation, Fmi3ModelExchange, Status};
+use crate::{Error, Result};
+use openmodelica_fmi::VarType;
+
+mod bindings {
+    //! The WIT is shared with the wasm-side adapter rather than copied.
+    wasmtime::component::bindgen!({
+        path: "../openmodelica_fmi3_wasm/wit",
+        world: "model-exchange-and-co-simulation-fmu",
+    });
+}
+
+use bindings::exports::fmi::fmi3::co_simulation::GuestCoSimulationInstance;
+use bindings::exports::fmi::fmi3::model_exchange::GuestModelExchangeInstance;
+use bindings::fmi::fmi3::types::Status as WitStatus;
+
+fn status(s: WitStatus) -> Status {
+    match s {
+        WitStatus::Ok => Status::Ok,
+        WitStatus::Warning => Status::Warning,
+        WitStatus::Discard => Status::Discard,
+        WitStatus::Error => Status::Error,
+        WitStatus::Fatal => Status::Fatal,
+    }
+}
+
+/// A component call that traps, or a status the master cannot continue from.
+fn trap(call: &'static str, e: impl std::fmt::Display) -> Error {
+    Error::Load(format!("{call}: {e}"))
+}
+
+fn check(call: &'static str, s: WitStatus) -> Result<()> {
+    let s = status(s);
+    if s.is_ok() { Ok(()) } else { Err(Error::Status { call, status: s }) }
+}
+
+/// Unwrap what a WIT `result<T, status>` returned.
+fn unwrap<T>(call: &'static str, r: std::result::Result<T, WitStatus>) -> Result<T> {
+    r.map_err(|s| Error::Status { call, status: status(s) })
+}
+
+// ── Host state ──────────────────────────────────────────────────────────────
+
+/// What the component's imports are served from: the log callback and WASI (the
+/// FMU's stdout, and the preopen a file-reading `external "C"` needs).
+pub struct Host {
+    /// What the FMU logged since the master last drained it.
+    log: Vec<(Status, String, String)>,
+    /// The FMU's stdout, which is where the simulation log goes (C's FMU prints
+    /// the `-lv` streams with `printf`). Captured rather than inherited, so the
+    /// caller can fold it into the run's log instead of the terminal.
+    stdout: wasmtime_wasi::p2::pipe::MemoryOutputPipe,
+    wasi: wasmtime_wasi::WasiCtx,
+    table: wasmtime::component::ResourceTable,
+}
+
+impl wasmtime_wasi::WasiView for Host {
+    fn ctx(&mut self) -> wasmtime_wasi::WasiCtxView<'_> {
+        wasmtime_wasi::WasiCtxView { ctx: &mut self.wasi, table: &mut self.table }
+    }
+}
+
+impl bindings::fmi::fmi3::types::Host for Host {}
+
+impl bindings::fmi::fmi3::callbacks::Host for Host {
+    fn log_message(&mut self, _instance_name: String, s: WitStatus, category: String, message: String) {
+        self.log.push((status(s), category, message));
+    }
+    fn clock_update(&mut self) {}
+    fn lock_preemption(&mut self) {}
+    fn unlock_preemption(&mut self) {}
+}
+
+impl bindings::fmi::fmi3::intermediate_update_callbacks::Host for Host {
+    /// The master handles events between communication points instead, so it
+    /// never asks the FMU to return early from inside a step.
+    fn intermediate_update(&mut self, _t: f64, _set: bool, _get: bool, _finished: bool, _early: bool) -> (bool, f64) {
+        (false, 0.0)
+    }
+}
+
+// ── The component ───────────────────────────────────────────────────────────
+
+/// The engine every artifact is compiled and run with. A `.cwasm` records the
+/// configuration and is refused by an engine configured differently, so the
+/// exporter (`CodegenWasmJit::native_fmu::precompile`) uses these same settings.
+pub fn engine() -> Result<Engine> {
+    let mut cfg = Config::new();
+    cfg.wasm_component_model(true);
+    // A model with external "C" carries the `model_error` tag its call sites catch.
+    cfg.wasm_exceptions(true);
+    Engine::new(&cfg).map_err(|e| trap("wasmtime engine", e))
+}
+
+pub struct WasmArtifact {
+    engine: Engine,
+    component: Component,
+    /// Where `Modelica.Utilities.Files.loadResource` and a file-backed table read
+    /// from, preopened as the component's `/`. Not part of the compilation, so an
+    /// exporter that compiles the component before writing the files beside it
+    /// says where they are afterwards ([`use_resources`](Self::use_resources)).
+    resources: std::sync::Mutex<Option<std::path::PathBuf>>,
+}
+
+impl WasmArtifact {
+    /// Deserialize a `.cwasm` this build precompiled. Loading is a mmap and a
+    /// relocation pass, not a compilation — which is the whole point of exporting
+    /// one.
+    ///
+    /// # Safety
+    /// wasmtime cannot validate a precompiled artifact; the caller vouches that
+    /// the bytes came from `precompile` on this machine.
+    pub unsafe fn from_cwasm(bytes: &[u8], resources: Option<&Path>) -> Result<WasmArtifact> {
+        let engine = engine()?;
+        let component = unsafe { Component::deserialize(&engine, bytes) }
+            .map_err(|e| trap("deserializing the precompiled artifact", e))?;
+        Ok(WasmArtifact { engine, component, resources: std::sync::Mutex::new(resources.map(Path::to_path_buf)) })
+    }
+
+    /// Deserialize a `.cwasm` **from a file**, which wasmtime maps rather than
+    /// reads: loading an artifact is then a few page faults whatever its size.
+    ///
+    /// # Safety
+    /// As [`from_cwasm`](Self::from_cwasm): the file has to be one this build
+    /// precompiled.
+    pub unsafe fn from_cwasm_file(path: &Path, resources: Option<&Path>) -> Result<WasmArtifact> {
+        let engine = engine()?;
+        let component = unsafe { Component::deserialize_file(&engine, path) }
+            .map_err(|e| trap("deserializing the precompiled artifact", e))?;
+        Ok(WasmArtifact { engine, component, resources: std::sync::Mutex::new(resources.map(Path::to_path_buf)) })
+    }
+
+    /// Compile the component itself, for an artifact with no `.cwasm` for this
+    /// platform.
+    pub fn compile(bytes: &[u8], resources: Option<&Path>) -> Result<WasmArtifact> {
+        let engine = engine()?;
+        let component =
+            Component::new(&engine, bytes).map_err(|e| trap("compiling the artifact", e))?;
+        Ok(WasmArtifact { engine, component, resources: std::sync::Mutex::new(resources.map(Path::to_path_buf)) })
+    }
+
+    /// Compile `component` for this machine and return the `.cwasm` bytes.
+    pub fn precompile(bytes: &[u8]) -> Result<Vec<u8>> {
+        engine()?.precompile_component(bytes).map_err(|e| trap("precompiling the artifact", e))
+    }
+
+    /// The `.cwasm` bytes for what is already compiled here: serializing an
+    /// artifact is writing out machine code that exists, where `precompile`
+    /// would compile it a second time.
+    pub fn serialize(&self) -> Result<Vec<u8>> {
+        self.component.serialize().map_err(|e| trap("serializing the artifact", e))
+    }
+
+    /// Point the component at its resources, for a caller that compiled it before
+    /// they were on disk.
+    pub fn use_resources(&self, dir: &Path) {
+        *self.resources.lock().unwrap_or_else(|e| e.into_inner()) = Some(dir.to_path_buf());
+    }
+
+    fn store(&self) -> Result<Store<Host>> {
+        let mut builder = wasmtime_wasi::WasiCtxBuilder::new();
+        // 16 MB: a chatty `-lv` run of a long simulation, and no more.
+        let stdout = wasmtime_wasi::p2::pipe::MemoryOutputPipe::new(16 << 20);
+        builder.stdout(stdout.clone()).stderr(stdout.clone());
+        let resources = self.resources.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        if let Some(dir) = resources.filter(|d| d.is_dir()) {
+            builder
+                .preopened_dir(&dir, "/", wasmtime_wasi::DirPerms::READ, wasmtime_wasi::FilePerms::READ)
+                .map_err(|e| trap("preopening the resources directory", e))?;
+        }
+        Ok(Store::new(
+            &self.engine,
+            Host {
+                log: Vec::new(),
+                stdout,
+                wasi: builder.build(),
+                table: wasmtime::component::ResourceTable::new(),
+            },
+        ))
+    }
+
+    fn linker(&self) -> Result<Linker<Host>> {
+        let mut linker: Linker<Host> = Linker::new(&self.engine);
+        wasmtime_wasi::p2::add_to_linker_sync(&mut linker)
+            .map_err(|e| trap("linking WASI", e))?;
+        bindings::ModelExchangeAndCoSimulationFmu::add_to_linker::<
+            Host,
+            wasmtime::component::HasSelf<Host>,
+        >(&mut linker, |s| s)
+        .map_err(|e| trap("linking the FMI callbacks", e))?;
+        Ok(linker)
+    }
+
+    fn instantiate(&self) -> Result<(Store<Host>, bindings::ModelExchangeAndCoSimulationFmu)> {
+        let linker = self.linker()?;
+        let mut store = self.store()?;
+        let world =
+            bindings::ModelExchangeAndCoSimulationFmu::instantiate(&mut store, &self.component, &linker)
+                .map_err(|e| trap("instantiating the artifact", e))?;
+        Ok((store, world))
+    }
+
+    pub fn model_exchange(&self, name: &str, logging_on: bool) -> Result<WasmInstance> {
+        let (mut store, world) = self.instantiate()?;
+        let res = self.resource_path();
+        let handle = world
+            .fmi_fmi3_model_exchange()
+            .model_exchange_instance()
+            .call_instantiate_model_exchange(&mut store, name, "", &res, false, logging_on)
+            .map_err(|e| trap("fmi3InstantiateModelExchange", e))?
+            .ok_or_else(|| Error::Instantiate {
+                call: "fmi3InstantiateModelExchange",
+                log: std::mem::take(&mut store.data_mut().log),
+            })?;
+        Ok(WasmInstance { store, world, handle, kind: Kind::Me })
+    }
+
+    /// Instantiate the Co-Simulation interface. `event_mode` lets the FMU stop at
+    /// its own events and hand them to the master, with early return.
+    pub fn co_simulation(&self, name: &str, logging_on: bool, event_mode: bool) -> Result<WasmInstance> {
+        let (mut store, world) = self.instantiate()?;
+        let res = self.resource_path();
+        let handle = world
+            .fmi_fmi3_co_simulation()
+            .co_simulation_instance()
+            .call_instantiate_co_simulation(
+                &mut store, name, "", &res, false, logging_on, event_mode, event_mode, &[],
+            )
+            .map_err(|e| trap("fmi3InstantiateCoSimulation", e))?
+            .ok_or_else(|| Error::Instantiate {
+                call: "fmi3InstantiateCoSimulation",
+                log: std::mem::take(&mut store.data_mut().log),
+            })?;
+        Ok(WasmInstance { store, world, handle, kind: Kind::Cs })
+    }
+
+    /// Run the model's own simulation runtime inside the artifact (`om:sim/run`).
+    /// `args` are the runtime flags a simulation executable would be given.
+    pub fn run_simulation(&self, args: &[String]) -> Result<SimRun> {
+        let (mut store, world) = self.instantiate()?;
+        let out = world
+            .om_sim_simulation()
+            .call_run(&mut store, args)
+            .map_err(|e| trap("om:sim/simulation.run", e))?
+            .map_err(Error::Simulation)?;
+        Ok(SimRun {
+            file: out.file,
+            linear_file: out.linear_file,
+            rows: out.rows,
+            solver: out.solver,
+            log: std::mem::take(&mut store.data_mut().log),
+            output: stdout_of(&store),
+        })
+    }
+
+    /// What `fmi3Instantiate*` is told its resources are. The component's own
+    /// root, since the preopen above is what it reaches them through.
+    fn resource_path(&self) -> String {
+        if self.resources.lock().unwrap_or_else(|e| e.into_inner()).is_some() {
+            "/".to_string()
+        } else {
+            String::new()
+        }
+    }
+}
+
+/// What the artifact's own simulation runtime produced.
+pub struct SimRun {
+    /// The result file's bytes, empty when the run was asked to emit none.
+    pub file: Vec<u8>,
+    /// `-l`'s linearized model: its file name and content.
+    pub linear_file: Option<(String, String)>,
+    pub rows: u32,
+    /// The integration method the run actually used.
+    pub solver: String,
+    pub log: Vec<(Status, String, String)>,
+    /// What the run printed: the `-lv` streams and the model's own `print`.
+    pub output: String,
+}
+
+fn stdout_of(store: &Store<Host>) -> String {
+    String::from_utf8_lossy(&store.data().stdout.contents()).into_owned()
+}
+
+enum Kind {
+    Me,
+    Cs,
+}
+
+/// One instantiated FMI interface of an artifact.
+pub struct WasmInstance {
+    store: Store<Host>,
+    world: bindings::ModelExchangeAndCoSimulationFmu,
+    handle: ResourceAny,
+    kind: Kind,
+}
+
+impl WasmInstance {
+    fn me(&mut self) -> (&mut Store<Host>, GuestModelExchangeInstance<'_>, ResourceAny) {
+        let WasmInstance { store, world, handle, .. } = self;
+        (store, world.fmi_fmi3_model_exchange().model_exchange_instance(), *handle)
+    }
+    fn cs(&mut self) -> (&mut Store<Host>, GuestCoSimulationInstance<'_>, ResourceAny) {
+        let WasmInstance { store, world, handle, .. } = self;
+        (store, world.fmi_fmi3_co_simulation().co_simulation_instance(), *handle)
+    }
+}
+
+/// The common interface is declared on both resources with identical shapes; the
+/// arms are textually the same and resolve to different generated types.
+macro_rules! common {
+    ($self:ident, |$store:ident, $g:ident, $h:ident| $body:expr) => {
+        match $self.kind {
+            Kind::Me => {
+                let ($store, $g, $h) = $self.me();
+                $body
+            }
+            Kind::Cs => {
+                let ($store, $g, $h) = $self.cs();
+                $body
+            }
+        }
+    };
+}
+
+/// One `fmi3Get*` family member, widened to `f64` for the recorder.
+macro_rules! get_numeric {
+    ($store:ident, $g:ident, $h:ident, $call:ident, $name:literal, $vrs:expr, $values:expr) => {{
+        let got = unwrap($name, $g.$call($store, $h, $vrs).map_err(|e| trap($name, e))?)?;
+        for (o, v) in $values.iter_mut().zip(&got) {
+            *o = *v as f64;
+        }
+        Ok(())
+    }};
+}
+
+macro_rules! set_numeric {
+    ($store:ident, $g:ident, $h:ident, $call:ident, $name:literal, $ty:ty, $vrs:expr, $values:expr) => {{
+        let buf: Vec<$ty> = $values.iter().map(|v| *v as $ty).collect();
+        check($name, $g.$call($store, $h, $vrs, &buf).map_err(|e| trap($name, e))?)
+    }};
+}
+
+impl Fmi3 for WasmInstance {
+    fn get_version(&mut self) -> String {
+        let WasmInstance { store, world, .. } = self;
+        world.fmi_fmi3_common().call_get_version(store).unwrap_or_else(|_| "3.0".to_string())
+    }
+
+    fn enter_initialization_mode(
+        &mut self,
+        tolerance: Option<f64>,
+        start_time: f64,
+        stop_time: Option<f64>,
+    ) -> Result<()> {
+        common!(self, |store, g, h| check(
+            "fmi3EnterInitializationMode",
+            g.call_enter_initialization_mode(store, h, tolerance, start_time, stop_time)
+                .map_err(|e| trap("fmi3EnterInitializationMode", e))?
+        ))
+    }
+
+    fn exit_initialization_mode(&mut self) -> Result<()> {
+        common!(self, |store, g, h| check(
+            "fmi3ExitInitializationMode",
+            g.call_exit_initialization_mode(store, h)
+                .map_err(|e| trap("fmi3ExitInitializationMode", e))?
+        ))
+    }
+
+    fn enter_event_mode(&mut self) -> Result<()> {
+        common!(self, |store, g, h| check(
+            "fmi3EnterEventMode",
+            g.call_enter_event_mode(store, h).map_err(|e| trap("fmi3EnterEventMode", e))?
+        ))
+    }
+
+    fn update_discrete_states(&mut self) -> Result<DiscreteStates> {
+        let info = common!(self, |store, g, h| unwrap(
+            "fmi3UpdateDiscreteStates",
+            g.call_update_discrete_states(store, h)
+                .map_err(|e| trap("fmi3UpdateDiscreteStates", e))?
+        ))?;
+        Ok(DiscreteStates {
+            need_update: info.new_discrete_states_needed,
+            terminate: info.terminate_simulation,
+            nominals_changed: info.nominals_of_continuous_states_changed,
+            states_changed: info.values_of_continuous_states_changed,
+            next_event_time: info.next_event_time_defined.then_some(info.next_event_time),
+        })
+    }
+
+    fn terminate(&mut self) -> Result<()> {
+        common!(self, |store, g, h| check(
+            "fmi3Terminate",
+            g.call_terminate(store, h).map_err(|e| trap("fmi3Terminate", e))?
+        ))
+    }
+
+    fn get_numeric(&mut self, ty: VarType, vrs: &[u32], values: &mut [f64]) -> Result<()> {
+        match ty.wire() {
+            VarType::Float64 => {
+                common!(self, |store, g, h| get_numeric!(store, g, h, call_get_float64, "fmi3GetFloat64", vrs, values))
+            }
+            VarType::Float32 => {
+                common!(self, |store, g, h| get_numeric!(store, g, h, call_get_float32, "fmi3GetFloat32", vrs, values))
+            }
+            VarType::Int8 => common!(self, |store, g, h| get_numeric!(store, g, h, call_get_int8, "fmi3GetInt8", vrs, values)),
+            VarType::UInt8 => common!(self, |store, g, h| get_numeric!(store, g, h, call_get_uint8, "fmi3GetUInt8", vrs, values)),
+            VarType::Int16 => common!(self, |store, g, h| get_numeric!(store, g, h, call_get_int16, "fmi3GetInt16", vrs, values)),
+            VarType::UInt16 => common!(self, |store, g, h| get_numeric!(store, g, h, call_get_uint16, "fmi3GetUInt16", vrs, values)),
+            VarType::Int32 => common!(self, |store, g, h| get_numeric!(store, g, h, call_get_int32, "fmi3GetInt32", vrs, values)),
+            VarType::UInt32 => common!(self, |store, g, h| get_numeric!(store, g, h, call_get_uint32, "fmi3GetUInt32", vrs, values)),
+            VarType::Int64 => common!(self, |store, g, h| get_numeric!(store, g, h, call_get_int64, "fmi3GetInt64", vrs, values)),
+            VarType::UInt64 => common!(self, |store, g, h| get_numeric!(store, g, h, call_get_uint64, "fmi3GetUInt64", vrs, values)),
+            VarType::Boolean => {
+                let got = common!(self, |store, g, h| unwrap(
+                    "fmi3GetBoolean",
+                    g.call_get_boolean(store, h, vrs).map_err(|e| trap("fmi3GetBoolean", e))?
+                ))?;
+                for (o, v) in values.iter_mut().zip(&got) {
+                    *o = *v as u8 as f64;
+                }
+                Ok(())
+            }
+            ty => Err(Error::Unsupported(format!("reading a {} as a number", ty.as_str()))),
+        }
+    }
+
+    fn set_numeric(&mut self, ty: VarType, vrs: &[u32], values: &[f64]) -> Result<()> {
+        match ty.wire() {
+            VarType::Float64 => {
+                common!(self, |store, g, h| check(
+                    "fmi3SetFloat64",
+                    g.call_set_float64(store, h, vrs, values).map_err(|e| trap("fmi3SetFloat64", e))?
+                ))
+            }
+            VarType::Float32 => common!(self, |store, g, h| set_numeric!(store, g, h, call_set_float32, "fmi3SetFloat32", f32, vrs, values)),
+            VarType::Int8 => common!(self, |store, g, h| set_numeric!(store, g, h, call_set_int8, "fmi3SetInt8", i8, vrs, values)),
+            VarType::UInt8 => common!(self, |store, g, h| set_numeric!(store, g, h, call_set_uint8, "fmi3SetUInt8", u8, vrs, values)),
+            VarType::Int16 => common!(self, |store, g, h| set_numeric!(store, g, h, call_set_int16, "fmi3SetInt16", i16, vrs, values)),
+            VarType::UInt16 => common!(self, |store, g, h| set_numeric!(store, g, h, call_set_uint16, "fmi3SetUInt16", u16, vrs, values)),
+            VarType::Int32 => common!(self, |store, g, h| set_numeric!(store, g, h, call_set_int32, "fmi3SetInt32", i32, vrs, values)),
+            VarType::UInt32 => common!(self, |store, g, h| set_numeric!(store, g, h, call_set_uint32, "fmi3SetUInt32", u32, vrs, values)),
+            VarType::Int64 => common!(self, |store, g, h| set_numeric!(store, g, h, call_set_int64, "fmi3SetInt64", i64, vrs, values)),
+            VarType::UInt64 => common!(self, |store, g, h| set_numeric!(store, g, h, call_set_uint64, "fmi3SetUInt64", u64, vrs, values)),
+            VarType::Boolean => {
+                let buf: Vec<bool> = values.iter().map(|v| *v != 0.0).collect();
+                common!(self, |store, g, h| check(
+                    "fmi3SetBoolean",
+                    g.call_set_boolean(store, h, vrs, &buf).map_err(|e| trap("fmi3SetBoolean", e))?
+                ))
+            }
+            ty => Err(Error::Unsupported(format!("writing a {} as a number", ty.as_str()))),
+        }
+    }
+
+    fn get_string(&mut self, vrs: &[u32]) -> Result<Vec<String>> {
+        common!(self, |store, g, h| unwrap(
+            "fmi3GetString",
+            g.call_get_string(store, h, vrs).map_err(|e| trap("fmi3GetString", e))?
+        ))
+    }
+
+    fn set_string(&mut self, vrs: &[u32], values: &[&str]) -> Result<()> {
+        let owned: Vec<String> = values.iter().map(|s| (*s).to_string()).collect();
+        common!(self, |store, g, h| check(
+            "fmi3SetString",
+            g.call_set_string(store, h, vrs, &owned).map_err(|e| trap("fmi3SetString", e))?
+        ))
+    }
+
+    fn take_log(&mut self) -> Vec<(Status, String, String)> {
+        std::mem::take(&mut self.store.data_mut().log)
+    }
+}
+
+impl WasmInstance {
+    /// What the FMU has printed: its simulation log, which C's FMU sends to the
+    /// importer's stdout.
+    pub fn output(&self) -> String {
+        stdout_of(&self.store)
+    }
+}
+
+impl Fmi3ModelExchange for WasmInstance {
+    fn enter_continuous_time_mode(&mut self) -> Result<()> {
+        let (store, g, h) = self.me();
+        check(
+            "fmi3EnterContinuousTimeMode",
+            g.call_enter_continuous_time_mode(store, h)
+                .map_err(|e| trap("fmi3EnterContinuousTimeMode", e))?,
+        )
+    }
+
+    fn set_time(&mut self, time: f64) -> Result<()> {
+        let (store, g, h) = self.me();
+        check("fmi3SetTime", g.call_set_time(store, h, time).map_err(|e| trap("fmi3SetTime", e))?)
+    }
+
+    fn set_continuous_states(&mut self, states: &[f64]) -> Result<()> {
+        let (store, g, h) = self.me();
+        check(
+            "fmi3SetContinuousStates",
+            g.call_set_continuous_states(store, h, states)
+                .map_err(|e| trap("fmi3SetContinuousStates", e))?,
+        )
+    }
+
+    fn get_continuous_states(&mut self, states: &mut [f64]) -> Result<()> {
+        let (store, g, h) = self.me();
+        let got = unwrap(
+            "fmi3GetContinuousStates",
+            g.call_get_continuous_states(store, h).map_err(|e| trap("fmi3GetContinuousStates", e))?,
+        )?;
+        states.copy_from_slice(&got[..states.len().min(got.len())]);
+        Ok(())
+    }
+
+    fn get_continuous_state_derivatives(&mut self, ders: &mut [f64]) -> Result<()> {
+        let (store, g, h) = self.me();
+        let got = unwrap(
+            "fmi3GetContinuousStateDerivatives",
+            g.call_get_continuous_state_derivatives(store, h)
+                .map_err(|e| trap("fmi3GetContinuousStateDerivatives", e))?,
+        )?;
+        ders.copy_from_slice(&got[..ders.len().min(got.len())]);
+        Ok(())
+    }
+
+    fn get_event_indicators(&mut self, indicators: &mut [f64]) -> Result<()> {
+        let (store, g, h) = self.me();
+        let got = unwrap(
+            "fmi3GetEventIndicators",
+            g.call_get_event_indicators(store, h).map_err(|e| trap("fmi3GetEventIndicators", e))?,
+        )?;
+        indicators.copy_from_slice(&got[..indicators.len().min(got.len())]);
+        Ok(())
+    }
+
+    fn get_nominals_of_continuous_states(&mut self, nominals: &mut [f64]) -> Result<()> {
+        let (store, g, h) = self.me();
+        let got = unwrap(
+            "fmi3GetNominalsOfContinuousStates",
+            g.call_get_nominals_of_continuous_states(store, h)
+                .map_err(|e| trap("fmi3GetNominalsOfContinuousStates", e))?,
+        )?;
+        nominals.copy_from_slice(&got[..nominals.len().min(got.len())]);
+        Ok(())
+    }
+
+    fn completed_integrator_step(&mut self, no_set_state_prior: bool) -> Result<CompletedStep> {
+        let (store, g, h) = self.me();
+        let r = unwrap(
+            "fmi3CompletedIntegratorStep",
+            g.call_completed_integrator_step(store, h, no_set_state_prior)
+                .map_err(|e| trap("fmi3CompletedIntegratorStep", e))?,
+        )?;
+        Ok(CompletedStep { enter_event_mode: r.enter_event_mode, terminate: r.terminate_simulation })
+    }
+
+    fn get_directional_derivative(
+        &mut self,
+        unknowns: &[u32],
+        knowns: &[u32],
+        seed: &[f64],
+        sensitivity: &mut [f64],
+    ) -> Result<()> {
+        let (store, g, h) = self.me();
+        let got = unwrap(
+            "fmi3GetDirectionalDerivative",
+            g.call_get_directional_derivative(store, h, unknowns, knowns, seed)
+                .map_err(|e| trap("fmi3GetDirectionalDerivative", e))?,
+        )?;
+        sensitivity.copy_from_slice(&got[..sensitivity.len().min(got.len())]);
+        Ok(())
+    }
+
+    fn get_number_of_continuous_states(&mut self) -> Result<usize> {
+        let (store, g, h) = self.me();
+        Ok(unwrap(
+            "fmi3GetNumberOfContinuousStates",
+            g.call_get_number_of_continuous_states(store, h)
+                .map_err(|e| trap("fmi3GetNumberOfContinuousStates", e))?,
+        )? as usize)
+    }
+
+    fn get_number_of_event_indicators(&mut self) -> Result<usize> {
+        let (store, g, h) = self.me();
+        Ok(unwrap(
+            "fmi3GetNumberOfEventIndicators",
+            g.call_get_number_of_event_indicators(store, h)
+                .map_err(|e| trap("fmi3GetNumberOfEventIndicators", e))?,
+        )? as usize)
+    }
+}
+
+impl Fmi3CoSimulation for WasmInstance {
+    fn enter_step_mode(&mut self) -> Result<()> {
+        let (store, g, h) = self.cs();
+        check("fmi3EnterStepMode", g.call_enter_step_mode(store, h).map_err(|e| trap("fmi3EnterStepMode", e))?)
+    }
+
+    fn do_step(&mut self, point: f64, size: f64, no_set_state_prior: bool) -> Result<DoStep> {
+        let (store, g, h) = self.cs();
+        let r = unwrap(
+            "fmi3DoStep",
+            g.call_do_step(store, h, point, size, no_set_state_prior).map_err(|e| trap("fmi3DoStep", e))?,
+        )?;
+        Ok(DoStep {
+            event_handling_needed: r.event_handling_needed,
+            terminate: r.terminate_simulation,
+            early_return: r.early_return,
+            last_successful_time: r.last_successful_time,
+        })
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/lib.rs
@@ -25,6 +25,10 @@ pub mod ffi;
 #[cfg(target_arch = "wasm32")]
 pub mod wasm_host;
 
+/// An fmi-ls-wasm component driven in this process by wasmtime.
+#[cfg(all(feature = "component", not(target_arch = "wasm32")))]
+pub mod component;
+
 use openmodelica_fmi::{InterfaceKind, ModelDescription, VarType};
 
 #[derive(Debug)]
@@ -40,6 +44,8 @@ pub enum Error {
     Io(String),
     /// The integrator gave up (step size underflow, no convergence).
     Solver(&'static str),
+    /// The FMU's own simulation runtime reported a failure.
+    Simulation(String),
     /// The FMU asked for termination during initialization.
     TerminatedAtInit,
     Cancelled,
@@ -60,6 +66,7 @@ impl std::fmt::Display for Error {
             Error::Load(m) => write!(f, "cannot load the FMU binary: {m}"),
             Error::Io(m) => write!(f, "{m}"),
             Error::Solver(m) => write!(f, "{m}"),
+            Error::Simulation(m) => write!(f, "{m}"),
             Error::TerminatedAtInit => {
                 write!(f, "the FMU requested termination during initialization")
             }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Globals.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Globals.rs
@@ -251,4 +251,10 @@ thread_local! {
     // Index 31 — backendInterface
     // Declared in openmodelica_frontend::Globals.
     // Type: BackendInterface::BackendInterfaceFunctions
+
+    /// Index 33 — the FMI index -> value reference table an FMI 3.0
+    /// `<ModelStructure>` is written through. Live only while one is being
+    /// written; source: `SimCodeUtil.cacheFMI3ValueReferences`.
+    pub static fmi3ValueReferenceCache: RefCell<Option<metamodelica::Array<ArcStr>>> =
+        const { RefCell::new(None) };
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
@@ -532,6 +532,15 @@ const ADAPTER_VARIANTS: &[AdapterVariant] = &[
         label: "me_cs+SUNDIALS",
         cargo_args: &["--no-default-features", "--features", "me,cs,sundials"],
     },
+    // The same me_cs adapter with an FMI 3.0 C API instead of the component's WIT
+    // exports, for a host that links it as a dylink library: it is then a *fixed*
+    // library, compiled once into the on-disk `.cwasm` cache rather than into
+    // every model's component.
+    AdapterVariant {
+        name: "mecs_capi",
+        label: "me_cs (C API)",
+        cargo_args: &["--no-default-features", "--features", "me,cs,capi"],
+    },
 ];
 
 fn build_fmi3_adapter(crate_dir: &Path, out_dir: &Path, v: &AdapterVariant) {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/lib.rs
@@ -17,6 +17,12 @@ pub static FMI3_ME_ADAPTER: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/fm
 /// substitutes for one — cheaper than a fourth adapter blob in every omc.
 pub static FMI3_MECS_ADAPTER: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/fmi3_mecs_adapter.wasm"));
 
+/// The me_cs adapter as a plain dylink library exporting the FMI 3.0 C API
+/// (`om_fmi3*`), for the artifact form a host links itself: being fixed, it is
+/// compiled once into the on-disk AOT cache instead of into every component.
+pub static FMI3_MECS_CAPI_ADAPTER: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/fmi3_mecs_capi_adapter.wasm"));
+
 /// The me_cs world with CVODE/IDA in the embedded driver, for an FMU exported with
 /// `method="cvode"`/`"ida"`; the calls are imports
 /// `openmodelica_wasi_libc::SUNDIALS_DYLINK` resolves.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -1762,3 +1762,212 @@ impl Drop for InWasmSession {
     }
 }
 
+
+// ===========================================================================
+// The dylink artifact: a model kernel linked against the FMI3 adapter
+// ===========================================================================
+//
+// A component is compiled as one artifact, so the megabyte of adapter, libc and
+// runtime inside it is compiled again for every model. Reached this way instead,
+// the adapter is a *fixed* dylink library and takes the on-disk `.cwasm` cache
+// (`aot_module`) that the runtime and the `external "C"` libraries already use:
+// this machine compiles it once, and a model's export compiles only the model.
+
+/// A loaded artifact: the runtime, the FMI3 adapter and the model kernel sharing
+/// one linear memory, with the adapter's `om_fmi3*`/`om_sim_run` reachable.
+pub struct DylinkFmu {
+    store: Store,
+    loaded: crate::dylink_engine::Loaded,
+    memory: wasmtime::Memory,
+    alloc: wasmtime::TypedFunc<u32, u32>,
+    /// The model, held so the store keeps it for as long as the adapter can call it.
+    _instance: Option<wasmtime::Instance>,
+}
+
+/// One library of an artifact, as `CodegenWasmJit::artifact` read it out of the
+/// export.
+pub struct ArtifactLib {
+    pub name: String,
+    pub bytes: Vec<u8>,
+}
+
+impl DylinkFmu {
+    /// Link `model` — the kernel, an ordinary module — against `adapter` and
+    /// whatever its `external "C"` needs. `resources` is the guest's `/`.
+    pub fn load(
+        adapter: &'static [u8],
+        model: &[u8],
+        ext: &[ArtifactLib],
+        external_c: bool,
+        lapack: bool,
+        resources: &str,
+    ) -> std::result::Result<DylinkFmu, String> {
+        use crate::dylink_engine::Library;
+        if adapter.is_empty() {
+            return Err("CodegenWasmJit: this omc has no FMI3 C-API adapter (build with the \
+                        wasm32-unknown-unknown toolchain)"
+                .to_string());
+        }
+        let engine = sim_engine();
+        let mut linker = wasmtime::Linker::new(engine);
+        add_host_builtins(&mut linker)?;
+        wasi_shim::add_to_linker(&mut linker)?;
+        let runtime_module = runtime_module()?;
+        let mut store = wasmtime::Store::new(engine, WasiCtx::new(resources, Vec::new()));
+        let rt_inst = wts(linker.instantiate(&mut store, runtime_module))?;
+        wts(linker.instance(&mut store, "rt", rt_inst))?;
+        let memory = rt_inst
+            .get_memory(&mut store, "memory")
+            .ok_or_else(|| "CodegenWasmJit: runtime has no `memory` export".to_string())?;
+        let table = rt_inst
+            .get_table(&mut store, "__indirect_function_table")
+            .ok_or_else(|| "CodegenWasmJit: runtime has no table export".to_string())?;
+        crate::host::set_sim_memory(memory);
+        let ext_rt = crate::dylink_engine::ExtRt {
+            str_new: wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_str_new"))?,
+            str_data: wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_str_data"))?,
+            release: wts(rt_inst.get_typed_func::<u32, ()>(&mut store, "rt_release"))?,
+            alloc: wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc"))?,
+            free: wts(rt_inst.get_typed_func::<u32, ()>(&mut store, "rt_free"))?,
+            record_new: wts(rt_inst.get_typed_func::<(u32, u32), u32>(&mut store, "rt_record_new"))?,
+            nls: Some(NlsHooks {
+                recovering: wts(rt_inst.get_typed_func::<(), i32>(&mut store, "rt_nls_recovering"))?,
+                note: wts(rt_inst.get_typed_func::<(), ()>(&mut store, "rt_nls_note_assert"))?,
+            }),
+        };
+        // The model is instantiated the way the ordinary simulation path
+        // instantiates it — a plain module bound to the runtime under `rt`, its
+        // code non-PIC and its calls direct. Only the adapter is a dylink library,
+        // because only the adapter is shared between models and worth caching; a
+        // PIC model would pay for that relocatability in its hot loop.
+        // The `rt` names the host serves rather than the runtime module: the same
+        // ones the ordinary simulation path defines before instantiating a model.
+        define_print_import(&mut linker, memory)?;
+        crate::host::define_uri_import(&mut linker, memory, ext_rt.str_new.clone(), ext_rt.str_data.clone())?;
+        // The model's `external "C"` first: the model imports those and the
+        // adapter imports the model, so the three go in that order.
+        let mut ext_libs: Vec<Library> = Vec::new();
+        if external_c {
+            let libc = openmodelica_wasi_libc::LIBC_PIC;
+            if libc.is_empty() {
+                return Err("CodegenWasmJit: this omc was built without the PIC wasi-libc, so it \
+                            cannot load an artifact whose model uses external \"C\""
+                    .to_string());
+            }
+            ext_libs.push(Library::builtin("libc.so", libc));
+        }
+        for l in ext {
+            // Fixed: the artifact holds the same bytes every run, so they are worth
+            // the on-disk `.cwasm` rather than a compile per instantiation.
+            ext_libs.push(Library { name: l.name.clone(), bytes: l.bytes.clone(), fixed: true });
+        }
+        if external_c {
+            ext_libs.push(Library::builtin("modelicaexternalc", openmodelica_wasi_libc::EXTERNAL_C_DYLINK));
+            if !openmodelica_wasi_libc::USERTAB_DYLINK.is_empty() {
+                ext_libs.push(Library::builtin("usertab", openmodelica_wasi_libc::USERTAB_DYLINK));
+            }
+        }
+        if lapack && !crate::LAPACK_DYLINK.is_empty() {
+            ext_libs.push(Library::builtin("lapack", crate::LAPACK_DYLINK));
+        }
+        let model_module = wts(wasmtime::Module::new(engine, model))?;
+        if !ext_libs.is_empty() {
+            let utilities = crate::dylink_engine::modelica_utilities_imports(&mut store, &ext_rt);
+            let libs = crate::dylink_engine::load(
+                &mut store,
+                engine,
+                memory,
+                table,
+                &ext_rt.alloc,
+                &ext_libs,
+                &utilities,
+            )?;
+            crate::host::set_shadow_stack(libs.shadow_stack());
+            let wanted: Vec<String> = model_module
+                .imports()
+                .filter(|i| i.module() == "ext")
+                .map(|i| i.name().to_string())
+                .collect();
+            for name in wanted {
+                let f = libs.func_or_addr(&mut store, &name).ok_or_else(|| {
+                    format!("CodegenWasmJit: the artifact's model needs `external \"C\"` function `{name}`, \
+                             which none of the libraries beside it defines")
+                })?;
+                wts(linker.define(&store, "ext", &name, f))?;
+            }
+        }
+        let model_inst = wts(linker.instantiate(&mut store, &model_module))?;
+        // What the adapter calls into: the model's entry points, and the runtime's
+        // primitives, both as ordinary cross-instance calls.
+        let mut host: std::collections::HashMap<String, wasmtime::Func> =
+            crate::dylink_engine::modelica_utilities_imports(&mut store, &ext_rt);
+        for inst in [model_inst, rt_inst] {
+            let exports: Vec<(String, wasmtime::Extern)> = inst
+                .exports(&mut store)
+                .map(|e| (e.name().to_string(), e.into_extern()))
+                .collect();
+            for (name, ext) in exports {
+                if let wasmtime::Extern::Func(f) = ext {
+                    host.entry(name).or_insert(f);
+                }
+            }
+        }
+        let loaded =
+            crate::dylink_engine::load(&mut store, engine, memory, table, &ext_rt.alloc, &[Library::builtin("fmi3adapter", adapter)], &host)?;
+        crate::host::set_shadow_stack(loaded.shadow_stack());
+        Ok(DylinkFmu { store, loaded, memory, alloc: ext_rt.alloc, _instance: Some(model_inst) })
+    }
+
+    /// Scratch in the shared memory, for the arrays an FMI call passes by pointer.
+    pub fn alloc(&mut self, bytes: u32) -> std::result::Result<u32, String> {
+        self.alloc.call(&mut self.store, bytes.max(8)).map_err(|e| format!("rt_alloc: {e}"))
+    }
+
+    pub fn write(&mut self, addr: u32, bytes: &[u8]) -> std::result::Result<(), String> {
+        self.memory
+            .write(&mut self.store, addr as usize, bytes)
+            .map_err(|e| format!("artifact: write at {addr}: {e}"))
+    }
+
+    pub fn read(&mut self, addr: u32, out: &mut [u8]) -> std::result::Result<(), String> {
+        self.memory
+            .read(&mut self.store, addr as usize, out)
+            .map_err(|e| format!("artifact: read at {addr}: {e}"))
+    }
+
+    pub fn read_u32(&mut self, addr: u32) -> std::result::Result<u32, String> {
+        let mut b = [0u8; 4];
+        self.read(addr, &mut b)?;
+        Ok(u32::from_le_bytes(b))
+    }
+
+    pub fn read_f64(&mut self, addr: u32) -> std::result::Result<f64, String> {
+        let mut b = [0u8; 8];
+        self.read(addr, &mut b)?;
+        Ok(f64::from_le_bytes(b))
+    }
+
+    /// Call one of the adapter's exports. The FMI 3.0 entry points all take and
+    /// return machine words, so the parameters cross as `Val`.
+    pub fn call(&mut self, name: &str, args: &[wasmtime::Val]) -> std::result::Result<i32, String> {
+        let f = *self
+            .loaded
+            .func(name)
+            .ok_or_else(|| format!("CodegenWasmJit: the artifact's adapter has no `{name}`"))?;
+        let mut out = [wasmtime::Val::I32(0)];
+        f.call(&mut self.store, args, &mut out).map_err(|e| format!("{name}: {e:#}"))?;
+        match out[0] {
+            wasmtime::Val::I32(v) => Ok(v),
+            _ => Ok(0),
+        }
+    }
+
+    /// The same, for an entry point that returns nothing.
+    pub fn call_void(&mut self, name: &str, args: &[wasmtime::Val]) -> std::result::Result<(), String> {
+        let f = *self
+            .loaded
+            .func(name)
+            .ok_or_else(|| format!("CodegenWasmJit: the artifact's adapter has no `{name}`"))?;
+        f.call(&mut self.store, args, &mut []).map_err(|e| format!("{name}: {e:#}"))
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/index.html
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/index.html
@@ -217,7 +217,8 @@
       <select id="csSolver"></select>
       <label>Also run natively on</label>
       <div class="chk-group" id="fmuPlatforms"></div>
-      <p class="modal-hint">FMI 3.0 wasm component. Co-Simulation embeds the solver; Model Exchange leaves integration to the importer. A native platform adds a machine-code build of the same component, so importers that cannot run WebAssembly load the FMU too.</p>
+      <p class="modal-hint">FMI 3.0 wasm component, built around the module this model was compiled to — the export links an adapter onto it rather than translating again. Co-Simulation embeds the solver; Model Exchange leaves integration to the importer. A native platform adds a machine-code build of the same component, so importers that cannot run WebAssembly load the FMU too.</p>
+      <p class="modal-hint" id="csOnlyHint" hidden>Co-Simulation on its own is translated separately, so that export takes as long as a compile: it needs the output derivatives <code>fmi3GetOutputDerivatives</code> answers from, which only a pure Co-Simulation translation carries.</p>
     </div>
     <div class="modal-foot">
       <button class="ghost" id="exportCancel">Cancel</button>
@@ -391,7 +392,10 @@ function promote() {
   retireW1();
 }
 function retireW1() {
-  if (primaryWorker !== w1 && w1 && jobWorker !== w1) {
+  // Not while a job is on it: terminating a worker mid-call leaves the page
+  // waiting on a reply that can never come. An export holds w1 through
+  // activeExportWorker rather than jobWorker, and retires it when it finishes.
+  if (primaryWorker !== w1 && w1 && jobWorker !== w1 && activeExportWorker !== w1) {
     log('terminating w1');
     if (builtWorker === w1) { builtModel = null; builtWorker = null; }   // its model is gone → next run rebuilds
     w1.terminate(); w1 = null;
@@ -470,7 +474,8 @@ function fillSolverMenus(options) {
     for (const v of options[flag] || []) sel.add(new Option(v, v));
     sel.value = keep;                     // survives a second worker reporting the same set
   }
-  // The integration method has no "unset": it is a buildModel argument, not a flag.
+  // The integration method is the `-s` flag, so its menu is that flag's values —
+  // but with no "unset" entry: a run always names one.
   const m = el('method'), keep = m.value;
   if (options.s && options.s.length) {
     m.replaceChildren(...options.s.map((v) => new Option(v, v)));
@@ -554,7 +559,9 @@ async function run(kind) {                       // 'full' | 'resim'
     // Re-simulate the already-built model (fast, no recompile) when possible.
     if (kind === 'resim' && builtModel && builtWorker) {
       jobWorker = builtWorker;
-      const r = await call(builtWorker, 'resimulate', { name: builtModel, override: ov, solvers });
+      // The experiment reaches the run as simflags, so a changed stopTime,
+      // tolerance or solver is honoured here too — no rebuild.
+      const r = await call(builtWorker, 'resimulate', { name: builtModel, override: ov, solvers, ...settings });
       runMs = performance.now() - tRun;
       if (r.cancelled) { setStatus('Simulation cancelled.'); return; }
       if (!r.ok) return fail(r.error);
@@ -959,21 +966,31 @@ async function exportFmu({ fmuType, method, platforms }) {
     const worker = await pickWorker(text);
     if (!worker) throw new Error('compiler not ready');
     activeExportWorker = worker;   // so a Cancel targets this worker's control block
-    const name = parseModelName(text);
-    const lm = await call(worker, 'loadSource', { text, name });
-    if (!lm.ok) return fail(lm.error);
-    const r = await call(worker, 'exportFmu', { name: lm.name, fmuType, method, platforms });
+    // Loading the source again replaces the program in omc's symbol table, which
+    // is precisely what marks the compile step's translation stale — so an
+    // unchanged model goes straight to the export and links onto the kernel it
+    // already has. A changed one has to be reloaded, and is translated again.
+    let name = builtModel;
+    if (!(name && builtWorker === worker && text === lastText)) {
+      const lm = await call(worker, 'loadSource', { text, name: parseModelName(text) });
+      if (!lm.ok) return fail(lm.error);
+      name = lm.name;
+    }
+    const r = await call(worker, 'exportFmu', { name, fmuType, method, platforms });
     if (r.cancelled) { setStatus('Export cancelled.'); return; }
     if (!r.ok) return fail(r.error);
     downloadBlob(r.filename, r.bytes);
     setStatus(`Exported ${r.filename} (${fmuType}) — ${r.bytes.length} bytes.`);
   } catch (e) { fail('' + e); }
-  finally { exporting = false; activeExportWorker = null; exportBtn.textContent = 'Export FMU'; }
+  finally { exporting = false; activeExportWorker = null; exportBtn.textContent = 'Export FMU'; retireW1(); }
 }
 
 // FMU export dialog: pick interface(s) and (for CS) the embedded solver.
 const exportBackdrop = el('exportBackdrop'), fmiMe = el('fmiMe'), fmiCs = el('fmiCs'), csSolver = el('csSolver');
 function syncExportDialog() {
+  // Only a pure Co-Simulation export needs its own translation; every other
+  // combination is served by the one the model was compiled with.
+  el('csOnlyHint').hidden = !(fmiCs.checked && !fmiMe.checked);
   csSolver.disabled = !fmiCs.checked;
   el('exportGo').disabled = !(fmiMe.checked || fmiCs.checked);
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/omc-worker.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/omc-worker.js
@@ -239,14 +239,28 @@ function logModelOutput(prefix) {
 // Phase breakdown of the last `runResumable`, reported back with the snapshot.
 let lastPhases = null;
 
-// The run's simflags: `-override=` plus the solver selectors the page picked.
-// They are read at `omc_sim_start`, not baked into the build, so a re-simulate
-// honours a change without recompiling; an empty selection is left out.
+// The run's simflags: the experiment, `-override=` and the solver selectors the
+// page picked. They are read at `omc_sim_start`, not baked into the build, so a
+// re-simulate honours a change without recompiling; an empty selection is left
+// out. `-stepSize` travels with `-stopTime` because C's `read_experiment` reads
+// start/stop without it as "recompute for 500 intervals", and warns.
 function simflagsFor(a) {
   const sel = a.solvers || {};
   const flags = Object.keys(sel).filter((k) => sel[k]).map((k) => `-${k}=${sel[k]}`);
+  if (a.method) flags.push(`-s=${a.method}`);
+  if (a.stopTime) {
+    const intervals = Math.max(1, Math.round(a.intervals || 500));
+    flags.push(`-stopTime=${a.stopTime}`, `-stepSize=${(a.stopTime - startTimeOf(a.name)) / intervals}`);
+  }
+  if (a.tolerance) flags.push(`-tolerance=${a.tolerance}`);
   if (a.override) flags.push(a.override);
   return flags.join(' ');
+}
+
+// The model's own startTime, which the page never edits.
+function startTimeOf(name) {
+  const n = (omc_eval(`getSimulationOptions(${name})`).match(/-?[0-9][0-9.eE+-]*/g) || []).map(Number);
+  return Number.isFinite(n[0]) ? n[0] : 0;
 }
 
 // The settings a run used, to seed the dialog: the explicit ones the page sent, or
@@ -360,19 +374,17 @@ self.onmessage = async (ev) => {
         break;
       }
       case 'simulate': {
-        // buildModel (translate + JIT, bakes the settings) then runResumable (a
-        // cancellable chunked run + `.mat`). Omitted args use the experiment annotation.
-        const opts = [];
-        if (a.stopTime) opts.push(`stopTime=${a.stopTime}`);
-        if (a.intervals) opts.push(`numberOfIntervals=${a.intervals}`);
-        if (a.tolerance) opts.push(`tolerance=${a.tolerance}`);
-        if (a.method) opts.push(`method="${a.method}"`);
+        // translateModelFMU (translate + JIT) then runResumable (a cancellable
+        // chunked run + `.mat`). The kernel it lowers is the very module an Export
+        // FMU links its adapter onto, so pressing Export costs a link and an XML
+        // render rather than a second translation. The experiment travels in the
+        // simflags rather than being baked in, so changing it needs no rebuild.
         const _tb = performance.now();
-        const built = (await evalWithDownloads(`buildModel(${a.name}${opts.length ? ',' + opts.join(',') : ''})`, status)).trim();
+        const built = (await evalWithDownloads(
+          `translateModelFMU(${a.name}, version="3.0", fmuType="me_cs", platforms={"wasm"})`, status)).trim();
         const buildMs = performance.now() - _tb;
-        // buildModel → {"<prefix>","<initfile>"}; an empty first element means it failed.
-        if (!/^\{\s*"[^"]/.test(built)) return reply(simError('Build failed.'));
-        logCompilerMessages('buildModel ' + a.name);
+        if (built !== 'true') return reply(simError('Build failed.'));
+        logCompilerMessages('translateModelFMU ' + a.name);
         const _ts = performance.now();
         const st = await runResumable(a.name, simflagsFor(a), status);
         const simMs = performance.now() - _ts;
@@ -434,6 +446,9 @@ self.onmessage = async (ev) => {
         // writing <name>.fmu into the VFS; read it back and hand the bytes to the
         // page to download. No server, no external toolchain. fmuType is me / cs /
         // me_cs; method is the embedded Co-Simulation solver.
+        // The compile step's translation is still in memory, so this renders the
+        // metadata and links an adapter onto that kernel — except for a pure
+        // Co-Simulation export, whose preOptModules differ (see the dialog's hint).
         status('Exporting FMU…');
         clearCancel();   // discard a cancel that raced in before this export
         const fmuType = a.fmuType || 'me';

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -4409,6 +4409,7 @@ protected
   SimCode.SimulationSettings simSettings;
   list<String> libs;
   String FMUType = inFMUType;
+  Boolean isWasmFMU = isWasmFMUExport(FMUVersion, platforms);
 algorithm
   cache := inCache;
   if not FMI.checkFMIVersion(FMUVersion) then
@@ -4449,12 +4450,25 @@ algorithm
     defaultSimOpt := buildSimulationOptionsFromModelExperimentAnnotation(className, filenameprefix, SOME(defaultSimulationOptions));
     simSettings := convertSimulationOptionsToSimCode(defaultSimOpt);
   end if;
+  // The wasm FMU export uses the wasm-jit code generator, as buildModelFMU does;
+  // the flag change is reverted by translateModelFMU's saveFlags wrapper.
+  if isWasmFMU then
+    FlagsUtil.setConfigString(Flags.SIMCODE_TARGET, "wasm-jit");
+    FlagsUtil.setConfigString(Flags.FMU_NATIVE_PLATFORMS, stringDelimitList(List.select(platforms, isNotWasmPlatform), ","));
+  end if;
   FlagsUtil.setConfigBool(Flags.BUILDING_FMU, true);
   FlagsUtil.setConfigString(Flags.FMI_VERSION, FMUVersion);
 
   try
-    (success, cache, libs, _, _) := SimCodeMain.translateModel(SimCodeMain.TranslateModelKind.FMU(FMUType, fmuTargetName),
+    (success, cache, libs, _, _) := SimCodeMain.translateModel(SimCodeMain.TranslateModelKind.FMU(FMUType, fmuTargetName, isWasmFMU),
                                             cache, inEnv, className, filenameprefix, true, false, true, SOME(simSettings));
+    // A wasm translation wrote no FMU: it lowered the model kernel and kept it,
+    // so force its JIT compile (and resolve its external "C") here, as
+    // buildModel's compile phase does. The model is then ready to simulate and
+    // the buildModelFMU that follows only links and renders.
+    if success and isWasmFMU then
+      CodegenWasmJit.finishCompile(filenameprefix);
+    end if;
     outValue := Values.STRING((if not Testsuite.isRunning() then System.pwd() + Autoconf.pathDelimiter else "") + fmuTargetName + ".fmu");
   else
     success :=false;
@@ -4650,7 +4664,9 @@ protected function fmuMethodToSimulationFlag
    Only a method the FMU can integrate with: C's `FMI2CS_initializeSolverData`
    takes `euler`/`cvode` and rejects the rest at instantiation (so a model's own
    `dassl` default must not become `s:dassl`); a wasm FMU serves the whole
-   wasm-jit driver set. An unaccepted method is left out — the FMU keeps euler."
+   wasm-jit driver set. An unaccepted method is left out, and the FMU falls back
+   to what it defaults to without one: euler for C, the model's own method (else
+   DASKR) for wasm."
   input String method;
   input Boolean isWasmFMU;
 protected
@@ -4775,7 +4791,7 @@ protected
   String filenameprefix, fmutmp, logfile, configureLogFile, dir, cmd;
   String fmuTargetName;
   SimCode.SimulationSettings simSettings;
-  list<String> libs;
+  list<String> libs = {} "the reuse path translates nothing, so nothing reports libraries";
   Boolean isWindows;
   Boolean needs3rdPartyLibs;
   Integer platformIndex, platformCount;
@@ -4786,6 +4802,8 @@ protected
   Boolean wasmRequested = listMember("wasm", platforms);
   Boolean wasmTarget = Config.simCodeTarget() == "wasm-jit" or Config.simCodeTarget() == "wasm";
   Boolean isWasmFMU = isWasmFMUExport(FMUVersion, platforms);
+  Option<SimCode.SimCode> keptSimCode;
+  SimCode.SimCode keptTranslation;
   // Reached through the target, the caller still wants an FMU the ordinary
   // tooling can load, so it gets this machine's platform too.
   list<String> nativePlatforms = if wasmRequested then List.select(platforms, isNotWasmPlatform) else {"native"};
@@ -4841,9 +4859,22 @@ algorithm
   end if;
   FlagsUtil.setConfigBool(Flags.BUILDING_FMU, true);
   FlagsUtil.setConfigString(Flags.FMI_VERSION, FMUVersion);
+  // A translateModelFMU of this model, this FMI version and this kind of
+  // interface, off the program still loaded and under the flags still set, has
+  // already done the translation: render the metadata and link the adapter onto
+  // the kernel it left rather than translating again. The flags are read after
+  // the munging above so both phases fingerprint the same state.
+  keptSimCode := if isWasmFMU then SimCodeMain.fmuTranslationFor(FMUVersion, FMUType, className, SOME(simSettings)) else NONE();
   try
-    (success, cache, libs, _, _) := SimCodeMain.translateModel(SimCodeMain.TranslateModelKind.FMU(FMUType, fmuTargetName),
-                                            cache, inEnv, className, filenameprefix, true, false, true, SOME(simSettings));
+    if isSome(keptSimCode) then
+      SOME(keptTranslation) := keptSimCode;
+      Error.addCompilerNotification("Exporting the translation translateModelFMU already made; the model is not translated again.");
+      SimCodeMain.emitWasmFMU(keptTranslation, FMUVersion, FMUType, SymbolTable.getAbsyn());
+      success := true;
+    else
+      (success, cache, libs, _, _) := SimCodeMain.translateModel(SimCodeMain.TranslateModelKind.FMU(FMUType, fmuTargetName, false),
+                                              cache, inEnv, className, filenameprefix, true, false, true, SOME(simSettings));
+    end if;
     true := success;
     outValue := Values.STRING((if not Testsuite.isRunning() then System.pwd() + Autoconf.pathDelimiter else "") + fmuTargetName + ".fmu");
   else
@@ -4865,9 +4896,11 @@ algorithm
 
   // wasm FMU: CodegenWasmJit.emitMeFmu already wrote the self-contained
   // <name>.fmu (component linked in Rust, ZIP assembled in Rust) — nothing to
-  // build or zip. Just confirm it exists.
+  // build or zip. Just confirm it exists. With --fmuDirectory it is an unzipped
+  // directory of that name instead.
   if isWasmFMU then
-    if not System.regularFileExists(fmuTargetName + ".fmu") then
+    if not (System.regularFileExists(fmuTargetName + ".fmu")
+            or (Flags.getConfigBool(Flags.FMU_DIRECTORY) and System.directoryExists(fmuTargetName + ".fmu"))) then
       Error.addMessage(Error.SIMULATOR_BUILD_ERROR, {"wasm FMU export produced no " + fmuTargetName + ".fmu"});
       outValue := Values.STRING("");
       return;

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -57,6 +57,8 @@ import SimCodeFunction;
 import NSimCode; /* used for new backend */
 
 protected
+import AbsynUtil;
+import Array;
 import Autoconf;
 import AvlSetString;
 import BackendDAECreate;
@@ -128,6 +130,21 @@ import SerializeTaskSystemInfo;
 import File;
 
 public
+uniontype FmuTranslation
+  "The FMU-grade translation translateModelFMU left behind, which the
+   buildModelFMU that follows exports instead of translating the model again."
+  record FMU_TRANSLATION
+    SimCode.SimCode simCode;
+    String FMUVersion;
+    String kind "cs, or other: the preOptModules differ only for a pure Co-Simulation export";
+    Absyn.Path className;
+    Absyn.Program ast "what it was translated from, by reference: any edit replaces the record";
+    array<Boolean> debugFlags;
+    array<Flags.FlagData> configFlags;
+  end FMU_TRANSLATION;
+end FmuTranslation;
+
+public
 uniontype TranslateModelKind
   record NORMAL
   end NORMAL;
@@ -136,6 +153,7 @@ uniontype TranslateModelKind
   record FMU
     String kind;
     String targetName;
+    Boolean translateOnly "keep the translation in memory instead of writing the FMU (translateModelFMU)";
   end FMU;
 end TranslateModelKind;
 
@@ -178,6 +196,7 @@ protected function generateModelCodeFMU "
   input String filenamePrefix;
   input String fmuTargetName;
   input Option<SimCode.SimulationSettings> simSettings;
+  input Boolean translateOnly = false;
   output list<String> libs;
   output String fileDir;
   output Real timeSimCode;
@@ -212,9 +231,9 @@ algorithm
   System.realtimeTick(ClockIndexes.RT_CLOCK_TEMPLATES);
   /*Temporary disabled omsi fmu and generate C-fmu for omsicpp simcodetarget*/
   if Config.simCodeTarget() == "omsicpp" then
-     callTargetTemplatesFMU(simCode, "C", FMUVersion, FMUType, p);
+     callTargetTemplatesFMU(simCode, "C", FMUVersion, FMUType, p, translateOnly);
   else
-    callTargetTemplatesFMU(simCode, Config.simCodeTarget(), FMUVersion, FMUType, p);
+    callTargetTemplatesFMU(simCode, Config.simCodeTarget(), FMUVersion, FMUType, p, translateOnly);
   end if;
   timeTemplates := System.realtimeTock(ClockIndexes.RT_CLOCK_TEMPLATES);
 end generateModelCodeFMU;
@@ -449,7 +468,7 @@ algorithm
         // Minimal ModelStructure (state derivatives + outputs) so an FMI master
         // can drive Model Exchange integration. TODO: add dependencies.
         oldSimCode.modelStructure := SimCodeUtil.createMinimalFMIModelStructure(oldSimCode.modelInfo);
-        callTargetTemplatesFMU(oldSimCode, Config.simCodeTarget(), FMI.getFMIVersionString(), fmuType, SymbolTable.getAbsyn());
+        callTargetTemplatesFMU(oldSimCode, Config.simCodeTarget(), FMI.getFMIVersionString(), fmuType, SymbolTable.getAbsyn(), kind.translateOnly);
       then ();
       else algorithm
         callTargetTemplates(oldSimCode, Config.simCodeTarget());
@@ -825,6 +844,188 @@ algorithm
   paths := listReverse(paths);
 end visualizationCadFiles;
 
+protected function fmuTranslationKind
+  "What of `fmuType` a translation depends on. `introduceOutputRealDerivatives` is
+   added for a pure Co-Simulation export and nothing else, so me and me_cs share
+   one translation."
+  input String FMUType;
+  output String kind = if FMI.isFMICSType(FMUType) and not FMI.isFMIMEType(FMUType) then "cs" else "other";
+end fmuTranslationKind;
+
+protected function fmuTranslationFlags
+  "The flag state a translation depends on, copied because Flags hands out the
+   live arrays.
+
+   BUILDING_MODEL is normalised out: `translateModelCallBackendOB` sets it on
+   itself and the scripting wrapper's `saveFlags` clears it again, so a snapshot
+   taken during a translation never matches one taken before the next. Another
+   flag a translation sets on itself would only make the export miss, which is
+   the safe direction."
+  output array<Boolean> debugFlags;
+  output array<Flags.FlagData> configFlags;
+protected
+  Integer buildingModel;
+algorithm
+  Flags.FLAGS(debugFlags = debugFlags, configFlags = configFlags) := Flags.getFlags();
+  debugFlags := arrayCopy(debugFlags);
+  configFlags := arrayCopy(configFlags);
+  Flags.CONFIG_FLAG(index = buildingModel) := Flags.BUILDING_MODEL;
+  arrayUpdate(configFlags, buildingModel, Flags.BOOL_FLAG(false));
+end fmuTranslationFlags;
+
+public function keepFmuTranslation
+  "Remember this translation for the buildModelFMU that follows. The Absyn program
+   is kept by reference, since its identity is exactly the staleness test."
+  input SimCode.SimCode simCode;
+  input String FMUVersion;
+  input String FMUType;
+  input Absyn.Path className;
+protected
+  array<Boolean> debugFlags;
+  array<Flags.FlagData> configFlags;
+algorithm
+  (debugFlags, configFlags) := fmuTranslationFlags();
+  setGlobalRoot(Global.fmuTranslation, SOME(FMU_TRANSLATION(simCode, FMUVersion, fmuTranslationKind(FMUType),
+    className, SymbolTable.getAbsyn(), debugFlags, configFlags)));
+end keepFmuTranslation;
+
+protected function sameFmuSettings
+  "Whether two SimulationSettings describe the same translation. `method` is left
+   out: it reaches the model kernel and not modelDescription.xml, and the emitter
+   re-lowers the kernel for a method the kept one was not built with — so choosing
+   a Co-Simulation solver at export costs a lowering rather than a translation."
+  input Option<SimCode.SimulationSettings> a;
+  input Option<SimCode.SimulationSettings> b;
+  output Boolean same;
+protected
+  SimCode.SimulationSettings x, y;
+algorithm
+  same := match (a, b)
+    case (SOME(x), SOME(y))
+      algorithm
+        x.method := "";
+        y.method := "";
+      then valueEq(x, y);
+    case (NONE(), NONE()) then true;
+    else false;
+  end match;
+end sameFmuSettings;
+
+public function fmuTranslationFor
+  "The kept translation when it is the one this export needs: same class, same FMI
+   version, same kind of interface and the same experiment, translated from the
+   program still loaded and under the flags still set. NONE() otherwise, and then
+   the caller translates."
+  input String FMUVersion;
+  input String FMUType;
+  input Absyn.Path className;
+  input Option<SimCode.SimulationSettings> settings;
+  output Option<SimCode.SimCode> simCode = NONE();
+protected
+  array<Boolean> debugFlags;
+  array<Flags.FlagData> configFlags;
+  Option<FmuTranslation> kept = getGlobalRoot(Global.fmuTranslation) "getGlobalRoot is untyped: the match subject needs a declared type";
+algorithm
+  () := match kept
+    local
+      FmuTranslation t;
+    case SOME(t as FMU_TRANSLATION())
+      guard AbsynUtil.pathEqual(t.className, className)
+            and t.FMUVersion == FMUVersion
+            and t.kind == fmuTranslationKind(FMUType)
+            and referenceEq(t.ast, SymbolTable.getAbsyn())
+            and sameFmuSettings(t.simCode.simulationSettingsOpt, settings)
+      algorithm
+        (debugFlags, configFlags) := fmuTranslationFlags();
+        if Array.isEqual(t.debugFlags, debugFlags) and Array.isEqual(t.configFlags, configFlags) then
+          simCode := SOME(t.simCode);
+        end if;
+      then ();
+    else ();
+  end match;
+end fmuTranslationFor;
+
+public function wasmFMUSimulationFlagsJson
+  "The resources/<prefix>_flags.json a wasm FMU ships, the same one the C export
+   does. The emitter applies its `s` flag at export, since the component is linked
+   against one solver and cannot pick another at run time."
+  input SimCode.SimCode simCode;
+  output String json;
+algorithm
+  json := match simCode.fmiSimulationFlags
+    local
+      SimCode.FmiSimulationFlags flags;
+      String path;
+    case SOME(SimCode.FMI_SIMULATION_FLAGS_FILE(path=path)) then System.readFile(path);
+    case SOME(flags as SimCode.FMI_SIMULATION_FLAGS()) then
+      Tpl.textString(CodegenFMUCommon.fmuSimulationFlagsFile(Tpl.emptyTxt, flags));
+    else "";
+  end match;
+end wasmFMUSimulationFlagsJson;
+
+public function emitWasmFMU
+  "Render the FMI metadata and write the self-contained <name>.fmu: link the model
+   kernel with the adapter into an fmi-ls-wasm component (host-free, all in Rust —
+   no external wasm-merge/zip). Called either straight after the translation or,
+   when translateModelFMU already did that translation, against the SimCode it
+   kept — so the export is a link and an XML render rather than a second
+   translation."
+  input SimCode.SimCode simCode;
+  input String FMUVersion;
+  input String FMUType;
+  input Absyn.Program program;
+protected
+  String guid, modelDescriptionStr, simulationFlagsJson, htmlFile, htmlContent;
+  list<tuple<String,String>> extraFiles = {};
+  list<SimCode.FmiTerminal> terminals;
+  // `--fmuDirectory`: an export for an OpenModelica importer, which reads the
+  // model description and the artifact and nothing else.
+  Boolean bareExport = Flags.getConfigBool(Flags.FMU_DIRECTORY);
+algorithm
+  // The templates look the SimCode up through getSimCode(); an export off a kept
+  // translation has no callTargetTemplatesFMU around it to have set it.
+  setGlobalRoot(Global.optionSimCode, SOME(simCode));
+  guid := System.getUUIDStr();
+  // The same templates the C target uses, so the XML is byte-identical to it. No
+  // sourceFiles: a wasm FMU carries no C. The XML declaration comes from
+  // fmuModelDescriptionFile, which the C target reaches these through.
+  if FMI.isFMIVersion20(FMUVersion) then
+    modelDescriptionStr := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + Tpl.textString(
+      CodegenFMU2.fmiModelDescription(Tpl.emptyTxt, simCode, guid, FMUType, {}));
+  else
+    modelDescriptionStr := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + Tpl.textString(
+      CodegenFMU3.fmiModelDescription(Tpl.emptyTxt, simCode, guid, FMUType, {}));
+    ExecStat.execStat("FMU modelDescription.xml");
+    // The same XML the C target writes into terminalsAndIcons/. FMI 3.0 only. An
+    // unzipped export carries neither this nor the documentation, so it does not
+    // render them either.
+    if not bareExport then
+      terminals := SimCodeUtil.getFMI3Terminals(simCode);
+      if not listEmpty(terminals) then
+        extraFiles := ("terminalsAndIcons/terminalsAndIcons.xml",
+                       Tpl.textString(CodegenFMU3.fmiTerminalsAndIcons(Tpl.emptyTxt, terminals))) :: extraFiles;
+      end if;
+      ExecStat.execStat("FMU terminalsAndIcons.xml");
+    end if;
+  end if;
+  if not bareExport then
+    (htmlFile, htmlContent) := htmlDocumentation(program, simCode, FMUVersion);
+    if htmlFile <> "" then
+      extraFiles := ("documentation/" + htmlFile, htmlContent) :: extraFiles;
+    end if;
+    ExecStat.execStat("FMU documentation");
+  end if;
+  simulationFlagsJson := wasmFMUSimulationFlagsJson(simCode);
+  if FMI.isFMIMEType(FMUType) and FMI.isFMICSType(FMUType) then
+    CodegenWasmJit.emitMeCsFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, extraFiles, simulationFlagsJson);
+  elseif FMI.isFMICSType(FMUType) then
+    CodegenWasmJit.emitCsFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, extraFiles, simulationFlagsJson);
+  else
+    CodegenWasmJit.emitMeFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, extraFiles, simulationFlagsJson);
+  end if;
+  setGlobalRoot(Global.optionSimCode, NONE());
+end emitWasmFMU;
+
 protected function callTargetTemplatesFMU
 "Generate target code by passing the SimCode data structure to templates."
   input SimCode.SimCode simCode;
@@ -832,6 +1033,7 @@ protected function callTargetTemplatesFMU
   input String FMUVersion;
   input String FMUType;
   input Absyn.Program program;
+  input Boolean translateOnly = false "keep the translation in memory instead of writing the FMU";
 protected
   // "wasm" is the standalone simulation target and has no FMU export of its own;
   // an FMU built under it is the same fmi-ls-wasm component "wasm-jit" emits.
@@ -844,10 +1046,7 @@ algorithm
       String str, newdir, newpath, resourcesDir, dirname, htmlFile;
       String fmutmp;
       String guid;
-      String modelDescriptionStr;
-      String simulationFlagsJson;
       String htmlContent;
-      list<tuple<String,String>> extraFiles;
       list<SimCode.FmiTerminal> terminals;
       Boolean b;
       Boolean needSundials = false;
@@ -863,50 +1062,15 @@ algorithm
       SimCode.VarInfo varInfo;
     case (SimCode.SIMCODE(),"wasm-jit")
       algorithm
-        // wasm FMU export: link the model with the adapter into an fmi-ls-wasm
-        // component and write the self-contained <name>.fmu (host-free, all in
-        // Rust — no external wasm-merge/zip).
-        guid := System.getUUIDStr();
-        extraFiles := {};
-        // The same templates the C target uses, so the XML is byte-identical to
-        // it. No sourceFiles: a wasm FMU carries no C. The XML declaration comes
-        // from fmuModelDescriptionFile, which the C target reaches these through.
-        if FMI.isFMIVersion20(FMUVersion) then
-          modelDescriptionStr := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + Tpl.textString(
-            CodegenFMU2.fmiModelDescription(Tpl.emptyTxt, simCode, guid, FMUType, {}));
+        // Keep the translation either way: the export that follows — a second one
+        // of this model, or the first after a translateModelFMU — then links an
+        // adapter onto this kernel instead of translating again.
+        if translateOnly then
+          CodegenWasmJit.translateFmu(simCode, FMUType, wasmFMUSimulationFlagsJson(simCode));
         else
-          modelDescriptionStr := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + Tpl.textString(
-            CodegenFMU3.fmiModelDescription(Tpl.emptyTxt, simCode, guid, FMUType, {}));
-          // The same XML the C target writes into terminalsAndIcons/. FMI 3.0 only.
-          terminals := SimCodeUtil.getFMI3Terminals(simCode);
-          if not listEmpty(terminals) then
-            extraFiles := ("terminalsAndIcons/terminalsAndIcons.xml",
-                           Tpl.textString(CodegenFMU3.fmiTerminalsAndIcons(Tpl.emptyTxt, terminals))) :: extraFiles;
-          end if;
+          emitWasmFMU(simCode, FMUVersion, FMUType, program);
         end if;
-        (htmlFile, htmlContent) := htmlDocumentation(program, simCode, FMUVersion);
-        if htmlFile <> "" then
-          extraFiles := ("documentation/" + htmlFile, htmlContent) :: extraFiles;
-        end if;
-        // The same resources/<prefix>_flags.json the C export ships; the emitter
-        // applies its `s` flag at export, since the component is linked against
-        // one solver and cannot pick another at run time.
-        simulationFlagsJson := match simCode.fmiSimulationFlags
-          local
-            SimCode.FmiSimulationFlags flags;
-            String path;
-          case SOME(SimCode.FMI_SIMULATION_FLAGS_FILE(path=path)) then System.readFile(path);
-          case SOME(flags as SimCode.FMI_SIMULATION_FLAGS()) then
-            Tpl.textString(CodegenFMUCommon.fmuSimulationFlagsFile(Tpl.emptyTxt, flags));
-          else "";
-        end match;
-        if FMI.isFMIMEType(FMUType) and FMI.isFMICSType(FMUType) then
-          CodegenWasmJit.emitMeCsFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, extraFiles, simulationFlagsJson);
-        elseif FMI.isFMICSType(FMUType) then
-          CodegenWasmJit.emitCsFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, extraFiles, simulationFlagsJson);
-        else
-          CodegenWasmJit.emitMeFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, extraFiles, simulationFlagsJson);
-        end if;
+        keepFmuTranslation(simCode, FMUVersion, FMUType, simCode.modelInfo.name);
       then ();
 
     case (SimCode.SIMCODE(),"C")
@@ -1653,7 +1817,7 @@ algorithm
         case TranslateModelKind.FMU()
           algorithm
 
-            (libs,file_dir,timeSimCode,timeTemplates) := generateModelCodeFMU(dlow, initDAE, initDAE_lambda0, fmiDer, removedInitialEquationLst, SymbolTable.getAbsyn(), className, FMI.getFMIVersionString(), kind.kind, inFileNamePrefix, kind.targetName, inSimSettingsOpt);
+            (libs,file_dir,timeSimCode,timeTemplates) := generateModelCodeFMU(dlow, initDAE, initDAE_lambda0, fmiDer, removedInitialEquationLst, SymbolTable.getAbsyn(), className, FMI.getFMIVersionString(), kind.kind, inFileNamePrefix, kind.targetName, inSimSettingsOpt, kind.translateOnly);
           then (libs, file_dir, timeSimCode, timeTemplates);
         case TranslateModelKind.XML()
           algorithm

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -14877,6 +14877,60 @@ algorithm
   outValueReference := String(offset + localRef);
 end getFMI3ValueReference;
 
+protected function fmi3ModelVariableLists
+  "The variable lists in the order the FMI indices were handed out."
+  input SimCodeVar.SimVars vars;
+  output list<list<SimCodeVar.SimVar>> allLists;
+algorithm
+  allLists := {vars.stateVars, vars.derivativeVars, vars.algVars, vars.discreteAlgVars,
+               vars.intAlgVars, vars.boolAlgVars, vars.stringAlgVars,
+               vars.inputVars, vars.outputVars,
+               vars.paramVars, vars.intParamVars, vars.boolParamVars, vars.stringParamVars,
+               vars.aliasVars, vars.intAliasVars, vars.boolAliasVars, vars.stringAliasVars};
+end fmi3ModelVariableLists;
+
+public function cacheFMI3ValueReferences
+  "Build the FMI index -> value reference table the <ModelStructure> emitter reads,
+   and keep it for as long as one is being written (see clearFMI3ValueReferences).
+
+   Without it every unknown and every one of its dependencies searches all
+   seventeen variable lists for its index, which on a model with thousands of
+   variables is most of what exporting an FMI 3.0 FMU costs: FullRobot spent 15 of
+   its 33 export seconds in that search."
+  input SimCode.SimCode simCode;
+  // Susan calls this for its effect; the empty string is what it interpolates.
+  output String dummy = "";
+protected
+  list<list<SimCodeVar.SimVar>> allLists = fmi3ModelVariableLists(simCode.modelInfo.vars);
+  array<String> table;
+  Integer n = 0, i;
+algorithm
+  for lst in allLists loop
+    for v in lst loop
+      n := intMax(n, getVariableFMIIndex(v));
+    end for;
+  end for;
+  // Index 0 is no variable's, so an unmapped entry keeps its own number as the
+  // uncached lookup did.
+  table := arrayCreate(n, "");
+  for lst in allLists loop
+    for v in lst loop
+      i := getVariableFMIIndex(v);
+      if i > 0 and i <= n and stringEmpty(arrayGet(table, i)) then
+        arrayUpdate(table, i, getFMI3ValueReference(v, simCode));
+      end if;
+    end for;
+  end for;
+  setGlobalRoot(Global.fmi3ValueReferenceCache, SOME(table));
+end cacheFMI3ValueReferences;
+
+public function clearFMI3ValueReferences
+  "Drop what cacheFMI3ValueReferences built, so the next model builds its own."
+  output String dummy = "";
+algorithm
+  setGlobalRoot(Global.fmi3ValueReferenceCache, NONE());
+end clearFMI3ValueReferences;
+
 public function getFMI3ValueReferenceFromFMIIndex
   "Maps an FMI variable index (the 1-based position in the ModelVariables list as
    stored in the FmiModelStructure unknowns/dependencies) to the globally unique
@@ -14890,17 +14944,20 @@ public function getFMI3ValueReferenceFromFMIIndex
   input Integer inFMIIndex;
   output String outValueReference;
 protected
-  SimCode.ModelInfo modelInfo = inSimCode.modelInfo;
-  SimCodeVar.SimVars vars = modelInfo.vars;
-  list<list<SimCodeVar.SimVar>> allLists;
+  SimCodeVar.SimVars vars = inSimCode.modelInfo.vars;
+  Option<array<String>> cache;
+  array<String> table;
   Option<SimCodeVar.SimVar> found = NONE();
 algorithm
-  allLists := {vars.stateVars, vars.derivativeVars, vars.algVars, vars.discreteAlgVars,
-               vars.intAlgVars, vars.boolAlgVars, vars.stringAlgVars,
-               vars.inputVars, vars.outputVars,
-               vars.paramVars, vars.intParamVars, vars.boolParamVars, vars.stringParamVars,
-               vars.aliasVars, vars.intAliasVars, vars.boolAliasVars, vars.stringAliasVars};
-  for lst in allLists loop
+  cache := getGlobalRoot(Global.fmi3ValueReferenceCache);
+  if isSome(cache) then
+    SOME(table) := cache;
+    if inFMIIndex > 0 and inFMIIndex <= arrayLength(table) and not stringEmpty(arrayGet(table, inFMIIndex)) then
+      outValueReference := arrayGet(table, inFMIIndex);
+      return;
+    end if;
+  end if;
+  for lst in fmi3ModelVariableLists(vars) loop
     for v in lst loop
       if intEq(getVariableFMIIndex(v), inFMIIndex) then
         found := SOME(v);
@@ -15732,28 +15789,119 @@ algorithm
   end match;
 end isFMI3NestableAlias;
 
-public function getFMI3VariableAliases
-  "Return the SimVars that are FMI 3.0 <Alias> members of the variable `canonical`:
-   the nestable (see isFMI3NestableAlias) positive aliases whose alias target is
-   `canonical`. FMI 3.0 represents these as <Alias> child elements sharing the
-   canonical variable's valueReference, rather than as separate variables."
+protected function fmi3AliasTargetValueReference
+  "The value reference the nestable alias `v` shares with its target, i.e. the
+   value reference of the canonical variable it is an <Alias> of. `None` when the
+   target is not a variable this FMU exports."
+  input SimCodeVar.SimVar v;
   input SimCode.SimCode simCode;
-  input DAE.ComponentRef canonical;
+  output Option<Integer> vr;
+algorithm
+  vr := match v.aliasvar
+    local
+      DAE.ComponentRef cr;
+      Integer local_;
+    case SimCodeVar.ALIAS(varName = cr)
+      then match AvlTreeCRToInt.getOpt(simCode.valueReferences, cr)
+        case SOME(local_) then SOME(getFMI3TypeOffset(v.type_, simCode.modelInfo) + local_);
+        else NONE();
+      end match;
+    else NONE();
+  end match;
+end fmi3AliasTargetValueReference;
+
+public function cacheFMI3VariableAliases
+  "Build the value reference -> <Alias> members table getFMI3VariableAliases reads,
+   and keep it for as long as one modelDescription.xml is being written (see
+   clearFMI3VariableAliases).
+
+   Without it every variable emitted searches every alias the model has for the
+   ones nested under it, which is quadratic and is what rendering an FMI 3.0
+   modelDescription.xml costs: 14 of FullRobot's 24 export seconds."
+  input SimCode.SimCode simCode;
+  // Susan calls this for its effect; the empty string is what it interpolates.
+  output String dummy = "";
+protected
+  SimCodeVar.SimVars vars = simCode.modelInfo.vars;
+  list<list<SimCodeVar.SimVar>> aliasLists =
+    {vars.aliasVars, vars.intAliasVars, vars.boolAliasVars, vars.stringAliasVars};
+  array<list<SimCodeVar.SimVar>> table;
+  Integer n = 0, vr;
+algorithm
+  // Two passes: the table is indexed by value reference, whose range is only
+  // known once every alias has been resolved.
+  for lst in aliasLists loop
+    for v in lst loop
+      if isFMI3NestableAlias(v) then
+        n := match fmi3AliasTargetValueReference(v, simCode) case SOME(vr) then intMax(n, vr + 1); else n; end match;
+      end if;
+    end for;
+  end for;
+  table := arrayCreate(n, {});
+  for lst in aliasLists loop
+    for v in lst loop
+      if isFMI3NestableAlias(v) then
+        _ := match fmi3AliasTargetValueReference(v, simCode)
+          case SOME(vr)
+            algorithm arrayUpdate(table, vr + 1, v :: arrayGet(table, vr + 1)); then ();
+          else ();
+        end match;
+      end if;
+    end for;
+  end for;
+  for i in 1:n loop
+    arrayUpdate(table, i, listReverse(arrayGet(table, i)));
+  end for;
+  setGlobalRoot(Global.fmi3VariableAliasCache, SOME(table));
+end cacheFMI3VariableAliases;
+
+public function clearFMI3VariableAliases
+  "Drop what cacheFMI3VariableAliases built, so the next model builds its own."
+  output String dummy = "";
+algorithm
+  setGlobalRoot(Global.fmi3VariableAliasCache, NONE());
+end clearFMI3VariableAliases;
+
+public function getFMI3VariableAliases
+  "Return the SimVars that are FMI 3.0 <Alias> members of `canonical`: the nestable
+   (see isFMI3NestableAlias) positive aliases whose alias target is `canonical`.
+   FMI 3.0 represents these as <Alias> child elements sharing the canonical
+   variable's valueReference, rather than as separate variables."
+  input SimCode.SimCode simCode;
+  input SimCodeVar.SimVar canonical;
   output list<SimCodeVar.SimVar> aliases = {};
 protected
   SimCodeVar.SimVars vars = simCode.modelInfo.vars;
-  list<SimCodeVar.SimVar> all;
+  Option<array<list<SimCodeVar.SimVar>>> cached;
+  array<list<SimCodeVar.SimVar>> table;
+  Integer vr;
 algorithm
-  all := List.flatten({vars.aliasVars, vars.intAliasVars, vars.boolAliasVars, vars.stringAliasVars});
-  for v in all loop
-    if isFMI3NestableAlias(v) then
-      _ := match v.aliasvar
-        local DAE.ComponentRef cr;
-        case SimCodeVar.ALIAS(varName = cr) guard ComponentReferenceBasics.crefEqualNoStringCompare(cr, canonical)
-          algorithm aliases := v :: aliases; then ();
-        else ();
-      end match;
+  cached := getGlobalRoot(Global.fmi3VariableAliasCache);
+  if isSome(cached) then
+    SOME(table) := cached;
+    vr := getFMI3TypeOffset(canonical.type_, simCode.modelInfo)
+          + (match AvlTreeCRToInt.getOpt(simCode.valueReferences, canonical.name)
+             local Integer local_;
+             case SOME(local_) then local_;
+             else -1;
+             end match);
+    if vr >= 0 and vr < arrayLength(table) then
+      aliases := arrayGet(table, vr + 1);
     end if;
+    return;
+  end if;
+  for lst in {vars.aliasVars, vars.intAliasVars, vars.boolAliasVars, vars.stringAliasVars} loop
+    for v in lst loop
+      if isFMI3NestableAlias(v) then
+        _ := match v.aliasvar
+          local DAE.ComponentRef cr;
+          case SimCodeVar.ALIAS(varName = cr)
+            guard ComponentReferenceBasics.crefEqualNoStringCompare(cr, canonical.name)
+            algorithm aliases := v :: aliases; then ();
+          else ();
+        end match;
+      end if;
+    end for;
   end for;
   aliases := listReverse(aliases);
 end getFMI3VariableAliases;

--- a/OMCompiler/Compiler/Template/CodegenFMU3.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU3.tpl
@@ -107,12 +107,27 @@ case SIMCODE(__) then
     </LogCategories>
     >> %>
     <%DefaultExperiment3(simulationSettingsOpt)%>
-    <%fmiModelVariables3(simCode, FMUType)%>
-    <%modelStructure3(simCode, modelStructure)%>
+    <%fmiModelVariablesAndStructure3(simCode, FMUType, modelStructure)%>
     <%fmiOpenModelicaAnnotations(simCode)%>
   </fmiModelDescription>
   >>
 end fmiModelDescription;
+
+template fmiModelVariablesAndStructure3(SimCode simCode, String FMUType, Option<FmiModelStructure> modelStructure)
+ "<ModelVariables> and <ModelStructure>, with the two tables they are looked up
+  through built for the length of them: each variable asks which aliases nest
+  under it, and each structure entry asks which value reference its index is, and
+  both answers are a search of every variable the model has without a table."
+::=
+  let _ = SimCodeUtil.cacheFMI3VariableAliases(simCode)
+  let variables = fmiModelVariables3(simCode, FMUType)
+  let structure = modelStructure3(simCode, modelStructure)
+  let _ = SimCodeUtil.clearFMI3VariableAliases()
+  <<
+  <%variables%>
+  <%structure%>
+  >>
+end fmiModelVariablesAndStructure3;
 
 template fmiOpenModelicaAnnotations(SimCode simCode)
  "OpenModelica vendor annotations (<Figures> and <Visualization>) under one Tool
@@ -578,7 +593,7 @@ template AliasElements3(SimVar simVar, SimCode simCode)
 ::=
 match simVar
 case SIMVAR(__) then
-  match SimCodeUtil.getFMI3VariableAliases(simCode, name)
+  match SimCodeUtil.getFMI3VariableAliases(simCode, simVar)
   case {} then ''
   case aliases then (aliases |> a => AliasElement3(a) ;separator="\n")
 end AliasElements3;
@@ -723,12 +738,20 @@ template modelStructure3(SimCode simCode, Option<FmiModelStructure> fmiModelStru
 ::=
 match fmiModelStructure
 case SOME(fmistruct as FMIMODELSTRUCTURE(__)) then
+  // Every entry below looks its index up; without the table each lookup searches
+  // every variable the model has.
+  let _ = SimCodeUtil.cacheFMI3ValueReferences(simCode)
+  let outputs = ModelStructureOutputs3(simCode, fmistruct.fmiOutputs)
+  let derivatives = ModelStructureDerivatives3(simCode, fmistruct.fmiDerivatives)
+  let initials = ModelStructureInitialUnknowns3(simCode, fmistruct.fmiInitialUnknowns)
+  let indicators = EventIndicators3(simCode)
+  let _ = SimCodeUtil.clearFMI3ValueReferences()
   <<
   <ModelStructure>
-    <%ModelStructureOutputs3(simCode, fmistruct.fmiOutputs)%>
-    <%ModelStructureDerivatives3(simCode, fmistruct.fmiDerivatives)%>
-    <%ModelStructureInitialUnknowns3(simCode, fmistruct.fmiInitialUnknowns)%>
-    <%EventIndicators3(simCode)%>
+    <%outputs%>
+    <%derivatives%>
+    <%initials%>
+    <%indicators%>
   </ModelStructure>
   >>
 else

--- a/OMCompiler/Compiler/Template/CodegenWasmJit.mo
+++ b/OMCompiler/Compiler/Template/CodegenWasmJit.mo
@@ -98,6 +98,23 @@ algorithm
   fail();
 end emitStandalone;
 
+function translateFmu
+  " Lower the model in `simCode` to the WebAssembly kernel a wasm FMU is built
+    around and keep it in-process, without writing an FMU: the wasm counterpart of
+    the C target generating the FMU sources without building them
+    (translateModelFMU). The buildModelFMU that follows links an adapter onto this
+    kernel rather than translating the model a second time, and unless the model
+    has external \"C\" the kernel is also registered as the prepared simulation
+    model, so `simulate` runs the very module the FMU will carry. Implemented in
+    Rust. "
+  input SimCode.SimCode simCode;
+  input String fmuType "me, cs or me_cs: a pure Co-Simulation kernel embeds a different driver";
+  input String simulationFlagsJson "--fmiFlags as CodegenFMU renders it, empty when there are none";
+algorithm
+  Error.addInternalError("CodegenWasmJit.translateFmu: the wasm FMU target is only implemented in the Rust omc build", sourceInfo());
+  fail();
+end translateFmu;
+
 function emitMeFmu
   " wasm Model-Exchange export: lower the model, link it with the
     model-agnostic ME adapter into an fmi-ls-wasm component

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -1465,6 +1465,24 @@ package SimCodeUtil
     output String outValueReference;
   end getFMI3ValueReferenceFromFMIIndex;
 
+  function cacheFMI3ValueReferences
+    input SimCode.SimCode simCode;
+    output String dummy;
+  end cacheFMI3ValueReferences;
+
+  function clearFMI3ValueReferences
+    output String dummy;
+  end clearFMI3ValueReferences;
+
+  function cacheFMI3VariableAliases
+    input SimCode.SimCode simCode;
+    output String dummy;
+  end cacheFMI3VariableAliases;
+
+  function clearFMI3VariableAliases
+    output String dummy;
+  end clearFMI3VariableAliases;
+
   function numScalarElems
     input list<SimCodeVar.SimVar> vars;
     output Integer n;
@@ -1503,7 +1521,7 @@ package SimCodeUtil
 
   function getFMI3VariableAliases
     input SimCode.SimCode simCode;
-    input DAE.ComponentRef canonical;
+    input SimCodeVar.SimVar canonical;
     output list<SimCodeVar.SimVar> aliases;
   end getFMI3VariableAliases;
 

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1448,6 +1448,9 @@ constant ConfigFlag FMU_NATIVE_PLATFORMS = CONFIG_FLAG(171,
 constant ConfigFlag TPL_OUTPUT_DIR = CONFIG_FLAG(172, "tplOutputDir",
   NONE(), EXTERNAL(), STRING_FLAG(""), NONE(),
   "Directory the .mo generated from a Susan .tpl is written to. Empty (the\ndefault) writes it next to the .tpl, which is how the templates used to be\ngenerated into the source tree.");
+constant ConfigFlag FMU_DIRECTORY = CONFIG_FLAG(173, "fmuDirectory",
+  NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
+  "Write an exported FMU as an unzipped directory named <prefix>.fmu rather than\na zip file. An importer that reads a directory (OpenModelica's own does) then\npays neither the compression nor the extraction, which for a wasm FMU carrying a\nprecompiled artifact is most of what packing it costs. wasm FMUs only.");
 
 function getFlags
   "Loads the flags with getGlobalRoot. Assumes flags have been loaded."

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -442,7 +442,8 @@ constant list<Flags.ConfigFlag> allConfigFlags = {
   Flags.FMU_VERSION,
   Flags.TEARING_COST_MARGIN,
   Flags.FMU_NATIVE_PLATFORMS,
-  Flags.TPL_OUTPUT_DIR
+  Flags.TPL_OUTPUT_DIR,
+  Flags.FMU_DIRECTORY
 };
 
 public function new


### PR DESCRIPTION
`buildModelFMU(M, fmuType="me_cs", version="3.0")` under `--simCodeTarget=wasm-jit` writes one artifact, and `simulate(M, resimulateExecutable="M.fmu", simflags="-s ...")` runs it without translating the model again:

| `-s` | what runs |
| --- | --- |
| absent, or a solver | the artifact's own runtime, in wasm | | `fmi3:me[:solver]` | Model Exchange, omc integrating | | `fmi3:cs` | Co-Simulation, the artifact integrating |

The third face is new: `om:sim/simulation.run` decodes the model's embedded metadata and drives `sim_meta::driver` -- the driver a wasm-jit simulation runs -- inside the artifact, serializing the `.mat` with the writer the standalone export uses. The FMI faces are driven by the masters that drive an imported FMU.

`--fmuDirectory` writes it unzipped, holding only what an OpenModelica importer reads: no zip to deflate or inflate, no loader library, no documentation or icons (no longer even rendered). It is then not a component either, but the model kernel alone, which the host links against the FMI 3.0 adapter built as a dylink library exporting the C API (`openmodelica_fmi3_wasm`'s `capi` feature). Being a *fixed* library the adapter takes the on-disk `.cwasm` cache the simulation runtime and the `external "C"` libraries already use, so this machine compiles it once rather than into every model. `OMC_WASM_LINKED_ARTIFACT=0` asks for a component, which any FMI tool can also open.

Three things the linking has to get right, each found by measuring:

* The model is **not** a dylink library. As one, its data would go behind `__memory_base` and its calls through the indirect table, in the loop that dominates a run: a bouncing ball went 5.6ms -> 339ms. It is instantiated as the ordinary simulation path instantiates it.
* The order is `external "C"` libraries, then the model, then the adapter -- each imports the one before it.
* Linking is a relocation pass and not free (75ms for the adapter, 660ms with the tables), so the runs of one artifact share it and free the FMI instance between them: 660ms -> 0.1ms.

Most of what exporting an FMI 3.0 FMU cost was searching the variable lists. `<Alias>` nests a variable's positive aliases under the canonical one, and the emitter asked, for each of FullRobot's 3451 variables, which of the ~2500 aliases belonged to it -- by flattening all four alias lists and scanning them. `<ModelStructure>` did the same per unknown and per dependency, searching all seventeen lists for an FMI index.

Both now read a table built once per document and dropped at the end of it, so its lifetime is exactly the one being written and no model can see another's:

| built by | keyed on | read by |
| --- | --- | --- |
| `cacheFMI3VariableAliases` | value reference | `getFMI3VariableAliases` | | `cacheFMI3ValueReferences` | FMI index | `getFMI3ValueReferenceFromFMIIndex` |

`getFMI3VariableAliases` takes the canonical `SimVar` rather than its cref, since the value reference it keys on needs the variable's type. Both keep their uncached path for a caller that has built no table. The **C** FMI 3.0 export gets this too: rendering `modelDescription.xml` for FullRobot goes from 14.23s to 0.64s.

Export over what translating the same model costs, and the artifact:

| model | before | after | artifact |
| --- | --- | --- | --- |
| CauerLowPassAnalog | +0.47s | +0.00s | 0.03 MB | | CoupledClutches | +1.34s | +0.00s | 0.1 MB |
| DoublePendulum | +1.19s | +0.60s | 0.5 MB |
| FullRobot | +3.97s | +1.72s | 2.3 MB |

with load 0.1-0.4ms and instantiate 0.1-4ms. Model Exchange and Co-Simulation match the component; the artifact's own runtime is ~1.3x slower, that driver being inside the PIC adapter. `-d=execstat` reports the FMU-specific phases, which is what made any of this visible rather than deduced.

A Co-Simulation wasm FMU no longer defaults to euler: its embedded driver has the solvers a simulation has, so it keeps the model's own method and falls back to DASKR only for one it cannot step to a communication point. C defaults to euler because `fmu_read_flags.c` knows no other.

Verified against the C runtime on a bouncing ball (`h(3)` bit-identical through the artifact's own runtime, 1e-12 through Co-Simulation) and against the ordinary wasm-jit run on FullRobot, all three faces within `diffSimulationResults`' 1e-3. `external "C"` covered by TestCombiTable1D, TestExtGamma and FullRobot's tables.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
