### PR TITLE
wasm-jit: newton diagnostics, +profiling, homotopy CSV

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -211,12 +211,15 @@ openmodelica_codegen_wasm_jit_runtime/Cargo.toml
 openmodelica_codegen_wasm_jit_runtime/build-runtime.sh
 openmodelica_codegen_wasm_jit_runtime/build.rs
 openmodelica_codegen_wasm_jit_runtime/src/delay.rs
+openmodelica_codegen_wasm_jit_runtime/src/files.rs
 openmodelica_codegen_wasm_jit_runtime/src/jacobian_analysis.rs
 openmodelica_codegen_wasm_jit_runtime/src/lib.rs
 openmodelica_codegen_wasm_jit_runtime/src/lis.rs
+openmodelica_codegen_wasm_jit_runtime/src/newton_diagnostics.rs
 openmodelica_codegen_wasm_jit_runtime/src/nls.rs
 openmodelica_codegen_wasm_jit_runtime/src/primme_svds.c
 openmodelica_codegen_wasm_jit_runtime/src/nls_c_trace.rs
+openmodelica_codegen_wasm_jit_runtime/src/prof.rs
 openmodelica_codegen_wasm_jit_runtime/src/omclog.rs
 openmodelica_codegen_wasm_jit_runtime/src/model_ctx.rs
 openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -377,6 +380,7 @@ openmodelica_sim_meta/src/optimization/mod.rs
 openmodelica_sim_meta/src/optimization/model.rs
 openmodelica_sim_meta/src/optimization/setup.rs
 openmodelica_sim_meta/src/qss.rs
+openmodelica_sim_meta/src/profiling.rs
 openmodelica_sim_meta/src/rtclock.rs
 openmodelica_sim_meta/src/sync.rs
 openmodelica_sim_meta/src/sysstat.rs

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
@@ -15055,8 +15055,8 @@ fn emit_match<'a>(kind: &MatchKind, input: &TypedExp, cases: &[TypedCase], as_bi
                 // diverges (`continue`/`return`), so the fallback must diverge
                 // too: a value-typed `Err(…)` would not unify with the
                 // `!`-typed arms (and the `loop` body must stay `()`/`!`).
-                if active_tail.is_some() && ctx.current_fn_fallible {
-                    ",\n        _ => return Err(\"match: no arm matched\")".to_owned()
+                if matches!(ctx.qmode, QMode::TryBlock(_)) || (active_tail.is_some() && ctx.current_fn_fallible) {
+                    format!(",\n        _ => {}", emit_diverging_fail("match: no arm matched", false, ctx))
                 } else {
                     ",\n        _ => unreachable!(\"tail-call lowered match: no arm matched\")".to_owned()
                 }
@@ -15066,8 +15066,8 @@ fn emit_match<'a>(kind: &MatchKind, input: &TypedExp, cases: &[TypedCase], as_bi
                 // unifies with any T) and avoids `bail!`-style return-out
                 // semantics that wouldn't typecheck in every callsite.
                 ",\n        _ => unreachable!(\"match_deref! exhaustiveness placeholder\")".to_owned()
-            } else if ctx.current_fn_fallible {
-                ",\n        _ => return Err(\"match: no arm matched\")".to_owned()
+            } else if matches!(ctx.qmode, QMode::TryBlock(_)) || ctx.current_fn_fallible {
+                format!(",\n        _ => {}", emit_diverging_fail("match: no arm matched", false, ctx))
             } else {
                 // A non-fallible function can't `bail!`; a runtime miss of a
                 // non-exhaustive match panics instead (the typical source is an

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -57,7 +57,7 @@ use openmodelica_frontend_dump::ComponentReferenceBasics;
 
 use crate::CodegenWasmJitFunctions::{
     ArrayGroup, Attr, AttrTargets, BUILTINS, ConstGroup, ENV_EXTRA, ExtCallSig, FnCtx, FnInfo, Literals, NLS_BASE_GLOBAL, NLS_HIST_GLOBAL, NlsJob, RT_BUILTINS,
-    ScatterGroup, SimCtx, SimSlot, WTy, WTyVal, compile_function, compile_linear_system, compile_linear_system_analytic,
+    ProfPlan, ScatterGroup, SimCtx, SimSlot, WTy, WTyVal, compile_function, compile_linear_system, compile_linear_system_analytic,
     compile_linear_system_analytic_csc, compile_linear_system_symbolic,
     ClockInit, ClockUpdate,
     NlsResidual, NlsResiduals, backup_known_outputs, restore_known_outputs,
@@ -1213,7 +1213,10 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
         }
         let keep = output_selection(&model);
         capture_last_sim(&model, &run, &keep);
-        write_result(&model, &meta, &result_path(&flags, &meta, result_file), &run, &keep)?;
+        let path = result_path(&flags, &meta, result_file);
+        write_result(&model, &meta, &path, &run, &keep)?;
+        // C's `printModelInfo`, after the result file is closed.
+        openmodelica_sim_meta::profiling::finish(&meta, &path);
         post = write_lin_file(&meta, &run, &flags);
         Ok(())
     })();
@@ -1375,6 +1378,7 @@ mod session {
         let keep = output_selection(model);
         capture_last_sim(model, run, &keep);
         write_result(model, meta, result_file, run, &keep)?;
+        openmodelica_sim_meta::profiling::finish(meta, result_file);
         Ok(write_lin_file(meta, run, &simflags::flags()))
     }
 
@@ -3440,6 +3444,8 @@ pub(crate) struct SimVarMap {
     n_delays: u32,
     /// Number of `spatialDistribution(...)` operators (`spatialInfo.maxIndex + 1`).
     n_spatial: u32,
+    /// `+profiling`'s clock plan (`SimCtx::prof`).
+    prof: Option<Arc<ProfPlan>>,
 }
 
 /// Display name of a model variable's component reference (OMC `.`-separated
@@ -3824,6 +3830,7 @@ fn build_var_map(
         clock_fire_off: layout.clock_fire_off,
         n_delays: 0,
         n_spatial: 0,
+        prof: None,
     };
     let mut result_vars: Vec<ResultVar> = Vec::new();
     // User-settable parameters (isValueChangeable), collected as they are laid out.
@@ -4839,6 +4846,8 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     );
 
     let (mut var_map, mut result_vars, editable_params) = build_var_map(vars, &layout)?;
+    let (prof_plan, prof_info) = prof_plan(sim_code, mi)?;
+    var_map.prof = prof_plan;
     // DAE-mode residual/auxiliary variables: their own `SimData` regions, indexed by
     // the SimVar's `index` as C's `crefToCStr` does. Solver workspace, not results.
     for (svs, base) in [(&dae_res_vars, layout.dae_res_off), (&dae_aux_vars, layout.dae_aux_off)] {
@@ -5354,6 +5363,17 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     let fmi_vrs = if fmi_vrs { build_fmi_vrs(sim_code, &var_map, &layout)? } else { Vec::new() };
     // C labels its `-lv=LOG_NLS` unknowns from the `_info.json` `defines` array,
     // which `SerializeModelInfo` writes from these same `crefs`.
+    // C diagnoses (`newtonDiagnostics`) the systems of `initialEquations_lambda0`,
+    // or of `initialEquations` when there is no lambda0 section.
+    let nls_in = |eqs: &[Arc<SimCode::SimEqSystem>]| -> HashSet<i32> {
+        eqs.iter()
+            .filter_map(|e| match &**e {
+                SimCode::SimEqSystem::SES_NONLINEAR { nlSystem, .. } => Some(nlSystem.index),
+                _ => None,
+            })
+            .collect()
+    };
+    let diag_nls = if lambda0_eqs.is_empty() { nls_in(&initial_eqs) } else { nls_in(&lambda0_eqs) };
     let nls_vars = nls_systems
         .iter()
         .map(|sys| {
@@ -5362,10 +5382,20 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
             // the `size` residual ones at the end are read back.
             let eqns: Vec<i32> = lst(&sys.eqs).map(|e| eq_index_of(e)).collect();
             let tail = eqns.len().saturating_sub(names.len());
+            let pattern = match &sys.jacobianMatrix {
+                Some(jm) => [
+                    lst(&jm.nonlinear).count() as u32,
+                    lst(&jm.nonlinearT).count() as u32,
+                    lst(&jm.nonlinear).map(|(_, cols)| lst(cols).count() as u32).sum(),
+                ],
+                None => [0; 3],
+            };
             Ok(openmodelica_sim_meta::NlsVars {
                 eq_index: sys.index as u32,
                 names,
                 eqns: eqns[tail..].to_vec(),
+                pattern,
+                init_diag: diag_nls.contains(&sys.index),
             })
         })
         .collect::<Result<Vec<_>>>()?;
@@ -5499,6 +5529,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
             sim_code, vars, &recon, &recon_jac_infos, &var_map,
             mi.varInfo.numRelatedBoundaryConditions.max(0) as u32,
         )?,
+        prof_info,
     );
     let meta_bytes = openmodelica_sim_meta::encode(&meta);
     let meta_len = meta_bytes.len() as u32;
@@ -5981,6 +6012,10 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
         if let Some((fn_indices, _)) = &nls_wiring {
             let sizes: Vec<u32> = nls_systems.iter().map(|s| lst(&s.crefs).count() as u32).collect();
             emit_nls_start(&mut f, fn_indices, nls_hist_bytes, &sizes, &nls_nominals, &nls_bounds, &nls_patterns);
+            if let Some(p) = &var_map.prof {
+                f.instruction(&we::Instruction::I32Const((p.n_functions + p.n_blocks) as i32));
+                f.instruction(&we::Instruction::Call(rt_index("rt_prof_init").expect("rt_prof_init is a runtime builtin")));
+            }
         }
         if !thunk_indices.is_empty() {
             crate::CodegenWasmJitFunctions::closures::emit_start(&mut f, &thunk_indices, closure_global);
@@ -6872,6 +6907,7 @@ fn build_sim_meta(
     opt: Option<openmodelica_sim_meta::OptInfo>,
     inputs: Vec<openmodelica_sim_meta::InputVar>,
     recon: Option<openmodelica_sim_meta::ReconInfo>,
+    prof: Option<openmodelica_sim_meta::ProfInfo>,
 ) -> openmodelica_sim_meta::SimMeta {
     openmodelica_sim_meta::SimMeta {
         layout: *layout,
@@ -6904,6 +6940,7 @@ fn build_sim_meta(
         opt,
         inputs,
         recon,
+        prof,
     }
 }
 
@@ -7071,6 +7108,130 @@ fn flatten_eqs_ll(
         }
     }
     out
+}
+
+/// `+profiling`: the clock plan the instrumented code ticks and the report's
+/// metadata. C reads both out of `_info.json` (`simulation_info_json.c`): every
+/// equation in position order — which is index order — with a profile block for
+/// each linear/nonlinear system under `blocks`, for every equation under `all`.
+fn prof_plan(
+    sim_code: &SimCode::SimCode,
+    mi: &SimCode::ModelInfo,
+) -> Result<(Option<Arc<ProfPlan>>, Option<openmodelica_sim_meta::ProfInfo>)> {
+    use openmodelica_sim_meta::{ProfEq, ProfFn, ProfInfo, ProfVar, SrcInfo};
+    use openmodelica_util::Config;
+    // C's `measure_time_flag` initializer, in `CodegenC`'s order.
+    let level: u8 = if Config::profileHtml()? {
+        5
+    } else if Config::profileSome()? {
+        1
+    } else if Config::profileAll()? {
+        2
+    } else {
+        return Ok((None, None));
+    };
+    let src_info = |i: &metamodelica::SourceInfo| SrcInfo {
+        file: i.fileName.to_string(),
+        line_start: i.lineNumberStart,
+        col_start: i.columnNumberStart,
+        line_end: i.lineNumberEnd,
+        col_end: i.columnNumberEnd,
+        read_only: i.isReadOnly,
+    };
+    let mut fn_index = HashMap::new();
+    let mut functions = Vec::new();
+    for (i, f) in lst(&mi.functions).enumerate() {
+        use SimCodeFunction::Function::Function as F;
+        let (name, info) = match &**f {
+            F::FUNCTION { name, info, .. }
+            | F::PARALLEL_FUNCTION { name, info, .. }
+            | F::KERNEL_FUNCTION { name, info, .. }
+            | F::EXTERNAL_FUNCTION { name, info, .. }
+            | F::RECORD_CONSTRUCTOR { name, info, .. } => (name, info),
+        };
+        fn_index.insert(crate::CodegenWasmJitFunctions::mangle(name)?, i as u32);
+        functions.push(ProfFn {
+            name: openmodelica_frontend_dump::AbsynUtil::pathString(name.clone(), arcstr::literal!("."), true, false)?.to_string(),
+            info: src_info(info),
+        });
+    }
+    // C's `modelData` variable arrays, in `printModelInfo` order.
+    let mut vars = Vec::new();
+    for list in [
+        &mi.vars.stateVars, &mi.vars.derivativeVars, &mi.vars.algVars, &mi.vars.discreteAlgVars, &mi.vars.paramVars,
+        &mi.vars.intAlgVars, &mi.vars.intParamVars, &mi.vars.boolAlgVars, &mi.vars.boolParamVars,
+        &mi.vars.stringAlgVars, &mi.vars.stringParamVars,
+    ] {
+        for sv in lst(list) {
+            vars.push(ProfVar {
+                id: vars.len() as u32,
+                name: cref_display(&sv.name)?,
+                comment: sv.comment.to_string(),
+                info: src_info(&sv.source.info),
+            });
+        }
+    }
+    // Every equation the `_info.json` lists, by index; a system's defines are its
+    // unknowns, an assignment's its left-hand side.
+    let mut table: HashMap<i32, (bool, Vec<String>)> = HashMap::new();
+    let mut err = None;
+    let mut note = |e: &Arc<SimCode::SimEqSystem>| {
+        use SimCode::SimEqSystem as E;
+        let entry = match &**e {
+            E::SES_LINEAR { lSystem, .. } => {
+                lst(&lSystem.vars).map(|v| cref_display(&v.name)).collect::<Result<Vec<_>>>().map(|d| (true, d))
+            }
+            E::SES_NONLINEAR { nlSystem, .. } => {
+                lst(&nlSystem.crefs).map(cref_display).collect::<Result<Vec<_>>>().map(|d| (true, d))
+            }
+            E::SES_SIMPLE_ASSIGN { cref, .. } | E::SES_SIMPLE_ASSIGN_CONSTRAINTS { cref, .. } => {
+                cref_display(cref).map(|d| (false, vec![d]))
+            }
+            E::SES_ARRAY_CALL_ASSIGN { lhs, .. } => match &**lhs {
+                DAE::Exp::CREF { componentRef, .. } => cref_display(componentRef).map(|d| (false, vec![d])),
+                _ => Ok((false, Vec::new())),
+            },
+            _ => Ok((false, Vec::new())),
+        };
+        match entry {
+            Ok(v) => {
+                table.insert(eq_index_of(e), v);
+            }
+            Err(x) => err = Some(x),
+        }
+    };
+    for list in [
+        &sim_code.initialEquations, &sim_code.initialEquations_lambda0, &sim_code.removedInitialEquations,
+        &sim_code.allEquations, &sim_code.startValueEquations, &sim_code.nominalValueEquations,
+        &sim_code.minValueEquations, &sim_code.maxValueEquations, &sim_code.parameterEquations,
+        &sim_code.algorithmAndEquationAsserts, &sim_code.inlineEquations, &sim_code.jacobianEquations,
+    ] {
+        for e in lst(list) {
+            visit_nested_eqs(e, &mut note);
+        }
+    }
+    drop(note);
+    if let Some(x) = err {
+        return Err(x);
+    }
+    let n = table.keys().max().map_or(1, |m| (*m).max(0) + 1) as usize;
+    let mut equations = Vec::with_capacity(n);
+    let mut blocks = HashMap::new();
+    // Under `all` C's block 0 exists but belongs to no equation.
+    let all = level & 2 != 0;
+    let mut block_eqs: Vec<u32> = if all { vec![0] } else { Vec::new() };
+    for i in 0..n {
+        let (system, defines) = table.get(&(i as i32)).cloned().unwrap_or_default();
+        equations.push(ProfEq { id: i as u32, defines });
+        // `readEquations`: a block for each system under `blocks`, for every
+        // equation but the dummy under `all`.
+        if i > 0 && (all || (level & 1 != 0 && system)) {
+            blocks.insert(i as i32, block_eqs.len() as u32);
+            block_eqs.push(i as u32);
+        }
+    }
+    let plan = ProfPlan { level, n_functions: functions.len() as u32, n_blocks: block_eqs.len() as u32, fn_index, blocks };
+    Ok((Some(Arc::new(plan)), Some(ProfInfo { level, functions, vars, equations, blocks: block_eqs })))
 }
 
 /// Visit `e` and every equation nested inside it, along the paths
@@ -7241,6 +7402,7 @@ pub(crate) fn sim_ctx(var_map: &SimVarMap) -> SimCtx {
         zc_context: false,
         clock_fire_off: var_map.clock_fire_off,
         sub_clock_off: None,
+        prof: var_map.prof.clone(),
     }
 }
 
@@ -7922,6 +8084,35 @@ pub(crate) fn lower_equation(
     eq: &SimCode::SimEqSystem,
     eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
 ) -> Result<()> {
+    // C's `SIM_PROF_TICK_EQ` / `SIM_PROF_ACC_EQ` around a profiled block: every
+    // equation under `all`, the linear and nonlinear systems under `blocks` — where
+    // C's tick counts one call, its nonlinear block takes it back (the residual
+    // calls count) and its linear one adds the setup call.
+    let prof = ctx.sim.as_ref().and_then(|s| s.prof.clone());
+    let clock = prof.as_ref().and_then(|p| p.block_clock(eq_index_of(eq)));
+    if let Some(c) = clock {
+        crate::CodegenWasmJitFunctions::emit_prof(ctx, clock, "rt_prof_tick")?;
+        let all = prof.as_ref().is_some_and(|p| p.all());
+        let ncall = match eq {
+            SimCode::SimEqSystem::SES_NONLINEAR { .. } if !all => -1,
+            SimCode::SimEqSystem::SES_LINEAR { .. } if !all => 1,
+            _ => 0,
+        };
+        if ncall != 0 {
+            ctx.emit(we::Instruction::I32Const(c as i32));
+            ctx.emit(we::Instruction::I32Const(ncall));
+            ctx.emit(we::Instruction::Call(rt_index("rt_prof_add_ncall")?));
+        }
+    }
+    lower_equation_inner(ctx, eq, eq_index)?;
+    crate::CodegenWasmJitFunctions::emit_prof(ctx, clock, "rt_prof_acc")
+}
+
+fn lower_equation_inner(
+    ctx: &mut FnCtx,
+    eq: &SimCode::SimEqSystem,
+    eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
+) -> Result<()> {
     use SimCode::SimEqSystem as E;
     if let Some(info) = eq_info(eq) {
         ctx.set_src_loc(info);
@@ -8471,6 +8662,10 @@ fn nls_parts(
                 return Ok((inner, NlsResiduals::InverseAlgorithm(known), iter_vars));
             }
         }
+        // No unknowns either: the system is its inner equations, evaluated once.
+        if iter_vars.is_empty() {
+            return Ok((inner, NlsResiduals::Explicit(residuals), iter_vars));
+        }
         return Err("CodegenWasmJit: SES_NONLINEAR has no residual equations");
     }
     // Only checkable when every residual's row count is static. An adaptive
