### PR TITLE
wasm-jit: FMI 3.0 import, terminals, assert unwind

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -427,6 +427,7 @@ fn capture_last_sim(model: &SimModel, run: &sim_driver::RunResult, keep: &[bool]
     let params: Vec<CapturedParam> = model
         .editable_params
         .iter()
+        .filter(|p| !p.is_string)
         .map(|p| CapturedParam {
             name: p.name.clone(),
             comment: p.comment.clone(),
@@ -925,8 +926,9 @@ fn result_path(flags: &simflags::SimFlags, meta: &SimMeta, derived: &str) -> Str
 }
 
 /// Resolve each `-override=name=value` to its editable parameter's `SimData` slot.
-/// Returns `(param_overrides, start_overrides)`: plain parameters vs. state start
-/// values, applied at different points of initialization (see `run_initialization`).
+/// Returns `(param_overrides, start_overrides, string_overrides)`: plain parameters
+/// vs. state start values, applied at different points of initialization (see
+/// `run_initialization`), and the String parameters, whose value is bytes.
 ///
 /// C's `doOverride` also reports what it could not do, walking the `_init.xml`
 /// quantities in class order. The result signals are that roster in that order,
@@ -934,7 +936,7 @@ fn result_path(flags: &simflags::SimFlags, meta: &SimMeta, derived: &str) -> Str
 fn resolve_overrides(
     model: &SimModel,
     flags: &simflags::SimFlags,
-) -> (Vec<(u32, WTy, f64)>, Vec<(u32, WTy, f64)>) {
+) -> (Vec<(u32, WTy, f64)>, Vec<(u32, WTy, f64)>, Vec<(u32, String)>) {
     let raw = flags.override_raw.as_deref();
     let file = flags.override_file.as_ref();
     if let (Some(raw), Some((path, _))) = (raw, file) {
@@ -945,7 +947,7 @@ fn resolve_overrides(
     }
     if raw.is_none() && file.is_none() {
         omclog::info(omclog::SOLVER, false, "NO override given on the command line.");
-        return (Vec::new(), Vec::new());
+        return (Vec::new(), Vec::new(), Vec::new());
     }
     let given = |v: Option<&str>| v.unwrap_or("[not given]").to_string();
     omclog::info(omclog::SOLVER, false, &format!("-override={}", given(raw)));
@@ -969,10 +971,13 @@ fn resolve_overrides(
 
     let mut params = Vec::new();
     let mut starts = Vec::new();
+    let mut strings = Vec::new();
     let mut used: Vec<&str> = Vec::new();
-    // C's `singleOverride` walks the `_init.xml` quantities in class order.
-    for v in &model.result_vars {
-        let Some(&(name, val)) = map.iter().find(|(n, _)| *n == v.name) else { continue };
+    // C's `singleOverride` walks the `_init.xml` quantities in class order. The String
+    // parameters are not result signals, so they follow, as `_init.xml` has them.
+    let string_names = model.editable_params.iter().filter(|p| p.is_string).map(|p| p.name.as_str());
+    for name in model.result_vars.iter().map(|v| v.name.as_str()).chain(string_names) {
+        let Some(&(name, val)) = map.iter().find(|(n, _)| *n == name) else { continue };
         used.push(name);
         let Some(p) = model.editable_params.iter().find(|p| p.name == name) else {
             omclog::warning(
@@ -986,6 +991,10 @@ fn resolve_overrides(
             continue;
         };
         omclog::info(omclog::SOLVER, false, &format!("override {name} = {val}"));
+        if p.is_string {
+            strings.push((p.off, val.to_string()));
+            continue;
+        }
         // C warns only for the real and integer parameters (`warn_small_override`).
         let numeric_param = !p.is_start && (p.wty == WTy::F64 || !p.is_bool);
         if numeric_param && val.parse::<f64>().is_ok_and(|v| v.abs() < 1e-6) {
@@ -1011,7 +1020,7 @@ fn resolve_overrides(
         }
     }
     omclog::info(omclog::SOLVER, false, "override done!");
-    (params, starts)
+    (params, starts, strings)
 }
 
 /// Resolve `-iif=<file>` against the model's [`SimMeta::import_roster`] at `-iit`
@@ -1177,8 +1186,8 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
     sim_driver::set_result_file_reader(read_result_values);
     let (meta, experiment_log) = run_experiment(&model, &flags);
     openmodelica_wasi::wasi::start_stdout_capture();
-    let (param_ov, start_ov) = resolve_overrides(&model, &flags);
-    sim_driver::set_param_overrides(param_ov, start_ov);
+    let (param_ov, start_ov, string_ov) = resolve_overrides(&model, &flags);
+    sim_driver::set_param_overrides(param_ov, start_ov, string_ov);
     sim_driver::set_start_imports(resolve_start_imports(&meta, &flags));
     // `-abortSlowSimulation`: stop the run when chattering is detected.
     sim_driver::set_abort_slow(flags.abort_slow);
@@ -1395,8 +1404,8 @@ mod session {
             "CodegenWasmJit: unsupported output format"
         })?;
         openmodelica_wasi::wasi::start_stdout_capture();
-        let (param_ov, start_ov) = resolve_overrides(&model, &flags);
-        sim_driver::set_param_overrides(param_ov, start_ov);
+        let (param_ov, start_ov, string_ov) = resolve_overrides(&model, &flags);
+        sim_driver::set_param_overrides(param_ov, start_ov, string_ov);
         sim_driver::set_start_imports(resolve_start_imports(&meta, &flags));
         // Build the backend (instantiate, init, emit row 0). An init trap is usually
         // a failed `assert()`; the host driver routes it via `enrich_trap`.
@@ -2478,6 +2487,20 @@ fn add_resource(entries: &mut Vec<(String, Vec<u8>)>, path: &str) {
     }
 }
 
+/// Ship `dir` as the FMU's `terminalsAndIcons/`: the XML SimCode wrote and the icons
+/// the OMGraphics renderer put beside it, as the C export's `fmutmp` subtree is.
+fn add_terminals(entries: &mut Vec<(String, Vec<u8>)>, dir: &str) {
+    if dir.is_empty() {
+        return;
+    }
+    let Ok(files) = openmodelica_wasi::fs::read_dir(dir) else { return };
+    for e in files {
+        if let Ok(bytes) = openmodelica_wasi::fs::read(&format!("{}/{}", dir.trim_end_matches('/'), e.name)) {
+            entries.push((format!("terminalsAndIcons/{}", e.name), bytes));
+        }
+    }
+}
+
 /// A ZIP assembled in-process rather than by an external `zip`, deflated unless
 /// that would grow the entry.
 /// `--fmuDirectory`: the same entries as files under `path`, which then names a
@@ -2584,9 +2607,10 @@ pub fn emitMeFmu(
     _guid: ArcStr,
     model_description: ArcStr,
     extra_files: Arc<List<(ArcStr, ArcStr)>>,
+    terminals_dir: ArcStr,
     simulation_flags_json: ArcStr,
 ) -> Result<()> {
-    emit_fmu(sim_code, fmu_path, model_description, extra_files, simulation_flags_json, (FMI3_ME_ADAPTER, &[]), "ME")
+    emit_fmu(sim_code, fmu_path, model_description, extra_files, terminals_dir, simulation_flags_json, (FMI3_ME_ADAPTER, &[]), "ME")
 }
 
 /// Co-Simulation: the FMU integrates itself, so the adapter embeds the driver.
@@ -2601,9 +2625,10 @@ pub fn emitCsFmu(
     _guid: ArcStr,
     model_description: ArcStr,
     extra_files: Arc<List<(ArcStr, ArcStr)>>,
+    terminals_dir: ArcStr,
     simulation_flags_json: ArcStr,
 ) -> Result<()> {
-    emit_fmu(sim_code, fmu_path, model_description, extra_files, simulation_flags_json, (FMI3_MECS_ADAPTER, FMI3_MECS_SUNDIALS_ADAPTER), "CS")
+    emit_fmu(sim_code, fmu_path, model_description, extra_files, terminals_dir, simulation_flags_json, (FMI3_MECS_ADAPTER, FMI3_MECS_SUNDIALS_ADAPTER), "CS")
 }
 
 /// me_cs: one component exporting both interfaces (the wasm equivalent of a
@@ -2614,9 +2639,10 @@ pub fn emitMeCsFmu(
     _guid: ArcStr,
     model_description: ArcStr,
     extra_files: Arc<List<(ArcStr, ArcStr)>>,
+    terminals_dir: ArcStr,
     simulation_flags_json: ArcStr,
 ) -> Result<()> {
-    emit_fmu(sim_code, fmu_path, model_description, extra_files, simulation_flags_json, (FMI3_MECS_ADAPTER, FMI3_MECS_SUNDIALS_ADAPTER), "me_cs")
+    emit_fmu(sim_code, fmu_path, model_description, extra_files, terminals_dir, simulation_flags_json, (FMI3_MECS_ADAPTER, FMI3_MECS_SUNDIALS_ADAPTER), "me_cs")
 }
 
 /// Say that the FMU answers `fmi3GetDirectionalDerivative` when the model was
@@ -2975,6 +3001,7 @@ fn emit_fmu(
     fmu_path: ArcStr,
     model_description: ArcStr,
     extra_files: Arc<List<(ArcStr, ArcStr)>>,
+    terminals_dir: ArcStr,
     simulation_flags_json: ArcStr,
     adapter: (&[u8], &[u8]),
     kind: &str,
@@ -3019,11 +3046,11 @@ fn emit_fmu(
         let mut entries = vec![
             ("modelDescription.xml".to_string(), announce_directional_derivatives(&model_description, &model).into_bytes()),
         ];
-        // terminalsAndIcons/, documentation/ — whatever the caller rendered.
         if !bare {
             for (name, content) in lst(&extra_files) {
                 entries.push((name.to_string(), content.as_bytes().to_vec()));
             }
+            add_terminals(&mut entries, &terminals_dir);
         }
         // What the FMU was built with, where C's carries what its runtime reads.
         if !simulation_flags_json.is_empty() {
@@ -3582,6 +3609,7 @@ fn build_var_map(
     let mut editable: Vec<EditableParam> = Vec::new();
     // Collected separately: the `push_editable` closure borrows `editable`. Merged below.
     let mut start_editable: Vec<EditableParam> = Vec::new();
+    let mut string_editable: Vec<EditableParam> = Vec::new();
     let mut push_editable = |sv: &SimCodeVar::SimVar, name: &str, off: u32, wty: WTy| {
         if sv.isValueChangeable && is_result_output(sv) {
             if let Some(disp) = result_name(name) {
@@ -3593,6 +3621,7 @@ fn build_var_map(
                     wty,
                     is_start: false,
                     is_bool: is_boolean_type(&sv.type_),
+                    is_string: false,
                     enum_names: enumeration_names(&sv.type_).unwrap_or_default(),
                 });
             }
@@ -3645,6 +3674,7 @@ fn build_var_map(
                     wty: WTy::F64,
                     is_start: true,
                     is_bool: is_boolean_type(&sv.type_),
+                    is_string: false,
                     enum_names: enumeration_names(&sv.type_).unwrap_or_default(),
                 });
             }
@@ -3707,7 +3737,24 @@ fn build_var_map(
         insert_var(&mut map, sv, layout.str_off + (i as u32) * 4, WTy::I32, true)?;
     }
     for (k, sv) in lst(&vars.stringParamVars).enumerate() {
-        insert_var(&mut map, sv, layout.sparam_off + (k as u32) * 4, WTy::I32, true)?;
+        let off = layout.sparam_off + (k as u32) * 4;
+        insert_var(&mut map, sv, off, WTy::I32, true)?;
+        // Not a result signal, but `_init.xml` lists it and C's `-override` reaches it.
+        if sv.isValueChangeable && is_result_output(sv)
+            && let Some(disp) = result_name(&cref_display(&sv.name)?)
+        {
+            string_editable.push(EditableParam {
+                name: disp,
+                comment: sv.comment.to_string(),
+                unit: sv.unit.to_string(),
+                off,
+                wty: WTy::I32,
+                is_start: false,
+                is_bool: false,
+                is_string: true,
+                enum_names: Vec::new(),
+            });
+        }
     }
     // External objects: one i32 pointer-registry handle each. Not heap (no ARC);
     // the constructor (a parameter equation) writes the handle, the destructor
@@ -3856,6 +3903,7 @@ fn build_var_map(
 
     finalize_array_groups(&mut map)?;
     editable.extend(start_editable);
+    editable.extend(string_editable);
     Ok((map, result_vars, editable))
 }
 
@@ -4439,6 +4487,30 @@ fn ext_import_sig(sig: &ExtCallSig) -> openmodelica_wasm_jit::sig::FnSig {
 }
 
 /// `fmi_vrs`: also record the FMI value-reference table (FMU export only).
+/// One `<entry>$guard`, per the wrappers `build_sim_model` emits.
+fn build_guard_fn(target: u32) -> we::Function {
+    use we::Instruction as I;
+    let mut f = we::Function::new([(1, we::ValType::I32)]);
+    let threw = 1; // param 0 is the SimData pointer
+    f.instruction(&I::Block(we::BlockType::Empty)); // done
+    f.instruction(&I::Block(we::BlockType::Result(we::ValType::EXNREF))); // handler
+    f.instruction(&I::TryTable(we::BlockType::Empty, vec![we::Catch::OneRef { tag: 0, label: 0 }].into()));
+    f.instruction(&I::LocalGet(0));
+    f.instruction(&I::Call(target));
+    f.instruction(&I::End); // try_table
+    f.instruction(&I::I32Const(0));
+    f.instruction(&I::LocalSet(threw));
+    f.instruction(&I::Br(1)); // done
+    f.instruction(&I::End); // handler: the exception is on the stack
+    f.instruction(&I::Drop);
+    f.instruction(&I::I32Const(1));
+    f.instruction(&I::LocalSet(threw));
+    f.instruction(&I::End); // done
+    f.instruction(&I::LocalGet(threw));
+    f.instruction(&I::End);
+    f
+}
+
 fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost) -> Result<SimModel> {
     crate::CodegenWasmJitFunctions::set_record_decls(&sim_code.recordDecls)?;
     let mi = &sim_code.modelInfo;
@@ -4878,7 +4950,13 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     // proposal.
     let throw_fn_type = types.len();
     types.ty().function([], []);
-    let error_tag_type = (!ext_imports.is_empty()).then_some(throw_fn_type);
+    // A host-free module also carries one: nothing outside it catches a trap, so a
+    // failed `assert()` unwinds to the entry point it fired under instead.
+    let host_free = matches!(ext_host, ExtHost::Wasm);
+    let error_tag_type = (!ext_imports.is_empty() || host_free).then_some(throw_fn_type);
+    // `<entry>$guard`'s type: (i32 SimData) -> i32, nonzero if it threw.
+    let guard_fn_type = types.len();
+    types.ty().function([we::ValType::I32], [we::ValType::I32]);
     let mut model_fn_type: Vec<u32> = Vec::with_capacity(model_fns.len());
     for f in &model_fns {
         let (_, sig) = function_signature(f)?;
@@ -4970,6 +5048,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     // With a tag in the module, every `ext` call is lowered under a `try_table`
     // (tag index 0: the module imports none).
     crate::CodegenWasmJitFunctions::set_ext_error_catch(error_tag_type.map(|_| 0));
+    crate::CodegenWasmJitFunctions::set_assert_throw_tag(host_free.then_some(0));
     // Model functions first, in index order; poll for cancellation between them so
     // a long emit is interruptible like the frontend/backend upstream.
     for f in &model_fns {
@@ -5529,6 +5608,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
 
     // --- Function section (type index per body, in body order). ---
     crate::CodegenWasmJitFunctions::set_ext_error_catch(None);
+    crate::CodegenWasmJitFunctions::set_assert_throw_tag(None);
 
     let mut functions = we::FunctionSection::new();
     for ti in &model_fn_type {
@@ -5679,6 +5759,46 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
         }));
     }
 
+    // `<entry>$guard`: the entry point under a `try_table` for the model-error tag, so
+    // the adapter answers a status rather than trapping — a trapped component is done.
+    let guarded: Vec<(&str, u32)> = vec![
+        ("functionParameters", eqfn.parameters),
+        ("functionInitialEquations", eqfn.initial),
+        ("functionInitStartValues", eqfn.init_start_values),
+        ("functionODE", eqfn.ode),
+        ("functionAlgebraics", eqfn.algebraics),
+        ("functionOutputs", outputs_idx),
+        ("callExternalObjectDestructors", destructors_idx),
+        ("initSample", init_sample_idx),
+        ("functionZeroCrossingsEquations", zc_equations_idx),
+        ("functionStateSetJacobians", stateset_jac_idx),
+        ("functionJacA_constantEqns", jac_a_idx),
+        ("functionJacA_column", jac_a_idx + 1),
+        ("functionInitialEquations_lambda0", init_lambda0_idx),
+        ("functionCheckAsserts", check_asserts_idx),
+        ("functionUpdateRelations", update_relations_idx),
+        ("functionStoreDelayed", store_delayed_idx),
+        ("functionInitDelay", init_delay_idx),
+        ("functionStoreSpatialDistribution", store_spatial_idx),
+        ("functionInitSpatialDistribution", init_spatial_idx),
+        ("functionUpdateBoundParameters", update_bound_params_idx),
+        ("functionUpdateBoundVariableAttributes", update_bound_attrs_idx),
+        ("functionRemovedInitialEquations", removed_init_idx),
+        ("functionInitSynchronous", sync_idx.0),
+        ("symbolicInlineSystem", sym_inline_idx),
+        ("linearJacA", linz_jac_idx),
+        ("linearJacB", linz_jac_idx + 1),
+        ("linearJacC", linz_jac_idx + 2),
+        ("linearJacD", linz_jac_idx + 3),
+    ];
+    let guard_base = import_base + bodies.len() as u32;
+    if error_tag_type.is_some() {
+        for (_, target) in &guarded {
+            functions.function(guard_fn_type);
+            bodies.push(build_guard_fn(*target));
+        }
+    }
+
     // --- Code section. ---
     let mut code = we::CodeSection::new();
     for body in &bodies {
@@ -5742,6 +5862,11 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
         exports.export("evaluateDAEResiduals", we::ExportKind::Func, idx);
     }
     exports.export("symbolicInlineSystem", we::ExportKind::Func, sym_inline_idx);
+    if error_tag_type.is_some() {
+        for (k, (name, _)) in guarded.iter().enumerate() {
+            exports.export(&format!("{name}$guard"), we::ExportKind::Func, guard_base + k as u32);
+        }
+    }
 
     // --- Name section: without it a trap backtrace is bare function indices. The
     // unnamed remainder is the NLS callbacks, the closure thunks and `start`. ---
@@ -9746,6 +9871,9 @@ mod link_tests {
             funcs.function(4);
         }
         funcs.function(5); // om_throw_model_error
+        for _ in &one_arg {
+            funcs.function(0); // <entry>$guard: (i32)->i32, like rt_alloc's type
+        }
         m.section(&funcs);
 
         // Defined-func indices start at 1 (rt_alloc is import 0).
@@ -9765,6 +9893,11 @@ mod link_tests {
             we::ExportKind::Func,
             meta_ptr_idx + 3 + two_arg.len() as u32,
         );
+        // The adapter reaches the one-argument entry points only through their guards.
+        let guard_base = meta_ptr_idx + 4 + two_arg.len() as u32;
+        for (i, name) in one_arg.iter().enumerate() {
+            exports.export(&format!("{name}$guard"), we::ExportKind::Func, guard_base + i as u32);
+        }
         m.section(&exports);
 
         let mut code = we::CodeSection::new();
@@ -9800,6 +9933,13 @@ mod link_tests {
         throw.instruction(&I::Unreachable);
         throw.instruction(&I::End);
         code.function(&throw);
+        // Each guard: nothing threw.
+        for _ in &one_arg {
+            let mut f = we::Function::new([]);
+            f.instruction(&I::I32Const(0));
+            f.instruction(&I::End);
+            code.function(&f);
+        }
         m.section(&code);
 
         m.finish()

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -260,12 +260,14 @@ fn builtin_index(name: &str) -> Option<u32> {
 /// `rt_*` indices are unaffected), just before the generated functions. The host
 /// closures live in `runtime::add_host_builtins`.
 ///
-/// `rt_assert(msg, file, sline, scol, eline, ecol, isReadOnly, cond, initial) -> shouldTrap`
+/// `rt_assert(msg, file, sline, scol, eline, ecol, isReadOnly, cond, initial, sim_data) -> shouldTrap`
 /// records the failed assertion and answers whether the generated code must trap:
 /// it need not while the driver has asserts suppressed (C's `noThrowAsserts`).
 /// `cond` is the dumped condition, or 0 for a model/runtime error, which is never
 /// suppressed; it comes last so callers that already pushed the message append.
-/// `initial` is C's `initial()` at the assert site, for the message header.
+/// `initial` is C's `initial()` at the assert site, for the message header, and
+/// `sim_data` is C's `data` (0 outside a simulation), which an FMU heads the logged
+/// block with the time from.
 ///
 /// `rt_assert_warning(cond, msg, file, sline, scol, eline, ecol, isReadOnly, initial)`
 /// records a *non-fatal* (AssertionLevel.warning) violation — the string handles
@@ -292,7 +294,7 @@ fn builtin_index(name: &str) -> Option<u32> {
 pub(crate) const ENV_EXTRA: &[(&str, &[WTy], &[WTy])] = &[
     (
         "rt_assert",
-        &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32],
+        &[WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32, WTy::I32],
         &[WTy::I32],
     ),
     (
@@ -2967,6 +2969,25 @@ pub(crate) fn set_ext_error_catch(tag: Option<u32>) {
     EXT_ERROR_CATCH.with(|c| c.set(tag));
 }
 
+thread_local! {
+    /// The tag a failed `assert()` throws, while lowering a host-free module. Unset
+    /// where a trap is the end of the run anyway, so C's `unreachable` is enough.
+    static ASSERT_THROW_TAG: std::cell::Cell<Option<u32>> = const { std::cell::Cell::new(None) };
+}
+
+pub(crate) fn set_assert_throw_tag(tag: Option<u32>) {
+    ASSERT_THROW_TAG.with(|c| c.set(tag));
+}
+
+/// End the computation the failed `assert()` was part of: a host-free module unwinds
+/// to its `<entry>$guard`, anything else traps.
+fn emit_assert_unwind(ctx: &mut FnCtx) {
+    match ASSERT_THROW_TAG.with(|c| c.get()) {
+        Some(tag) => ctx.emit(we::Instruction::Throw(tag)),
+        None => ctx.emit(we::Instruction::Unreachable),
+    }
+}
+
 fn emit_general_external_call(ctx: &mut FnCtx, ext_name: &str, args: &[Arc<DAE::Exp>], arg_types: &[SigTy]) -> Result<Vec<SigTy>> {
     let key = format!("ext.{ext_name}");
     let (index, params, results) = match ctx.by_name.get(&key) {
@@ -4467,10 +4488,11 @@ fn emit_assert(
     ctx.emit(we::Instruction::End);
     report_args(ctx)?;
     emit_initial_flag(ctx);
+    emit_sim_data_or_zero(ctx);
     ctx.emit(we::Instruction::Call(env_extra_index("rt_assert")?));
-    // Trap unless the driver took it (suppressed during the event search).
+    // Unwind unless the driver took it (suppressed during the event search).
     ctx.emit(we::Instruction::If(we::BlockType::Empty));
-    ctx.emit(we::Instruction::Unreachable);
+    emit_assert_unwind(ctx);
     ctx.emit(we::Instruction::End);
     ctx.emit(we::Instruction::End);
     Ok(())
@@ -4507,9 +4529,10 @@ fn emit_model_error(ctx: &mut FnCtx) -> Result<()> {
     }
     ctx.emit(we::Instruction::I32Const(0)); // no condition: never suppressed
     emit_initial_flag(ctx);
+    emit_sim_data_or_zero(ctx);
     ctx.emit(we::Instruction::Call(env_extra_index("rt_assert")?));
     ctx.emit(we::Instruction::Drop);
-    ctx.emit(we::Instruction::Unreachable);
+    emit_assert_unwind(ctx);
     Ok(())
 }
 
@@ -9314,9 +9337,10 @@ fn emit_runtime_error(ctx: &mut FnCtx, msg: &str) -> Result<()> {
     }
     ctx.emit(we::Instruction::I32Const(0)); // no condition: never suppressed
     emit_initial_flag(ctx);
+    emit_sim_data_or_zero(ctx);
     ctx.emit(we::Instruction::Call(env_extra_index("rt_assert")?));
     ctx.emit(we::Instruction::Drop);
-    ctx.emit(we::Instruction::Unreachable);
+    emit_assert_unwind(ctx);
     Ok(())
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -1903,6 +1903,18 @@ pub extern "C" fn rt_str_new(len: u32) -> u32 {
     obj
 }
 
+/// Assign a fresh String holding `bytes` to the handle slot at `addr`, releasing what
+/// was there — the generated code's own String assignment.
+pub fn set_string_slot(addr: u32, bytes: &[u8]) {
+    let old = unsafe { load_u32(addr) };
+    let obj = rt_str_new(bytes.len() as u32);
+    unsafe {
+        core::ptr::copy_nonoverlapping(bytes.as_ptr(), rt_str_data(obj) as *mut u8, bytes.len());
+        store_u32(addr, obj);
+    }
+    rt_release(old);
+}
+
 /// Byte length of a string.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_str_len(obj: u32) -> u32 {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -95,6 +95,10 @@ impl SimEngine for InWasmEngine {
         dst.copy_from_slice(buf);
         Ok(())
     }
+    fn set_string(&mut self, addr: u32, bytes: &[u8]) -> driver::Result<()> {
+        crate::set_string_slot(addr, bytes);
+        Ok(())
+    }
     fn call1_raw(&mut self, name: &str, arg: u32) -> driver::Result<()> {
         let slot = slot_of(name).ok_or("in-wasm engine: unknown model function")?;
         if !self.present(slot) {
@@ -275,9 +279,21 @@ pub extern "C" fn rt_sim_set_overrides(ptr: u32, len: u32) -> i32 {
         }
         Some(openmodelica_sim_meta::driver::StartImports { file, time, values })
     };
+    let strings = |p: &mut usize| -> Option<Vec<(u32, alloc::string::String)>> {
+        let n = u32_at(p)? as usize;
+        let mut out = Vec::with_capacity(n);
+        for _ in 0..n {
+            let off = u32_at(p)?;
+            let len = u32_at(p)? as usize;
+            let s = alloc::string::String::from_utf8_lossy(bytes.get(*p..*p + len)?).into_owned();
+            *p += len;
+            out.push((off, s));
+        }
+        Some(out)
+    };
     match (group(&mut p), group(&mut p)) {
         (Some(params), Some(starts)) => {
-            openmodelica_sim_meta::driver::set_param_overrides(params, starts);
+            openmodelica_sim_meta::driver::set_param_overrides(params, starts, strings(&mut p).unwrap_or_default());
             openmodelica_sim_meta::driver::set_start_imports(imports(&mut p));
             0
         }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -99,6 +99,10 @@ impl SimEngine for StandaloneEngine {
         dst.copy_from_slice(buf);
         Ok(())
     }
+    fn set_string(&mut self, addr: u32, bytes: &[u8]) -> driver::Result<()> {
+        crate::set_string_slot(addr, bytes);
+        Ok(())
+    }
     fn call1_raw(&mut self, name: &str, arg: u32) -> driver::Result<()> {
         unsafe {
             match name {
@@ -340,7 +344,7 @@ pub extern "C" fn _start() {
 /// assertion, so print the message (`msg` is an `rt` String handle:
 /// `[refcount:u32][len:u32][utf8…]`) and trap, which aborts the command.
 #[unsafe(no_mangle)]
-pub extern "C" fn rt_assert(msg: i32, _file: i32, _sline: i32, _scol: i32, _eline: i32, _ecol: i32, _read_only: i32, _cond: i32, _initial: i32) -> i32 {
+pub extern "C" fn rt_assert(msg: i32, _file: i32, _sline: i32, _scol: i32, _eline: i32, _ecol: i32, _read_only: i32, _cond: i32, _initial: i32, _sim_data: i32) -> i32 {
     if msg != 0 {
         let h = msg as u32;
         let len = unsafe { crate::load_u32(h + 4) } as usize;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/description.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/description.rs
@@ -197,6 +197,14 @@ pub struct ClockInfo {
     pub shift_counter: u64,
 }
 
+/// The `<Binary>` attributes (FMI 3.0 only).
+#[derive(Clone, Debug)]
+pub struct BinaryInfo {
+    pub mime_type: String,
+    /// `None` when the FMU set no upper bound on the value's size.
+    pub max_size: Option<u64>,
+}
+
 /// An `<Alias>` child (FMI 3.0): another name for the same value reference.
 #[derive(Clone, Debug)]
 pub struct VariableAlias {
@@ -236,6 +244,7 @@ pub struct Variable {
     pub clocks: Vec<u32>,
     pub dimensions: Vec<Dimension>,
     pub clock: Option<ClockInfo>,
+    pub binary: Option<BinaryInfo>,
     pub aliases: Vec<VariableAlias>,
     /// FMI 1.0 only; [`Alias::NoAlias`] everywhere else.
     pub alias: Alias,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/parse/mod.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/parse/mod.rs
@@ -207,6 +207,7 @@ pub(crate) fn blank_variable(name: String, vr: u32, index: u32, ty: VarType) -> 
         clocks: Vec::new(),
         dimensions: Vec::new(),
         clock: None,
+        binary: None,
         aliases: Vec::new(),
         alias: Alias::NoAlias,
         can_handle_multiple_set_per_time_instant: false,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/parse/v3.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/parse/v3.rs
@@ -110,7 +110,10 @@ fn variables(root: Node) -> Result<Vec<Variable>> {
         v.variability = variability(
             attr(n, "variability"),
             match (ty, v.causality) {
-                (_, Causality::StructuralParameter) => Variability::Fixed,
+                // Spec: the default for a parameter of any kind is `fixed`.
+                (_, Causality::Parameter | Causality::StructuralParameter | Causality::CalculatedParameter) => {
+                    Variability::Fixed
+                }
                 (VarType::Float32 | VarType::Float64, _) => Variability::Continuous,
                 _ => Variability::Discrete,
             },
@@ -140,6 +143,10 @@ fn variables(root: Node) -> Result<Vec<Variable>> {
             .collect();
         v.start = start(n, ty);
         v.clock = (ty == VarType::Clock).then(|| clock_info(n));
+        v.binary = (ty == VarType::Binary).then(|| BinaryInfo {
+            mime_type: attr(n, "mimeType").unwrap_or("application/octet-stream").to_string(),
+            max_size: u64_attr(n, "maxSize"),
+        });
         v.aliases = children(n, "Alias")
             .filter_map(|a| {
                 Some(VariableAlias {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -39,33 +39,11 @@ use openmodelica_sim_meta::{decode, omclog, FmiVr, Layout, Neg, WTy, REAL_OFF, T
 // library's exports, and the model's `rt_*` + memory against this adapter's.
 #[link(wasm_import_module = "env")]
 unsafe extern "C" {
-    fn functionParameters(sim_data: u32);
-    fn functionInitStartValues(sim_data: u32);
-    fn functionInitialEquations(sim_data: u32);
-    fn functionInitialEquations_lambda0(sim_data: u32);
-    fn functionODE(sim_data: u32);
-    fn functionAlgebraics(sim_data: u32);
-    fn functionOutputs(sim_data: u32);
-    fn functionStateSetJacobians(sim_data: u32);
+    // The two-argument entry points, not yet guarded: a failed `assert()` in one of
+    // these still traps.
     fn functionZeroCrossings(sim_data: u32, gout: u32);
-    fn functionZeroCrossingsEquations(sim_data: u32);
-    fn functionUpdateRelations(sim_data: u32);
-    fn functionCheckAsserts(sim_data: u32);
-    fn functionStoreDelayed(sim_data: u32);
-    fn functionInitDelay(sim_data: u32);
-    fn functionStoreSpatialDistribution(sim_data: u32);
-    fn functionInitSpatialDistribution(sim_data: u32);
-    fn functionUpdateBoundParameters(sim_data: u32);
-    fn functionUpdateBoundVariableAttributes(sim_data: u32);
-    fn functionRemovedInitialEquations(sim_data: u32);
-    fn functionJacA_constantEqns(sim_data: u32);
-    fn functionJacA_column(sim_data: u32);
-    fn initSample(sim_data: u32);
-    fn functionInitSynchronous(sim_data: u32);
     fn functionUpdateSynchronous(sim_data: u32, base_idx: u32);
     fn functionEquationsSynchronous(sim_data: u32, idx: u32);
-    fn callExternalObjectDestructors(sim_data: u32);
-    fn symbolicInlineSystem(sim_data: u32);
     fn om_meta_ptr() -> u32;
     fn om_meta_len() -> u32;
 }
@@ -77,10 +55,68 @@ unsafe extern "C" {
 #[link(wasm_import_module = "env")]
 unsafe extern "C" {
     fn simulate(sim_data: u32, start: f64, stop: f64, n_steps: u32) -> u32;
-    fn linearJacA(sim_data: u32);
-    fn linearJacB(sim_data: u32);
-    fn linearJacC(sim_data: u32);
-    fn linearJacD(sim_data: u32);
+    #[link_name = "linearJacA$guard"]
+    fn linearJacA_guard(sim_data: u32) -> u32;
+    #[link_name = "linearJacB$guard"]
+    fn linearJacB_guard(sim_data: u32) -> u32;
+    #[link_name = "linearJacC$guard"]
+    fn linearJacC_guard(sim_data: u32) -> u32;
+    #[link_name = "linearJacD$guard"]
+    fn linearJacD_guard(sim_data: u32) -> u32;
+}
+
+// Each entry point again, wrapped by the emitter in a `try_table` for the model-error
+// tag: 1 means a failed `assert()` unwound out of it.
+#[link(wasm_import_module = "env")]
+unsafe extern "C" {
+    #[link_name = "functionParameters$guard"]
+    fn functionParameters_guard(sim_data: u32) -> u32;
+    #[link_name = "functionInitStartValues$guard"]
+    fn functionInitStartValues_guard(sim_data: u32) -> u32;
+    #[link_name = "functionInitialEquations$guard"]
+    fn functionInitialEquations_guard(sim_data: u32) -> u32;
+    #[link_name = "functionInitialEquations_lambda0$guard"]
+    fn functionInitialEquations_lambda0_guard(sim_data: u32) -> u32;
+    #[link_name = "functionODE$guard"]
+    fn functionODE_guard(sim_data: u32) -> u32;
+    #[link_name = "functionAlgebraics$guard"]
+    fn functionAlgebraics_guard(sim_data: u32) -> u32;
+    #[link_name = "functionOutputs$guard"]
+    fn functionOutputs_guard(sim_data: u32) -> u32;
+    #[link_name = "functionStateSetJacobians$guard"]
+    fn functionStateSetJacobians_guard(sim_data: u32) -> u32;
+    #[link_name = "functionZeroCrossingsEquations$guard"]
+    fn functionZeroCrossingsEquations_guard(sim_data: u32) -> u32;
+    #[link_name = "functionUpdateRelations$guard"]
+    fn functionUpdateRelations_guard(sim_data: u32) -> u32;
+    #[link_name = "functionCheckAsserts$guard"]
+    fn functionCheckAsserts_guard(sim_data: u32) -> u32;
+    #[link_name = "functionStoreDelayed$guard"]
+    fn functionStoreDelayed_guard(sim_data: u32) -> u32;
+    #[link_name = "functionInitDelay$guard"]
+    fn functionInitDelay_guard(sim_data: u32) -> u32;
+    #[link_name = "functionStoreSpatialDistribution$guard"]
+    fn functionStoreSpatialDistribution_guard(sim_data: u32) -> u32;
+    #[link_name = "functionInitSpatialDistribution$guard"]
+    fn functionInitSpatialDistribution_guard(sim_data: u32) -> u32;
+    #[link_name = "functionUpdateBoundParameters$guard"]
+    fn functionUpdateBoundParameters_guard(sim_data: u32) -> u32;
+    #[link_name = "functionUpdateBoundVariableAttributes$guard"]
+    fn functionUpdateBoundVariableAttributes_guard(sim_data: u32) -> u32;
+    #[link_name = "functionRemovedInitialEquations$guard"]
+    fn functionRemovedInitialEquations_guard(sim_data: u32) -> u32;
+    #[link_name = "functionJacA_constantEqns$guard"]
+    fn functionJacA_constantEqns_guard(sim_data: u32) -> u32;
+    #[link_name = "functionJacA_column$guard"]
+    fn functionJacA_column_guard(sim_data: u32) -> u32;
+    #[link_name = "initSample$guard"]
+    fn initSample_guard(sim_data: u32) -> u32;
+    #[link_name = "functionInitSynchronous$guard"]
+    fn functionInitSynchronous_guard(sim_data: u32) -> u32;
+    #[link_name = "callExternalObjectDestructors$guard"]
+    fn callExternalObjectDestructors_guard(sim_data: u32) -> u32;
+    #[link_name = "symbolicInlineSystem$guard"]
+    fn symbolicInlineSystem_guard(sim_data: u32) -> u32;
 }
 
 // ── Messages ─────────────────────────────────────────────────────────────────
@@ -215,7 +251,14 @@ fn init_logging(name: String, logging_on: bool) {
     l.name = name;
     l.cats = if logging_on { !0 } else { 0 };
     driver::set_log_sink(log_sink);
+    driver::set_terminate_reporter(terminate_fmi);
     omclog::set_mask(omclog::FMU_STREAMS);
+}
+
+/// C's `omc_terminate_fmi`, which `fmi2Instantiate` installs: stderr, not the
+/// driver's `LOG_STDOUT` notice. The importer reports the terminate itself.
+fn terminate_fmi(pos: &str, msg: &str) {
+    stdio::stderr(alloc::format!("{pos}Modelica Terminate: {msg}!\n").as_bytes());
 }
 
 /// The runtime `String` behind a handle, empty for the null handle.
@@ -240,23 +283,40 @@ fn assert_message(msg: i32, file: i32, sline: i32) -> String {
     alloc::format!("{file}:{sline}: {msg}")
 }
 
-/// The runtime leaves `rt_assert` to the host on this target. C's FMU logs and then
-/// throws; the throw is a trap here, aborting the FMI call, which the master
-/// surfaces as a fatal status.
+/// C's FMU logs the violation then `longjmp`s out of the FMI call, which returns
+/// `fmi3Error` with the instance usable — so answer that the code must unwind.
+/// `cond` picks which C implementation is mirrored: `fmi2Instantiate` swaps in
+/// `omc_assert_fmi` only for the `FUNCTION_CONTEXT` pointer, while an equation
+/// `assert()` stays on `omc_assert_simulation_withEquationIndexes`'s `LOG_ASSERT`.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_assert(
     msg: i32,
     file: i32,
     sline: i32,
-    _scol: i32,
-    _eline: i32,
-    _ecol: i32,
-    _read_only: i32,
-    _cond: i32,
-    _initial: i32,
+    scol: i32,
+    eline: i32,
+    ecol: i32,
+    read_only: i32,
+    cond: i32,
+    initial: i32,
+    sim_data: i32,
 ) -> i32 {
+    if cond != 0 {
+        let info = driver::AssertInfo {
+            msg: rt_string(msg),
+            file: rt_string(file),
+            read_only: read_only != 0,
+            line_start: sline,
+            col_start: scol,
+            line_end: eline,
+            col_end: ecol,
+        };
+        let time = driver::read_f64(&Engine, sim_data as u32 + TIME_OFF).unwrap_or(0.0);
+        driver::log_assert_block(&info, &rt_string(cond), time, initial != 0);
+        return 1;
+    }
     fmi_log(Status::Error, CAT_ERROR, &assert_message(msg, file, sline));
-    core::arch::wasm32::unreachable()
+    1
 }
 
 /// Warning-level assertion: non-fatal, so continue (C's `omc_assert_fmi_warning`).
@@ -310,46 +370,56 @@ impl SimEngine for Engine {
         dst.copy_from_slice(buf);
         Ok(())
     }
+    fn set_string(&mut self, addr: u32, bytes: &[u8]) -> driver::Result<()> {
+        openmodelica_codegen_wasm_jit_runtime::set_string_slot(addr, bytes);
+        Ok(())
+    }
     fn call1_raw(&mut self, name: &str, arg: u32) -> driver::Result<()> {
-        unsafe {
+        let threw = unsafe {
             match name {
-                "functionParameters" => functionParameters(arg),
-                "functionInitStartValues" => functionInitStartValues(arg),
-                "functionInitialEquations" => functionInitialEquations(arg),
-                "functionInitialEquations_lambda0" => functionInitialEquations_lambda0(arg),
-                "functionODE" => functionODE(arg),
-                "functionAlgebraics" => functionAlgebraics(arg),
-                "functionOutputs" => functionOutputs(arg),
-                "functionStateSetJacobians" => functionStateSetJacobians(arg),
-                "functionZeroCrossingsEquations" => functionZeroCrossingsEquations(arg),
-                "functionUpdateRelations" => functionUpdateRelations(arg),
-                "functionCheckAsserts" => functionCheckAsserts(arg),
-                "functionStoreDelayed" => functionStoreDelayed(arg),
-                "functionInitDelay" => functionInitDelay(arg),
-                "functionStoreSpatialDistribution" => functionStoreSpatialDistribution(arg),
-                "functionInitSpatialDistribution" => functionInitSpatialDistribution(arg),
-                "functionUpdateBoundParameters" => functionUpdateBoundParameters(arg),
-                "functionUpdateBoundVariableAttributes" => functionUpdateBoundVariableAttributes(arg),
-                "functionRemovedInitialEquations" => functionRemovedInitialEquations(arg),
-                "functionJacA_constantEqns" => functionJacA_constantEqns(arg),
-                "functionJacA_column" => functionJacA_column(arg),
-                "initSample" => initSample(arg),
-                "functionInitSynchronous" => functionInitSynchronous(arg),
-                "callExternalObjectDestructors" => callExternalObjectDestructors(arg),
-                "symbolicInlineSystem" => symbolicInlineSystem(arg),
+                "functionParameters" => functionParameters_guard(arg),
+                "functionInitStartValues" => functionInitStartValues_guard(arg),
+                "functionInitialEquations" => functionInitialEquations_guard(arg),
+                "functionInitialEquations_lambda0" => functionInitialEquations_lambda0_guard(arg),
+                "functionODE" => functionODE_guard(arg),
+                "functionAlgebraics" => functionAlgebraics_guard(arg),
+                "functionOutputs" => functionOutputs_guard(arg),
+                "functionStateSetJacobians" => functionStateSetJacobians_guard(arg),
+                "functionZeroCrossingsEquations" => functionZeroCrossingsEquations_guard(arg),
+                "functionUpdateRelations" => functionUpdateRelations_guard(arg),
+                "functionCheckAsserts" => functionCheckAsserts_guard(arg),
+                "functionStoreDelayed" => functionStoreDelayed_guard(arg),
+                "functionInitDelay" => functionInitDelay_guard(arg),
+                "functionStoreSpatialDistribution" => functionStoreSpatialDistribution_guard(arg),
+                "functionInitSpatialDistribution" => functionInitSpatialDistribution_guard(arg),
+                "functionUpdateBoundParameters" => functionUpdateBoundParameters_guard(arg),
+                "functionUpdateBoundVariableAttributes" => functionUpdateBoundVariableAttributes_guard(arg),
+                "functionRemovedInitialEquations" => functionRemovedInitialEquations_guard(arg),
+                "functionJacA_constantEqns" => functionJacA_constantEqns_guard(arg),
+                "functionJacA_column" => functionJacA_column_guard(arg),
+                "initSample" => initSample_guard(arg),
+                "functionInitSynchronous" => functionInitSynchronous_guard(arg),
+                "callExternalObjectDestructors" => callExternalObjectDestructors_guard(arg),
+                "symbolicInlineSystem" => symbolicInlineSystem_guard(arg),
                 #[cfg(all(feature = "me", feature = "cs"))]
-                "linearJacA" => linearJacA(arg),
+                "linearJacA" => linearJacA_guard(arg),
                 #[cfg(all(feature = "me", feature = "cs"))]
-                "linearJacB" => linearJacB(arg),
+                "linearJacB" => linearJacB_guard(arg),
                 #[cfg(all(feature = "me", feature = "cs"))]
-                "linearJacC" => linearJacC(arg),
+                "linearJacC" => linearJacC_guard(arg),
                 #[cfg(all(feature = "me", feature = "cs"))]
-                "linearJacD" => linearJacD(arg),
+                "linearJacD" => linearJacD_guard(arg),
                 _ => return Err(UNKNOWN_MODEL_FN),
             }
+        };
+        // The assertion was logged where it fired; the caller turns this into the
+        // status the FMI call answers with, leaving the instance usable.
+        if threw != 0 {
+            return Err(driver::ASSERT_ERR);
         }
         Ok(())
     }
+
     fn call2_raw(&mut self, name: &str, a: u32, b: u32) -> driver::Result<()> {
         unsafe {
             match name {
@@ -504,10 +574,10 @@ impl MeState {
     }
 
     /// `functionOutputs`, not `functionAlgebraics`: a getter runs no discrete update.
-    fn eval(&self) {
+    fn eval(&self) -> driver::Result<()> {
         let mut e = Engine;
-        let _ = e.call1("functionODE", self.sim_data);
-        let _ = e.call1("functionOutputs", self.sim_data);
+        e.call1("functionODE", self.sim_data)?;
+        e.call1("functionOutputs", self.sim_data)
     }
 
     /// The state a value reference reads, when it is one of the continuous
@@ -560,7 +630,7 @@ impl MeState {
         if self.mode == Mode::Init {
             self.run_init()?;
         } else {
-            self.eval();
+            self.eval()?;
         }
         self.need_update = false;
         Ok(())
@@ -569,7 +639,7 @@ impl MeState {
     /// C's `initialization()`, repeatable: the overrides stay, so the importer can
     /// keep setting and get a fresh solve each time.
     fn run_init(&mut self) -> driver::Result<()> {
-        set_param_overrides(self.init_overrides.clone(), self.init_start_overrides.clone());
+        set_param_overrides(self.init_overrides.clone(), self.init_start_overrides.clone(), Vec::new());
         let mut e = Engine;
         let start_time = self.read_f64(TIME_OFF);
         // No `-csvInput` on the FMI path: the importer drives the inputs.
@@ -1325,7 +1395,7 @@ impl GuestModelExchangeInstance for Instance {
         let mut st = self.st.borrow_mut();
         let mut e = Engine;
         if st.need_update {
-            let _ = e.call1("functionODE", st.sim_data);
+            e.call1("functionODE", st.sim_data).map_err(|_| Status::Error)?;
             st.need_update = false;
         }
         if st.layout.n_zc == 0 {
@@ -1361,7 +1431,7 @@ impl GuestModelExchangeInstance for Instance {
     ) -> Result<CompletedStepResult, Status> {
         let mut st = self.st.borrow_mut();
         // C's `internal_CompletedIntegratorStep`; it leaves `_need_update` set.
-        st.eval();
+        st.eval().map_err(|_| Status::Error)?;
         st.need_update = true;
         Ok(CompletedStepResult {
             enter_event_mode: false,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_ls_wasm_to_native/src/fmi2.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_ls_wasm_to_native/src/fmi2.rs
@@ -631,15 +631,23 @@ pub unsafe extern "C" fn fmi2CompletedIntegratorStep(
     if enter_event_mode.is_null() || terminate_simulation.is_null() {
         return ERROR;
     }
-    let (mut enter, mut terminate) = (false, false);
-    let status = unsafe { crate::fmi3CompletedIntegratorStep(c, b(no_set_fmu_state_prior), &mut enter, &mut terminate) };
-    if status == OK {
-        unsafe {
-            *enter_event_mode = fmi2_bool(enter);
-            *terminate_simulation = fmi2_bool(terminate);
+    let Some(inst) = inst_mut(c) else { return ERROR };
+    let Some((store, g, h)) = inst.me() else { return ERROR };
+    match g.call_completed_integrator_step(&mut *store, h, b(no_set_fmu_state_prior)) {
+        Ok(Ok(r)) => {
+            unsafe {
+                *enter_event_mode = fmi2_bool(r.enter_event_mode);
+                *terminate_simulation = fmi2_bool(r.terminate_simulation);
+            }
+            OK
+        }
+        // The assertion unwound inside the FMU (or, failing that, trapped): C's
+        // wrapper reports it the same way from its `longjmp` catch.
+        Ok(Err(_)) | Err(_) => {
+            store.data_mut().log_fmi2_call(ERROR, "fmi2CompletedIntegratorStep: terminated by an assertion.");
+            ERROR
         }
     }
-    status
 }
 
 // ── Co-Simulation ───────────────────────────────────────────────────────────

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -470,6 +470,11 @@ pub trait SimEngine {
     /// C's `RHSFinalFlag` (`dassl.c`): 0 while DASKR evaluates the residual, 1
     /// while the accepted step's outputs are evaluated, for `external "C"` to read.
     fn set_rhs_final(&mut self, _final_eval: bool) {}
+    /// Assign a runtime String holding `bytes` to the String-handle slot at `addr`,
+    /// releasing what was there. Only an `-override` of a String parameter needs it.
+    fn set_string(&mut self, _addr: u32, _bytes: &[u8]) -> Result<()> {
+        Err("CodegenWasmJit: this backend cannot set a String")
+    }
 }
 
 /// C's `EVAL_CONTEXT`, mirrored from the runtime's `nls.rs`. `unsetContext` restores
@@ -618,7 +623,7 @@ impl StepRetry {
     fn undo(&mut self, e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<Option<f64>> {
         // Only a model error the region absorbed reaches C's catch; a rethrown
         // `assert()` is `MMC_THROW_INTERNAL`, which jumps past it.
-        let caught = self.end(e) || self.threw;
+        let caught = self.end(e) || self.threw || RUNTIME_ERROR.load(Ordering::Relaxed);
         if !caught || !self.stored {
             return Ok(None);
         }
@@ -1172,13 +1177,16 @@ mod overrides_store {
         use super::WTy;
         use alloc::vec::Vec;
         use core::cell::RefCell;
+        use alloc::string::String;
         std::thread_local! {
             static PARAM: RefCell<Vec<(u32, WTy, f64)>> = const { RefCell::new(Vec::new()) };
             static START: RefCell<Vec<(u32, WTy, f64)>> = const { RefCell::new(Vec::new()) };
+            static STRINGS: RefCell<Vec<(u32, String)>> = const { RefCell::new(Vec::new()) };
         }
-        pub fn set(p: Vec<(u32, WTy, f64)>, s: Vec<(u32, WTy, f64)>) {
+        pub fn set(p: Vec<(u32, WTy, f64)>, s: Vec<(u32, WTy, f64)>, t: Vec<(u32, String)>) {
             PARAM.with(|o| *o.borrow_mut() = p);
             START.with(|o| *o.borrow_mut() = s);
+            STRINGS.with(|o| *o.borrow_mut() = t);
         }
         pub fn params() -> Vec<(u32, WTy, f64)> {
             PARAM.with(|o| o.borrow().clone())
@@ -1186,19 +1194,24 @@ mod overrides_store {
         pub fn starts() -> Vec<(u32, WTy, f64)> {
             START.with(|o| o.borrow().clone())
         }
+        pub fn strings() -> Vec<(u32, String)> {
+            STRINGS.with(|o| o.borrow().clone())
+        }
     }
 
     #[cfg(not(feature = "std"))]
     mod imp {
         use super::WTy;
+        use alloc::string::String;
         use alloc::vec::Vec;
         use core::cell::UnsafeCell;
         // The in-wasm runtime is single-threaded, so a plain cell is sound.
-        struct Store(UnsafeCell<(Vec<(u32, WTy, f64)>, Vec<(u32, WTy, f64)>)>);
+        type Groups = (Vec<(u32, WTy, f64)>, Vec<(u32, WTy, f64)>, Vec<(u32, String)>);
+        struct Store(UnsafeCell<Groups>);
         unsafe impl Sync for Store {}
-        static STORE: Store = Store(UnsafeCell::new((Vec::new(), Vec::new())));
-        pub fn set(p: Vec<(u32, WTy, f64)>, s: Vec<(u32, WTy, f64)>) {
-            unsafe { *STORE.0.get() = (p, s) };
+        static STORE: Store = Store(UnsafeCell::new((Vec::new(), Vec::new(), Vec::new())));
+        pub fn set(p: Vec<(u32, WTy, f64)>, s: Vec<(u32, WTy, f64)>, t: Vec<(u32, String)>) {
+            unsafe { *STORE.0.get() = (p, s, t) };
         }
         pub fn params() -> Vec<(u32, WTy, f64)> {
             unsafe { (*STORE.0.get()).0.clone() }
@@ -1206,21 +1219,30 @@ mod overrides_store {
         pub fn starts() -> Vec<(u32, WTy, f64)> {
             unsafe { (*STORE.0.get()).1.clone() }
         }
+        pub fn strings() -> Vec<(u32, String)> {
+            unsafe { (*STORE.0.get()).2.clone() }
+        }
     }
 
-    pub use imp::{params, set, starts};
+    pub use imp::{params, set, starts, strings};
 }
 
 /// Set the parameter/start overrides applied by the next [`run_initialization`].
-pub fn set_param_overrides(params: Vec<(u32, WTy, f64)>, starts: Vec<(u32, WTy, f64)>) {
-    overrides_store::set(params, starts);
+/// `strings` are the String parameters among them, whose value is bytes rather
+/// than a number.
+pub fn set_param_overrides(
+    params: Vec<(u32, WTy, f64)>,
+    starts: Vec<(u32, WTy, f64)>,
+    strings: Vec<(u32, String)>,
+) {
+    overrides_store::set(params, starts, strings);
 }
 
-/// The overrides last set, as `(params, starts)`. A host driving the in-wasm
-/// session must forward these into it: the runtime module has its own copy of this
-/// store, which `set_param_overrides` on the host side does not reach.
-pub fn param_overrides() -> (Vec<(u32, WTy, f64)>, Vec<(u32, WTy, f64)>) {
-    (overrides_store::params(), overrides_store::starts())
+/// The overrides last set, as `(params, starts, strings)`. A host driving the
+/// in-wasm session must forward these into it: the runtime module has its own copy
+/// of this store, which [`set_param_overrides`] on the host side does not reach.
+pub fn param_overrides() -> (Vec<(u32, WTy, f64)>, Vec<(u32, WTy, f64)>, Vec<(u32, String)>) {
+    (overrides_store::params(), overrides_store::starts(), overrides_store::strings())
 }
 
 fn apply_overrides(e: &mut dyn SimEngine, sim_data: u32, overrides: &[(u32, WTy, f64)]) -> Result<()> {
@@ -1234,7 +1256,11 @@ fn apply_overrides(e: &mut dyn SimEngine, sim_data: u32, overrides: &[(u32, WTy,
 }
 
 fn apply_param_overrides(e: &mut dyn SimEngine, sim_data: u32) -> Result<()> {
-    apply_overrides(e, sim_data, &overrides_store::params())
+    apply_overrides(e, sim_data, &overrides_store::params())?;
+    for (off, value) in overrides_store::strings() {
+        e.set_string(sim_data + off, value.as_bytes())?;
+    }
+    Ok(())
 }
 
 /// What `-iif` found, by index into the concatenated [`SimMeta::import_roster`]. The
@@ -1420,7 +1446,9 @@ pub const ASSERT_ERR: &str = "assertion failed";
 /// cancelled run or a raw wasm trap is not. Which buffer it targeted, and so whether
 /// the step is retried, is [`StepRetry::undo`]'s.
 pub fn is_model_throw(err: &str) -> bool {
-    err == ASSERT_ERR
+    // An external function's `ModelicaError` unwinds as a bare engine trap; only the
+    // flag it left says the solver may retake the step.
+    err == ASSERT_ERR || RUNTIME_ERROR.load(Ordering::Relaxed)
 }
 /// C's `initialization()` returning nonzero: the reason is already logged.
 pub const INIT_FAILED_ERR: &str = "initialization failed";
@@ -2510,6 +2538,15 @@ pub(crate) fn terminated(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -
     Ok(true)
 }
 
+/// `printInfo`'s bracketed position, then the message.
+static TERMINATE_REPORTER: AtomicUsize = AtomicUsize::new(0);
+
+/// Report `terminate()` this way instead of as the driver's own notice — C's
+/// `omc_terminate`, which `fmi2Instantiate` swaps for `omc_terminate_fmi`.
+pub fn set_terminate_reporter(f: fn(&str, &str)) {
+    TERMINATE_REPORTER.store(f as usize, Ordering::Relaxed);
+}
+
 /// C's `checkSimulationTerminated` notice: the source position raw (`printInfo`,
 /// outside the message system) then the message, once per run. `at_init` picks
 /// the wording C uses before the main loop.
@@ -2520,10 +2557,16 @@ fn report_terminate(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout, at_ini
     let w = |i: u32| read_i32(e, sim_data + layout.term_info_off + i * 4);
     let msg = read_rt_string(e, w(0)?)?;
     let file = read_rt_string(e, w(1)?)?;
+    let ro = if w(6)? != 0 { "readonly" } else { "writable" };
+    let pos = format!("[{file}:{}:{}-{}:{}:{ro}]", w(2)?, w(3)?, w(4)?, w(5)?);
+    let p = TERMINATE_REPORTER.load(Ordering::Relaxed);
+    if p != 0 {
+        let f: fn(&str, &str) = unsafe { core::mem::transmute(p) };
+        f(&pos, &msg);
+        return Ok(());
+    }
     if !file.is_empty() {
-        let ro = if w(6)? != 0 { "readonly" } else { "writable" };
-        log_line(crate::omclog::STDOUT, crate::omclog::INFO,
-                 &format!("[{file}:{}:{}-{}:{}:{ro}]\n", w(2)?, w(3)?, w(4)?, w(5)?));
+        log_line(crate::omclog::STDOUT, crate::omclog::INFO, &format!("{pos}\n"));
     }
     let time = format_f(read_f64(e, sim_data + TIME_OFF)?);
     let at = if at_init { format!("at initialization (time {time})") } else { format!("at time {time}") };

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/Cargo.toml
@@ -22,6 +22,9 @@ regex = "1"
 roxmltree.workspace=true
 # FMU extraction in the hand-written FMIExt.rs.
 zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
+# The port's FMU reader, which `importFMU` reads an FMI 3.0 model description
+# with. `component` is the wasm-tools half, which nothing here looks at.
+openmodelica_fmi = { path = "../openmodelica_fmi", default-features = false }
 # Resolves the `d*_` symbols `src/Lapack.rs` declares, on every target, in place
 # of a system `liblapack.so` — so wasm (nothing to link) and Windows (no MSVC-ABI
 # LAPACK) run the same code as Linux instead of a reduced fallback.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/FMIExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/FMIExt.rs
@@ -80,22 +80,32 @@ static JM_LOG_LEVEL: std::sync::OnceLock<i32> = std::sync::OnceLock::new();
 
 /// jm_log_level_warning.
 const JM_LOG_LEVEL_WARNING: i32 = 3;
+/// jm_log_level_error.
+const JM_LOG_LEVEL_ERROR: i32 = 2;
 
 /// FMIImpl.c's `importlogger`. The tokens read message/level/module because
 /// c_add_message reverses them.
-fn jm_log_warning(module: &str, message: &str) {
-    if JM_LOG_LEVEL_WARNING > *JM_LOG_LEVEL.get().unwrap_or(&JM_LOG_LEVEL_WARNING) {
+fn jm_log(level: i32, level_name: ArcStr, severity: ErrorTypes::Severity, module: &str, message: &str) {
+    if level > *JM_LOG_LEVEL.get().unwrap_or(&JM_LOG_LEVEL_WARNING) {
         return;
     }
     let _ = Error::addMessage(
         ErrorTypes::Message {
             id: -1,
             ty: ErrorTypes::MessageType::SCRIPTING,
-            severity: ErrorTypes::Severity::WARNING,
+            severity,
             message: arcstr::literal!("module = %s, log level = %s: %s"),
         },
-        metamodelica::list![ArcStr::from(message), arcstr::literal!("WARNING"), ArcStr::from(module)],
+        metamodelica::list![ArcStr::from(message), level_name, ArcStr::from(module)],
     );
+}
+
+fn jm_log_warning(module: &str, message: &str) {
+    jm_log(JM_LOG_LEVEL_WARNING, arcstr::literal!("WARNING"), ErrorTypes::Severity::WARNING, module, message);
+}
+
+fn jm_log_error(module: &str, message: &str) {
+    jm_log(JM_LOG_LEVEL_ERROR, arcstr::literal!("ERROR"), ErrorTypes::Severity::ERROR, module, message);
 }
 
 type InitializeFMIImportResult = (
@@ -191,6 +201,19 @@ pub fn initializeFMIImport(
                 add_scripting_error(CS_UNSUPPORTED_ERR, &["CoSimulation"]);
                 return Ok(failure());
             }
+            Ok((true, Some(0), Some(0), info, typedefs, experiment, Some(0), vars))
+        }
+        Some("3.0") => {
+            // `fmi3_import_parse_xml` reports what its scheme does not know before
+            // anything is read out of the document, then does the same for the
+            // FMU's `terminalsAndIcons.xml` if it has one.
+            fmi3_scheme_diagnostics(&root, FMI3_MD_ELEMENTS, FMI3_MD_ATTRIBUTES);
+            terminals_and_icons_diagnostics(&inWorkingDirectory);
+            let Some((info, typedefs, experiment, vars)) = parse_fmi3(&xml_text, inInputConnectors, inOutputConnectors)
+            else {
+                add_scripting_error(PARSE_ERR, &[]);
+                return Ok(failure());
+            };
             Ok((true, Some(0), Some(0), info, typedefs, experiment, Some(0), vars))
         }
         // Missing attribute, wrong root element, or an unsupported version
@@ -742,4 +765,352 @@ fn parse_type_definitions(
     // fmilib's name-sorted table order, then reversed by prepending.
     enums.sort_by(|a, b| a.name.as_bytes().cmp(b.name.as_bytes()));
     Some(prepended_list(enums))
+}
+
+// ───────────────────────────────── FMI 3.0 ───────────────────────────────
+//
+// fmilib parses a 3.0 FMU with a generic XML driver plus a *scheme*: the element
+// and attribute names it knows. Anything outside it is reported, which an import
+// prints — hence the tables and the two diagnostics passes below.
+
+const FMI3XML: &str = "FMI3XML";
+const XSI_NS: &str = "http://www.w3.org/2001/XMLSchema-instance";
+
+/// `FMI3_XML_ELMLIST_MODEL_DESCR`.
+const FMI3_MD_ELEMENTS: &[&str] = &[
+    "fmiModelDescription", "ModelExchange", "CoSimulation", "ScheduledExecution", "SourceFiles",
+    "File", "UnitDefinitions", "Unit", "BaseUnit", "DisplayUnit", "TypeDefinitions", "SimpleType",
+    "Item", "DefaultExperiment", "VendorAnnotations", "Tool", "ModelVariables", "Dimension",
+    "Start", "Alias", "Annotations", "LogCategories", "Category", "Float64Type", "Float32Type",
+    "Int64Type", "Int32Type", "Int16Type", "Int8Type", "UInt64Type", "UInt32Type", "UInt16Type",
+    "UInt8Type", "BooleanType", "BinaryType", "ClockType", "StringType", "EnumerationType",
+    "ModelStructure", "Output", "ContinuousStateDerivative", "ClockedState", "InitialUnknown",
+    "EventIndicator", "Float64", "Float32", "Int64", "Int32", "Int16", "Int8", "UInt64", "UInt32",
+    "UInt16", "UInt8", "Boolean", "Binary", "Clock", "String", "Enumeration",
+];
+
+/// `FMI3_XML_ATTRLIST_MODEL_DESCR`, with `FMI3_SI_BASE_UNITS` spelled out.
+const FMI3_MD_ATTRIBUTES: &[&str] = &[
+    "fmiVersion", "name", "description", "factor", "offset", "inverse",
+    "kg", "m", "s", "A", "K", "mol", "cd", "rad",
+    "quantity", "unit", "displayUnit", "relativeQuantity", "unbounded", "min", "max", "nominal",
+    "declaredType", "start", "derivative", "reinit", "startTime", "stopTime", "tolerance",
+    "stepSize", "value", "valueReference", "variability", "causality", "initial", "previous",
+    "clocks", "canHandleMultipleSetPerTimeInstant", "intermediateUpdate", "mimeType", "maxSize",
+    "intervalVariability", "canBeDeactivated", "priority", "intervalDecimal", "shiftDecimal",
+    "supportsFraction", "resolution", "intervalCounter", "shiftCounter", "dependencies",
+    "dependenciesKind", "modelName", "modelIdentifier", "instantiationToken", "author",
+    "copyright", "license", "version", "generationTool", "generationDateAndTime",
+    "variableNamingConvention", "numberOfEventIndicators", "input", "needsExecutionTool",
+    "canBeInstantiatedOnlyOncePerProcess", "canGetAndSetFMUState", "canSerializeFMUState",
+    "providesDirectionalDerivatives", "providesDirectionalDerivative", "providesAdjointDerivatives",
+    "providesPerElementDependencies", "providesEvaluateDiscreteStates",
+    "needsCompletedIntegratorStep", "canHandleVariableCommunicationStepSize",
+    "fixedInternalStepSize", "maxOutputDerivativeOrder", "recommendedIntermediateInputSmoothness",
+    "providesIntermediateUpdate", "mightReturnEarlyFromDoStep",
+    "canReturnEarlyAfterIntermediateUpdate", "hasEventMode",
+];
+
+/// `FMI_XML_ELMLIST_TERM_ICON` / `FMI_XML_ATTRLIST_TERM_ICON`: the whole scheme.
+const TERM_ICON_ELEMENTS: &[&str] = &[
+    "fmiTerminalsAndIcons", "Terminals", "Terminal", "TerminalMemberVariable",
+    "TerminalStreamMemberVariable", "TerminalGraphicalRepresentation",
+];
+const TERM_ICON_ATTRIBUTES: &[&str] = &["fmiVersion", "name", "description"];
+
+/// The attribute half of `fmi3_parse_element_start`. An unknown element is skipped
+/// along with its subtree, as `skipElementCnt` does.
+fn fmi3_scheme_diagnostics(node: &roxmltree::Node<'_, '_>, elements: &[&str], attributes: &[&str]) {
+    if !elements.contains(&node.tag_name().name()) {
+        return;
+    }
+    for a in node.attributes() {
+        match a.namespace() {
+            Some(XSI_NS) => match a.name() {
+                "noNamespaceSchemaLocation" => jm_log_warning(
+                    FMI3XML,
+                    &format!(
+                        "Attribute noNamespaceSchemaLocation='{}' is ignored. Using standard fmiModelDescription.xsd.",
+                        a.value()
+                    ),
+                ),
+                "nil" | "type" => jm_log_warning(
+                    FMI3XML,
+                    &format!("Attribute {{{XSI_NS}}}{}={} is ignored", a.name(), a.value()),
+                ),
+                "schemaLocation" => {}
+                other => jm_log_error(
+                    FMI3XML,
+                    &format!("Unknown attribute '{XSI_NS}|{other}={}' in XML", a.value()),
+                ),
+            },
+            // A namespace fmilib has no expat prefix for reaches the name test bare.
+            _ if attributes.contains(&a.name()) => {}
+            _ if a.name().starts_with("providesPartialDerivativesOf_") => jm_log_warning(
+                FMI3XML,
+                &format!(
+                    "FMI API function fmiGetPartialDerivatives is removed from the specification. \
+                     Attribute {} will be ignored.",
+                    a.name()
+                ),
+            ),
+            _ => jm_log_error(FMI3XML, &format!("Unknown attribute '{}={}' in XML", a.name(), a.value())),
+        }
+    }
+    for child in node.children().filter(|c| c.is_element()) {
+        fmi3_scheme_diagnostics(&child, elements, attributes);
+    }
+}
+
+/// `fmi3_xml_parse_terminals_and_icons`, run after the model description. A missing
+/// or unreadable file is not an error (fmilib logs it at info level, which is dropped).
+fn terminals_and_icons_diagnostics(working_directory: &str) {
+    let path = format!("{working_directory}/terminalsAndIcons/terminalsAndIcons.xml");
+    let Ok(bytes) = openmodelica_wasi::fs::read(&path) else { return };
+    let Ok(text) = String::from_utf8(bytes) else { return };
+    let Ok(doc) = roxmltree::Document::parse(&text) else { return };
+    fmi3_scheme_diagnostics(&doc.root_element(), TERM_ICON_ELEMENTS, TERM_ICON_ATTRIBUTES);
+}
+
+/// `FMIImpl__initializeFMI3Import`, over the model description `openmodelica_fmi`
+/// read. The `fmi3_import_get_*` calls C makes are a *view* of that document, so only
+/// the view is written out: fmilib's spellings, and the reversed lists the
+/// MetaModelica caller expects.
+///
+/// FMI 1.0 and 2.0 keep their own readers below — they must reproduce fmilib's
+/// quirks, which the shared reader deliberately does not have.
+fn parse_fmi3(
+    xml: &str,
+    input_connectors: bool,
+    output_connectors: bool,
+) -> Option<ParsedModelDescription> {
+    use openmodelica_fmi::{Causality, Dimension, Start, VarType, Variability};
+
+    let md = openmodelica_fmi::model_description(xml).ok()?;
+
+    // FMIImpl takes the model identifier of the interface it imports, Model Exchange
+    // first (fmi3_fmu_kind_enu_t: me = 2, cs = 4, se = 8).
+    let (fmi_type, interface) = [(2, &md.model_exchange), (4, &md.co_simulation), (8, &md.scheduled_execution)]
+        .into_iter()
+        .find_map(|(kind, i)| Some((kind, i.as_ref()?)))?;
+
+    let info = FMI::Info {
+        fmiVersion: arcstr::literal!("3.0"),
+        fmiType: fmi_type,
+        fmiModelName: ArcStr::from(md.model_name.as_str()),
+        fmiModelIdentifier: ArcStr::from(interface.model_identifier.as_str()),
+        fmiGuid: ArcStr::from(md.instantiation_token.as_str()),
+        fmiDescription: escaped_description(md.description.as_deref()),
+        fmiGenerationTool: ArcStr::from(md.generation_tool.as_deref().unwrap_or("")),
+        fmiGenerationDateAndTime: ArcStr::from(md.generation_date_and_time.as_deref().unwrap_or("")),
+        fmiVariableNamingConvention: ArcStr::from(md.variable_naming_convention.as_str()),
+        // FMI 3.0 has no scalar counts: both come from the <ModelStructure> lists.
+        fmiNumberOfContinuousStates: descending_int_list(md.model_structure.continuous_state_derivatives.len() as u32),
+        fmiNumberOfEventIndicators: descending_int_list(md.number_of_event_indicators),
+    };
+
+    // Only enumeration types are imported, as in FMI 1.0/2.0.
+    let mut enums: Vec<FMI::TypeDefinitions> = Vec::new();
+    for td in md.type_definitions.iter().filter(|t| t.ty == VarType::Enumeration) {
+        let mut items: Vec<_> = td.items.iter().collect();
+        items.sort_by_key(|i| i.value);
+        enums.push(FMI::TypeDefinitions {
+            name: ArcStr::from(make_string_fmi_safe(&td.name)),
+            description: ArcStr::from(td.description.as_deref().unwrap_or("")),
+            quantity: ArcStr::from(td.quantity.as_deref().unwrap_or("")),
+            min: items.first().map(|i| i.value as i32).unwrap_or(0),
+            max: items.last().map(|i| i.value as i32).unwrap_or(0),
+            items: prepended_list(items.into_iter().rev().map(|i| FMI::EnumerationItem {
+                name: ArcStr::from(i.name.as_str()),
+                description: ArcStr::from(i.description.as_deref().unwrap_or("")),
+            })),
+        });
+    }
+    enums.sort_by(|a, b| a.name.as_bytes().cmp(b.name.as_bytes()));
+
+    let experiment = fmi3_default_experiment(&md);
+
+    let mut variables: Vec<FMI::ModelVariables> = Vec::new();
+    let mut placements = (60, 60);
+    for v in &md.variables {
+        // getFMI3ModelVariableCausality: a structural parameter is reported as a
+        // parameter, and the independent one is named so the wrapper can leave it out.
+        let causality = match v.causality {
+            Causality::Input => arcstr::literal!("input"),
+            Causality::Output => arcstr::literal!("output"),
+            Causality::Parameter | Causality::StructuralParameter => arcstr::literal!("parameter"),
+            Causality::Independent => arcstr::literal!("independent"),
+            Causality::Local | Causality::CalculatedParameter => arcstr::literal!(""),
+        };
+        // getFMI3ModelVariableVariability: only "constant" is passed through; the
+        // rest leaves the wrapper on the Modelica default.
+        let variability = if v.variability == Variability::Constant {
+            arcstr::literal!("constant")
+        } else {
+            arcstr::literal!("")
+        };
+        // An enumeration's Modelica type is the name of its declared type; Binary
+        // and Clock have none.
+        let declared = ArcStr::from(make_string_fmi_safe(v.declared_type.as_deref().unwrap_or("")));
+        let base_type = match v.ty {
+            VarType::Float32 | VarType::Float64 => arcstr::literal!("Real"),
+            VarType::Int8 | VarType::UInt8 | VarType::Int16 | VarType::UInt16
+            | VarType::Int32 | VarType::UInt32 | VarType::Int64 | VarType::UInt64 => arcstr::literal!("Integer"),
+            VarType::Boolean => arcstr::literal!("Boolean"),
+            VarType::String => arcstr::literal!("String"),
+            VarType::Enumeration => declared.clone(),
+            VarType::Binary | VarType::Clock => arcstr::literal!(""),
+        };
+        // `fmi3_base_type_to_string` has no name for the two types outside the
+        // base-type enum's string table.
+        let fmi_type = match v.ty {
+            VarType::Binary | VarType::Clock => arcstr::literal!("Error"),
+            t => ArcStr::from(t.as_str()),
+        };
+        // A dimension given by a value reference is only known once the FMU is
+        // instantiated, and is reported as 0.
+        let dimensions = prepended_list(v.dimensions.iter().rev().map(|d| match d {
+            Dimension::Fixed(k) => *k as i32,
+            Dimension::ValueReference(_) => 0,
+        }));
+        // The records take a list because a variable can be an array; C reads only the
+        // scalar start.
+        let start = if v.dimensions.is_empty() { v.start.as_ref() } else { None };
+
+        let (mut x1, mut x2, mut y1, mut y2) = (0, 0, 0, 0);
+        if causality == "input" && input_connectors {
+            (x1, x2, y1, y2) = (-120, -100, placements.0, placements.0 + 20);
+            placements.0 -= 25;
+        } else if causality == "output" && output_connectors {
+            (x1, x2, y1, y2) = (100, 120, placements.1, placements.1 + 20);
+            placements.1 -= 25;
+        }
+
+        macro_rules! variable {
+            ($variant:ident, $start_value:expr $(, $extra:ident : $value:expr)*) => {
+                FMI::ModelVariables::$variant {
+                    // fmilib variable pointer in C; carries no meaning here.
+                    instance: 0,
+                    name: ArcStr::from(make_string_fmi_safe(&v.name)),
+                    description: escaped_description(v.description.as_deref()),
+                    baseType: base_type,
+                    fmiType: fmi_type,
+                    variability,
+                    causality,
+                    hasStartValue: v.start.is_some(),
+                    isFixed: v.variability == Variability::Fixed,
+                    valueReference: v.value_reference as i32,
+                    dimensions,
+                    $($extra: $value,)*
+                    startValue: $start_value,
+                    x1Placement: x1,
+                    x2Placement: x2,
+                    y1Placement: y1,
+                    y2Placement: y2,
+                }
+            };
+        }
+        let first_int = || match start {
+            Some(Start::Ints(i)) => prepended_list(i.first().map(|&i| i as i32)),
+            _ => metamodelica::nil(),
+        };
+        variables.push(match v.ty {
+            VarType::Float32 | VarType::Float64 => variable!(
+                FMI3REALVARIABLE,
+                match start {
+                    Some(Start::Reals(r)) => prepended_list(r.first().map(|&r| metamodelica::Real::from(r))),
+                    _ => metamodelica::nil(),
+                }
+            ),
+            VarType::Boolean => variable!(
+                FMI3BOOLEANVARIABLE,
+                match start {
+                    Some(Start::Bools(b)) => prepended_list(b.first().copied()),
+                    _ => metamodelica::nil(),
+                }
+            ),
+            VarType::String => variable!(
+                FMI3STRINGVARIABLE,
+                match start {
+                    Some(Start::Strings(s)) => prepended_list(s.first().map(|s| ArcStr::from(s.as_str()))),
+                    _ => metamodelica::nil(),
+                }
+            ),
+            VarType::Enumeration => variable!(FMI3ENUMERATIONVARIABLE, first_int(), declaredType: declared),
+            VarType::Binary => variable!(
+                FMI3BINARYVARIABLE,
+                // `getFMI3ModelVariableStartValue` reads no start for a Binary.
+                metamodelica::nil(),
+                mimeType: ArcStr::from(v.binary.as_ref().map(|b| b.mime_type.as_str()).unwrap_or("")),
+                maxSize: v.binary.as_ref().and_then(|b| b.max_size).unwrap_or(0) as i32
+            ),
+            VarType::Clock => FMI::ModelVariables::FMI3CLOCKVARIABLE {
+                instance: 0,
+                name: ArcStr::from(make_string_fmi_safe(&v.name)),
+                description: escaped_description(v.description.as_deref()),
+                baseType: base_type,
+                fmiType: fmi_type,
+                variability,
+                causality,
+                hasStartValue: v.start.is_some(),
+                isFixed: v.variability == Variability::Fixed,
+                valueReference: v.value_reference as i32,
+                dimensions,
+                intervalVariability: ArcStr::from(
+                    v.clock.as_ref().map(|c| interval_variability_string(c.interval_variability)).unwrap_or(""),
+                ),
+                intervalDecimal: metamodelica::Real::from(
+                    v.clock.as_ref().and_then(|c| c.interval_decimal).unwrap_or(0.0),
+                ),
+                hasIntervalDecimal: v.clock.as_ref().is_some_and(|c| c.interval_decimal.is_some()),
+                x1Placement: x1,
+                x2Placement: x2,
+                y1Placement: y1,
+                y2Placement: y2,
+            },
+            _ => variable!(FMI3INTEGERVARIABLE, first_int()),
+        });
+    }
+    Some((info, prepended_list(enums), experiment, prepended_list(variables)))
+}
+
+/// `getFMI3IntervalVariability`, which FMI Library has no `to_string` for.
+fn interval_variability_string(v: openmodelica_fmi::IntervalVariability) -> &'static str {
+    use openmodelica_fmi::IntervalVariability as I;
+    match v {
+        I::Constant => "constant",
+        I::Fixed => "fixed",
+        I::Tunable => "tunable",
+        I::Changing => "changing",
+        I::Countdown => "countdown",
+        I::Triggered => "triggered",
+    }
+}
+
+/// `<DefaultExperiment>`: each fmilib getter warns when its attribute was absent,
+/// and FMIImpl.c reads them in this order.
+fn fmi3_default_experiment(md: &openmodelica_fmi::ModelDescription) -> FMI::ExperimentAnnotation {
+    let de = md.default_experiment;
+    let mut values = [0.0, 1.0, 1e-4];
+    for (value, (getter, given)) in values.iter_mut().zip([
+        ("start", de.and_then(|d| d.start_time)),
+        ("stop", de.and_then(|d| d.stop_time)),
+        ("tolerance", de.and_then(|d| d.tolerance)),
+    ]) {
+        match given {
+            Some(v) => *value = v,
+            None => jm_log_warning(
+                FMI3XML,
+                &format!(
+                    "fmi3_xml_get_default_experiment_{getter}: returning default value, \
+                     since no attribute was defined in modelDescription"
+                ),
+            ),
+        }
+    }
+    FMI::ExperimentAnnotation {
+        fmiExperimentStartTime: metamodelica::Real::from(values[0]),
+        fmiExperimentStopTime: metamodelica::Real::from(values[1]),
+        fmiExperimentTolerance: metamodelica::Real::from(values[2]),
+    }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
@@ -617,7 +617,14 @@ pub fn systemCall(command: ArcStr, outFile: ArcStr) -> i32 {
     // Spawn /bin/sh -c <command>; if outFile is non-empty, redirect both
     // stdout and stderr there. Returns the child's exit code, or -1 on
     // spawn failure.
+    use std::io::Write;
     use std::process::{Command, Stdio};
+    // C's `fflush(NULL)` around the call: the child writes to the same fd 1, so
+    // whatever `print()` left in the buffer has to be out first.
+    let flush = || {
+        let _ = std::io::stdout().flush();
+    };
+    flush();
     let mut cmd = Command::new("/bin/sh");
     cmd.arg("-c").arg(command.as_str());
     if !outFile.is_empty() {
@@ -633,10 +640,12 @@ pub fn systemCall(command: ArcStr, outFile: ArcStr) -> i32 {
             Err(_) => return -1,
         }
     }
-    match cmd.status() {
+    let status = match cmd.status() {
         Ok(s) => s.code().unwrap_or(-1),
         Err(_) => -1,
-    }
+    };
+    flush();
+    status
 }
 
 pub fn popen(command: ArcStr) -> (ArcStr, i32) {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
@@ -439,7 +439,7 @@ pub mod lin_solve {
 #[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
 pub fn add_host_builtins<T: 'static>(linker: &mut wasmtime::Linker<T>) -> Result<()> {
     let wt = |r: std::result::Result<&mut wasmtime::Linker<T>, wasmtime::Error>| r.map(|_| ()).map_err(|_| "CodegenWasmJit: wasm engine error");
-    wt(linker.func_wrap("rt", "rt_assert", |msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32, cond: i32, initial: i32| -> i32 {
+    wt(linker.func_wrap("rt", "rt_assert", |msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32, cond: i32, initial: i32, _sim_data: i32| -> i32 {
         assert_failed(cond, msg, file, sline, scol, eline, ecol, read_only, initial)
     }))?;
     wt(linker.func_wrap("rt", "rt_ext_stack_save", |mut caller: wasmtime::Caller<'_, T>| -> std::result::Result<i32, wasmtime::Error> {
@@ -627,7 +627,7 @@ impl HostMem {
 pub fn add_host_builtins(store: &mut wasmer::Store, imports: &mut wasmer::Imports) -> Result<HostMem> {
     use wasmer::Function;
     imports.define("rt", "rt_assert", Function::new_typed(store,
-        |msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32, cond: i32, initial: i32| -> i32 {
+        |msg: i32, file: i32, sline: i32, scol: i32, eline: i32, ecol: i32, read_only: i32, cond: i32, initial: i32, _sim_data: i32| -> i32 {
             assert_failed(cond, msg, file, sline, scol, eline, ecol, read_only, initial)
         }));
     imports.define("rt", "rt_assert_warning", Function::new_typed(store,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -471,6 +471,9 @@ pub struct EditableParam {
     pub is_start: bool,
     /// A Boolean quantity: reads an `-override` value C's `read_value_bool` way.
     pub is_bool: bool,
+    /// A String quantity: `off` holds a runtime-String handle, so an `-override`
+    /// value is assigned as bytes rather than read as a number.
+    pub is_string: bool,
     /// Enumeration literal names (1-based index → name), empty for non-enum.
     pub enum_names: Vec<String>,
 }
@@ -551,7 +554,7 @@ pub fn inwasm_driver_enabled() -> bool {
 /// `rt_sim_set_overrides`.
 #[cfg(feature = "jit")]
 pub fn encode_overrides() -> Vec<u8> {
-    let (params, starts) = crate::sim_driver::param_overrides();
+    let (params, starts, strings) = crate::sim_driver::param_overrides();
     let mut b = Vec::new();
     for group in [&params, &starts] {
         b.extend_from_slice(&(group.len() as u32).to_le_bytes());
@@ -560,6 +563,12 @@ pub fn encode_overrides() -> Vec<u8> {
             b.extend_from_slice(&(if matches!(wty, WTy::F64) { 0u32 } else { 1u32 }).to_le_bytes());
             b.extend_from_slice(&val.to_le_bytes());
         }
+    }
+    b.extend_from_slice(&(strings.len() as u32).to_le_bytes());
+    for (off, val) in &strings {
+        b.extend_from_slice(&off.to_le_bytes());
+        b.extend_from_slice(&(val.len() as u32).to_le_bytes());
+        b.extend_from_slice(val.as_bytes());
     }
     if let Some(i) = crate::sim_driver::start_imports() {
         b.extend_from_slice(&(i.values.len() as u32).to_le_bytes());

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -1179,6 +1179,19 @@ impl sim_driver::SimEngine for WasmerEngine {
             let _ = f.call(&mut self.store, time);
         }
     }
+    fn set_string(&mut self, addr: u32, bytes: &[u8]) -> Result<()> {
+        let exports = &self.rt_inst.exports;
+        let str_new = wt(exports.get_typed_function::<u32, u32>(&self.store, "rt_str_new"))?;
+        let str_data = wt(exports.get_typed_function::<u32, u32>(&self.store, "rt_str_data"))?;
+        let release = wt(exports.get_typed_function::<u32, ()>(&self.store, "rt_release"))?;
+        let mut old = [0u8; 4];
+        self.read_bytes(addr, &mut old)?;
+        let obj = wt(str_new.call(&mut self.store, bytes.len() as u32))?;
+        let at = wt(str_data.call(&mut self.store, obj))?;
+        self.write_bytes(at, bytes)?;
+        self.write_bytes(addr, &obj.to_le_bytes())?;
+        wt(release.call(&mut self.store, u32::from_le_bytes(old)))
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -1559,6 +1559,18 @@ impl sim_driver::SimEngine for WasmtimeEngine {
     fn set_rhs_final(&mut self, final_eval: bool) {
         openmodelica_util::dynload::set_rhs_final_flag(final_eval);
     }
+    fn set_string(&mut self, addr: u32, bytes: &[u8]) -> Result<()> {
+        let str_new = wt(self.rt_inst.get_typed_func::<u32, u32>(&mut self.store, "rt_str_new"))?;
+        let str_data = wt(self.rt_inst.get_typed_func::<u32, u32>(&mut self.store, "rt_str_data"))?;
+        let release = wt(self.rt_inst.get_typed_func::<u32, ()>(&mut self.store, "rt_release"))?;
+        let mut old = [0u8; 4];
+        self.read_bytes(addr, &mut old)?;
+        let obj = wt(str_new.call(&mut self.store, bytes.len() as u32))?;
+        let at = wt(str_data.call(&mut self.store, obj))?;
+        self.write_bytes(at, bytes)?;
+        self.write_bytes(addr, &obj.to_le_bytes())?;
+        wt(release.call(&mut self.store, u32::from_le_bytes(old)))
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -4478,7 +4478,7 @@ algorithm
   FlagsUtil.setConfigString(Flags.FMI_VERSION, "");
 end callTranslateModelFMU;
 
-protected function generateFMI3GraphicalRepresentation
+public function generateFMI3GraphicalRepresentation
   "FMI 3.0 graphical user annotations (issue #15686 task 9). Using the in-memory
    model instance (issue #15219) for the *graphical* side only, this renders the
    model Icon to terminalsAndIcons/icon.png (+ icon.svg), adds an FMI 3.0

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -976,6 +976,7 @@ public function emitWasmFMU
   input Absyn.Program program;
 protected
   String guid, modelDescriptionStr, simulationFlagsJson, htmlFile, htmlContent;
+  String fmutmp, terminalsDir = "";
   list<tuple<String,String>> extraFiles = {};
   list<SimCode.FmiTerminal> terminals;
   // `--fmuDirectory`: an export for an OpenModelica importer, which reads the
@@ -996,14 +997,25 @@ algorithm
     modelDescriptionStr := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + Tpl.textString(
       CodegenFMU3.fmiModelDescription(Tpl.emptyTxt, simCode, guid, FMUType, {}));
     ExecStat.execStat("FMU modelDescription.xml");
-    // The same XML the C target writes into terminalsAndIcons/. FMI 3.0 only. An
-    // unzipped export carries neither this nor the documentation, so it does not
-    // render them either.
+    // terminalsAndIcons/ by the C target's route: SimCode writes the XML, then the
+    // OMGraphics renderer adds the <GraphicalRepresentation> and the icons beside it.
     if not bareExport then
+      // The C export's scratch directory; old contents would be shipped verbatim.
+      fmutmp := Util.hashFileNamePrefix(simCode.fileNamePrefix) + ".fmutmp";
+      if System.directoryExists(fmutmp) and not System.removeDirectory(fmutmp) then
+        Error.addInternalError("Failed to remove directory: " + fmutmp, sourceInfo());
+        fail();
+      end if;
+      terminalsDir := fmutmp + "/terminalsAndIcons/";
       terminals := SimCodeUtil.getFMI3Terminals(simCode);
       if not listEmpty(terminals) then
-        extraFiles := ("terminalsAndIcons/terminalsAndIcons.xml",
-                       Tpl.textString(CodegenFMU3.fmiTerminalsAndIcons(Tpl.emptyTxt, terminals))) :: extraFiles;
+        Util.createDirectoryTree(terminalsDir);
+        System.writeFile(terminalsDir + "terminalsAndIcons.xml",
+                         Tpl.textString(CodegenFMU3.fmiTerminalsAndIcons(Tpl.emptyTxt, terminals)));
+      end if;
+      CevalScriptBackend.generateFMI3GraphicalRepresentation(simCode.modelInfo.name, fmutmp, simCode.fileNamePrefix);
+      if not System.directoryExists(terminalsDir) then
+        terminalsDir := "";
       end if;
       ExecStat.execStat("FMU terminalsAndIcons.xml");
     end if;
@@ -1017,11 +1029,11 @@ algorithm
   end if;
   simulationFlagsJson := wasmFMUSimulationFlagsJson(simCode);
   if FMI.isFMIMEType(FMUType) and FMI.isFMICSType(FMUType) then
-    CodegenWasmJit.emitMeCsFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, extraFiles, simulationFlagsJson);
+    CodegenWasmJit.emitMeCsFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, extraFiles, terminalsDir, simulationFlagsJson);
   elseif FMI.isFMICSType(FMUType) then
-    CodegenWasmJit.emitCsFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, extraFiles, simulationFlagsJson);
+    CodegenWasmJit.emitCsFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, extraFiles, terminalsDir, simulationFlagsJson);
   else
-    CodegenWasmJit.emitMeFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, extraFiles, simulationFlagsJson);
+    CodegenWasmJit.emitMeFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, extraFiles, terminalsDir, simulationFlagsJson);
   end if;
   setGlobalRoot(Global.optionSimCode, NONE());
 end emitWasmFMU;

--- a/OMCompiler/Compiler/Template/CodegenFMU3.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU3.tpl
@@ -381,22 +381,18 @@ case SIMCODE(__) then
 end ModelExchange3;
 
 template CoSimulation3(SimCode simCode, list<String> sourceFiles)
- "Generates the CoSimulation element for FMI 3.0. The capabilities are the
-  runtime's, so they depend on the code-generation target: the wasm-jit adapter
-  integrates itself and has no output derivatives, but supports Event Mode
-  (stops at events and reports them when the importer negotiates eventModeUsed)."
+ "Generates the CoSimulation element for FMI 3.0."
 ::=
 match simCode
 case SIMCODE(__) then
   let modelIdentifier = modelNamePrefix(simCode)
-  let isWasm = if stringEq(Config.simCodeTarget(), "wasm-jit") then "true" else "false"
   <<
   <CoSimulation
     modelIdentifier="<%Util.escapeModelicaStringToXmlString(modelIdentifier)%>"
     needsExecutionTool="false"
     canHandleVariableCommunicationStepSize="true"
     canBeInstantiatedOnlyOncePerProcess="false"
-    maxOutputDerivativeOrder="<%if stringEq(isWasm, "true") then "0" else "1"%>"
+    maxOutputDerivativeOrder="1"
     providesIntermediateUpdate="false"
     mightReturnEarlyFromDoStep="true"
     canReturnEarlyAfterIntermediateUpdate="false"

--- a/OMCompiler/Compiler/Template/CodegenWasmJit.mo
+++ b/OMCompiler/Compiler/Template/CodegenWasmJit.mo
@@ -128,7 +128,8 @@ function emitMeFmu
   input String fmuPath;
   input String guid;
   input String modelDescription;
-  input list<tuple<String,String>> extraFiles "further (path inside the FMU, content) entries: terminalsAndIcons, documentation";
+  input list<tuple<String,String>> extraFiles "further (path inside the FMU, content) entries: documentation";
+  input String terminalsDir "directory shipped as terminalsAndIcons/ (the XML and the rendered icons); empty for none";
   input String simulationFlagsJson "--fmiFlags as CodegenFMU renders it, empty when there are none";
 algorithm
   Error.addInternalError("CodegenWasmJit.emitMeFmu: the wasm FMU target is only implemented in the Rust omc build", sourceInfo());
@@ -143,7 +144,8 @@ function emitCsFmu
   input String fmuPath;
   input String guid;
   input String modelDescription;
-  input list<tuple<String,String>> extraFiles "further (path inside the FMU, content) entries: terminalsAndIcons, documentation";
+  input list<tuple<String,String>> extraFiles "further (path inside the FMU, content) entries: documentation";
+  input String terminalsDir "directory shipped as terminalsAndIcons/ (the XML and the rendered icons); empty for none";
   input String simulationFlagsJson "--fmiFlags as CodegenFMU renders it, empty when there are none";
 algorithm
   Error.addInternalError("CodegenWasmJit.emitCsFmu: the wasm FMU target is only implemented in the Rust omc build", sourceInfo());
@@ -158,7 +160,8 @@ function emitMeCsFmu
   input String fmuPath;
   input String guid;
   input String modelDescription;
-  input list<tuple<String,String>> extraFiles "further (path inside the FMU, content) entries: terminalsAndIcons, documentation";
+  input list<tuple<String,String>> extraFiles "further (path inside the FMU, content) entries: documentation";
+  input String terminalsDir "directory shipped as terminalsAndIcons/ (the XML and the rendered icons); empty for none";
   input String simulationFlagsJson "--fmiFlags as CodegenFMU renders it, empty when there are none";
 algorithm
   Error.addInternalError("CodegenWasmJit.emitMeCsFmu: the wasm FMU target is only implemented in the Rust omc build", sourceInfo());

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testChangeParam.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testChangeParam.mos
@@ -42,7 +42,12 @@ val(a, 1);
 val(y, 1);
 getErrorString();
 
-system("./test_ChangeParam_me_FMU -override a=-2,i=-10,b=false,s=\"bar\" -r test_ChangeParam.mat");
+// Re-run what was just built with the parameters overridden. resimulateExecutable
+// rather than system("./<model>"): the same run for a compiled target, and the only
+// one that exists for a target with no executable.
+simulate(test_ChangeParam_me_FMU, numberOfIntervals=1,
+         simflags="-override a=-2,i=-10,b=false,s=\"bar\" -r test_ChangeParam.mat",
+         resimulateExecutable="test_ChangeParam_me_FMU");
 readSimulationResult("test_ChangeParam.mat", {x,a,y});
 getErrorString();
 
@@ -73,9 +78,13 @@ getErrorString();
 // 2.0
 // 6.389089928644395
 // ""
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// record SimulationResult
+//     resultFile = "test_ChangeParam.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 1, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'test_ChangeParam_me_FMU', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-override a=-2,i=-10,b=false,s=\\'bar\\' -r test_ChangeParam.mat'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
-// 0
+// "
+// end SimulationResult;
 // {{1.0, 1.0, 1.0, 0.13533632118380395, 0.13533632118380395}, {-2.0, -2.0, -2.0, -2.0, -2.0}, {-11.0, -11.0, -11.0, -10.135336321183804, -10.135336321183804}}
 // ""
 // endResult


### PR DESCRIPTION
`importFMU` had no FMI 3.0 branch: `initializeFMIImport` mapped 3.0 to the "unknown version" arm and gave up. It now reads the model description through `openmodelica_fmi`, the port's own FMU reader, and writes out the view `FMIImpl__initializeFMI3Import` builds from the `fmi3_import_get_*` calls.

fmilib reaches the same document with a generic XML driver plus a *scheme* -- the element and attribute names it knows -- and reports whatever falls outside it. An import therefore always prints a warning for `xsi:noNamespaceSchemaLocation` and, when the FMU has a `terminalsAndIcons.xml`, an error per attribute its much smaller scheme does not know. Both passes are reproduced so the messages match.

On the export side the wasm FMU shipped `terminalsAndIcons/` as a single in-memory string, which cannot carry the PNG/SVG icons. `emitWasmFMU` now writes the XML into the C target's `.fmutmp` scratch directory, runs the OMGraphics renderer over it as the C export does, and hands the emitter the directory; a stale directory is removed first so nothing is shipped twice. `CoSimulation3` also drops its wasm-only `maxOutputDerivativeOrder="0"`.

## A failed assert no longer ends the FMU

C's `omc_assert_fmi` logs the violation and `longjmp`s to the buffer the FMI entry point set: the call returns `fmi2Error` and the instance stays usable, so the importer can retake the step. The wasm FMU trapped instead, and a trap ends a wasmtime component instance for good -- every later call answered `Error`.

A host-free module now carries the `model_error` tag whatever the model does, and a failed `assert()` throws it rather than executing `unreachable`. Each driver entry point gets an `<entry>$guard` wrapper -- the entry point called under a `try_table` for that tag, answering whether it threw -- and the adapter calls those, turning a throw into the status the FMI call reports. The unwind stops one frame deeper than C's does, at the model entry point rather than the FMI one, which is what lets the Rust adapter above it return a status normally.

The FMU's own error paths had been written against the trap, so they dropped what they now have to pass on: `eval()` ignored both its calls and `get_event_indicators` ignored its `functionODE`, while `fmi2CompletedIntegratorStep` only logged the assertion when the guest trapped. The *importing* simulation had to learn the throw too: an external function's `ModelicaError` reaches the step loop as a bare engine trap rather than `ASSERT_ERR`, so `is_model_throw` never held and C's one `retrySimulationStep` never ran.

## Also

| Change | Why |
| --- | --- |
| String `-override` | `_init.xml` lists String parameters and C's `singleOverride` reaches them; `SimEngine::set_string` assigns one through the runtime's String heap | | `rt_assert` takes `sim_data` | an FMU logs the violation where it fires and heads the `LOG_ASSERT` block with the run's time | | `terminate()` reporter | C's `omc_terminate_fmi`, which `fmi2Instantiate` installs in place of the driver's `LOG_STDOUT` notice | | `System.systemCall` | C's `fflush(NULL)` around the child, so testsuite output stays ordered | | FMI 3.0 `<Binary>` | `mimeType`/`maxSize` were not read; a parameter of any causality defaults to `fixed` |

`testChangeParam.mos` re-runs the built model with `resimulateExecutable` rather than `system("./<model>")`; a target with no executable has no way to do the latter.

Not enabled: `testAssert.mos`. It now reproduces C's whole retry sequence with every log line matching, but C evaluates the wrapper twice per step where this evaluates it once, and stops after the single retry where this takes one more step. Both are about how often the outer driver evaluates the wrapper's equation, not about the unwind. The two-argument entry points (`functionZeroCrossings`, `functionUpdateSynchronous`, `functionEquationsSynchronous`) are also still unguarded, needing a second wrapper signature.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