@@ -8683,6 +8878,11 @@ fn build_nls_nominal_map(vars: &SimCodeVar::SimVars) -> HashMap<String, (f64, f6
 struct NlsJacInfo {
     seed_offs: Vec<u32>,
     result_offs: Vec<u32>,
+    /// This system's own seed/column slots. The new backend names every system's
+    /// Jacobian variables after the *same* matrix (`$SEED_ALG_LS_JAC_1.u`,
+    /// `$pDER_ALG_LS_JAC_1.$RES_SIM_0`, ...), so the shared cref map only keeps the
+    /// last system that registered them; lowering a Jacobian body binds these back.
+    slots: Vec<(String, SimSlot)>,
 }
 
 /// The residual row a Jacobian result var maps to: its `SimVar.index`, which is
@@ -9094,7 +9294,7 @@ fn build_nls_jac_infos(
         // A homotopy system's Jacobian is `n×(n+1)`: a `__HOM_LAMBDA` column, no row.
         let n_cols = count(&jm.seedVars);
         let n_rows = n_cols - nls_lambda_extra(sys) as usize;
-        let (info, _) = register_jac_slots(jm, n_rows, n_cols, &mut cursor, var_map)
+        let (info, _, slots) = register_jac_slots(jm, n_rows, n_cols, &mut cursor, var_map)
             .map_err(|_| "CodegenWasmJit: nonlinear-system Jacobian seed columns are not a permutation")?;
         let result_offs: Vec<u32> = info
             .result_offs
@@ -9102,7 +9302,7 @@ fn build_nls_jac_infos(
             .map(|o| o.ok_or("CodegenWasmJit: nonlinear-system Jacobian is missing a residual row"))
             .collect::<Result<_>>()?;
         let seed_offs = info.seed_offs;
-        infos.insert(sys.index, NlsJacInfo { seed_offs, result_offs });
+        infos.insert(sys.index, NlsJacInfo { seed_offs, result_offs, slots });
     }
     finalize_array_groups(var_map)?;
     Ok(infos)
@@ -9217,7 +9417,7 @@ fn build_linz_jac_infos(
         // the output region, so cover both shapes.
         let rows = plan.real_rows[k].max(plan.rows[k]) as usize;
         let cols = plan.real_cols[k] as usize;
-        let (info, _) = register_jac_slots(jm, rows, cols, &mut cursor, var_map)?;
+        let (info, _, _) = register_jac_slots(jm, rows, cols, &mut cursor, var_map)?;
         infos.push(Some(info));
     }
     // The new backend's column code reads seed/result arrays whole.
@@ -9227,7 +9427,7 @@ fn build_linz_jac_infos(
         Some(jm) => {
             let n = plan.real_rows[0] as usize;
             let mut map = var_map.clone();
-            let (info, zero_offs) = register_jac_slots(jm, n, n, &mut cursor, &mut map)?;
+            let (info, zero_offs, _) = register_jac_slots(jm, n, n, &mut cursor, &mut map)?;
             finalize_array_groups(&mut map)?;
             Some(AdjJacInfo { info, zero_offs, map })
         }
@@ -9250,9 +9450,13 @@ fn register_jac_slots(
     cols: usize,
     cursor: &mut u32,
     var_map: &mut SimVarMap,
-) -> Result<(LinzJacInfo, Vec<u32>)> {
+) -> Result<(LinzJacInfo, Vec<u32>, Vec<(String, SimSlot)>)> {
     use openmodelica_backend_types::BackendDAE::VarKind;
     let column_vars = jac_column_vars(jm);
+    // The pairs this matrix registered. Two matrices can name their variables alike
+    // (the new backend names every system's after the same one), and then the shared
+    // map only keeps the last; lowering a body binds these back over it.
+    let mut registered: Vec<(String, SimSlot)> = Vec::new();
     // The new backend lists an array's base beside its elements.
     let mut bases: HashSet<String> = HashSet::new();
     for sv in lst(&jm.seedVars).chain(column_vars.iter()) {
@@ -9266,7 +9470,9 @@ fn register_jac_slots(
             return Ok(None);
         }
         let off = *cursor;
-        Arc::make_mut(&mut var_map.vars).insert(key, SimSlot { off, wty: WTy::F64, negate: Neg::None, heap: false });
+        let slot = SimSlot { off, wty: WTy::F64, negate: Neg::None, heap: false };
+        registered.push((key.clone(), slot));
+        Arc::make_mut(&mut var_map.vars).insert(key, slot);
         for g in array_element_keys(&sv.name)? {
             var_map.array_acc.entry(g.base).or_default().push(AccElem {
                 subs: g.subs,
@@ -9297,7 +9503,7 @@ fn register_jac_slots(
     }
     let seed_offs = jac_seed_offs_by_column(jm, &listed, cols)
         .ok_or("CodegenWasmJit: linearization Jacobian seed columns are not a permutation")?;
-    Ok((LinzJacInfo { seed_offs, result_offs }, others))
+    Ok((LinzJacInfo { seed_offs, result_offs }, others, registered))
 }
 
 /// One matrix's seed slots (column order) and result slots (row order; `None` is
@@ -9730,7 +9936,7 @@ fn build_nls_fns(
             }
             Ok(())
         };
-        emit_nls_residual_body(&mut ctx, &slots, &residuals, &mut lower_inner)?;
+        emit_nls_residual_body(&mut ctx, nlsystem.index, &slots, &residuals, &mut lower_inner)?;
         finish(ctx)
     };
     // load(sim_data, x): 2 params.
@@ -9748,7 +9954,15 @@ fn build_nls_fns(
                 .ok_or_else(|| "CodegenWasmJit: nonlinear-system Jacobian has no column")?;
             let constant_eqns: Vec<Arc<SimCode::SimEqSystem>> = lst(&col.constantEqns).cloned().collect();
             let column_eqns: Vec<Arc<SimCode::SimEqSystem>> = lst(&col.columnEqns).cloned().collect();
-            let mut ctx = FnCtx::new_sim_params(mk_sim(), by_name, literals, 3);
+            // Bind this matrix's own seed/column slots over the shared map, which
+            // holds whichever system registered the shared names last.
+            let mut sim = mk_sim();
+            let mut vars = (*sim.vars).clone();
+            for (key, slot) in &info.slots {
+                vars.insert(key.clone(), *slot);
+            }
+            sim.vars = Arc::new(vars);
+            let mut ctx = FnCtx::new_sim_params(sim, by_name, literals, 3);
             let mut lower_inner = |c: &mut FnCtx| -> Result<()> {
                 for eq in &inner {
                     lower_equation(c, eq, eq_index)?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -513,6 +513,15 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     // Recoverable-assert hooks for a nonlinear-solver residual (see `nls.rs`).
     ("rt_nls_recovering", &[], &[WTy::I32]),
     ("rt_nls_note_assert", &[], &[]),
+    // C's `assertCommonVar` when a catcher is open: `(msg, sim_data, initial)`,
+    // non-zero when the caller must return instead of trapping.
+    ("rt_assert_common", &[WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
+    // `+profiling`: C's `rt_init` / `SIM_PROF_TICK_*` / `SIM_PROF_ACC_*` /
+    // `SIM_PROF_ADD_NCALL_EQ` (see `prof.rs`).
+    ("rt_prof_init", &[WTy::I32], &[]),
+    ("rt_prof_tick", &[WTy::I32], &[]),
+    ("rt_prof_acc", &[WTy::I32], &[]),
+    ("rt_prof_add_ncall", &[WTy::I32, WTy::I32], &[]),
     // C's `throwStreamPrint` and the reporting half of its `DIVISION_SIM`.
     ("rt_throw_stream", &[WTy::I32], &[]),
     ("rt_div_sim", &[WTy::F64, WTy::F64, WTy::I32, WTy::F64, WTy::I32], &[WTy::F64]),
@@ -1383,6 +1392,28 @@ pub(crate) struct FnCtx<'a> {
 ///
 /// The maps are shared (`Arc`) with `SimVarMap`, not copied: one `SimCtx` is built
 /// per generated function and a large model has hundreds of them.
+/// `+profiling`: which clock each profiled function and equation block ticks —
+/// C's `<fn>_index` defines and `profileBlockIndex` (see `prof.rs`).
+pub(crate) struct ProfPlan {
+    /// C's `measure_time_flag`: bit 1 `blocks`, bit 2 `all`, bit 4 html.
+    pub(crate) level: u8,
+    pub(crate) n_functions: u32,
+    pub(crate) n_blocks: u32,
+    /// Mangled function name -> clock.
+    pub(crate) fn_index: HashMap<String, u32>,
+    /// Equation index -> profile block; the block's clock is `n_functions + block`.
+    pub(crate) blocks: HashMap<i32, u32>,
+}
+
+impl ProfPlan {
+    pub(crate) fn all(&self) -> bool {
+        self.level & 2 != 0
+    }
+    pub(crate) fn block_clock(&self, eq_index: i32) -> Option<u32> {
+        self.blocks.get(&eq_index).map(|b| self.n_functions + b)
+    }
+}
+
 pub(crate) struct SimCtx {
     /// wasm local index holding the `SimData` base pointer.
     pub(crate) data_local: u32,
@@ -1474,6 +1505,8 @@ pub(crate) struct SimCtx {
     /// Sub-clock block of the clocked partition being lowered — C's
     /// `baseClockIndex`/`subClockIndex`, resolved to an address. `None` outside one.
     pub(crate) sub_clock_off: Option<u32>,
+    /// `+profiling`'s clock plan; `None` for a model translated without it.
+    pub(crate) prof: Option<Arc<ProfPlan>>,
 }
 
 /// One base clock's `SimData` slots and its parameter-dependent init expressions
@@ -1537,11 +1570,12 @@ pub(crate) struct NlsJob {
 }
 
 /// Per-system solver state for `n` unknowns: a count (padded to 8), C's
-/// `lastTimeSolved`, the residual scaling carried between calls, and `HIST_DEPTH`
-/// stored solutions (time + `n`). Matches `rt_solve_nls`'s layout.
+/// `lastTimeSolved`, the residual scaling carried between calls, C's
+/// `nlsxExtrapolation`, and `HIST_DEPTH` stored solutions (time + `n`). Matches
+/// `rt_solve_nls`'s layout.
 pub(crate) fn nls_hist_bytes(n: u32) -> u32 {
     const DEPTH: u32 = 10; // = the runtime's `nls::HIST_DEPTH`
-    16 + 8 * n + DEPTH * (8 + 8 * n)
+    16 + 8 * n + 8 * n + DEPTH * (8 + 8 * n)
 }
 
 /// Model global holding the base address of the NLS extrapolation-history block
@@ -1697,7 +1731,7 @@ impl<'a> FnCtx<'a> {
         self.instrs.len()
     }
 
-    fn emit(&mut self, i: we::Instruction<'static>) {
+    pub(crate) fn emit(&mut self, i: we::Instruction<'static>) {
         // Track structured-control nesting so `break`/`continue` can compute their
         // relative branch depth. `Else` keeps the same frame; `End` closes one.
         match i {
@@ -4702,7 +4736,6 @@ fn emit_math_domain_guard(ctx: &mut FnCtx, name: &str, arg: &Arc<DAE::Exp>, d: &
     }
     ctx.emit(I::I32Eqz);
     ctx.emit(I::If(we::BlockType::Empty));
-    emit_nls_recoverable_return(ctx)?;
     let call = format!("{name}({})", dumped_exp(arg)?);
     emit_str_literal(ctx, format!("Model error: Argument of {call} {}", d.head).as_bytes())?;
     ctx.emit(I::LocalGet(t));
@@ -4713,6 +4746,22 @@ fn emit_math_domain_guard(ctx: &mut FnCtx, name: &str, arg: &Arc<DAE::Exp>, d: &
     ctx.emit(I::Call(rt_index("rt_concat")?));
     emit_str_literal(ctx, d.tail.as_bytes())?;
     ctx.emit(I::Call(rt_index("rt_concat")?));
+    let msg = ctx.alloc_temp(WTy::I32);
+    ctx.emit(I::LocalTee(msg));
+    // C's `assertCommonVar` warns and throws; a solver or the step catches the
+    // throw, so the evaluation returns instead of trapping.
+    match ctx.sim.as_ref().map(|s| s.data_local) {
+        Some(data) => ctx.emit(I::LocalGet(data)),
+        None => ctx.emit(I::I32Const(0)),
+    }
+    emit_initial_flag(ctx);
+    ctx.emit(I::Call(rt_index("rt_assert_common")?));
+    ctx.emit(I::If(we::BlockType::Empty));
+    release_heap_locals(ctx)?;
+    push_outputs(ctx);
+    ctx.emit(I::Return);
+    ctx.emit(I::End);
+    ctx.emit(I::LocalGet(msg));
     emit_model_error(ctx)?;
     ctx.emit(I::End);
 
@@ -8437,14 +8486,21 @@ fn compile_call(
             let w = compile_exp(ctx, a)?;
             coerce(ctx, w, p.wty());
         }
+        // C's `SIM_PROF_TICK_FN` / `SIM_PROF_ACC_FN` around a profiled call.
+        let clock = prof_fn_clock(ctx, &mangled);
+        emit_prof(ctx, clock, "rt_prof_tick")?;
         ctx.emit(we::Instruction::Call(index));
+        emit_prof(ctx, clock, "rt_prof_acc")?;
         return Ok(results);
     }
     // A call whose result is a record and which is not a generated function is a
     // record constructor `R(v1, …)` (the constructor function itself is not
     // emitted — construction is lowered inline).
     if let Ok(rty @ SigTy::Record { .. }) = sig_ty_quiet(&attr.ty) {
+        let clock = prof_fn_clock(ctx, &mangled);
+        emit_prof(ctx, clock, "rt_prof_tick")?;
         compile_record_call(ctx, &attr.ty, args)?;
+        emit_prof(ctx, clock, "rt_prof_acc")?;
         return Ok(vec![rty]);
     }
     // Otherwise it must be a (builtin) math/string function.
@@ -8473,6 +8529,21 @@ fn compile_call(
         return compile_spatial_distribution(ctx, args).map(|_| vec![SigTy::Real, SigTy::Real]);
     }
     compile_math_builtin(ctx, &name, args, attr).map(|s| vec![s])
+}
+
+/// The profiling clock of the generated function `mangled`, in a simulation with
+/// `+profiling`; C profiles every non-builtin call outside a function body.
+fn prof_fn_clock(ctx: &FnCtx, mangled: &str) -> Option<u32> {
+    ctx.sim.as_ref()?.prof.as_ref()?.fn_index.get(mangled).copied()
+}
+
+/// `rt_prof_tick(clock)` / `rt_prof_acc(clock)` / …, when there is a clock.
+pub(crate) fn emit_prof(ctx: &mut FnCtx, clock: Option<u32>, hook: &str) -> Result<()> {
+    if let Some(c) = clock {
+        ctx.emit(we::Instruction::I32Const(c as i32));
+        ctx.emit(we::Instruction::Call(rt_index(hook)?));
+    }
+    Ok(())
 }
 
 /// `(out0, out1) = spatialDistribution(index, in0, in1, x, positiveVelocity,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -83,11 +83,25 @@ pub(crate) enum NlsResiduals {
 /// by `call_indirect`.
 pub(crate) fn emit_nls_residual_body(
     ctx: &mut FnCtx,
+    eq_index: i32,
     slots: &[u32],
     residuals: &NlsResiduals,
     lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
 ) -> Result<()> {
     use we::Instruction as I;
+    // C's `residualFunc`: `SIM_PROF_ADD_NCALL_EQ(block, 1)` under `blocks`, the
+    // block's own tick/acc under `all`.
+    let prof = ctx.sim.as_ref().and_then(|s| s.prof.clone());
+    let clock = prof.as_ref().and_then(|p| p.block_clock(eq_index));
+    if let Some(c) = clock {
+        if prof.as_ref().is_some_and(|p| p.all()) {
+            super::emit_prof(ctx, clock, "rt_prof_tick")?;
+        } else {
+            ctx.emit(I::I32Const(c as i32));
+            ctx.emit(I::I32Const(1));
+            ctx.emit(I::Call(rt_index("rt_prof_add_ncall")?));
+        }
+    }
     for (j, &off) in slots.iter().enumerate() {
         ctx.emit(I::LocalGet(0)); // SimData
         ctx.emit(I::LocalGet(1)); // x
@@ -138,6 +152,9 @@ pub(crate) fn emit_nls_residual_body(
                 emit_generic_residual(ctx, iterators, scal_indices, exp, *res_index)?;
             }
         }
+    }
+    if prof.as_ref().is_some_and(|p| p.all()) {
+        super::emit_prof(ctx, clock, "rt_prof_acc")?;
     }
     Ok(())
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/files.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/files.rs
@@ -1,0 +1,47 @@
+//! The files a solver writes beside the result — C's `omc_fopen` under the model
+//! prefix, e.g. the homotopy path CSV. With a host present the host writes them
+//! (a JIT module has no file system); the standalone module writes them itself;
+//! an FMU adapter build has no sink and drops them.
+
+use alloc::string::String;
+use core::cell::UnsafeCell;
+
+struct PrefixCell(UnsafeCell<String>);
+unsafe impl Sync for PrefixCell {}
+static PREFIX: PrefixCell = PrefixCell(UnsafeCell::new(String::new()));
+
+/// C's `modelData->modelFilePrefix`.
+pub(crate) fn set_prefix(prefix: &str) {
+    *unsafe { &mut *PREFIX.0.get() } = String::from(prefix);
+}
+
+pub(crate) fn prefix() -> &'static str {
+    unsafe { &*PREFIX.0.get() }
+}
+
+/// [`set_prefix`] across the module boundary: `len` UTF-8 bytes at `ptr`.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_set_file_prefix(ptr: u32, len: u32) {
+    let bytes = unsafe { core::slice::from_raw_parts(ptr as *const u8, len as usize) };
+    set_prefix(&String::from_utf8_lossy(bytes));
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "host_log", not(feature = "standalone")))]
+#[link(wasm_import_module = "env")]
+unsafe extern "C" {
+    fn rt_host_write_file(name: u32, name_len: u32, data: u32, data_len: u32);
+}
+
+/// Write `data` to `name`, relative to the working directory as C's executable does.
+#[cfg(all(target_arch = "wasm32", feature = "host_log", not(feature = "standalone")))]
+pub(crate) fn write_file(name: &str, data: &str) {
+    unsafe { rt_host_write_file(name.as_ptr() as u32, name.len() as u32, data.as_ptr() as u32, data.len() as u32) };
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "standalone"))]
+pub(crate) fn write_file(name: &str, data: &str) {
+    let _ = std::fs::write(name, data);
+}
+
+#[cfg(not(all(target_arch = "wasm32", any(feature = "standalone", all(feature = "host_log", not(feature = "standalone"))))))]
+pub(crate) fn write_file(_name: &str, _data: &str) {}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -41,6 +41,7 @@
 extern crate alloc;
 
 mod delay;
+mod files;
 // C's `jacobian_analysis.c` plus the derivative test `kinsolSolver.c` keeps: only
 // the SUNDIALS solvers call them.
 #[cfg(sundials)]
@@ -49,7 +50,9 @@ mod jacobian_analysis;
 /// inside a solve.
 #[cfg(sundials)]
 mod model_ctx;
+mod newton_diagnostics;
 mod nls;
+pub mod prof;
 mod omclog;
 pub use nls::{rt_nls_clean_history, rt_set_step_size};
 #[cfg(test)]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/newton_diagnostics.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/newton_diagnostics.rs
@@ -1,0 +1,533 @@
+//! C's `newton_diagnostics.c`: the `-lv=LOG_NLS_NEWTON_DIAGNOSTICS` report on an
+//! initial nonlinear system's start values, printed before the system is solved.
+//!
+//! From the first Newton step `dx = -J⁻¹ f(x0)` and a finite-difference Hessian of
+//! the symbolic Jacobian it ranks the unknowns and equations by the indicators of
+//! Deuflhard's convergence theory: `alpha_i` (how far equation `i` is from its
+//! quadratic model), `Gamma_ijk` (curvature along the step) and `sigma_jj` (the
+//! solution's sensitivity to unknown `j`).
+
+use alloc::format;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use crate::omclog;
+
+const STREAM: omclog::Stream = omclog::NLS_NEWTON_DIAGNOSTICS;
+
+/// What the metadata knows about one system, beyond its variable names.
+pub(crate) struct DiagInfo {
+    /// `numberOfEqns`, `numberOfVars`, `numberOfNonlinear` of C's `NONLINEAR_PATTERN`.
+    pub pattern: [u32; 3],
+    /// The system is in the section C diagnoses: `initialEquations_lambda0`, or
+    /// `initialEquations` for a model without a lambda0 section.
+    pub init_diag: bool,
+    /// SimCode index of each residual equation, in solver order.
+    pub eqns: Vec<u32>,
+}
+
+/// The model callbacks the report needs.
+pub(crate) struct Callbacks<'a> {
+    /// Residual `f(x)`; returns whether the evaluation hit a model error.
+    pub residual: &'a mut dyn FnMut(&[f64], &mut [f64]) -> bool,
+    /// Column-major `n×n` symbolic Jacobian at `x`, `fj[c*n + r] = ∂f_r/∂x_c`.
+    pub jacobian: &'a mut dyn FnMut(&[f64], &mut [f64]),
+}
+
+fn info(msg: &str) {
+    omclog::info(STREAM, false, msg);
+}
+
+fn open(msg: &str) {
+    omclog::info(STREAM, true, msg);
+}
+
+fn close() {
+    omclog::close(STREAM);
+}
+
+/// Width of C's `%<w>d` index field, chosen by the system size the way C does.
+fn idx(i: usize, m: usize, quirk: bool) -> String {
+    let w = if m < 10 {
+        1
+    } else if m < 100 {
+        2
+    } else if m < 1000 {
+        3
+    } else if !quirk && m < 10000 {
+        4
+    } else {
+        5
+    };
+    format!("{i:>w$}")
+}
+
+fn f14(v: f64) -> String {
+    omclog::f(v, 14, 10)
+}
+
+/// Row-major `m×m` inverse through LU; `None` when singular (C prints and goes on
+/// with the partial factorization — the report is then meaningless, so stop).
+fn invert(m: usize, a: &[Vec<f64>]) -> Option<Vec<Vec<f64>>> {
+    let mut col = vec![0.0f64; m * m];
+    for i in 0..m {
+        for j in 0..m {
+            col[j * m + i] = a[i][j];
+        }
+    }
+    let mut ipiv = vec![0i32; m];
+    if openmodelica_lapack::dgetrf(m, m, &mut col, m, &mut ipiv) != 0 {
+        return None;
+    }
+    if openmodelica_lapack::dgetri(m, &mut col, m, &ipiv) != 0 {
+        return None;
+    }
+    Some((0..m).map(|i| (0..m).map(|j| col[j * m + i]).collect()).collect())
+}
+
+fn mat_mult(a: &[Vec<f64>], b: &[Vec<f64>]) -> Vec<Vec<f64>> {
+    let ra = a.len();
+    let cb = b.first().map_or(0, |r| r.len());
+    let inner = b.len();
+    let mut c = vec![vec![0.0f64; cb]; ra];
+    for i in 0..ra {
+        for j in 0..cb {
+            for k in 0..inner {
+                c[i][j] += a[i][k] * b[k][j];
+            }
+        }
+    }
+    c
+}
+
+/// C's `newtonDiagnostics`. `x0` is the start point, `f` the residual there,
+/// `names` the unknowns' names.
+pub(crate) fn newton_diagnostics(
+    eq_index: u32,
+    x0: &[f64],
+    f: &[f64],
+    names: &[String],
+    diag: &DiagInfo,
+    cb: &mut Callbacks,
+) {
+    let m = x0.len();
+    let name = |j: usize| names.get(j).map_or("", |s| s.as_str());
+    let mut lambda = 1.0f64;
+    info(&format!("Running newton diagnostics for system {eq_index}"));
+
+    // fx[i][j] = ∂f_i/∂x_j
+    let mut fj = vec![0.0f64; m * m];
+    (cb.jacobian)(x0, &mut fj);
+    let fx: Vec<Vec<f64>> = (0..m).map(|i| (0..m).map(|j| fj[j * m + i]).collect()).collect();
+
+    // First Newton step dx = -fx⁻¹ f.
+    let mut dx = vec![0.0f64; m];
+    {
+        let mut a = vec![0.0f64; m * m];
+        for i in 0..m {
+            for j in 0..m {
+                a[j * m + i] = fx[i][j];
+            }
+        }
+        let mut b = f.to_vec();
+        let mut ipiv = vec![0i32; m];
+        let info_ = openmodelica_lapack::dgesv(m, 1, &mut a, m, &mut ipiv, &mut b, m);
+        if info_ > 0 {
+            info(&format!(
+                "getFirstNewtonStep: the first Newton step could not be computed; the info satus is : {info_}"
+            ));
+        } else {
+            for j in 0..m {
+                dx[j] = -b[j];
+            }
+        }
+    }
+
+    // Hessian fxx[i][k][j] = ∂fx[i][j]/∂x_k by central differences of the Jacobian.
+    let eps = 1.0e-7;
+    let nominal_x = 1.0e-4;
+    let mut fxx = vec![vec![vec![0.0f64; m]; m]; m];
+    let mut fj_pls = vec![0.0f64; m * m];
+    let mut fj_min = vec![0.0f64; m * m];
+    let mut xp = x0.to_vec();
+    for k in 0..m {
+        let delta_x = eps * libm::fmax(libm::fabs(x0[k]), nominal_x);
+        xp[k] = x0[k] + delta_x;
+        (cb.jacobian)(&xp, &mut fj_pls);
+        xp[k] = x0[k] - delta_x;
+        (cb.jacobian)(&xp, &mut fj_min);
+        xp[k] = x0[k];
+        for j in 0..m {
+            for i in 0..m {
+                let v = (fj_pls[j * m + i] - fj_min[j * m + i]) / (2.0 * delta_x);
+                if v.is_nan() {
+                    info(&format!(
+                        "NaN detected: fxx[{}][{}][{}]: fxPls[{}][{}] = {}, fxMin[{}][{}] = {}, delta_x = {}\n",
+                        i + 1,
+                        j + 1,
+                        k + 1,
+                        i + 1,
+                        j + 1,
+                        omclog::f(fj_pls[j * m + i], 0, 6),
+                        i + 1,
+                        j + 1,
+                        omclog::f(fj_min[j * m + i], 0, 6),
+                        omclog::f(delta_x, 0, 6)
+                    ));
+                    return;
+                }
+                fxx[i][k][j] = v;
+            }
+        }
+    }
+
+    // Nonlinear equations: those whose residual is not linear along the step.
+    let mut x1 = vec![0.0f64; m];
+    let mut f_x1 = vec![0.0f64; m];
+    let mut failed = true;
+    let mut first = true;
+    while failed {
+        if !first {
+            let d_lambda = 0.7;
+            info(&format!(
+                "Dampening factor lowered from {} to {}",
+                omclog::f(lambda, 7, 3),
+                omclog::f(lambda * d_lambda, 7, 3)
+            ));
+            lambda *= d_lambda;
+        }
+        first = false;
+        for i in 0..m {
+            x1[i] = x0[i] + lambda * dx[i];
+        }
+        failed = (cb.residual)(&x1, &mut f_x1);
+    }
+    let eps_nl = 1.0e-9;
+    let n_idx: Vec<usize> =
+        (0..m).filter(|&i| libm::fabs(f_x1[i] + (lambda - 1.0) * f[i]) > eps_nl).collect();
+    let p = n_idx.len();
+    if p == 0 {
+        info("Newton diagnostics terminated: no non-linear equations!");
+        return;
+    }
+
+    // Nonlinear unknowns: a column of the Hessian with any entry above eps.
+    let w_idx: Vec<usize> = (0..m)
+        .filter(|&j| (0..m).any(|k| (0..m).any(|i| libm::fabs(fxx[k][i][j]) > eps_nl)))
+        .collect();
+    let q = w_idx.len();
+    let z_idx: Vec<usize> = (0..m).filter(|i| !w_idx.contains(i)).collect();
+
+    open("Information about the system from non-linear pattern");
+    info(&format!("Total number of equations    = {}", diag.pattern[0]));
+    info(&format!("Number of unknowns           = {}", diag.pattern[1]));
+    info(&format!("Number of non-linear entries = {}", diag.pattern[2]));
+    close();
+
+    open("Information about the initial guess");
+    open("Vector x0 of unknowns");
+    for i in 0..m {
+        info(&format!("x0[{}] = {}  ({})", idx(i + 1, m, true), f14(x0[i]), name(i)));
+    }
+    close();
+    open("Residual function values of all equations f(x0)");
+    for i in 0..m {
+        if libm::fabs(f[i]) > 1.0e-9 {
+            info(&format!("f[{}] = {}", idx(i + 1, m, false), f14(f[i])));
+        }
+    }
+    close();
+    open("Vector w0 of nonlinear unknowns");
+    for i in 0..q {
+        // C numbers w0 from q+1 on in the two widest branches.
+        let no = if m < 1000 { i + 1 } else { i + q + 1 };
+        info(&format!(
+            "w0[{}] = x0[{}] = {}  ({})",
+            idx(no, m, false),
+            idx(w_idx[i] + 1, m, false),
+            f14(x0[w_idx[i]]),
+            name(w_idx[i])
+        ));
+    }
+    close();
+    if m > q {
+        open("Vector z0 of nonlinear unknowns");
+        for i in 0..m - q {
+            info(&format!("z0[{}] = {}  ({})", idx(i + 1, m - q, false), f14(x0[z_idx[i]]), name(z_idx[i])));
+        }
+        close();
+    }
+    open("Residual function values of all nonlinear equations n(w0)");
+    for i in 0..p {
+        info(&format!(
+            "n[{}] = f[{}] = {}",
+            idx(i + 1, m, false),
+            idx(n_idx[i] + 1, m, false),
+            f14(f[n_idx[i]])
+        ));
+    }
+    close();
+    info(&format!("Final damping factor lambda = {}", omclog::g(lambda, 0, 3)));
+    close();
+
+    // Largest residual of the nonlinear part: f + fz·dz over the linear unknowns.
+    let mut max_res = 0.0f64;
+    for i in 0..m {
+        let mut fz_dz = 0.0;
+        for &z in &z_idx {
+            fz_dz += fx[i][z] * dx[z];
+        }
+        max_res = libm::fmax(max_res, libm::fabs(f[i] + fz_dz));
+    }
+
+    // alpha_i: the residual's departure from its quadratic model at x0 + λ·dx.
+    let mut x1_star = vec![0.0f64; m];
+    for j in 0..m {
+        x1_star[j] = x0[j] + lambda * dx[j];
+    }
+    let mut f_x1_star = vec![0.0f64; m];
+    (cb.residual)(&x1_star, &mut f_x1_star);
+    let w1_star_w0: Vec<f64> = w_idx.iter().map(|&w| lambda * dx[w]).collect();
+    let mut alpha = vec![0.0f64; p];
+    for (i, &ni) in n_idx.iter().enumerate() {
+        let mut w_fww_w = 0.0;
+        for j in 0..q {
+            let mut acc = 0.0;
+            for k in 0..q {
+                let h = fxx[ni][w_idx[k]][w_idx[j]];
+                if !h.is_nan() && h != 0.0 {
+                    acc += w1_star_w0[k] * h;
+                }
+            }
+            w_fww_w += acc * w1_star_w0[j];
+        }
+        alpha[i] = libm::fabs(f_x1_star[ni] - (1.0 - lambda) * f[ni] - 0.5 * w_fww_w)
+            / (libm::pow(lambda, 3.0) * max_res);
+    }
+
+    // Gamma_ijk: curvature of nonlinear equation i along the step in (w_j, w_k).
+    let mut gamma = vec![vec![vec![0.0f64; q]; q]; p];
+    for i in 0..p {
+        for j in 0..q {
+            for k in 0..q {
+                let h = fxx[n_idx[i]][w_idx[j]][w_idx[k]];
+                gamma[i][j][k] = if !h.is_nan() && h != 0.0 {
+                    libm::fabs(0.5 * h * (dx[w_idx[j]] * dx[w_idx[k]]) / max_res)
+                } else {
+                    0.0
+                };
+            }
+        }
+    }
+
+    // Sigma = |diag(dw)⁻¹| · (-fx⁻¹ · (dxᵀ·fxx))[w,w] · diag(dw)
+    let Some(mut inv_fx) = invert(m, &fx) else {
+        info("getInvJacobian: LU factorization could not be computed; the info status is : 1");
+        return;
+    };
+    let mut h_i = vec![vec![0.0f64; m]; m];
+    for i in 0..m {
+        for j in 0..m {
+            for k in 0..m {
+                h_i[i][j] += dx[k] * fxx[i][k][j];
+            }
+        }
+    }
+    for row in inv_fx.iter_mut() {
+        for v in row.iter_mut() {
+            *v = -*v;
+        }
+    }
+    let tmp1 = mat_mult(&inv_fx, &h_i);
+    let tmp2: Vec<Vec<f64>> = (0..q).map(|i| (0..q).map(|j| tmp1[w_idx[i]][w_idx[j]]).collect()).collect();
+    let mut w_diag = vec![vec![0.0f64; q]; q];
+    for i in 0..q {
+        w_diag[i][i] = dx[w_idx[i]];
+    }
+    let Some(mut inv_w) = invert(q, &w_diag) else {
+        info("getInvJacobian: LU factorization could not be computed; the info status is : 1");
+        return;
+    };
+    for row in inv_w.iter_mut() {
+        for v in row.iter_mut() {
+            *v = libm::fabs(*v);
+        }
+    }
+    let sigma = mat_mult(&mat_mult(&inv_w, &tmp2), &w_diag);
+
+    print_results(m, p, q, &n_idx, &w_idx, x0, &alpha, &gamma, &sigma, names, diag);
+    info("Newton diagnostics complete!");
+}
+
+/// C's `PrintResults`: the indicators above `eps`, then ranked by variable and by
+/// equation.
+fn print_results(
+    m: usize,
+    p: usize,
+    q: usize,
+    n_idx: &[usize],
+    w_idx: &[usize],
+    x0: &[f64],
+    alpha: &[f64],
+    gamma: &[Vec<Vec<f64>>],
+    sigma: &[Vec<f64>],
+    names: &[String],
+    diag: &DiagInfo,
+) {
+    let name = |j: usize| names.get(j).map_or("", |s| s.as_str());
+    let eps = 1.0e-2;
+    open("Values of relevant indicators");
+    open(&format!("alpha_i > {}", omclog::f(eps, 5, 3)));
+    for i in 0..p {
+        if alpha[i] > eps {
+            info(&format!("alpha_{:<3} =  {}", n_idx[i] + 1, omclog::f(alpha[i], 5, 2)));
+        }
+    }
+    close();
+    open(&format!("Gamma_ijk > {}", omclog::f(eps, 5, 3)));
+    for i in 0..p {
+        for j in 0..q {
+            for k in j..q {
+                if gamma[i][j][k] > eps {
+                    info(&format!(
+                        "Gamma_{:<4}_{:<4}_{:<4} =  {}",
+                        n_idx[i] + 1,
+                        w_idx[j] + 1,
+                        w_idx[k] + 1,
+                        omclog::f(gamma[i][j][k], 5, 2)
+                    ));
+                }
+            }
+        }
+    }
+    close();
+    open(&format!("sigma_jj > {}", omclog::f(eps, 5, 3)));
+    for i in 0..q {
+        if libm::fabs(sigma[i][i]) > eps {
+            info(&format!(
+                "sigma_{:<4}_{:<4} = {}",
+                w_idx[i] + 1,
+                w_idx[i] + 1,
+                omclog::f(libm::fabs(sigma[i][i]), 5, 2)
+            ));
+        }
+    }
+    close();
+    close();
+
+    // Rank Gamma and sigma together, largest first, down to eps.
+    enum Pick {
+        Gamma(usize, usize, usize),
+        Scalar(usize),
+    }
+    let rank = |scalars: &[f64], scalar_idx: &dyn Fn(usize) -> f64| -> Vec<Pick> {
+        let mut gamma_checked = vec![vec![vec![false; q]; q]; p];
+        let mut scalar_checked = vec![false; scalars.len()];
+        let mut picks = Vec::new();
+        for _ in 0..p * q * q + m {
+            let mut best_g = -1.0e10;
+            let mut gi = (0, 0, 0);
+            for i in 0..p {
+                for j in 0..q {
+                    for k in j..q {
+                        if gamma[i][j][k] > best_g && !gamma_checked[i][j][k] {
+                            best_g = gamma[i][j][k];
+                            gi = (i, j, k);
+                        }
+                    }
+                }
+            }
+            let mut best_s = -1.0e10;
+            let mut si = 0;
+            for i in 0..scalars.len() {
+                let v = scalar_idx(i);
+                if v > best_s && !scalar_checked[i] {
+                    best_s = v;
+                    si = i;
+                }
+            }
+            if best_g < eps && best_s < eps {
+                break;
+            }
+            if best_g > best_s {
+                gamma_checked[gi.0][gi.1][gi.2] = true;
+                picks.push(Pick::Gamma(gi.0, gi.1, gi.2));
+            } else {
+                scalar_checked[si] = true;
+                picks.push(Pick::Scalar(si));
+            }
+        }
+        picks
+    };
+
+    open("Ranked indicators");
+    open("By variable");
+    info("Var no.  Var name                                  Initial guess  max(Gamma,sigma)");
+    info("-------  ----------------------------------------  -------------  ----------------");
+    let sig_diag: Vec<f64> = (0..q).map(|i| libm::fabs(sigma[i][i])).collect();
+    let mut printed: Vec<usize> = Vec::new();
+    for pick in rank(&sig_diag, &|i| sig_diag[i]) {
+        match pick {
+            Pick::Scalar(s) => {
+                if !printed.contains(&s) {
+                    info(&format!(
+                        "{:>7}  {:>40}  {}    {}",
+                        w_idx[s] + 1,
+                        name(w_idx[s]),
+                        omclog::g(x0[w_idx[s]], 13, 7),
+                        omclog::f(sig_diag[s], 5, 2)
+                    ));
+                    printed.push(s);
+                }
+            }
+            Pick::Gamma(i, j, k) => {
+                let pj = printed.contains(&j);
+                let pk = printed.contains(&k);
+                for (already, v) in [(pj, j), (pk, k)] {
+                    if !already {
+                        info(&format!(
+                            "{:>7}  {:>40}  {}  {}",
+                            w_idx[v] + 1,
+                            name(w_idx[v]),
+                            omclog::g(x0[w_idx[v]], 13, 7),
+                            omclog::f(gamma[i][j][k], 5, 2)
+                        ));
+                        printed.push(v);
+                    }
+                }
+            }
+        }
+    }
+    close();
+
+    open("By equation");
+    info("Eq no.  Eq idx    max(alpha,Gamma)");
+    info("------  ------    ----------------");
+    let eq_idx = |i: usize| diag.eqns.get(i).copied().unwrap_or(0);
+    let mut printed: Vec<usize> = Vec::new();
+    for pick in rank(alpha, &|i| alpha[i]) {
+        match pick {
+            Pick::Scalar(a) => {
+                if !printed.contains(&a) {
+                    let v = if alpha[a] < 1.0e3 { omclog::f(alpha[a], 5, 2) } else { omclog::e(alpha[a], 5, 2) };
+                    info(&format!("{:>6}  {:>6}  {}", n_idx[a] + 1, eq_idx(n_idx[a]), v));
+                    printed.push(a);
+                }
+            }
+            Pick::Gamma(i, j, k) => {
+                if !printed.contains(&i) {
+                    info(&format!(
+                        "{:>6}  {:>6}  {}",
+                        n_idx[i] + 1,
+                        eq_idx(n_idx[i]),
+                        omclog::f(gamma[i][j][k], 5, 2)
+                    ));
+                    printed.push(i);
+                }
+            }
+        }
+    }
+    close();
+    close();
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -319,6 +319,37 @@ pub extern "C" fn rt_nls_assert_failed(
     }
 }
 
+/// C's `assertCommonVar` (a math builtin's domain guard): `omc_assert_warning`
+/// heads the `LOG_ASSERT` block and `throwStreamPrintWithEquationIndexes` adds the
+/// message and unwinds. Returns non-zero where the unwind is caught — a solver
+/// residual or the step — so the caller returns; the model-error path reports a
+/// fatal one. `msg` is this call's to release.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_assert_common(msg: i32, sim_data: i32, initial: i32) -> i32 {
+    if !error_caught() {
+        return 0;
+    }
+    if throw_reports() {
+        use openmodelica_sim_meta::TIME_OFF;
+        let time = if sim_data != 0 { unsafe { load_f64(sim_data as u32 + TIME_OFF) } } else { 0.0 };
+        crate::omclog::warning(
+            crate::omclog::ASSERT,
+            false,
+            &alloc::format!(
+                "The following assertion has been violated {}at time {}",
+                if initial != 0 { "during initialization " } else { "" },
+                crate::omclog::f(time, 0, 6)
+            ),
+        );
+        crate::omclog::debug(crate::omclog::ASSERT, false, &rt_string(msg));
+    }
+    rt_nls_note_assert();
+    if msg != 0 {
+        crate::rt_release(msg as u32);
+    }
+    1
+}
+
 /// C's stage switch in `va_omc_assert_simulation_withEquationIndexes`.
 fn assert_logged() -> bool {
     match ERROR_STAGE[0].load(Ordering::Relaxed) {
@@ -543,6 +574,18 @@ pub(crate) fn lu_solve(a: &[f64], b: &mut [f64], n: usize) -> bool {
     lu_solve_singular_pivot(a, b, n).is_none()
 }
 
+/// [`lu_solve`] also reporting C's `detJac`: `dgesv` leaves the factors in `A`, and
+/// `linearSolverWrapper` reads their diagonal, so the permutation's sign is not in it.
+pub(crate) fn lu_solve_det(a: &[f64], b: &mut [f64], n: usize) -> Option<f64> {
+    let mut lu = a[..n * n].to_vec();
+    let mut ipiv = alloc::vec![0i32; n];
+    if openmodelica_lapack::dgetrf(n, n, &mut lu, n, &mut ipiv) != 0 {
+        return None;
+    }
+    openmodelica_lapack::dgetrs("N", n, 1, &lu, n, &ipiv, b, n);
+    Some((0..n).map(|k| lu[k * n + k]).product())
+}
+
 /// [`lu_solve`] reporting `dgesv`'s `info`: `None` on success, else the 0-based
 /// index of the first zero pivot, straight from `dgetrf`. `A` is copied because
 /// `dgetrf` factors in place and the caller keeps it for the total-pivot fallback.
@@ -630,6 +673,8 @@ pub(crate) fn total_pivot_solve(a: &[f64], b: &mut [f64], n: usize) -> bool {
 /// `n+1` solution into `x`. Returns `0` on success, `-1` if under-determined.
 fn total_pivot_augmented(n: usize, x: &mut [f64], a: &mut [f64], pos: &mut i32, casual: bool) -> i32 {
     let m = n + 1;
+    crate::omclog::debug_matrix_double(crate::omclog::NLS_JAC, "Linear System Matrix [Jac res]:", a, n, m);
+    crate::omclog::debug_vector_double(crate::omclog::NLS_JAC, "vector b:", &a[n * n..n * n + n]);
     let mut n_pivot = n;
     let mut rank = n;
     let mut ind_row: alloc::vec::Vec<usize> = (0..n).collect();
@@ -676,6 +721,7 @@ fn total_pivot_augmented(n: usize, x: &mut [f64], a: &mut [f64], pos: &mut i32, 
     for k in 0..n {
         det *= a[ind_row[k] + ind_col[k] * n];
     }
+    crate::omclog::debug_double(crate::omclog::NLS_JAC, "Determinant = ", det);
     if det.is_nan() {
         return -1;
     }
@@ -807,6 +853,14 @@ impl HomFail {
     }
 }
 
+/// C's adaptive-homotopy path CSV (`_nonlinsys<k>_adaptive_<local|global>_homotopy_<pos|neg>.csv`),
+/// written only for an initial-homotopy run under `LOG_INIT_HOMOTOPY`.
+struct HomExport {
+    name: alloc::string::String,
+    /// The system's iteration-variable names, for the header.
+    vars: alloc::vec::Vec<alloc::string::String>,
+}
+
 /// The homotopy `H(y)` a continuation tracks, `y = [x, λ]` with `m = n+1` entries:
 /// C's `h_function` / `hJac_dh` pair, in its two variants.
 trait Homotopy {
@@ -919,6 +973,7 @@ fn homotopy_algorithm(
     xscaling: &[f64],
     start_dir: f64,
     log: crate::omclog::Stream,
+    export: Option<HomExport>,
     hom: &mut impl Homotopy,
 ) -> core::result::Result<usize, HomFail> {
     let t = crate::solvers::hom_tuning();
@@ -936,6 +991,26 @@ fn homotopy_algorithm(
 
     let mut hvec = vec![0.0f64; n];
     hom.h(&y0, &mut hvec);
+
+    // C's `pFile`: header (`"lambda"` then the unknowns) and the start row.
+    let mut csv = export.map(|e| {
+        crate::omclog::info(
+            crate::omclog::INIT_HOMOTOPY,
+            false,
+            &alloc::format!("The homotopy path will be exported to {}.", e.name),
+        );
+        let mut s = alloc::string::String::from("\"sep=,\"\n\"lambda\"");
+        for v in &e.vars {
+            s.push_str(&alloc::format!(",\"{v}\""));
+        }
+        s.push_str("\n0.0");
+        for v in &y0[..n] {
+            s.push(',');
+            s.push_str(&crate::omclog::g(*v, 0, 16));
+        }
+        s.push('\n');
+        (e.name, s)
+    });
 
     let mut iter: i32 = 0;
     let mut num_steps = 0usize;
@@ -1091,9 +1166,20 @@ fn homotopy_algorithm(
             }
             y0.copy_from_slice(&y1);
             prev_tangent.copy_from_slice(&tangent);
+            if let Some((_, s)) = csv.as_mut() {
+                s.push_str(&crate::omclog::g(y0[n], 0, 16));
+                for v in &y0[..n] {
+                    s.push(',');
+                    s.push_str(&crate::omclog::g(*v, 0, 16));
+                }
+                s.push('\n');
+            }
         }
     }
     crate::omclog::info(log, false, &alloc::format!("homotopy parameter lambda = {}", fmt_g6(y0[n])));
+    if let Some((name, s)) = csv {
+        crate::files::write_file(&name, &s);
+    }
     y.copy_from_slice(&y1);
     Ok(num_steps)
 }
@@ -1203,11 +1289,11 @@ fn homotopy_solve(
     let ok = match variant {
         HomVariant::Newton => {
             let mut hom = NewtonHom { n, fx0, fx: vec![0.0f64; n], xscaling: &xscaling, eval };
-            homotopy_algorithm(n, &mut y, &xscaling, start_dir, crate::omclog::NLS_HOMOTOPY, &mut hom).is_ok()
+            homotopy_algorithm(n, &mut y, &xscaling, start_dir, crate::omclog::NLS_HOMOTOPY, None, &mut hom).is_ok()
         }
         HomVariant::Fixpoint => {
             let mut hom = FixpointHom { n, x0: x0v.clone(), fx: vec![0.0f64; n], xscaling: &xscaling, eval };
-            homotopy_algorithm(n, &mut y, &xscaling, start_dir, crate::omclog::NLS_HOMOTOPY, &mut hom).is_ok()
+            homotopy_algorithm(n, &mut y, &xscaling, start_dir, crate::omclog::NLS_HOMOTOPY, None, &mut hom).is_ok()
         }
     };
     if ok {
@@ -1224,6 +1310,7 @@ fn init_homotopy_solve<'e>(
     x: &mut [f64],
     nominal: &[f64],
     bounds: &[f64],
+    export: Option<(u32, bool, alloc::vec::Vec<alloc::string::String>)>,
     eval: &mut (dyn FnMut(&[f64], &mut [f64]) + 'e),
     mut jac: Option<&mut (dyn FnMut(&[f64], &mut [f64]) + 'e)>,
 ) -> Option<usize> {
@@ -1258,6 +1345,16 @@ fn init_homotopy_solve<'e>(
         );
         let mut y = vec![0.0f64; m];
         y[..n].copy_from_slice(&x0);
+        // C's `_nonlinsys<k>_adaptive_<local|global>_homotopy_<pos|neg>.csv`.
+        let hom_export = export.as_ref().map(|(sys_num, global, vars)| HomExport {
+            name: alloc::format!(
+                "{}_nonlinsys{sys_num}_adaptive_{}_homotopy_{}.csv",
+                crate::files::prefix(),
+                if *global { "global" } else { "local" },
+                if dir > 0.0 { "pos" } else { "neg" }
+            ),
+            vars: vars.clone(),
+        });
         let r = {
             let mut hom = InitHom {
                 n,
@@ -1266,7 +1363,7 @@ fn init_homotopy_solve<'e>(
                 eval,
                 jac: jac.as_deref_mut(),
             };
-            homotopy_algorithm(n, &mut y, &xscaling, dir, crate::omclog::INIT_HOMOTOPY, &mut hom)
+            homotopy_algorithm(n, &mut y, &xscaling, dir, crate::omclog::INIT_HOMOTOPY, hom_export, &mut hom)
         };
         match r {
             Ok(steps) => {
@@ -1617,20 +1714,70 @@ fn log_assert_handled() {
 /// earlier rungs. It is the last thing C tries, and reaching the far end of it is
 /// what solves BranchingDynamicPipes' 79-unknown medium system at lambda = 1.
 ///
-/// `x_start` and `warm` are C's `nlsx` (the point `solveHomotopy` settled on) and
-/// `nlsxOld`; `x` holds the solution, or the last iterate when every rung fails.
+/// `x_start`, `warm` and `extrapolation` are C's `nlsx` (the point `solveHomotopy`
+/// settled on), `nlsxOld` and `nlsxExtrapolation`; `x` holds the solution, or the
+/// last iterate when every rung fails.
+///
+/// With a symbolic Jacobian C runs `hybrj` over it and hands it over unscaled even
+/// while the unknowns are x-scaled (`wrapper_fvec_hybrj` never rescales the
+/// analytic columns); the dogleg's path, and so the root, depends on that.
 #[allow(clippy::too_many_arguments)]
 fn hybrd_c(
     n: usize,
     x: &mut [f64],
     x_start: &[f64],
     warm: &[f64],
+    extrapolation: &[f64],
     nominal: &[f64],
     bounds: &[f64],
     t: &HomotopyTrace,
     eval: &mut dyn FnMut(&[f64], &mut [f64]),
+    mut jac: Option<&mut dyn FnMut(&[f64], &mut [f64])>,
     set_continuous: &mut dyn FnMut(bool),
 ) -> bool {
+    use crate::omclog;
+    let log_v = omclog::active(omclog::NLS_V);
+    let names = var_names(t.eq_index);
+    // C's `printVector`.
+    let print_vector = |name: &str, v: &[f64]| {
+        omclog::info(omclog::NLS_V, true, name);
+        for (i, x) in v.iter().enumerate() {
+            omclog::info(omclog::NLS_V, false, &alloc::format!("[{i:>2}] {}", omclog::g(*x, 20, 12)));
+        }
+        omclog::close(omclog::NLS_V);
+    };
+    let log_rung = |msg: &str| {
+        if log_v {
+            omclog::info(omclog::NLS_V, false, msg);
+        }
+    };
+    if log_v {
+        omclog::info(
+            omclog::NLS_V,
+            true,
+            &alloc::format!(
+                "Start solving Non-Linear System {} (size {n}) at time {} with Hybrd Solver",
+                t.eq_index,
+                fmt_g6(t.time)
+            ),
+        );
+        for i in 0..n {
+            let name = names.get(i).map_or("", |s| s.as_str());
+            omclog::info(omclog::NLS_V, true, &alloc::format!("{}. {name} = {}", i + 1, omclog::f(x_start[i], 0, 6)));
+            omclog::info(
+                omclog::NLS_V,
+                false,
+                &alloc::format!(
+                    "    nominal = {}\nold = {}\nextrapolated = {}",
+                    omclog::f(nominal[i], 0, 6),
+                    omclog::f(warm[i], 0, 6),
+                    omclog::f(extrapolation[i], 0, 6)
+                ),
+            );
+            omclog::close(omclog::NLS_V);
+        }
+        omclog::close(omclog::NLS_V);
+    }
     const XTOL: f64 = 1.0e-12;
     /// C's `hybrdData->epsfcn`; `fdjac1` derives its step from it as C does.
     const EPSFCN: f64 = 1.0e-12;
@@ -1668,10 +1815,17 @@ fn hybrd_c(
             xv[i] = xv[i].max(bounds[2 * i]).min(bounds[2 * i + 1]);
             xscale[i] = xv[i].abs().max(nominal[i]).max(1e-16);
         }
+        if log_v {
+            print_vector("scaling factors x vector", &xscale);
+            print_vector("Iteration variable values", &xv);
+        }
         if use_xscaling {
             for i in 0..n {
                 xv[i] /= xscale[i];
             }
+        }
+        if log_v {
+            print_vector("Iteration variable values (scaled)", &xv);
         }
         set_continuous(continuous);
         arm_attempt();
@@ -1687,9 +1841,21 @@ fn hybrd_c(
                 fjacobian: Some(&mut fjacobian),
                 diag: diag.as_deref(),
             };
-            minpack::hybrd_hooked(
-                &mut seval, &mut hooks, n, &mut xv, &mut fvec, XTOL, maxfev, EPSFCN, factor,
-            )
+            match jac.as_deref_mut() {
+                Some(jac) => {
+                    let mut unscaled_j = vec![0.0f64; n];
+                    let mut sjac = |sx: &[f64], fj: &mut [f64]| {
+                        for i in 0..n {
+                            unscaled_j[i] = if use_xscaling { sx[i] * xscale[i] } else { sx[i] };
+                        }
+                        jac(&unscaled_j, fj);
+                    };
+                    minpack::hybrj_hooked(&mut seval, &mut sjac, &mut hooks, n, &mut xv, &mut fvec, XTOL, maxfev, factor)
+                }
+                None => minpack::hybrd_hooked(
+                    &mut seval, &mut hooks, n, &mut xv, &mut fvec, XTOL, maxfev, EPSFCN, factor,
+                ),
+            }
         };
         if use_xscaling {
             for i in 0..n {
@@ -1739,7 +1905,16 @@ fn hybrd_c(
             for i in 0..n {
                 scaled[i] = fvec[i] * (1.0 / res_scaling[i]);
             }
-            (enorm(&fvec), enorm(&scaled))
+            if log_v {
+                omclog::info(omclog::NLS_V, true, "scaling factors for residual vector");
+                for i in 0..n {
+                    omclog::info(omclog::NLS_V, true, &alloc::format!("scaled residual [{i}] : {}", omclog::e(scaled[i], 0, 20)));
+                    omclog::info(omclog::NLS_V, false, &alloc::format!("scaling factor [{i}] : {}", omclog::e(res_scaling[i], 0, 20)));
+                    omclog::close(omclog::NLS_V);
+                }
+                omclog::close(omclog::NLS_V);
+            }
+            (minpack::enorm(&fvec), minpack::enorm(&scaled))
         };
         // C's `if (info < 4 && xerror > local_tol && xerror_scaled > local_tol) info = 4`:
         // only the residual decides, and a rejected run advances a rung.
@@ -1756,6 +1931,11 @@ fn hybrd_c(
             arm_attempt();
             eval(&xv, &mut fvec);
             if !attempt_aborted() {
+                if log_v {
+                    omclog::info(omclog::NLS_V, true, "System solved");
+                    omclog::info(omclog::NLS_V, false, &alloc::format!("{retries} retries\n{} restarts", retries2 + retries3));
+                    omclog::close(omclog::NLS_V);
+                }
                 set_continuous(true);
                 return true;
             }
@@ -1785,30 +1965,36 @@ fn hybrd_c(
                 xv[assert_retries - 1] += 0.01 * nominal[assert_retries - 1];
             }
             assert_retries += 1;
+            log_rung(&alloc::format!(" - try to handle a problem with a called assert vary initial value a bit. (Retry: {assert_retries})"));
         } else if retries < 3 {
             restart(&mut xv, &nlsx);
             factor /= 10.0;
             retries += 1;
+            log_rung(&alloc::format!(" - iteration making no progress:\t decreasing initial step bound to {}.", omclog::f(factor, 0, 6)));
         } else if retries < 4 {
             for i in 0..n {
                 xv[i] += nominal[i] * 0.1;
             }
             factor = initial_factor;
             retries += 1;
+            log_rung("iteration making no progress:\t vary solution point by 1%.");
         } else if retries < 5 {
             // C's "try old values as x-scaling factors"; the constrain-x block above
             // overwrites them again, in C too, so this is a plain restart.
             restart(&mut xv, &nlsx);
             retries += 1;
+            log_rung("iteration making no progress:\t try old values as scaling factors.");
         } else if retries < 6 {
             restart(&mut xv, &nlsx);
             use_xscaling = false;
             retries += 1;
+            log_rung("iteration making no progress:\t try without scaling at all.");
         } else if retries < 7 && discrete_call {
             xv.copy_from_slice(&warm);
             continuous = false;
             non_continuous = true;
             retries += 1;
+            log_rung(" - iteration making no progress:\t try to solve a discontinuous system.");
         } else if retries2 < 1 {
             xv.copy_from_slice(&warm);
             use_xscaling = true;
@@ -1816,6 +2002,7 @@ fn hybrd_c(
             factor = initial_factor;
             retries = 0;
             retries2 += 1;
+            log_rung(" - iteration making no progress:\t use old values instead extrapolated.");
         } else if retries2 < 2 {
             restart(&mut xv, &nlsx);
             for v in xv.iter_mut() {
@@ -1823,6 +2010,7 @@ fn hybrd_c(
             }
             retries = 0;
             retries2 += 1;
+            log_rung(" - iteration making no progress:\t vary initial point by adding 1%.");
         } else if retries2 < 3 {
             restart(&mut xv, &nlsx);
             for v in xv.iter_mut() {
@@ -1830,15 +2018,18 @@ fn hybrd_c(
             }
             retries = 0;
             retries2 += 1;
+            log_rung(" - iteration making no progress:\t vary initial point by -1%.");
         } else if retries2 < 4 {
             xv.copy_from_slice(nominal);
             retries = 0;
             retries2 += 1;
+            log_rung(" - iteration making no progress:\t try scaling factor as initial point.");
         } else if retries2 < 5 && !assert_called {
             restart(&mut xv, &nlsx);
             diag = Some(res_scaling.iter().map(|v| libm::fabs(*v).max(1e-16)).collect());
             retries = 0;
             retries2 += 1;
+            log_rung(" - iteration making no progress:\t try with own scaling factors.");
         } else if retries3 < 1 {
             restart(&mut xv, &nlsx);
             diag = Some(vec![1.0f64; n]);
@@ -1846,6 +2037,7 @@ fn hybrd_c(
             retries = 0;
             retries2 = 0;
             retries3 += 1;
+            log_rung(" - iteration making no progress:\t disable solver internal scaling.");
         } else if retries3 < 6 {
             restart(&mut xv, &nlsx);
             local_tol *= 10.0;
@@ -1854,7 +2046,9 @@ fn hybrd_c(
             retries = 0;
             retries2 = 0;
             retries3 += 1;
+            log_rung(&alloc::format!(" - iteration making no progress:\t reduce the tolerance slightly to {}.", omclog::e(local_tol, 0, 6)));
         } else {
+            log_rung(&alloc::format!("### No Solution! ###\n after {} restarts", retries * retries2 * retries3));
             x.copy_from_slice(&xv);
             set_continuous(true);
             return false;
@@ -2215,6 +2409,49 @@ pub extern "C" fn rt_nls_set_names(eq_index: u32, ptr: u32, len: u32) {
     names.push((eq_index, list));
 }
 
+/// What `-lv=LOG_NLS_NEWTON_DIAGNOSTICS` needs per system beyond the names, keyed
+/// by equation index; shipped by the host like [`rt_nls_set_names`].
+struct DiagCell(UnsafeCell<alloc::vec::Vec<(u32, crate::newton_diagnostics::DiagInfo)>>);
+unsafe impl Sync for DiagCell {}
+static DIAG: DiagCell = DiagCell(UnsafeCell::new(alloc::vec::Vec::new()));
+
+/// `eqns` is `len` little-endian u32 at `ptr` in this module's memory;
+/// `eq_index == u32::MAX` clears the roster.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_nls_set_diag(eq_index: u32, n_eqns: u32, n_vars: u32, n_nonlinear: u32, init_diag: u32, ptr: u32, len: u32) {
+    let diag = unsafe { &mut *DIAG.0.get() };
+    if eq_index == u32::MAX {
+        diag.clear();
+        return;
+    }
+    let eqns = (0..len).map(|i| unsafe { load_u32(ptr + 4 * i) }).collect();
+    diag.push((
+        eq_index,
+        crate::newton_diagnostics::DiagInfo { pattern: [n_eqns, n_vars, n_nonlinear], init_diag: init_diag != 0, eqns },
+    ));
+}
+
+/// [`rt_nls_set_diag`] for a driver in the same module.
+pub(crate) fn set_diag(systems: &[openmodelica_sim_meta::NlsVars]) {
+    *unsafe { &mut *DIAG.0.get() } = systems
+        .iter()
+        .map(|s| {
+            (
+                s.eq_index,
+                crate::newton_diagnostics::DiagInfo {
+                    pattern: s.pattern,
+                    init_diag: s.init_diag,
+                    eqns: s.eqns.iter().map(|e| *e as u32).collect(),
+                },
+            )
+        })
+        .collect();
+}
+
+fn diag_info(eq_index: u32) -> Option<&'static crate::newton_diagnostics::DiagInfo> {
+    unsafe { &*DIAG.0.get() }.iter().find(|(e, _)| *e == eq_index).map(|(_, d)| d)
+}
+
 /// C's `printNonLinearInitialInfo`, under the `solve_nonlinear_system` header.
 fn log_nls_enter(eq_index: u32, time: f64, x: &[f64], nominal: &[f64]) {
     use crate::omclog;
@@ -2273,7 +2510,7 @@ fn log_nls_leave(eq_index: u32, solved: bool, x: &[f64]) {
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_nls_clean_history(time: f64) {
     for &(addr, n) in unsafe { &*ROSTER.0.get() } {
-        let mut hist = MemHistory { count_addr: addr, base: addr + 16 + (n * 8) as u32, n };
+        let mut hist = MemHistory { count_addr: addr, base: addr + 16 + 2 * (n * 8) as u32, n };
         history_clean(&mut hist, time);
     }
 }
@@ -2419,9 +2656,14 @@ fn newton_c(
     const LAMBDA_MIN_C: f64 = 1.0e-4;
     let ftol_sq = newton_ftol() * newton_ftol();
     let xtol_sq = newton_xtol() * newton_xtol();
+    // C's `vec2NormSqrd`: the plain sum of squares. Squaring [`enorm`] instead
+    // rounds twice, and these measures decide the damping and the convergence test.
     let nsq = |v: &[f64]| -> f64 {
-        let e = enorm(v);
-        e * e
+        let mut s = 0.0;
+        for x in v {
+            s += x * x;
+        }
+        s
     };
 
     // C's `xStart`: the retries below vary off this, not off the last varied point.
@@ -2443,6 +2685,7 @@ fn newton_c(
     let mut rp = vec![0.0f64; n];
     let mut step = vec![0.0f64; n]; // C's dy0 (the full Newton step −J⁻¹f)
     let mut jac = vec![0.0f64; n * n];
+    let mut aug = vec![0.0f64; n * (n + 1)]; // C's `fJac`, whose last column is `fvec`
 
     // The Jacobian is w.r.t. *scaled* unknowns: both of C's paths scale column `j` by
     // `xScaling[j]`, and the step is unscaled after the solve. `resScaling` is a row
@@ -2566,6 +2809,9 @@ fn newton_c(
     let mut iter = 0i32;
     let mut neg_steps = 0i32;
     let mut small_steps = 0i32;
+    // C's `solverinfo == 1`, which its first iteration cannot see: the entry phase's
+    // total-pivot solve reports a vanishing determinant only to the log.
+    let mut vanishing = false;
     loop {
         stat_inc(STAT_NLS_ITER);
         if let Some(t) = trace {
@@ -2740,6 +2986,10 @@ fn newton_c(
             }
             return (true, !last_was_good);
         }
+        if vanishing {
+            crate::omclog::debug_string(crate::omclog::DT, "It is not the solution.");
+            return (false, false);
+        }
         iter += 1;
         // C's `maxNumberOfIterations = size*100`.
         if iter > max_iter {
@@ -2793,21 +3043,40 @@ fn newton_c(
             return (false, false);
         }
         row_scaling(n, &jac, res_scaling);
-        // C's `linearSolverWrapper` at the head of the next iteration: solve J·d = f
+        // C's `linearSolverWrapper` at the head of the next iteration, over the
+        // row-equilibrated `[J f]` its `scaleMatrixRows` leaves behind: solve J·d = f
         // in scaled unknowns, unscale, negate so `x1 = x + step`.
-        step.copy_from_slice(&fvec);
-        if !lu_solve(&jac, &mut step, n) {
-            stat_inc(STAT_NEWTON_SINGULAR);
-            if trace.is_some() {
-                crate::omclog::debug_string(crate::omclog::NLS_V, "Linear lapack solver failed!!!");
-                crate::omclog::debug_string(crate::omclog::NLS_V, BAR);
-                crate::omclog::debug_string(crate::omclog::NLS_V, NO_CONVERGE);
-                crate::omclog::debug_string(crate::omclog::NLS_V, BAR);
+        aug[..n * n].copy_from_slice(&jac);
+        aug[n * n..].copy_from_slice(&fvec);
+        scale_matrix_rows_aug(n, &mut aug);
+        step.copy_from_slice(&aug[n * n..]);
+        let det = match lu_solve_det(&aug[..n * n], &mut step, n) {
+            Some(d) => d,
+            None => {
+                stat_inc(STAT_NEWTON_SINGULAR);
+                if trace.is_some() {
+                    crate::omclog::debug_string(crate::omclog::NLS_V, "Linear lapack solver failed!!!");
+                    crate::omclog::debug_string(crate::omclog::NLS_V, BAR);
+                    crate::omclog::debug_string(crate::omclog::NLS_V, NO_CONVERGE);
+                    crate::omclog::debug_string(crate::omclog::NLS_V, BAR);
+                }
+                return (false, false);
             }
-            return (false, false);
+        };
+        // `linearSolverWrapper` returns 1 for a casual tearing set whose determinant is
+        // on its way to singular: the step keeps the sign `dgesv` gave it (C skips the
+        // `vecScalarMult(n, x, -1, x)` there) and, unless this iterate turns out to be
+        // the solution, the Newton ends on it.
+        vanishing = casual && libm::fabs(det) < 1e-9;
+        if vanishing {
+            crate::omclog::debug_string(
+                crate::omclog::DT,
+                "The determinant of the casual tearing set is vanishing, let's fail if this is not the solution...",
+            );
         }
+        let sign = if vanishing { 1.0 } else { -1.0 };
         for (s, sc) in step.iter_mut().zip(xscaling.iter()) {
-            *s = -*s * sc;
+            *s = sign * *s * sc;
         }
     }
 }
@@ -3440,6 +3709,26 @@ pub extern "C" fn rt_solve_nls(
     }
     set_no_throw_div_zero(true);
     let sys0 = sys_counts();
+    if n == 0 {
+        // No unknowns: C's Newton evaluates the residual once and finds the empty
+        // vector converged, so the inner equations run once.
+        let residual: extern "C" fn(u32, u32, u32) = unsafe { core::mem::transmute(res_idx as usize) };
+        let saved = enter_eval();
+        residual(sim_data, 0, 0);
+        let threw = leave_eval(saved);
+        if threw {
+            unsafe {
+                if load_u32(nls_fail_addr) == 0 {
+                    store_u32(nls_fail_addr, eq_index + 1);
+                }
+            }
+            stat_inc(STAT_NLS_FAIL);
+        }
+        set_no_throw_div_zero(false);
+        let now = sys_counts();
+        crate::sysstats::end([now[0] - sys0[0], now[1] - sys0[1], now[2] - sys0[2]]);
+        return i32::from(threw);
+    }
     // Relation mode (C's hysteresis): Newton always holds relations (mode 0) so it
     // is smooth; mode 2 (init) is fresh throughout; mode 1 (event) re-solves with
     // fresh relations until the discrete state stabilizes (mixed-system iteration).
@@ -3575,7 +3864,8 @@ pub extern "C" fn rt_solve_nls(
         }
     };
 
-    // Per-system state: count | lastTimeSolved | resScaling[n] | DEPTH × (time, x[n]).
+    // Per-system state: count | lastTimeSolved | resScaling[n] | nlsxExtrapolation[n]
+    // | DEPTH × (time, x[n]).
     // `resScaling` is C's `homotopyData->resScaling`, which lives in the per-system
     // solver data and survives between calls, starting zeroed (= unscaled).
     // The entries are C's `oldValueList`. Depth is what makes the exact-time hit
@@ -3583,7 +3873,9 @@ pub extern "C" fn rt_solve_nls(
     // calls, and only a deep list still holds it.
     let last_solved_addr = hist_addr + 8;
     let scale_addr = hist_addr + 16;
-    let mut hist = MemHistory { count_addr: hist_addr, base: scale_addr + (n * 8) as u32, n };
+    // C's `nlsxExtrapolation`, a per-system buffer only `getInitialGuess` writes.
+    let extrap_addr = scale_addr + (n * 8) as u32;
+    let mut hist = MemHistory { count_addr: hist_addr, base: extrap_addr + (n * 8) as u32, n };
     let mut res_scaling: alloc::vec::Vec<f64> =
         (0..n).map(|i| unsafe { load_f64(scale_addr + (i * 8) as u32) }).collect();
 
@@ -3599,10 +3891,20 @@ pub extern "C" fn rt_solve_nls(
         if hpick.exact {
             stat_inc(STAT_NLS_GUESS_HIT);
         }
+        // `getInitialGuess` publishes what it picked to the system's own buffer.
         history_guess(&hist, &hpick, time, &mut guess);
         history_old(&hist, &hpick, &mut nlsx_old);
+        for (i, g) in guess.iter().enumerate() {
+            unsafe { store_f64(extrap_addr + (i * 8) as u32, *g) };
+        }
     } else {
+        // C's "if last solving is too long ago use just old values" assigns `nlsx`
+        // alone and leaves `nlsxExtrapolation` where the last `getInitialGuess` put
+        // it — zeroes until this system has taken the other branch once.
         stat_inc(STAT_NLS_STALE);
+        for (i, g) in guess.iter_mut().enumerate() {
+            *g = unsafe { load_f64(extrap_addr + (i * 8) as u32) };
+        }
     }
 
     let mut scratch = vec![0.0f64; n];
@@ -3612,7 +3914,10 @@ pub extern "C" fn rt_solve_nls(
     // (`solveContinuous`); an event primes once live, then holds.
     let discrete_call = saved_rel_fresh == 1;
     let mixed = mixed != 0 && discrete_call;
-    let mut x = if discrete_call { nlsx_old.clone() } else { guess.clone() };
+    // `functionInitialEquations` sets `discreteCall` too, so an initial system starts
+    // from `nlsx`: its extrapolation is still zeroes, and the equidistant homotopy
+    // hands each lambda step the previous one's solution through the unknowns.
+    let mut x = if saved_rel_fresh != 0 { nlsx_old.clone() } else { guess.clone() };
     // C's `relationsPreBackup`; `updateInnerEquation` primes at `nlsx`. C gates it on
     // `discreteCall`, which `functionInitialEquations` also sets, so an initial system
     // gets it too — with relations already fresh there, only an event moves the flag.
@@ -3646,6 +3951,35 @@ pub extern "C" fn rt_solve_nls(
     }
     // C's `ERROR_NONLINEARSOLVER` region starts here, after `updateInnerEquation`.
     let _stage = enter_nls_stage();
+    // C runs `newtonDiagnostics` on an initial system here, over `nlsx` and the
+    // residual `updateInnerEquation` left in `resValues`. Its own residual and
+    // Jacobian calls go to the callbacks directly, uncounted.
+    if saved_rel_fresh == 2 && crate::omclog::active(crate::omclog::NLS_NEWTON_DIAGNOSTICS) {
+        if let Some(diag) = diag_info(eq_index).filter(|d| d.init_diag) {
+            if jac_idx == u32::MAX {
+                crate::omclog::error(crate::omclog::ASSERT, false, "NEWTON_DIAGNOSTICS: numeric jacobian not yet supported.");
+            } else {
+                let feval0 = n_feval.get();
+                let jac0 = JAC_EVALS.load(Ordering::Relaxed);
+                let names = var_names(eq_index);
+                let mut residual = |xs: &[f64], r: &mut [f64]| {
+                    eval(xs, r);
+                    eval_threw()
+                };
+                let mut jacobian = |xs: &[f64], fj: &mut [f64]| jaceval(xs, fj);
+                crate::newton_diagnostics::newton_diagnostics(
+                    eq_index,
+                    &nlsx_old,
+                    &scratch,
+                    &names,
+                    diag,
+                    &mut crate::newton_diagnostics::Callbacks { residual: &mut residual, jacobian: &mut jacobian },
+                );
+                n_feval.set(feval0);
+                JAC_EVALS.store(jac0, Ordering::Relaxed);
+            }
+        }
+    }
     let mut fvec = vec![0.0f64; n];
     let maxfev = n * 10000;
     // Last residual eval was at the returned `x`, so the epilogue need not repeat
@@ -3682,8 +4016,28 @@ pub extern "C" fn rt_solve_nls(
         i32::MIN // the arc-length solver alone
     };
     let sys_num = nls_sys_number(hist_addr);
+    // C's `pFile`: the path CSV, written under `LOG_INIT_HOMOTOPY` only.
+    let mut hom_csv: Option<(alloc::string::String, alloc::string::String)> = None;
+    let mut open_hom_csv = |csv: &mut Option<(alloc::string::String, alloc::string::String)>| {
+        if !crate::omclog::active(crate::omclog::INIT_HOMOTOPY) {
+            return;
+        }
+        let name = alloc::format!("{}_nonlinsys{sys_num}_equidistant_local_homotopy.csv", crate::files::prefix());
+        crate::omclog::info(
+            crate::omclog::INIT_HOMOTOPY,
+            false,
+            &alloc::format!("The homotopy path of system {sys_num} will be exported to {name}."),
+        );
+        let mut head = alloc::string::String::from("\"sep=,\"\n\"lambda\"");
+        for v in var_names(eq_index) {
+            head.push_str(&alloc::format!(",\"{v}\""));
+        }
+        head.push('\n');
+        *csv = Some((name, head));
+    };
     if attempt == 0 {
         log_local_homotopy_start(sys_num, true);
+        open_hom_csv(&mut hom_csv);
     }
     if attempt == -2 {
         log_local_adaptive_start(sys_num);
@@ -3691,6 +4045,8 @@ pub extern "C" fn rt_solve_nls(
     // The strict set solved the component in place of this casual one, so the
     // unknowns already hold the answer: nothing to settle, no failure to report.
     let mut strict_used = false;
+    // Whether `solveWithInitHomotopy`, rather than the `solveNLS` ladder, solved it.
+    let mut init_hom_solved = false;
     let mut converged = if attempt == i32::MIN { false } else { 'attempts: loop {
         if attempt == -2 {
             // C sets `lambda = 0` before the lambda0-system pre-solve.
@@ -3712,6 +4068,8 @@ pub extern "C" fn rt_solve_nls(
             // A system C would hand to kinsol+KLU: scaled Newton over the CSC Jacobian
             // (`kinsol_sparse_solve`). The dense ladder below is O(n^2) per Jacobian and
             // O(n^3) per step, which is what the sparse choice exists to avoid.
+            // `start_point` below is C's `xStart` (`discreteCall ? nlsx :
+            // nlsxExtrapolation`), which every solver starts its first try from.
             let converged = if !sparse && pick == Nls::KinsolB {
                 // C hands *every* system to the selected solver; without a sparsity
                 // pattern `initKinsolMemory` takes its dense linear solver, and
@@ -3722,7 +4080,7 @@ pub extern "C" fn rt_solve_nls(
                 )
             } else if sparse {
                 kinsol_sparse_solve(
-                    n, &mut x, &guess, &warm, &nominal, sim_data, x_ptr, jac_idx, jac_ptr,
+                    n, &mut x, &start_point, &warm, &nominal, sim_data, x_ptr, jac_idx, jac_ptr,
                     pat_addr, nnz as usize, jac_csc, lss_handle, eq_index, time, &nlsx_old, &mut eval,
                 )
             } else if pick == Nls::Newton {
@@ -3739,7 +4097,7 @@ pub extern "C" fn rt_solve_nls(
                 // Both start directions, as C's runHomotopy.
                 let mut ok = false;
                 for &dir in &[1.0f64, -1.0] {
-                    let mut hx = guess.clone();
+                    let mut hx = start_point.clone();
                     if homotopy_solve(n, &mut hx, &nominal, dir, HomVariant::Newton, &mut eval) {
                         x.copy_from_slice(&hx);
                         ok = true;
@@ -3801,7 +4159,9 @@ pub extern "C" fn rt_solve_nls(
                             if !converged {
                                 stat_inc(STAT_NLS_RETRY);
                                 converged = hybrd_c(
-                                    n, &mut x, &nlsx, &warm, &nominal, &bounds, &t, &mut eval, &mut set_cont,
+                                    n, &mut x, &nlsx, &warm, &guess, &nominal, &bounds, &t, &mut eval,
+                                    has_jac.then_some(&mut jaceval as &mut dyn FnMut(&[f64], &mut [f64])),
+                                    &mut set_cont,
                                 );
                                 if !converged {
                                     best.copy_from_slice(&x);
@@ -3831,7 +4191,8 @@ pub extern "C" fn rt_solve_nls(
                 if !homotopy_solver && !converged {
                     stat_inc(STAT_NLS_RETRY);
                     converged = hybrd_c(
-                        n, &mut x, &nlsx, &warm, &nominal, &bounds, &t, &mut eval, &mut set_cont,
+                        n, &mut x, &nlsx, &warm, &guess, &nominal, &bounds, &t, &mut eval,
+                        has_jac.then_some(&mut jaceval as &mut dyn FnMut(&[f64], &mut [f64])), &mut set_cont,
                     );
                     if !converged {
                         best.copy_from_slice(&x);
@@ -3841,7 +4202,8 @@ pub extern "C" fn rt_solve_nls(
                 if !converged && homotopy_solver && !strict_used {
                     stat_inc(STAT_NLS_RETRY);
                     converged = hybrd_c(
-                        n, &mut x, &best, &warm, &nominal, &bounds, &t, &mut eval, &mut set_cont,
+                        n, &mut x, &best, &warm, &guess, &nominal, &bounds, &t, &mut eval,
+                        has_jac.then_some(&mut jaceval as &mut dyn FnMut(&[f64], &mut [f64])), &mut set_cont,
                     );
                 }
                 // Not C's; these catch what C gives up on.
@@ -3944,6 +4306,7 @@ pub extern "C" fn rt_solve_nls(
                 break 'attempts false;
             }
             log_local_homotopy_start(sys_num, false);
+            open_hom_csv(&mut hom_csv);
             attempt = 0;
             continue;
         }
@@ -3959,6 +4322,14 @@ pub extern "C" fn rt_solve_nls(
                 fmt_g6((attempt as f64 / hom_steps as f64).min(1.0))
             ),
         );
+        if let Some((_, csv)) = hom_csv.as_mut() {
+            csv.push_str(&crate::omclog::g((attempt as f64 / hom_steps as f64).min(1.0), 0, 16));
+            for v in &x {
+                csv.push(',');
+                csv.push_str(&crate::omclog::g(*v, 0, 16));
+            }
+            csv.push('\n');
+        }
         if attempt >= hom_steps {
             crate::stat_add(crate::STAT_HOMOTOPY_STEPS, hom_steps as u64);
             break 'attempts true;
@@ -3969,6 +4340,9 @@ pub extern "C" fn rt_solve_nls(
         guess.copy_from_slice(&x);
         nlsx_old.copy_from_slice(&x);
     } };
+    if let Some((name, csv)) = hom_csv {
+        crate::files::write_file(&name, &csv);
+    }
     // C's `solveWithInitHomotopy`: run along the model's own homotopy path.
     if adaptive_homotopy && !converged && !strict_used && (hom_method == HOM_GLOBAL_ADAPTIVE || lambda0_ok) {
         crate::omclog::info(
@@ -3993,11 +4367,15 @@ pub extern "C" fn rt_solve_nls(
                 *v = unsafe { load_f64(jac_ptr + (k * 8) as u32) };
             }
         };
+        let export = crate::omclog::active(crate::omclog::INIT_HOMOTOPY).then(|| {
+            (sys_num, hom_method == HOM_GLOBAL_ADAPTIVE, var_names(eq_index).to_vec())
+        });
         let steps = init_homotopy_solve(
             n,
             &mut y,
             &nominal,
             &bounds,
+            export,
             &mut eval,
             has_hom_jac.then_some(&mut hom_jac as &mut dyn FnMut(&[f64], &mut [f64])),
         );
@@ -4006,15 +4384,28 @@ pub extern "C" fn rt_solve_nls(
             crate::stat_add(crate::STAT_HOMOTOPY_STEPS, steps as u64);
             converged = true;
             settled = false;
+            init_hom_solved = true;
         }
     }
     if retried {
         // `hybrd_c`'s rung may have left the flag held.
         unsafe { store_u32(rel_fresh_addr, 1) };
     }
-    // Leave the slots + torn variables at the solution. C leaves them wherever its
-    // last trial step put them, so this has no counterpart in its feval count.
-    if converged && !settled && !strict_used {
+    // `solveNLS`'s `NLS_MIXED` tail closes with `getIterationVars(data, nlsx)`, so the
+    // solution is *harvested* from the unknown slots wherever the last residual
+    // evaluation left them: a Newton that rejected its last trial point (issue #6419)
+    // still reports that point, with the torn variables consistent with it. Nothing is
+    // evaluated, so C's feval count has no entry for it. `solveWithInitHomotopy` is
+    // not `solveNLS`, and so is not harvested.
+    let harvest =
+        converged && !strict_used && !init_hom_solved && matches!(pick, Nls::Default | Nls::Mixed);
+    if harvest {
+        load(sim_data, x_ptr);
+        for i in 0..n {
+            x[i] = unsafe { load_f64(x_ptr + (i * 8) as u32) };
+        }
+    } else if converged && !settled && !strict_used {
+        // The other `-nls` solvers publish the solver's own answer instead.
         let uncounted = n_feval.get();
         eval(&x, &mut scratch);
         n_feval.set(uncounted);
@@ -4244,7 +4635,7 @@ mod tests {
         };
         let mut cont = |_: bool| {};
         let t = HomotopyTrace { eq_index: 0, time: 0.0, discrete: true, initial: true, header: true };
-        assert!(hybrd_c(n, &mut x, &x_start, &warm, &nominal, &bounds, &t, &mut eval, &mut cont));
+        assert!(hybrd_c(n, &mut x, &x_start, &warm, &x_start, &nominal, &bounds, &t, &mut eval, None, &mut cont));
         for i in 0..n {
             assert!((x[i] - (i + 1) as f64).abs() < 1e-6, "x={x:?}");
         }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/prof.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/prof.rs
@@ -1,0 +1,132 @@
+//! C's `rtclock` clocks from `SIM_TIMER_FIRST_FUNCTION` on — one per profiled
+//! function and equation block (`SIM_PROF_TICK_FN/EQ`, `SIM_PROF_ACC_*`,
+//! `SIM_PROF_ADD_NCALL_EQ`) — kept in the module, where the instrumented code
+//! runs. The driver reads a row per step and the run's totals at the end, and
+//! clears them between steps as C's `clear_rt_step` does.
+
+use alloc::vec::Vec;
+use core::cell::UnsafeCell;
+
+#[derive(Clone, Copy, Default)]
+struct Clock {
+    tick: f64,
+    /// Since the last clear (C's `acc_tp`, `rt_clock_ncall`).
+    acc: f64,
+    ncall: u32,
+    /// Over the run (C's `total_tp`, `max_tp`, `rt_clock_ncall_{total,min,max}`).
+    total: f64,
+    max: f64,
+    ncall_total: u32,
+    ncall_min: u32,
+    ncall_max: u32,
+}
+
+struct Store(UnsafeCell<Vec<Clock>>);
+unsafe impl Sync for Store {}
+static CLOCKS: Store = Store(UnsafeCell::new(Vec::new()));
+struct Buf(UnsafeCell<Vec<u8>>);
+unsafe impl Sync for Buf {}
+static BUF: Buf = Buf(UnsafeCell::new(Vec::new()));
+
+/// Bytes per clock in [`rt_prof_dump`]'s record.
+pub const DUMP_RECORD: usize = 40;
+
+fn clocks() -> &'static mut Vec<Clock> {
+    unsafe { &mut *CLOCKS.0.get() }
+}
+
+fn now() -> f64 {
+    openmodelica_sim_meta::driver::now_ms_host() / 1000.0
+}
+
+/// `n` clocks, all zero: C's `rt_init`.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_prof_init(n: u32) {
+    let c = clocks();
+    c.clear();
+    c.resize(n as usize, Clock::default());
+    let b = unsafe { &mut *BUF.0.get() };
+    b.clear();
+    b.resize(n as usize * DUMP_RECORD, 0);
+}
+
+/// C's `rt_tick`: open the clock and count the call.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_prof_tick(ix: u32) {
+    if let Some(c) = clocks().get_mut(ix as usize) {
+        c.tick = now();
+        c.ncall += 1;
+    }
+}
+
+/// C's `rt_accumulate`.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_prof_acc(ix: u32) {
+    if let Some(c) = clocks().get_mut(ix as usize) {
+        c.acc += now() - c.tick;
+    }
+}
+
+/// C's `rt_add_ncall`.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_prof_add_ncall(ix: u32, n: i32) {
+    if let Some(c) = clocks().get_mut(ix as usize) {
+        c.ncall = c.ncall.wrapping_add_signed(n);
+    }
+}
+
+/// C's `rt_clear` over every clock — `clear_rt_step`: the step's share joins the
+/// run's totals and the extremes.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_prof_clear(_unused: u32) {
+    for c in clocks().iter_mut() {
+        c.total += c.acc;
+        c.ncall_total += c.ncall;
+        if c.acc > c.max {
+            c.max = c.acc;
+        }
+        if c.ncall != 0 {
+            c.ncall_min = if c.ncall_min != 0 && c.ncall_min < c.ncall { c.ncall_min } else { c.ncall };
+            c.ncall_max = c.ncall_max.max(c.ncall);
+        }
+        c.acc = 0.0;
+        c.ncall = 0;
+    }
+}
+
+/// The step row C's `fmtEmitStep` writes for the clocks: `n` u32 call counts,
+/// then `n` f64 seconds, little-endian at the returned address.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_prof_row() -> u32 {
+    let c = clocks();
+    let b = unsafe { &mut *BUF.0.get() };
+    let n = c.len();
+    for (i, k) in c.iter().enumerate() {
+        b[4 * i..4 * i + 4].copy_from_slice(&k.ncall.to_le_bytes());
+    }
+    for (i, k) in c.iter().enumerate() {
+        let o = 4 * n + 8 * i;
+        b[o..o + 8].copy_from_slice(&k.acc.to_le_bytes());
+    }
+    b.as_ptr() as u32
+}
+
+/// Every clock's run totals at the returned address, [`DUMP_RECORD`] bytes each:
+/// `total`, `max`, `acc` (f64) then `ncall_total`, `ncall_min`, `ncall_max`,
+/// `ncall` (u32).
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_prof_dump() -> u32 {
+    let c = clocks();
+    let b = unsafe { &mut *BUF.0.get() };
+    for (i, k) in c.iter().enumerate() {
+        let o = DUMP_RECORD * i;
+        b[o..o + 8].copy_from_slice(&k.total.to_le_bytes());
+        b[o + 8..o + 16].copy_from_slice(&k.max.to_le_bytes());
+        b[o + 16..o + 24].copy_from_slice(&k.acc.to_le_bytes());
+        b[o + 24..o + 28].copy_from_slice(&k.ncall_total.to_le_bytes());
+        b[o + 28..o + 32].copy_from_slice(&k.ncall_min.to_le_bytes());
+        b[o + 32..o + 36].copy_from_slice(&k.ncall_max.to_le_bytes());
+        b[o + 36..o + 40].copy_from_slice(&k.ncall.to_le_bytes());
+    }
+    b.as_ptr() as u32
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -175,6 +175,12 @@ impl SimEngine for InWasmEngine {
     fn context_addr(&mut self) -> u32 {
         crate::nls::rt_context_addr()
     }
+    fn prof_row(&mut self) -> u32 {
+        crate::prof::rt_prof_row()
+    }
+    fn prof_dump(&mut self) -> u32 {
+        crate::prof::rt_prof_dump()
+    }
     fn error_stage_addr(&mut self) -> u32 {
         crate::nls::rt_error_stage_addr()
     }
@@ -328,7 +334,11 @@ pub extern "C" fn rt_sim_start(meta_ptr: u32, meta_len: u32, fn_base: u32, prese
     driver::set_log_sink(crate::omclog::sink);
 
     crate::nls::rt_set_step_size(model.step_size());
+    crate::files::set_prefix(&model.prefix);
     // `-lv=LOG_NLS` names the iteration variables; only the metadata has them.
+    if openmodelica_sim_meta::omclog::active(openmodelica_sim_meta::omclog::NLS_NEWTON_DIAGNOSTICS) {
+        crate::nls::set_diag(&model.nls_vars);
+    }
     crate::nls::set_var_names(if openmodelica_sim_meta::omclog::wants_nls_var_names(openmodelica_sim_meta::omclog::mask()) {
         model.nls_vars.iter().map(|s| (s.eq_index, s.names.clone())).collect()
     } else {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -171,6 +171,12 @@ impl SimEngine for StandaloneEngine {
     fn context_addr(&mut self) -> u32 {
         crate::nls::rt_context_addr()
     }
+    fn prof_row(&mut self) -> u32 {
+        crate::prof::rt_prof_row()
+    }
+    fn prof_dump(&mut self) -> u32 {
+        crate::prof::rt_prof_dump()
+    }
     fn error_stage_addr(&mut self) -> u32 {
         crate::nls::rt_error_stage_addr()
     }
@@ -197,6 +203,7 @@ fn run() {
     let sim_data = crate::rt_alloc(m.layout.total);
     let mut engine = StandaloneEngine;
     crate::nls::rt_set_step_size(m.step_size());
+    crate::files::set_prefix(&m.prefix);
 
     // wasip1 has a monotonic clock, so `-alarm` works; nothing cancels a command.
     driver::set_clock(now_ms);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -454,6 +454,14 @@ pub trait SimEngine {
     fn context_addr(&mut self) -> u32 {
         0
     }
+    /// The runtime's `rt_prof_row` / `rt_prof_dump` (see `profiling`): the address
+    /// of the profiling clocks' step row and run totals, 0 without the export.
+    fn prof_row(&mut self) -> u32 {
+        0
+    }
+    fn prof_dump(&mut self) -> u32 {
+        0
+    }
     /// Address of the runtime's error stage / absorbed-error pair, or 0 when the
     /// backend has no such export.
     fn error_stage_addr(&mut self) -> u32 {
@@ -576,6 +584,7 @@ impl StepRetry {
         self.rows_mark = rows;
         self.in_step = true;
         self.threw = false;
+        THROW_PAST_STEP.store(false, Ordering::Relaxed);
         self.save = set_error_stage(e, addr, ERROR_SIMULATION_STEP);
     }
 
@@ -624,7 +633,7 @@ impl StepRetry {
         // Only a model error the region absorbed reaches C's catch; a rethrown
         // `assert()` is `MMC_THROW_INTERNAL`, which jumps past it.
         let caught = self.end(e) || self.threw || RUNTIME_ERROR.load(Ordering::Relaxed);
-        if !caught || !self.stored {
+        if !caught || THROW_PAST_STEP.load(Ordering::Relaxed) || !self.stored {
             return Ok(None);
         }
         if self.armed {
@@ -723,6 +732,15 @@ pub fn enrich_trap_init(e: &mut dyn SimEngine, err: &'static str, start_time: f6
 /// Set by [`note_runtime_error`]; consumed by the trap it precedes.
 static RUNTIME_ERROR: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
 
+/// C's `getBestJumpBuffer`: a model error raised under `ERROR_EVENTHANDLING` goes to
+/// `globalJumpBuffer`, past `performSimulation`'s per-step catch, so the step is not
+/// retaken.
+static THROW_PAST_STEP: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+
+fn note_throw_past_step() {
+    THROW_PAST_STEP.store(true, Ordering::Relaxed);
+}
+
 /// C's `va_throwStreamPrint(NULL, …)`, which an external function's `ModelicaError`
 /// reaches: log the message on `LOG_ASSERT` and unwind. It has no condition and no
 /// source position, so the trap that follows must not go looking for the assertion
@@ -743,9 +761,11 @@ pub fn note_runtime_error_flag() {
 /// Drop one a previous run left behind (only a trap consumes it).
 pub fn clear_runtime_error() {
     RUNTIME_ERROR.store(false, Ordering::Relaxed);
+    THROW_PAST_STEP.store(false, Ordering::Relaxed);
 }
 
 fn enrich_trap_impl(e: &mut dyn SimEngine, err: &'static str, init_time: Option<f64>) -> &'static str {
+    THROW_PAST_STEP.store(false, Ordering::Relaxed);
     if RUNTIME_ERROR.swap(false, Ordering::Relaxed) {
         if init_time.is_some() {
             omclog::info(omclog::ASSERT, false, "simulation terminated by an assertion at initialization");
@@ -1970,8 +1990,11 @@ fn init_model(
     // Seed the delay buffers / transported profiles and snapshot `zeroCrossingsPre`
     // for step 1.
     store_operators(e, sim_data, layout)?;
+    // C's `functionInitialEquations` clears `discreteCall` on the way out. A model
+    // that neither integrates (no states) nor crosses (no zero crossings) reaches no
+    // other writer, and would spend the whole run in initialization mode.
+    write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
     if layout.n_zc > 0 {
-        write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
         save_zc_pre(e, sim_data, layout)?;
         e.call2(MODEL_FN_ZC, sim_data, sim_data + layout.zc_off)?;
     }
@@ -2701,9 +2724,27 @@ fn emit_row(
     write_i32(e, sim_data + layout.nls_fail_off, 0)?;
     write_time(e, sim_data, time)?;
     eval_continuous(e, sim_data, layout)?;
+    emit_row_evaluated(e, rows, sim_data, layout, time, stop)
+}
+
+/// [`emit_row`] for a point C's `updateContinuousSystem` has already run at. A second
+/// pass is not idempotent: `delayImpl` interpolates toward the *current* expression
+/// value, so it walks a `delay()` chain one propagation step further than C.
+fn emit_row_evaluated(
+    e: &mut dyn SimEngine,
+    rows: &mut Vec<f64>,
+    sim_data: u32,
+    layout: &SimLayout,
+    time: f64,
+    stop: f64,
+) -> Result<()> {
     check_nls(e, sim_data, layout)?;
     capture_row(e, rows, sim_data, layout)?;
-    check_asserts(e, sim_data, layout, if time >= stop { omclog::WARNING } else { omclog::INFO })
+    let checked = check_asserts(e, sim_data, layout, if time >= stop { omclog::WARNING } else { omclog::INFO });
+    // C's `fmtEmitStep`, once per global step.
+    #[cfg(feature = "std")]
+    crate::profiling::on_row(e, time);
+    checked
 }
 
 /// C's `finishSimulation`: a discrete update with `terminal()` true and one more
@@ -3378,17 +3419,33 @@ fn probe_zero_crossings(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout
     read_zero_crossings(e, sim_data, layout, out)
 }
 
+/// Drop the violations [`update_zero_crossings`] kept for a row evaluated again since.
+fn supersede(e: &mut dyn SimEngine, evaluated: &mut bool) {
+    if core::mem::take(evaluated) {
+        let _ = e.take_pending_warnings();
+    }
+}
+
 /// C's `updateContinuousSystem` + `saveZeroCrossings`, what `checkForStateEvent`
-/// compares against: detection runs off a full evaluation.
-fn update_zero_crossings(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout, time: f64, out: &mut [f64]) -> Result<()> {
-    // The row re-evaluates this point and reports what it raises; flush anything
-    // older so only this pass's violations are dropped below.
+/// compares against: detection runs off a full evaluation. `keep` holds this pass's
+/// violations for a row emitted from it.
+fn update_zero_crossings(
+    e: &mut dyn SimEngine,
+    sim_data: u32,
+    layout: &SimLayout,
+    time: f64,
+    out: &mut [f64],
+    keep: bool,
+) -> Result<()> {
+    // Flush older ones, so only this pass's are in hand below.
     drain_asserts(e, sim_data, omclog::INFO)?;
     write_i32(e, sim_data + layout.nls_fail_off, 0)?;
     write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
     write_time(e, sim_data, time)?;
     eval_continuous(e, sim_data, layout)?;
-    let _ = e.take_pending_warnings();
+    if !keep {
+        let _ = e.take_pending_warnings();
+    }
     read_zero_crossings(e, sim_data, layout, out)
 }
 
@@ -3633,6 +3690,9 @@ fn fire_time_event(
     let save = set_error_stage(e, addr, ERROR_EVENTHANDLING);
     let r = fire_time_event_inner(e, samples, sim_data, layout, te);
     took_error_stage(e, addr, save);
+    if r.is_err() {
+        note_throw_past_step();
+    }
     r
 }
 
@@ -3753,6 +3813,9 @@ pub fn event_update(
     let save = set_error_stage(e, addr, ERROR_EVENTHANDLING);
     let r = event_update_inner(e, sim_data, layout, samples, time);
     took_error_stage(e, addr, save);
+    if r.is_err() {
+        note_throw_past_step();
+    }
     r
 }
 
@@ -4138,9 +4201,12 @@ pub fn drive(
 
     // C's `measure_time_flag`: the clocks run only when the block that renders
     // them will be printed.
-    rtclock::reset(omclog::active(omclog::STATS) || omclog::active(omclog::STATS_V));
+    // `+profiling` is C's other `measure_time_flag` source.
+    rtclock::reset(omclog::active(omclog::STATS) || omclog::active(omclog::STATS_V) || model.prof.is_some());
     rtclock::tick(rtclock::TOTAL);
     rtclock::tick(rtclock::PREINIT);
+    #[cfg(feature = "std")]
+    crate::profiling::start(model);
 
     let mut stats = SolveStats::default();
     let use_events = layout.n_samples > 0 || layout.n_zc > 0 || !model.clocks.is_empty();
@@ -4195,8 +4261,9 @@ pub fn drive(
         // do: it never returns until it is done. Nor can it retry a step a model
         // error threw in (C's `retrySimulationStep`), which is why a model that only
         // reached `euler` for want of states -- where the loop saves nothing anyway,
-        // there being no integration -- keeps the host driver.
-        if !use_events && method == "euler" && layout.n_states > 0 && !host_driven && !csv_input_given() {
+        // there being no integration -- keeps the host driver. `+profiling` also
+        // needs the row-emitting loop (`fmtEmitStep`), so it stays off this path.
+        if !use_events && method == "euler" && layout.n_states > 0 && !host_driven && !csv_input_given() && model.prof.is_none() {
             // Fast in-wasm Euler (one host->wasm call; not resumable/cancellable).
             label = "euler-wasm";
             solver_setup(e, model, sim_data)?;
@@ -4305,6 +4372,8 @@ pub fn drive(
     }
     recon_res?;
     rtclock::accumulate(rtclock::TOTAL);
+    #[cfg(feature = "std")]
+    crate::profiling::end_of_run(e);
     (stats.timers, stats.tcalls) = rtclock::snapshot();
     stats.systems = e.sys_stats();
     Ok((RunResult { rows, n_reals, params, stats, lin }, label))
@@ -7985,6 +8054,9 @@ impl Driver for EventsDriver {
                 // C's `MMC_TRY_INTERNAL(simulationJumpBuffer)` around the whole step.
                 self.retry.open(e, self.rows.len());
                 open_assert_window();
+                // C's `updateContinuousSystem` landed on the grid point and nothing
+                // has moved the state since: the row is emitted from it, as C's is.
+                let mut evaluated = false;
                 // Handle every event (state or sample) up to `tout`, earliest first.
                 loop {
                     save_old_real(e, sim_data, layout)?; // C's `rotateRingBuffer`
@@ -8000,7 +8072,8 @@ impl Driver for EventsDriver {
                     // A state event bracketed in (t, subtarget]?
                     let mut troot = None;
                     if layout.n_zc > 0 && subtarget - self.core.t > eps {
-                        update_zero_crossings(e, sim_data, layout, subtarget, &mut scratch)?;
+                        evaluated = subtarget >= tout - eps;
+                        update_zero_crossings(e, sim_data, layout, subtarget, &mut scratch, evaluated)?;
                         if zc_crossed(&zc0, &scratch) {
                             troot = Some(locate_zc_root(
                                 e, sim_data, layout, self.core.t, subtarget, &zc0, &scratch,
@@ -8008,8 +8081,9 @@ impl Driver for EventsDriver {
                         }
                     }
                     if let Some(tr) = troot {
+                        supersede(e, &mut evaluated);
                         // The bisection left `SimData` at its last trial point.
-                        update_zero_crossings(e, sim_data, layout, tr, &mut scratch)?;
+                        update_zero_crossings(e, sim_data, layout, tr, &mut scratch, false)?;
                         log_state_event(tr, &zc_crossed_idx(&zc0, &scratch), model);
                         if !no_event_emit() {
                             capture_pre(e, &mut self.rows, sim_data, layout, tr)?; // pre-event row
@@ -8050,6 +8124,7 @@ impl Driver for EventsDriver {
                     // it is due at or before this grid point; otherwise the interval
                     // is clean up to `tout`.
                     if te <= subtarget + SAMPLE_EPS {
+                        supersede(e, &mut evaluated);
                         event_step = true;
                         log_time_event(te, &self.samp, model);
                         write_i32(e, sim_data + layout.rel_fresh_off, 0)?; // held pre row
@@ -8084,6 +8159,7 @@ impl Driver for EventsDriver {
                         self.sync.take_fired(e, subtarget)?;
                     }
                     if self.sync.next_time() <= subtarget + SYNC_EPS {
+                        supersede(e, &mut evaluated);
                         event_step = true;
                         self.core.t = subtarget;
                         write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
@@ -8108,7 +8184,11 @@ impl Driver for EventsDriver {
                 }
                 if !grid_covered {
                     write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
-                    let emitted = emit_row(e, &mut self.rows, sim_data, layout, tout, model.stop_time);
+                    let emitted = if evaluated {
+                        emit_row_evaluated(e, &mut self.rows, sim_data, layout, tout, model.stop_time)
+                    } else {
+                        emit_row(e, &mut self.rows, sim_data, layout, tout, model.stop_time)
+                    };
                     close_assert_window(e, sim_data).and(emitted)?;
                     if terminated(e, sim_data, layout)? {
                         self.retry.end(e);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -36,6 +36,9 @@ pub(crate) mod extinput;
 /// `-reconcile*`, which needs a filesystem too.
 #[cfg(feature = "std")]
 pub mod datarecon;
+/// `+profiling`'s files, which need one as well.
+#[cfg(feature = "std")]
+pub mod profiling;
 pub mod optimization;
 pub(crate) mod qss;
 pub mod rtclock;
@@ -1059,6 +1062,8 @@ pub struct SimMeta {
     /// What the `-reconcile*` procedures need; `None` unless the model was
     /// translated with `--preOptModules+=dataReconciliation`.
     pub recon: Option<ReconInfo>,
+    /// `+profiling`; `None` for a model translated without it.
+    pub prof: Option<ProfInfo>,
 }
 
 /// One `input` variable. C writes the file's value both to the `start` attribute,
@@ -1073,15 +1078,69 @@ pub struct InputVar {
     pub name: String,
 }
 
+/// A source position, as C's `FILE_INFO`.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct SrcInfo {
+    pub file: String,
+    pub line_start: i32,
+    pub col_start: i32,
+    pub line_end: i32,
+    pub col_end: i32,
+    pub read_only: bool,
+}
+
+/// What `+profiling` reports on (`_prof.xml` / `_prof.json`): C's `modelDataXml`
+/// functions and equations plus the `modelData` variable arrays.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ProfInfo {
+    /// C's `measure_time_flag`: 1 `blocks`, 5 `blocks+html`, 2 `all`.
+    pub level: u8,
+    /// In `modelInfo.functions` order — the clock index of function `i` is `i`.
+    pub functions: Vec<ProfFn>,
+    /// C's `modelData` variable arrays in `printModelInfo` order.
+    pub vars: Vec<ProfVar>,
+    /// Dense by equation index (`_info.json` position); index 0 is the dummy.
+    pub equations: Vec<ProfEq>,
+    /// Equation index of profile block `k` — clock `functions.len() + k`.
+    pub blocks: Vec<u32>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ProfFn {
+    pub name: String,
+    pub info: SrcInfo,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ProfVar {
+    pub id: u32,
+    pub name: String,
+    pub comment: String,
+    pub info: SrcInfo,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ProfEq {
+    pub id: u32,
+    /// The variables the equation defines (`_info.json` `defines`).
+    pub defines: Vec<String>,
+}
+
 /// [`SimMeta::nls_vars`] entry.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct NlsVars {
     pub eq_index: u32,
     pub names: Vec<String>,
     /// The tail of C's `eqn_simcode_indices` — the SimCode index of each residual
-    /// equation, in solver order, which `LOG_NLS_SVD` names its rows by. C keeps
-    /// the torn equations ahead of them and slices; only the tail is read.
+    /// equation, in solver order, which `LOG_NLS_SVD` and
+    /// `LOG_NLS_NEWTON_DIAGNOSTICS` name their rows by. C keeps the torn equations
+    /// ahead of them and slices; only the tail is read.
     pub eqns: Vec<i32>,
+    /// C's `NONLINEAR_PATTERN` counts: equations, unknowns, nonlinear entries.
+    pub pattern: [u32; 3],
+    /// In the section `LOG_NLS_NEWTON_DIAGNOSTICS` reports on (see
+    /// `newtonDiagnostics`'s caller in C's `solve_nonlinear_system`).
+    pub init_diag: bool,
 }
 
 impl SimMeta {
@@ -1320,7 +1379,7 @@ impl SimMeta {
 // the crate dependency-free and trivially buildable for every target.
 
 const MAGIC: &[u8; 4] = b"OMSM";
-const VERSION: u32 = 15;
+const VERSION: u32 = 16;
 
 fn put_u32(o: &mut Vec<u8>, v: u32) {
     o.extend_from_slice(&v.to_le_bytes());
@@ -1540,6 +1599,10 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
             put_str(&mut o, n);
         }
         put_u32s(&mut o, &v.eqns.iter().map(|e| *e as u32).collect::<Vec<_>>());
+        for c in v.pattern {
+            put_u32(&mut o, c);
+        }
+        o.push(v.init_diag as u8);
     }
     put_u32(&mut o, m.n_lin_systems);
     match &m.dae {
@@ -1670,6 +1733,40 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
             put_str(&mut o, &rc.model_file);
             put_str(&mut o, &rc.model_dir);
             put_str(&mut o, &rc.version);
+        }
+    }
+    fn put_info(o: &mut Vec<u8>, i: &SrcInfo) {
+        put_str(o, &i.file);
+        for v in [i.line_start, i.col_start, i.line_end, i.col_end] {
+            put_u32(o, v as u32);
+        }
+        o.push(i.read_only as u8);
+    }
+    match &m.prof {
+        None => o.push(0),
+        Some(p) => {
+            o.push(p.level);
+            put_u32(&mut o, p.functions.len() as u32);
+            for f in &p.functions {
+                put_str(&mut o, &f.name);
+                put_info(&mut o, &f.info);
+            }
+            put_u32(&mut o, p.vars.len() as u32);
+            for v in &p.vars {
+                put_u32(&mut o, v.id);
+                put_str(&mut o, &v.name);
+                put_str(&mut o, &v.comment);
+                put_info(&mut o, &v.info);
+            }
+            put_u32(&mut o, p.equations.len() as u32);
+            for e in &p.equations {
+                put_u32(&mut o, e.id);
+                put_u32(&mut o, e.defines.len() as u32);
+                for d in &e.defines {
+                    put_str(&mut o, d);
+                }
+            }
+            put_u32s(&mut o, &p.blocks);
         }
     }
     o
@@ -1968,7 +2065,9 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
             names.push(r.string()?);
         }
         let eqns = r.u32s()?.into_iter().map(|v| v as i32).collect();
-        nls_vars.push(NlsVars { eq_index, names, eqns });
+        let pattern = [r.u32()?, r.u32()?, r.u32()?];
+        let init_diag = r.u8()? != 0;
+        nls_vars.push(NlsVars { eq_index, names, eqns, pattern, init_diag });
     }
     let n_lin_systems = r.u32()?;
     let dae = match r.u8()? {
@@ -2138,10 +2237,43 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
             })
         }
     };
+    let mut info = |r: &mut Reader| -> core::result::Result<SrcInfo, &'static str> {
+        Ok(SrcInfo {
+            file: r.string()?,
+            line_start: r.u32()? as i32,
+            col_start: r.u32()? as i32,
+            line_end: r.u32()? as i32,
+            col_end: r.u32()? as i32,
+            read_only: r.u8()? != 0,
+        })
+    };
+    let prof = match r.u8()? {
+        0 => None,
+        level => {
+            let mut functions = Vec::new();
+            for _ in 0..r.u32()? {
+                functions.push(ProfFn { name: r.string()?, info: info(&mut r)? });
+            }
+            let mut vars = Vec::new();
+            for _ in 0..r.u32()? {
+                vars.push(ProfVar { id: r.u32()?, name: r.string()?, comment: r.string()?, info: info(&mut r)? });
+            }
+            let mut equations = Vec::new();
+            for _ in 0..r.u32()? {
+                let id = r.u32()?;
+                let mut defines = Vec::new();
+                for _ in 0..r.u32()? {
+                    defines.push(r.string()?);
+                }
+                equations.push(ProfEq { id, defines });
+            }
+            Some(ProfInfo { level, functions, vars, equations, blocks: r.u32s()? })
+        }
+    };
     Ok(SimMeta {
         layout, start_time, stop_time, n_intervals, method, tolerance, output_format, prefix,
         model_name, vars, jac_a, state_sets, fmi_vrs, zc_desc, rel_desc, params, attr_log,
-        removed_init_desc, nls_warnings, sample_index, soti, sens_params, nls_vars, n_lin_systems, dae, clocks, lin, opt, inputs, recon,
+        removed_init_desc, nls_warnings, sample_index, soti, sens_params, nls_vars, n_lin_systems, dae, clocks, lin, opt, inputs, recon, prof,
     })
 }
 
@@ -2221,6 +2353,8 @@ mod tests {
                 eq_index: 1074,
                 names: vec!["pipe.medium.T".to_string(), "pipe.medium.p".to_string()],
                 eqns: vec![1072, 1073],
+                pattern: [2, 2, 3],
+                init_diag: true,
             }],
             n_lin_systems: 2,
             dae: Some(DaeInfo {
@@ -2305,6 +2439,13 @@ mod tests {
                 model_file: "MyModel.mo".to_string(),
                 model_dir: "/tmp".to_string(),
                 version: "v1.25.0".to_string(),
+            }),
+            prof: Some(ProfInfo {
+                level: 5,
+                functions: vec![ProfFn { name: "f".to_string(), info: SrcInfo { file: "a.mo".to_string(), line_start: 1, col_start: 2, line_end: 3, col_end: 4, read_only: true } }],
+                vars: vec![ProfVar { id: 7, name: "x".to_string(), comment: "c".to_string(), info: SrcInfo::default() }],
+                equations: vec![ProfEq { id: 0, defines: vec![] }, ProfEq { id: 1, defines: vec!["x".to_string()] }],
+                blocks: vec![1],
             }),
         }
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/profiling.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/profiling.rs
@@ -1,0 +1,563 @@
+//! C's `+profiling` output: the per-step `_prof.intdata` / `_prof.realdata`
+//! (`fmtInit` / `fmtEmitStep` in `perform_simulation.c.inc`) and the report
+//! `modelinfo.c` writes at the end — `_prof.xml`, `_prof.plt`, `_prof.json` — with
+//! `gnuplot` and `xsltproc` run over them for `blocks+html`.
+//!
+//! The function and block clocks live in the runtime module (`prof.rs`), where the
+//! instrumented code runs; the driver's own clocks are [`rtclock`].
+
+use std::cell::RefCell;
+use std::fs::File;
+use std::io::Write;
+
+use crate::driver::{format_g, SimEngine};
+use crate::{omclog, rtclock, ProfInfo, SimMeta};
+
+/// Bytes per clock in the runtime's `rt_prof_dump` record.
+const DUMP_RECORD: usize = 40;
+
+/// One clock's run totals, as `rt_prof_dump` hands them over.
+#[derive(Clone, Copy, Default)]
+struct Totals {
+    total: f64,
+    max: f64,
+    ncall_total: u32,
+    ncall_min: u32,
+    ncall_max: u32,
+}
+
+struct Profiler {
+    level: u8,
+    n: usize,
+    real: Option<File>,
+    int: Option<File>,
+    step: u32,
+    /// `-outputPath` with its trailing separator, or empty.
+    out: String,
+    prefix: String,
+    totals: Vec<Totals>,
+}
+
+thread_local! {
+    static PROF: RefCell<Option<Profiler>> = const { RefCell::new(None) };
+}
+
+/// C's `fmtInit`, at the start of a run whose model was translated with
+/// `+profiling`: open the step files and start the step clock.
+pub fn start(model: &SimMeta) {
+    let Some(p) = &model.prof else {
+        PROF.with(|c| *c.borrow_mut() = None);
+        return;
+    };
+    let out = crate::simflags::with_flags(|f| f.output_path.clone()).map(|d| format!("{d}/")).unwrap_or_default();
+    let n = p.functions.len() + p.blocks.len();
+    let open = |suffix: &str| -> Option<File> {
+        let name = format!("{out}{}{suffix}", model.prefix);
+        match File::create(&name) {
+            Ok(f) => Some(f),
+            Err(e) => {
+                omclog::warning(
+                    omclog::STDOUT,
+                    false,
+                    &format!("Time measurements output file {name} could not be opened: {e}"),
+                );
+                None
+            }
+        }
+    };
+    let real = open("_prof.realdata");
+    let int = if real.is_some() { open("_prof.intdata") } else { None };
+    let (real, int) = if int.is_none() { (None, None) } else { (real, int) };
+    rtclock::tick(rtclock::STEP);
+    PROF.with(|c| {
+        *c.borrow_mut() = Some(Profiler {
+            level: p.level,
+            n,
+            real,
+            int,
+            step: 0,
+            out,
+            prefix: model.prefix.clone(),
+            totals: vec![Totals::default(); n],
+        })
+    });
+}
+
+/// C's `fmtEmitStep` then `clear_rt_step`, once per emitted row.
+pub fn on_row(e: &mut dyn SimEngine, time: f64) {
+    PROF.with(|c| {
+        if let Some(p) = c.borrow_mut().as_mut() {
+            p.emit_step(e, time);
+            p.clear_step(e);
+        }
+    });
+}
+
+/// The clocks' run totals, read while the engine is still up.
+pub fn end_of_run(e: &mut dyn SimEngine) {
+    PROF.with(|c| {
+        if let Some(p) = c.borrow_mut().as_mut() {
+            p.totals = read_totals(e, p.n);
+        }
+    });
+}
+
+/// C's `printModelInfo` and `printModelInfoJSON`, after the result file is written.
+pub fn finish(model: &SimMeta, result_file: &str) {
+    let Some(mut p) = PROF.with(|c| c.borrow_mut().take()) else { return };
+    let Some(info) = &model.prof else { return };
+    p.real = None;
+    p.int = None;
+    print_model_info(&p, info, model, result_file);
+    print_model_info_json(&p, info, model, result_file);
+}
+
+fn read_totals(e: &mut dyn SimEngine, n: usize) -> Vec<Totals> {
+    let ptr = e.prof_dump();
+    let mut buf = vec![0u8; n * DUMP_RECORD];
+    if ptr == 0 || e.read_bytes(ptr, &mut buf).is_err() {
+        return vec![Totals::default(); n];
+    }
+    let f64_at = |o: usize| f64::from_le_bytes(buf[o..o + 8].try_into().unwrap());
+    let u32_at = |o: usize| u32::from_le_bytes(buf[o..o + 4].try_into().unwrap());
+    (0..n)
+        .map(|i| {
+            let o = i * DUMP_RECORD;
+            Totals {
+                total: f64_at(o),
+                max: f64_at(o + 8),
+                ncall_total: u32_at(o + 24),
+                ncall_min: u32_at(o + 28),
+                ncall_max: u32_at(o + 32),
+            }
+        })
+        .collect()
+}
+
+impl Profiler {
+    fn emit_step(&mut self, e: &mut dyn SimEngine, time: f64) {
+        let (Some(real), Some(int)) = (self.real.as_mut(), self.int.as_mut()) else { return };
+        rtclock::accumulate(rtclock::STEP);
+        rtclock::tick(rtclock::OVERHEAD);
+        let n = self.n;
+        let mut row = vec![0u8; n * 12];
+        let ptr = e.prof_row();
+        let ok = ptr != 0 && e.read_bytes(ptr, &mut row).is_ok();
+        let mut ok = ok && int.write_all(&self.step.to_le_bytes()).is_ok();
+        self.step += 1;
+        ok = ok && real.write_all(&time.to_le_bytes()).is_ok();
+        ok = ok && real.write_all(&rtclock::accumulated(rtclock::STEP).to_le_bytes()).is_ok();
+        ok = ok && int.write_all(&row[..4 * n]).is_ok();
+        ok = ok && real.write_all(&row[4 * n..]).is_ok();
+        rtclock::accumulate(rtclock::OVERHEAD);
+        if !ok {
+            omclog::warning(
+                omclog::SOLVER,
+                false,
+                "Disabled time measurements because the output file could not be generated",
+            );
+            self.real = None;
+            self.int = None;
+        }
+    }
+
+    /// C's `clear_rt_step`.
+    fn clear_step(&mut self, e: &mut dyn SimEngine) {
+        let _ = e.call1_if_present_raw("rt_prof_clear", 0);
+        rtclock::clear(rtclock::STEP);
+        rtclock::tick(rtclock::STEP);
+    }
+}
+
+fn file_size(name: &str) -> i64 {
+    std::fs::metadata(name).map(|m| m.len() as i64).unwrap_or(-1)
+}
+
+fn xml_escape(s: &str) -> String {
+    let mut o = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '<' => o.push_str("&lt;"),
+            '>' => o.push_str("&gt;"),
+            '\'' => o.push_str("&apos;"),
+            '"' => o.push_str("&quot;"),
+            c => o.push(c),
+        }
+    }
+    o
+}
+
+fn json_escape(s: &str) -> String {
+    let mut o = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => o.push_str("\\\""),
+            '\\' => o.push_str("\\\\"),
+            '\n' => o.push_str("\\n"),
+            '\u{8}' => o.push_str("\\b"),
+            '\u{c}' => o.push_str("\\f"),
+            '\r' => o.push_str("\\r"),
+            '\t' => o.push_str("\\t"),
+            c if (c as u32) < 0x20 => o.push_str(&format!("\\u{:04x}", c as u32)),
+            c => o.push(c),
+        }
+    }
+    o
+}
+
+/// C's `strftime("%Y-%m-%d %H:%M:%S")` of `localtime(time(NULL))`; UTC here,
+/// there being no tz database in wasm.
+fn date_string() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let days = secs.div_euclid(86400);
+    let rem = secs.rem_euclid(86400);
+    // Howard Hinnant's civil-from-days.
+    let z = days + 719468;
+    let era = z.div_euclid(146097);
+    let doe = z.rem_euclid(146097);
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!("{y:04}-{m:02}-{d:02} {:02}:{:02}:{:02}", rem / 3600, (rem / 60) % 60, rem % 60)
+}
+
+fn info_tag(out: &mut String, level: usize, info: &crate::SrcInfo) {
+    out.push_str(&" ".repeat(level));
+    out.push_str(&format!(
+        "<info filename=\"{}\" startline=\"{}\" startcol=\"{}\" endline=\"{}\" endcol=\"{}\" readonly=\"{}\" />\n",
+        xml_escape(&info.file),
+        info.line_start,
+        info.col_start,
+        info.line_end,
+        info.col_end,
+        if info.read_only { "readonly" } else { "writable" }
+    ));
+}
+
+/// C's `printPlotCommand`: the gnuplot script for one clock (`i < 0`: the step
+/// clock) — an SVG thumbnail, then the full plot, each with a call-count twin.
+fn plot_command(
+    plt: &mut String,
+    p: &Profiler,
+    plot_format: &str,
+    title: &str,
+    n_all: usize,
+    i: isize,
+    id: u32,
+    id_prefix: &str,
+) {
+    let (out, prefix) = (&p.out, &p.prefix);
+    let time_plot = |lw: u32| {
+        format!(
+            "plot \"{out}{prefix}_prof.realdata\" binary format=\"%{}double\" using 1:(${}>1e-9 ? ${} : 1e-30) w l lw {lw}\n",
+            2 + n_all,
+            3 + i,
+            3 + i
+        )
+    };
+    let count_plot =
+        |lw: u32| format!("plot \"{out}{prefix}_prof.intdata\" binary format=\"%{}uint32\" using {} w l lw {lw}\n", 1 + n_all, 2 + i);
+    let (mut nmin, mut nmax) = (0u32, 0u32);
+    let (mut ymin, mut ymax) = (0.0f64, 0.0f64);
+    let mut ygraphmax = 0.0f64;
+    if i >= 0 {
+        let t = p.totals[i as usize];
+        nmin = t.ncall_min;
+        nmax = t.ncall_max;
+        ymin = if nmin == 0 { -0.01 } else { nmin as f64 * 0.95 };
+        ymax = if nmax == 0 { 0.01 } else { nmax as f64 * 1.05 };
+        ygraphmax = t.max * 1.01 + 1e-30;
+    }
+    let yrange = |plt: &mut String| {
+        if i >= 0 {
+            plt.push_str(&format!("set yrange [*:{}]\n", format_g(ygraphmax, 6)));
+        } else {
+            plt.push_str("set yrange [*:*]\n");
+        }
+    };
+    let count_range = |plt: &mut String| {
+        if nmin == nmax {
+            plt.push_str(&format!("set yrange [{}:{}]\n", format_g(ymin, 6), format_g(ymax, 6)));
+        } else {
+            plt.push_str("set yrange [*:*]\n");
+        }
+    };
+    plt.push_str("set terminal svg\n");
+    plt.push_str("unset xtics\n");
+    plt.push_str("unset ytics\n");
+    plt.push_str("unset border\n");
+    plt.push_str(&format!("set output \"{out}{prefix}_prof.{id_prefix}{id}.thumb.svg\"\n"));
+    plt.push_str("set title\n");
+    plt.push_str("set xlabel\n");
+    plt.push_str("set ylabel\n");
+    plt.push_str("set log y\n");
+    yrange(plt);
+    plt.push_str(&time_plot(4));
+    plt.push_str("set nolog xy\n");
+    if i >= 0 {
+        plt.push_str("unset ytics\n");
+        count_range(plt);
+        plt.push_str(&format!("set output \"{out}{prefix}_prof.{id_prefix}{id}_count.thumb.svg\"\n"));
+        plt.push_str(&count_plot(4));
+        plt.push_str("set ytics\n");
+    }
+    plt.push_str("set xtics\n");
+    plt.push_str("set ytics\n");
+    plt.push_str("set border\n");
+    plt.push_str(&format!("set terminal {plot_format}\n"));
+    plt.push_str(&format!("set title \"{title}\"\n"));
+    plt.push_str("set xlabel \"Global step at time\"\n");
+    plt.push_str("set ylabel \"Execution time [s]\"\n");
+    plt.push_str(&format!("set output \"{out}{prefix}_prof.{id_prefix}{id}.{plot_format}\"\n"));
+    plt.push_str("set log y\n");
+    yrange(plt);
+    plt.push_str(&time_plot(2));
+    plt.push_str("set nolog xy\n");
+    if i >= 0 {
+        count_range(plt);
+        plt.push_str("set xlabel \"Global step number\"\n");
+        plt.push_str("set ylabel \"Execution count\"\n");
+        plt.push_str(&format!("set output \"{out}{prefix}_prof.{id_prefix}{id}_count.{plot_format}\"\n"));
+        plt.push_str(&count_plot(2));
+    }
+}
+
+fn print_model_info(p: &Profiler, info: &ProfInfo, model: &SimMeta, result_file: &str) {
+    let (out, prefix) = (&p.out, &p.prefix);
+    let plot_format = crate::simflags::with_flags(|f| f.measure_time_plot_format.clone()).unwrap_or_else(|| "svg".to_string());
+    let n_fn = info.functions.len();
+    let n_all = n_fn + info.blocks.len();
+    let mut x = String::new();
+    let mut plt = String::new();
+    plt.push_str("set terminal svg\n");
+    plt.push_str("set nokey\n");
+    plt.push_str("set format y \"%g\"\n");
+    plot_command(&mut plt, p, &plot_format, "Execution time of global steps", n_all, -1, 999, "");
+    x.push_str(
+        "<!DOCTYPE doc [  <!ELEMENT simulation (modelinfo, variables, functions, equations)>  \
+         <!ATTLIST variable id ID #REQUIRED>  <!ELEMENT equation (refs)>  <!ATTLIST equation id ID #REQUIRED>  \
+         <!ELEMENT profileblocks (profileblock*)>  <!ELEMENT profileblock (refs, ncall, time, maxTime)>  \
+         <!ELEMENT refs (ref*)>  <!ATTLIST ref refid IDREF #REQUIRED>  ]>\n",
+    );
+    let f6 = |v: f64| format!("{v:.6}");
+    let f9 = |v: f64| format!("{v:.9}");
+    x.push_str("<simulation>\n<modelinfo>\n");
+    x.push_str(&format!("  <name>{}</name>\n", xml_escape(&model.model_name)));
+    x.push_str(&format!("  <prefix>{}</prefix>\n", xml_escape(prefix)));
+    x.push_str(&format!("  <date>{}</date>\n", xml_escape(&date_string())));
+    x.push_str(&format!("  <method>{}</method>\n", xml_escape(&model.method)));
+    x.push_str(&format!("  <outputFormat>{}</outputFormat>\n", xml_escape(&model.output_format)));
+    x.push_str(&format!("  <outputFilename>{}</outputFilename>\n", xml_escape(result_file)));
+    x.push_str(&format!("  <outputFilesize>{}</outputFilesize>\n", file_size(result_file)));
+    x.push_str(&format!("  <overheadTime>{}</overheadTime>\n", f6(rtclock::accumulated(rtclock::OVERHEAD))));
+    x.push_str(&format!("  <preinitTime>{}</preinitTime>\n", f6(rtclock::accumulated(rtclock::PREINIT))));
+    x.push_str(&format!("  <initTime>{}</initTime>\n", f6(rtclock::accumulated(rtclock::INIT))));
+    x.push_str(&format!("  <eventTime>{}</eventTime>\n", f6(rtclock::accumulated(rtclock::EVENT))));
+    x.push_str(&format!("  <outputTime>{}</outputTime>\n", f6(rtclock::accumulated(rtclock::OUTPUT))));
+    x.push_str(&format!("  <jacobianTime>{}</jacobianTime>\n", f6(rtclock::accumulated(rtclock::JACOBIAN))));
+    x.push_str(&format!("  <totalTime>{}</totalTime>\n", f6(rtclock::accumulated(rtclock::TOTAL))));
+    x.push_str(&format!("  <totalStepsTime>{}</totalStepsTime>\n", f6(rtclock::total(rtclock::STEP))));
+    x.push_str(&format!("  <numStep>{}</numStep>\n", rtclock::ncall_total(rtclock::STEP)));
+    x.push_str(&format!("  <maxTime>{}</maxTime>\n", f9(rtclock::max_accumulated(rtclock::STEP))));
+    x.push_str("</modelinfo>\n<modelinfo_ext>\n");
+    x.push_str(&format!("  <odeTime>{}</odeTime>\n", f6(rtclock::accumulated(rtclock::FUNCTION_ODE))));
+    x.push_str(&format!("  <odeTimeTicks>{}</odeTimeTicks>\n", rtclock::ncall(rtclock::FUNCTION_ODE)));
+    x.push_str("</modelinfo_ext>\n<profilingdataheader>\n");
+    let data_name = format!("{prefix}_prof.data");
+    x.push_str(&format!("  <filename>{}</filename>\n", xml_escape(&data_name)));
+    x.push_str(&format!("  <filesize>{}</filesize>\n", file_size(&data_name)));
+    x.push_str("  <format>\n    <uint32>step</uint32>\n    <double>time</double>\n    <double>cpu time</double>\n");
+    for f in &info.functions {
+        x.push_str(&format!("    <uint32>{} (calls)</uint32>\n", xml_escape(&f.name)));
+    }
+    for id in &info.blocks {
+        x.push_str(&format!("    <uint32>Equation {id} (calls)</uint32>\n"));
+    }
+    for f in &info.functions {
+        x.push_str(&format!("    <double>{} (cpu time)</double>\n", xml_escape(&f.name)));
+    }
+    for id in &info.blocks {
+        x.push_str(&format!("    <double>Equation {id} (cpu time)</double>\n"));
+    }
+    x.push_str("  </format>\n</profilingdataheader>\n<variables>\n");
+    for v in &info.vars {
+        x.push_str(&format!("  <variable id=\"var{}\" name=\"{}\" comment=\"{}\">\n", v.id, xml_escape(&v.name), xml_escape(&v.comment)));
+        info_tag(&mut x, 4, &v.info);
+        x.push_str("  </variable>\n");
+    }
+    x.push_str("</variables>\n<functions>\n");
+    for (i, f) in info.functions.iter().enumerate() {
+        plot_command(&mut plt, p, &plot_format, &f.name, n_all, i as isize, i as u32, "fun");
+        let t = p.totals[i];
+        x.push_str(&format!("  <function id=\"fun{i}\">\n"));
+        x.push_str(&format!("    <name>{}</name>\n", xml_escape(&f.name)));
+        x.push_str(&format!("    <ncall>{}</ncall>\n", t.ncall_total));
+        x.push_str(&format!("    <time>{}</time>\n", f9(t.total)));
+        x.push_str(&format!("    <maxTime>{}</maxTime>\n", f9(t.max)));
+        info_tag(&mut x, 6, &f.info);
+        x.push_str("  </function>\n");
+    }
+    x.push_str("</functions>\n<equations>\n");
+    let var_id = |name: &str| info.vars.iter().find(|v| v.name == name).map_or(0, |v| v.id);
+    for eq in &info.equations {
+        x.push_str(&format!("  <equation id=\"eq{}\">\n    <refs>\n", eq.id));
+        for d in &eq.defines {
+            x.push_str(&format!("      <ref refid=\"var{}\" />\n", var_id(d)));
+        }
+        x.push_str("    </refs>\n");
+        x.push_str("    <calcinfo time=\"0.000000\" count=\"0\"/>\n");
+        x.push_str("  </equation>\n");
+    }
+    x.push_str("</equations>\n<profileblocks>\n");
+    for (k, id) in info.blocks.iter().enumerate() {
+        let i = n_fn + k;
+        plot_command(&mut plt, p, &plot_format, "equation", n_all, i as isize, *id, "eq");
+        let t = p.totals[i];
+        x.push_str("  <profileblock>\n");
+        x.push_str(&format!("    <ref refid=\"eq{id}\"/>\n"));
+        x.push_str(&format!("    <ncall>{}</ncall>\n", t.ncall_total));
+        x.push_str(&format!("    <time>{}</time>\n", f9(t.total)));
+        x.push_str(&format!("    <maxTime>{}</maxTime>\n", f9(t.max)));
+        x.push_str("  </profileblock>\n");
+    }
+    x.push_str("</profileblocks>\n</simulation>\n");
+    let xml_name = format!("{out}{prefix}_prof.xml");
+    let plt_name = format!("{out}{prefix}_prof.plt");
+    if let Err(e) = std::fs::write(&xml_name, x) {
+        omclog::warning(omclog::STDOUT, false, &format!("Failed to open {xml_name}: {e}"));
+        return;
+    }
+    if let Err(e) = std::fs::write(&plt_name, plt) {
+        omclog::warning(omclog::DIVISION, false, &format!("Plots of profiling data were disabled: {e}\n"));
+        return;
+    }
+    let html = p.level & 4 != 0;
+    if html {
+        let cmd = format!("gnuplot {plt_name}");
+        if !run_shell(&cmd) {
+            omclog::warning(omclog::DIVISION, false, &format!("Plot command failed: {cmd}\n"));
+        }
+    }
+    let (gen_html_failed, cmd) = match std::env::var("OPENMODELICAHOME") {
+        Ok(omhome) => {
+            let cmd = format!(
+                "xsltproc -o {out}{prefix}_prof.html {omhome}/share/omc/scripts/default_profiling.xsl {out}{prefix}_prof.xml"
+            );
+            (html && !run_shell(&cmd), cmd)
+        }
+        Err(_) => (true, "OPENMODELICAHOME missing".to_string()),
+    };
+    if gen_html_failed {
+        omclog::warning(omclog::STDOUT, false, &format!("Failed to generate html version of profiling results: {cmd}\n"));
+    }
+    if html {
+        omclog::info(
+            omclog::STDOUT,
+            false,
+            &format!(
+                "Time measurements are stored in {out}{prefix}_prof.html (human-readable) and {out}{prefix}_prof.xml (for XSL transforms or more details)"
+            ),
+        );
+    } else {
+        omclog::info(omclog::STDOUT, false, &format!("Time measurements are stored in {out}{prefix}_prof.json"));
+    }
+}
+
+/// C's `system(cmd)` through `/bin/sh`; `true` on exit status 0. A wasm build
+/// has no processes to run.
+fn run_shell(cmd: &str) -> bool {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        std::process::Command::new("sh").arg("-c").arg(cmd).status().map(|s| s.success()).unwrap_or(false)
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = cmd;
+        false
+    }
+}
+
+/// C's `convertProfileData`: transpose the step files in place from one record
+/// per step to one series per column.
+fn convert_profile_data(p: &Profiler) {
+    let n_all = p.n;
+    let (out, prefix) = (&p.out, &p.prefix);
+    fn transpose(path: &str, elem: usize, cols: usize) {
+        let Ok(bytes) = std::fs::read(path) else { return };
+        let row = elem * cols;
+        if row == 0 || bytes.len() % row != 0 {
+            return;
+        }
+        let rows = bytes.len() / row;
+        let mut t = vec![0u8; bytes.len()];
+        for r in 0..rows {
+            for c in 0..cols {
+                let src = r * row + c * elem;
+                let dst = (c * rows + r) * elem;
+                t[dst..dst + elem].copy_from_slice(&bytes[src..src + elem]);
+            }
+        }
+        let _ = std::fs::write(path, t);
+    }
+    transpose(&format!("{out}{prefix}_prof.intdata"), 4, 1 + n_all);
+    transpose(&format!("{out}{prefix}_prof.realdata"), 8, 2 + n_all);
+}
+
+fn print_model_info_json(p: &Profiler, info: &ProfInfo, model: &SimMeta, result_file: &str) {
+    let (out, prefix) = (&p.out, &p.prefix);
+    convert_profile_data(p);
+    let n_fn = info.functions.len();
+    let g = |v: f64| format_g(v, 6);
+    let mut j = String::new();
+    // C sums the top-level blocks only; the equation table has no parents here, so
+    // every block counts.
+    let total_eqs: f64 = (0..info.blocks.len()).map(|k| p.totals[n_fn + k].total).sum();
+    j.push_str(&format!("{{\n\"name\":\"{}\"", json_escape(&model.model_name)));
+    j.push_str(&format!(",\n\"prefix\":\"{}\"", json_escape(prefix)));
+    j.push_str(&format!(",\n\"date\":\"{}\"", json_escape(&date_string())));
+    j.push_str(&format!(",\n\"method\":\"{}\"", json_escape(&model.method)));
+    j.push_str(&format!(",\n\"outputFormat\":\"{}\"", json_escape(&model.output_format)));
+    j.push_str(&format!(",\n\"outputFilename\":\"{}\"", json_escape(result_file)));
+    j.push_str(&format!(",\n\"outputFilesize\":{}", file_size(result_file)));
+    j.push_str(&format!(",\n\"overheadTime\":{}", g(rtclock::accumulated(rtclock::OVERHEAD))));
+    j.push_str(&format!(",\n\"preinitTime\":{}", g(rtclock::accumulated(rtclock::PREINIT))));
+    j.push_str(&format!(",\n\"initTime\":{}", g(rtclock::accumulated(rtclock::INIT))));
+    j.push_str(&format!(",\n\"eventTime\":{}", g(rtclock::accumulated(rtclock::EVENT))));
+    j.push_str(&format!(",\n\"outputTime\":{}", g(rtclock::accumulated(rtclock::OUTPUT))));
+    j.push_str(&format!(",\n\"jacobianTime\":{}", g(rtclock::accumulated(rtclock::JACOBIAN))));
+    j.push_str(&format!(",\n\"totalTime\":{}", g(rtclock::accumulated(rtclock::TOTAL))));
+    j.push_str(&format!(",\n\"totalStepsTime\":{}", g(rtclock::accumulated(rtclock::STEP))));
+    j.push_str(&format!(",\n\"totalTimeProfileBlocks\":{}", g(total_eqs)));
+    j.push_str(&format!(",\n\"numStep\":{}", rtclock::ncall_total(rtclock::STEP)));
+    j.push_str(&format!(",\n\"maxTime\":{}", format_g(rtclock::max_accumulated(rtclock::STEP), 9)));
+    j.push_str(",\n\"functions\":[");
+    for (i, f) in info.functions.iter().enumerate() {
+        let t = p.totals[i];
+        j.push_str(if i == 0 { "\n" } else { ",\n" });
+        j.push_str(&format!(
+            "{{\"name\":\"{}\",\"ncall\":{},\"time\":{:.9},\"maxTime\":{:.9}}}",
+            json_escape(&f.name),
+            t.ncall_total,
+            t.total,
+            t.max
+        ));
+    }
+    j.push_str("\n],\n\"profileBlocks\":[");
+    for (k, id) in info.blocks.iter().enumerate() {
+        let t = p.totals[n_fn + k];
+        j.push_str(if k == 0 { "\n" } else { ",\n" });
+        j.push_str(&format!("{{\"id\":{id},\"ncall\":{},\"time\":{:.9},\"maxTime\":{:.9}}}", t.ncall_total, t.total, t.max));
+    }
+    j.push_str("\n]\n}");
+    let name = format!("{out}{prefix}_prof.json");
+    if let Err(e) = std::fs::write(&name, j) {
+        omclog::warning(omclog::STDOUT, false, &format!("Failed to open file {name} for writing: {e}"));
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/rtclock.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/rtclock.rs
@@ -40,9 +40,14 @@ struct Clocks {
     tick: [f64; N],
     acc: [f64; N],
     ncall: [u64; N],
+    /// C's `total_tp` / `max_tp` / `rt_clock_ncall_total`, fed by [`clear`].
+    total: [f64; N],
+    max: [f64; N],
+    ncall_total: [u64; N],
 }
 
-const EMPTY: Clocks = Clocks { on: false, tick: [0.0; N], acc: [0.0; N], ncall: [0; N] };
+const EMPTY: Clocks =
+    Clocks { on: false, tick: [0.0; N], acc: [0.0; N], ncall: [0; N], total: [0.0; N], max: [0.0; N], ncall_total: [0; N] };
 
 // The driver is single-threaded per run (as is the in-wasm session), so a plain
 // cell is enough and keeps `tick` off the atomics.
@@ -86,8 +91,41 @@ pub fn accumulate(ix: usize) {
 }
 
 /// C's `rt_ncall`.
-fn ncall(ix: usize) -> u64 {
+pub fn ncall(ix: usize) -> u64 {
     clocks().ncall[ix]
+}
+
+/// C's `rt_clear`: the clock's share since the last clear joins the run's total
+/// and maximum, and it starts over.
+pub fn clear(ix: usize) {
+    let c = clocks();
+    c.total[ix] += c.acc[ix];
+    c.ncall_total[ix] += c.ncall[ix];
+    if c.acc[ix] > c.max[ix] {
+        c.max[ix] = c.acc[ix];
+    }
+    c.acc[ix] = 0.0;
+    c.ncall[ix] = 0;
+}
+
+/// C's `rt_accumulated`, in seconds.
+pub fn accumulated(ix: usize) -> f64 {
+    clocks().acc[ix] / 1000.0
+}
+
+/// C's `rt_total`, in seconds.
+pub fn total(ix: usize) -> f64 {
+    clocks().total[ix] / 1000.0
+}
+
+/// C's `rt_max_accumulated`, in seconds.
+pub fn max_accumulated(ix: usize) -> f64 {
+    clocks().max[ix] / 1000.0
+}
+
+/// C's `rt_ncall_total`.
+pub fn ncall_total(ix: usize) -> u64 {
+    clocks().ncall_total[ix]
 }
 
 /// C's `solver_main` head: pre-initialization ends where initialization begins.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/lib.rs
@@ -151,18 +151,41 @@ pub fn format_g(v: f64, p: i32) -> String {
     if !v.is_finite() || v == 0.0 {
         return format!("{v}");
     }
-    let exp = libm::floor(libm::log10(libm::fabs(v))) as i32;
     let trim = |s: String| -> String {
         if !s.contains('.') {
             return s;
         }
         s.trim_end_matches('0').trim_end_matches('.').to_string()
     };
+    let (mut exp, mut m) = decimal_exp(v);
     if exp < -4 || exp >= p {
-        let m = trim(format!("{:.*}", (p - 1) as usize, v / libm::pow(10.0, exp as f64)));
-        return format!("{m}e{}{:02}", if exp < 0 { '-' } else { '+' }, exp.abs());
+        let mut s = format!("{:.*}", (p - 1) as usize, m);
+        // The rounding can carry the mantissa back over ten.
+        if s.trim_start_matches('-').starts_with("10") {
+            exp += 1;
+            m /= 10.0;
+            s = format!("{:.*}", (p - 1) as usize, m);
+        }
+        return format!("{}e{}{:02}", trim(s), if exp < 0 { '-' } else { '+' }, exp.abs());
     }
     trim(format!("{:.*}", (p - 1 - exp).max(0) as usize, v))
+}
+
+/// `v`'s decimal exponent and the mantissa in `[1, 10)`. `log10` is not exactly
+/// rounded (the `libm` crate's lands an ULP off an exact power of ten, where glibc
+/// does not), so the mantissa decides the exponent rather than the other way round —
+/// otherwise `1e-06` prints as `10e-07`.
+pub(crate) fn decimal_exp(v: f64) -> (i32, f64) {
+    let mut exp = libm::floor(libm::log10(libm::fabs(v))) as i32;
+    let mut m = v / libm::pow(10.0, exp as f64);
+    if libm::fabs(m) >= 10.0 {
+        m /= 10.0;
+        exp += 1;
+    } else if libm::fabs(m) < 1.0 {
+        m *= 10.0;
+        exp -= 1;
+    }
+    (exp, m)
 }
 
 /// C's `%e`: six decimals on the mantissa, a two-digit exponent.
@@ -170,7 +193,11 @@ pub fn format_e(v: f64) -> String {
     if !v.is_finite() {
         return format!("{v}");
     }
-    let exp = if v == 0.0 { 0 } else { libm::floor(libm::log10(libm::fabs(v))) as i32 };
-    let m = v / libm::pow(10.0, exp as f64);
-    format!("{m:.6}e{}{:02}", if exp < 0 { '-' } else { '+' }, exp.abs())
+    let (mut exp, m) = if v == 0.0 { (0, 0.0) } else { decimal_exp(v) };
+    let mut s = format!("{m:.6}");
+    if s.trim_start_matches('-').starts_with("10") {
+        exp += 1;
+        s = format!("{:.6}", m / 10.0);
+    }
+    format!("{s}e{}{:02}", if exp < 0 { '-' } else { '+' }, exp.abs())
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/omclog.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/omclog.rs
@@ -105,6 +105,7 @@ pub const NLS_V: Stream = 33;
 pub const NLS_HOMOTOPY: Stream = 34;
 pub const NLS_JAC: Stream = 35;
 pub const NLS_JAC_SUMS: Stream = 37;
+pub const NLS_NEWTON_DIAGNOSTICS: Stream = 38;
 pub const NLS_DERIVATIVE_TEST: Stream = 39;
 pub const NLS_SVD: Stream = 40;
 pub const NLS_SVD_V: Stream = 41;
@@ -149,7 +150,9 @@ pub const SHOW_ALL_WARNINGS: Mask = 1 << 63;
 /// Which streams name a nonlinear system's iteration variables, and so need the
 /// roster the model metadata carries (C reads it out of `modelDataXml` instead).
 pub fn wants_nls_var_names(m: Mask) -> bool {
-    [NLS, NLS_DERIVATIVE_TEST, NLS_SVD, NLS_SVD_V].iter().any(|s| mask_has(m, *s))
+    [NLS, NLS_DERIVATIVE_TEST, NLS_SVD, NLS_SVD_V, INIT_HOMOTOPY, NLS_NEWTON_DIAGNOSTICS]
+        .iter()
+        .any(|s| mask_has(m, *s))
 }
 
 pub fn mask_has(m: Mask, s: Stream) -> bool {
@@ -538,15 +541,7 @@ fn exp_str(v: f64, prec: usize) -> String {
         return alloc::format!("{v}");
     }
     // Round in the mantissa's own scale, and carry when it rounds up to 10.
-    let mut exp = if v == 0.0 { 0 } else { libm::floor(libm::log10(libm::fabs(v))) as i32 };
-    let mut m = if v == 0.0 { 0.0 } else { v / libm::pow(10.0, exp as f64) };
-    if libm::fabs(m) >= 10.0 {
-        m /= 10.0;
-        exp += 1;
-    } else if v != 0.0 && libm::fabs(m) < 1.0 {
-        m *= 10.0;
-        exp -= 1;
-    }
+    let (mut exp, m) = if v == 0.0 { (0, 0.0) } else { crate::decimal_exp(v) };
     let mut s = alloc::format!("{m:.prec$}");
     if s.trim_start_matches('-').starts_with("10") {
         exp += 1;
@@ -694,6 +689,24 @@ pub fn debug_vector_double(stream: Stream, name: &str, v: &[f64]) {
         line.push_str(&cell);
     }
     info(stream, false, &line);
+    close(stream);
+}
+
+/// C's `debugMatrixDouble`: a `name [nxm-dim]` block holding one `%16.8g` line per
+/// row of the column-major `n`x`m` `a` (whose row stride is `m - 1`, as C's is).
+pub fn debug_matrix_double(stream: Stream, name: &str, a: &[f64], n: usize, m: usize) {
+    if !active(stream) {
+        return;
+    }
+    info(stream, true, &format!("{name} [{n}x{m}-dim]"));
+    for i in 0..n {
+        let mut line = String::new();
+        for j in 0..m {
+            line.push(' ');
+            line.push_str(&g(a[i + j * (m - 1)], 16, 8));
+        }
+        info(stream, false, &line);
+    }
     close(stream);
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/simflags.rs
@@ -161,6 +161,8 @@ pub struct SimFlags {
     pub single_precision: bool,
     /// `-outputPath=<dir>`: holds `<prefix>_res.<format>` unless `-r` names a file.
     pub output_path: Option<String>,
+    /// `-measureTimePlotFormat=<fmt>`: the `+profiling` plots' gnuplot terminal.
+    pub measure_time_plot_format: Option<String>,
     /// `-iit=<t>`: where `-iif`'s result file is read (C's `init_time`, default the
     /// start time).
     pub init_time: Option<f64>,
@@ -754,6 +756,7 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
             "noemit" => f.noemit = true,
             "single" => f.single_precision = true,
             "outputPath" => f.output_path = Some(value(name)?),
+            "measureTimePlotFormat" => f.measure_time_plot_format = Some(value(name)?),
             "iit" => f.init_time = Some(real(name, &value(name)?)?),
             "mei" => f.max_event_iter = Some(int(name, &value(name)?)?.max(0) as u32),
             "mbi" => f.max_bisection_iter = Some(int(name, &value(name)?)?.max(0) as u32),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
@@ -497,6 +497,23 @@ pub fn add_host_builtins<T: 'static>(linker: &mut wasmtime::Linker<T>) -> Result
         },
     ))?;
     wt(linker.func_wrap("env", "rt_host_now_ms", || -> f64 { openmodelica_sim_meta::driver::now_ms_host() }))?;
+    // The runtime's `files::write_file`: a solver's side file (the homotopy path
+    // CSV), written where C's executable writes it — the working directory.
+    wt(linker.func_wrap(
+        "env",
+        "rt_host_write_file",
+        |caller: wasmtime::Caller<'_, T>, name: u32, name_len: u32, data: u32, data_len: u32| {
+            let Some(memory) = sim_memory::get() else { return };
+            let bytes = memory.data(&caller);
+            let (Some(name), Some(data)) = (
+                bytes.get(name as usize..(name + name_len) as usize),
+                bytes.get(data as usize..(data + data_len) as usize),
+            ) else {
+                return;
+            };
+            let _ = std::fs::write(String::from_utf8_lossy(name).as_ref(), data);
+        },
+    ))?;
     wt(linker.func_wrap("env", "rt_host_cancel", || -> i32 { metamodelica::cancel::check_cancel() as i32 }))?;
     wt(linker.func_wrap("env", "rt_host_init_done", || openmodelica_sim_meta::driver::signal_init_done()))?;
     wt(linker.func_wrap("env", "rt_host_set_no_throw", |v: i32| set_no_throw_asserts(v != 0)))?;
@@ -700,6 +717,24 @@ pub fn add_host_builtins(store: &mut wasmer::Store, imports: &mut wasmer::Import
         ),
     );
     imports.define("env", "rt_host_now_ms", Function::new_typed(store, || -> f64 { openmodelica_sim_meta::driver::now_ms_host() }));
+    // See the wasmtime counterpart.
+    imports.define(
+        "env",
+        "rt_host_write_file",
+        Function::new_typed_with_env(
+            store,
+            &mem_env,
+            |env: wasmer::FunctionEnvMut<HostEnv>, name: u32, name_len: u32, data: u32, data_len: u32| {
+                let Some(memory) = env.data().mem.clone() else { return };
+                let mut nbuf = vec![0u8; name_len as usize];
+                let mut dbuf = vec![0u8; data_len as usize];
+                let view = memory.view(&env);
+                if view.read(name as u64, &mut nbuf).is_ok() && view.read(data as u64, &mut dbuf).is_ok() {
+                    let _ = std::fs::write(String::from_utf8_lossy(&nbuf).as_ref(), &dbuf);
+                }
+            },
+        ),
+    );
     imports.define("env", "rt_host_cancel", Function::new_typed(store, || -> i32 { metamodelica::cancel::check_cancel() as i32 }));
     imports.define("env", "rt_host_init_done", Function::new_typed(store, || openmodelica_sim_meta::driver::signal_init_done()));
     imports.define("env", "rt_host_set_no_throw", Function::new_typed(store, |v: i32| set_no_throw_asserts(v != 0)));

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -1055,6 +1055,7 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
         wts(set.call(&mut store, on as u32))?;
     }
     // See the wasmtime counterpart.
+    let diag_on = openmodelica_sim_meta::omclog::mask_has(log_mask, openmodelica_sim_meta::omclog::NLS_NEWTON_DIAGNOSTICS);
     if openmodelica_sim_meta::omclog::wants_nls_var_names(log_mask)
         && let Ok(set) = rt_inst.exports.get_typed_function::<(u32, u32, u32), ()>(&store, "rt_nls_set_names")
     {
@@ -1074,8 +1075,35 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
             }
         }
     }
+    // See the wasmtime counterpart.
+    if diag_on
+        && let Ok(set) = rt_inst.exports.get_typed_function::<(u32, u32, u32, u32, u32, u32, u32), ()>(&store, "rt_nls_set_diag")
+    {
+        let free = rt_inst.exports.get_typed_function::<u32, ()>(&store, "rt_free").ok();
+        wts(set.call(&mut store, u32::MAX, 0, 0, 0, 0, 0, 0))?;
+        for sys in &meta.nls_vars {
+            let blob: Vec<u8> = sys.eqns.iter().flat_map(|i| (*i as u32).to_le_bytes()).collect();
+            let ptr = wts(rt_alloc.call(&mut store, blob.len().max(1) as u32))?;
+            wts(memory.view(&store).write(ptr as u64, &blob))?;
+            let [ne, nv, nn] = sys.pattern;
+            wts(set.call(&mut store, sys.eq_index, ne, nv, nn, sys.init_diag as u32, ptr, sys.eqns.len() as u32))?;
+            if let Some(f) = &free {
+                wts(f.call(&mut store, ptr))?;
+            }
+        }
+    }
     if let Ok(set) = rt_inst.exports.get_typed_function::<f64, ()>(&store, "rt_set_step_size") {
         wts(set.call(&mut store, meta.step_size()))?;
+    }
+    // See the wasmtime counterpart.
+    if let Ok(set) = rt_inst.exports.get_typed_function::<(u32, u32), ()>(&store, "rt_set_file_prefix") {
+        let bytes = meta.prefix.as_bytes();
+        let ptr = wts(rt_alloc.call(&mut store, bytes.len().max(1) as u32))?;
+        wts(memory.view(&store).write(ptr as u64, bytes))?;
+        wts(set.call(&mut store, ptr, bytes.len() as u32))?;
+        if let Ok(free) = rt_inst.exports.get_typed_function::<u32, ()>(&store, "rt_free") {
+            wts(free.call(&mut store, ptr))?;
+        }
     }
     if bench {
         eprintln!("wasm-jit sim: compile {compile_time:?} | instantiate {inst_time:?}");
@@ -1195,6 +1223,18 @@ impl sim_driver::SimEngine for WasmerEngine {
         let words: Vec<f64> =
             bytes.chunks_exact(8).map(|c| f64::from_le_bytes(c.try_into().unwrap())).collect();
         openmodelica_sim_meta::sysstat::decode(&words)
+    }
+    fn prof_row(&mut self) -> u32 {
+        match self.rt_inst.exports.get_typed_function::<(), u32>(&self.store, "rt_prof_row") {
+            Ok(f) => f.call(&mut self.store).unwrap_or(0),
+            Err(_) => 0,
+        }
+    }
+    fn prof_dump(&mut self) -> u32 {
+        match self.rt_inst.exports.get_typed_function::<(), u32>(&self.store, "rt_prof_dump") {
+            Ok(f) => f.call(&mut self.store).unwrap_or(0),
+            Err(_) => 0,
+        }
     }
     fn context_addr(&mut self) -> u32 {
         match self.rt_inst.exports.get_typed_function::<(), u32>(&self.store, "rt_context_addr") {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -1391,6 +1391,7 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
     // `-lv=LOG_NLS` names the iteration variables, which only the metadata has. The
     // roster is per model, so it is cleared first and pushed only when the stream is
     // on: an ordinary run carries no names.
+    let diag_on = openmodelica_sim_meta::omclog::mask_has(log_mask, openmodelica_sim_meta::omclog::NLS_NEWTON_DIAGNOSTICS);
     if openmodelica_sim_meta::omclog::wants_nls_var_names(log_mask)
         && let Ok(set) = rt_inst.get_typed_func::<(u32, u32, u32), ()>(&mut store, "rt_nls_set_names")
     {
@@ -1410,9 +1411,35 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
             }
         }
     }
+    // `-lv=LOG_NLS_NEWTON_DIAGNOSTICS` also wants each system's equation indices
+    // and nonlinear-pattern counts.
+    if diag_on && let Ok(set) = rt_inst.get_typed_func::<(u32, u32, u32, u32, u32, u32, u32), ()>(&mut store, "rt_nls_set_diag") {
+        let free = rt_inst.get_typed_func::<u32, ()>(&mut store, "rt_free").ok();
+        wts(set.call(&mut store, (u32::MAX, 0, 0, 0, 0, 0, 0)))?;
+        for sys in &meta.nls_vars {
+            let blob: Vec<u8> = sys.eqns.iter().flat_map(|i| (*i as u32).to_le_bytes()).collect();
+            let ptr = wts(rt_alloc.call(&mut store, blob.len().max(1) as u32))?;
+            wts(memory.write(&mut store, ptr as usize, &blob))?;
+            let [ne, nv, nn] = sys.pattern;
+            wts(set.call(&mut store, (sys.eq_index, ne, nv, nn, sys.init_diag as u32, ptr, sys.eqns.len() as u32)))?;
+            if let Some(f) = &free {
+                wts(f.call(&mut store, ptr))?;
+            }
+        }
+    }
     // The driver that owns the `SimMeta` stays on the host in this build.
     if let Ok(set) = rt_inst.get_typed_func::<f64, ()>(&mut store, "rt_set_step_size") {
         wts(set.call(&mut store, meta.step_size()))?;
+    }
+    // C's `modelFilePrefix`, which names the files the solvers write.
+    if let Ok(set) = rt_inst.get_typed_func::<(u32, u32), ()>(&mut store, "rt_set_file_prefix") {
+        let bytes = meta.prefix.as_bytes();
+        let ptr = wts(rt_alloc.call(&mut store, bytes.len().max(1) as u32))?;
+        wts(memory.write(&mut store, ptr as usize, bytes))?;
+        wts(set.call(&mut store, (ptr, bytes.len() as u32)))?;
+        if let Ok(free) = rt_inst.get_typed_func::<u32, ()>(&mut store, "rt_free") {
+            wts(free.call(&mut store, ptr))?;
+        }
     }
     if bench {
         eprintln!("wasm-jit sim: compile {compile_time:?} | instantiate {inst_time:?}");
@@ -1589,6 +1616,20 @@ impl sim_driver::SimEngine for WasmtimeEngine {
             }
         }
         out
+    }
+    fn prof_row(&mut self) -> u32 {
+        self.rt_inst
+            .get_typed_func::<(), u32>(&mut self.store, "rt_prof_row")
+            .ok()
+            .and_then(|f| f.call(&mut self.store, ()).ok())
+            .unwrap_or(0)
+    }
+    fn prof_dump(&mut self) -> u32 {
+        self.rt_inst
+            .get_typed_func::<(), u32>(&mut self.store, "rt_prof_dump")
+            .ok()
+            .and_then(|f| f.call(&mut self.store, ()).ok())
+            .unwrap_or(0)
     }
     fn context_addr(&mut self) -> u32 {
         self.rt_inst

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
@@ -431,11 +431,13 @@ void initializeNonlinearSystemData(DATA *data, threadData_t *threadData, NONLINE
     jacobian = NULL;
   }
 
-  /* allocate system data */
-  nonlinsys->nlsx = (double*) malloc(size*sizeof(double));
-  nonlinsys->nlsxExtrapolation = (double*) malloc(size*sizeof(double));
-  nonlinsys->nlsxOld = (double*) malloc(size*sizeof(double));
-  nonlinsys->resValues = (double*) malloc(size*sizeof(double));
+  /* allocate system data; zeroed because the "last solving is too long ago" branch
+   * of solve_nonlinear_system leaves nlsxExtrapolation -- which solveHomotopy and
+   * solveHybrd start a non-discrete call from -- unwritten. */
+  nonlinsys->nlsx = (double*) calloc(size, sizeof(double));
+  nonlinsys->nlsxExtrapolation = (double*) calloc(size, sizeof(double));
+  nonlinsys->nlsxOld = (double*) calloc(size, sizeof(double));
+  nonlinsys->resValues = (double*) calloc(size, sizeof(double));
 
   /* allocate value list*/
   nonlinsys->oldValueList = allocValueList(1, nonlinsys->size);


### PR DESCRIPTION
Five wasm-jit testsuite fixes plus the mmtorust codegen fix under them.

| Test | Fix |
| --- | --- |
| records/Ticket16177 | mmtorust: a non-exhaustive `match` inside a `try` block now breaks to the try label instead of `return Err`, so a refutable derivative lookup falls through as MetaModelica intends | | functions_eval/partialConstArray | a `SES_NONLINEAR` with no residuals and no unknowns is its inner equations, evaluated once | | newtonDiagnostics-01 | port of C's `newton_diagnostics.c` (`LOG_NLS_NEWTON_DIAGNOSTICS`): the alpha/Gamma/sigma indicators over an initial system's start values | | events/CheckEvents | a math-domain guard (`sqrt`/`log`/`asin`) now warns and unwinds through `rt_assert_common` like C's `assertCommonVar` when a solver or the step catches it | | initialization/homotopy4_solver | the local-equidistant sweep and the adaptive arc-length solver export their homotopy-path CSV under `LOG_INIT_HOMOTOPY`, with C's messages |

The `+profiling` output is ported alongside: the per-function and per-block clocks live in the runtime module (`prof.rs`), the driver's own clocks in `rtclock`, and `profiling.rs` writes `_prof.{intdata,realdata, xml,plt,json}` and runs gnuplot/xsltproc as `modelinfo.c` does. The `LOG_NLS_V` hybrd trace and the analytic-Jacobian `hybrj` path round out the nonlinear solver against C.

Solver files a run writes (the homotopy CSVs) reach the working directory through a host `rt_host_write_file` hook, or std directly for the standalone module.

Assisted-by: Claude Fable 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
