### PR TITLE
Update bomc diff-friendly with CMake

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,4 +57,36 @@ After Jenkins checks that all is OK a developer will:
 
 ## Bootstrapping sources
 
-Sometimes one would need to update the bootstrapping sources to add new features to the MetaModelica compiler. The bootstrapping sources are stored at: [OMBootstrapping](https://github.com/OpenModelica/OMBootstrapping.git), just make a PR for it with the contents of OMCompiler/Compiler/boot/build.
+`bomc`, the compiler used to translate the MetaModelica sources of `omc`, is built from
+pre-translated C sources instead of from the `.mo` files themselves. Those sources live in
+the [OMBootstrapping](https://github.com/OpenModelica/OMBootstrapping.git) repository,
+checked out as the submodule `OMCompiler/Compiler/boot/bomc`. They have to be refreshed
+whenever `bomc` becomes too old to translate the current `OMCompiler/Compiler/*.mo`, for
+example after adding MetaModelica syntax or new builtin functions.
+
+From a configured CMake build directory:
+
+```bash
+cmake --build build_cmake --target update-bootstrap-sources
+```
+
+This builds `omc`, translates the compiler a second time with `OPENMODELICA_BACKEND_STUBS=1`
+(so that the source file names baked into the generated C are basenames rather than the
+absolute paths of the tree it was built in) and copies the result into the submodule working
+tree. The result is reproducible: regenerating it from a different checkout, or at a
+different time, produces the same bytes. Use the `generate-bootstrap-sources` target instead
+to produce the sources under `<build_dir>/OMCompiler/Compiler/bootstrap-sources/` without
+touching the submodule.
+
+Afterwards:
+
+* commit the changes in `OMCompiler/Compiler/boot/bomc` and make a PR against OMBootstrapping
+* re-run `cmake` and rebuild to verify that `bomc` builds from the new sources
+* once merged, make a PR against OpenModelica moving the submodule to the new commit
+
+`bootstrap-sources/build/FakeBoostrappingExternals.c` is hand written and is left alone by
+the update. If the refreshed sources reference external C functions that `bomc` does not
+link, add stubs for them there.
+
+`bootstrap-sources/Makefile.sources` is not regenerated. It is only read by the autotools
+`bootstrap-from-tarball`; the CMake build of `bomc` globs `bootstrap-sources/build/*.c`.

--- a/OMCompiler/.gitignore
+++ b/OMCompiler/.gitignore
@@ -147,6 +147,7 @@ Compiler/OpenModelicaSetup
 Compiler/Makefile
 Compiler/OpenModelicaBootstrappingHeader.h
 Compiler/OpenModelicaBootstrappingHeader.h.log
+Compiler/OpenModelicaBootstrappingHeader.h.new
 Compiler/Script/Makefile
 Compiler/Script/OpenModelicaScriptingAPI.mo
 Compiler/Script/OpenModelicaScriptingAPIQt.cpp

--- a/OMCompiler/Compiler/.cmake/bootstrap_sources.cmake
+++ b/OMCompiler/Compiler/.cmake/bootstrap_sources.cmake
@@ -1,0 +1,172 @@
+# Regeneration of the bootstrapping sources kept in OMCompiler/Compiler/boot/bomc
+# (the OMBootstrapping submodule).
+#
+# bomc is built from pre-translated C sources instead of from the MetaModelica
+# sources, which is what breaks the chicken-and-egg problem of needing an omc to
+# build omc. Those C sources are a snapshot of what the compiler generates for
+# its own sources and have to be refreshed whenever bomc is too old to translate
+# the current Compiler/*.mo (new MetaModelica syntax, new builtins, ...).
+#
+#   cmake --build <build_dir> --target update-bootstrap-sources
+#
+# translates the compiler a second time and copies the result into the submodule
+# working tree, ready to be committed and PR'd to OMBootstrapping.
+#
+# Why a second translation instead of just copying <build_dir>/c_files:
+# every sourceInfo() in the compiler is constant folded into a SourceInfo literal
+# in the generated C, and its fileName is the absolute path of the .mo. A plain
+# copy would therefore embed the checkout of whoever ran the build, which is
+# noise in every diff and makes the snapshot unreproducible. Setting
+# OPENMODELICA_BACKEND_STUBS=1 makes Parser/parse.c store the basename instead
+# (members.filename_C_testsuiteFriendly). It is deliberately *not* set for the
+# normal build: that would strip the paths out of the shipped compiler's own
+# error and failtrace messages too.
+# The other half of that literal, the mtime of the .mo, is pinned to 0.0 by
+# Static.elabBuiltinSourceInfo for every build (OpenModelica#14399), so it needs
+# no flag here.
+#
+# The interface files (<name>.interface.mo, <name>.public.imports) do not depend
+# on that flag, so this reuses the ones the normal build already produced rather
+# than checking every interface twice.
+#
+# The other source of build-location dependent output is Susan: it writes the
+# path of the .tpl it was given into the generated .mo as a literal string, which
+# no parser flag can undo afterwards. .cmake/template_compilation.cmake therefore
+# invokes it with a path relative to the template's own directory.
+
+set(OMC_BOOTSTRAP_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/bootstrap-sources)
+# Mirror the layout of the submodule: bootstrap-sources/build/*.c
+set(OMC_BOOTSTRAP_C_DIR ${OMC_BOOTSTRAP_BINARY_DIR}/build)
+set(OMC_BOOTSTRAP_TARBALL_INCLUDE_DIR ${OMC_BOOTSTRAP_BINARY_DIR}/tarball-include)
+set(OMC_BOOTSTRAP_BOMC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/boot/bomc)
+
+# The snapshot is generated with the compiler that was just built, not with the
+# bomc used for the rest of this build. The whole point of updating it is to hand
+# the next generation of bomc whatever the current compiler emits.
+set(OMC_BOOTSTRAP_OMC $<TARGET_FILE:omc>)
+
+# Never pass ${GEN_DEBUG_SYMBOLS} here. It changes the generated C, and the
+# snapshot must not depend on the CMAKE_BUILD_TYPE of the tree it was made in.
+# ${CHECK_DEF_USE} on the other hand is a static check that leaves the output
+# alone, and is kept so this pass rejects exactly what the normal build rejects.
+
+macro(add_bootstrap_compile_step mo_source_file)
+
+    get_filename_component(file_name_no_ext ${mo_source_file} NAME_WLE)
+    get_filename_component(source_dir ${mo_source_file} DIRECTORY)
+
+    set(MM_PACKAGE_NAME ${file_name_no_ext})
+    set(MM_INPUT_SOURCE_DIR ${source_dir})
+    # Read the interfaces from the normal build tree, write the C to ours.
+    set(MM_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
+    set(MM_C_OUTPUT_DIR ${OMC_BOOTSTRAP_C_DIR})
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/.cmake/mm_compile.in.mos
+                   ${OMC_BOOTSTRAP_BINARY_DIR}/${file_name_no_ext}.compile.mos)
+
+    add_custom_command(
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${file_name_no_ext}.interface.mo.stamp
+                ${OMC_BOOTSTRAP_BINARY_DIR}/${file_name_no_ext}.compile.mos
+
+        COMMAND ${CMAKE_COMMAND} -E env OPENMODELICA_BACKEND_STUBS=1
+                ${OMC_BOOTSTRAP_OMC} -g=MetaModelica -n=1 ${CHECK_DEF_USE}
+                ${OMC_BOOTSTRAP_BINARY_DIR}/${file_name_no_ext}.compile.mos
+
+        OUTPUT  ${OMC_BOOTSTRAP_C_DIR}/${file_name_no_ext}.c
+                ${OMC_BOOTSTRAP_C_DIR}/${file_name_no_ext}_records.c
+                ${OMC_BOOTSTRAP_C_DIR}/${file_name_no_ext}.h
+                ${OMC_BOOTSTRAP_C_DIR}/${file_name_no_ext}_includes.h
+
+        BYPRODUCTS ${OMC_BOOTSTRAP_C_DIR}/${file_name_no_ext}.deps
+
+        COMMENT "Translating ${mo_source_file} for the bootstrapping sources"
+    )
+
+    set(OMC_BOOTSTRAP_C_FILES ${OMC_BOOTSTRAP_C_FILES}
+        ${OMC_BOOTSTRAP_C_DIR}/${file_name_no_ext}.c
+        ${OMC_BOOTSTRAP_C_DIR}/${file_name_no_ext}_records.c)
+endmacro(add_bootstrap_compile_step)
+
+
+# The snapshot covers everything the compiler is made of, backend included. bomc
+# does not link the external C implementations of the backend, which is what
+# bootstrap-sources/build/FakeBoostrappingExternals.c in the submodule is for. It
+# is hand written and left untouched by the update.
+foreach(OMC_MM_SOURCE ${OMC_MM_ALWAYS_SOURCES} ${OMC_MM_BACKEND_SOURCES})
+    add_bootstrap_compile_step(${OMC_MM_SOURCE})
+endforeach()
+
+
+# _main.c holds __omc_main(), the entry point calling Main.main. bomc pairs it
+# with .cmake/omc_main.c, which supplies main() itself.
+# GenerateEntryPoint.mos writes to the relative path "build/_main.c", hence the
+# working directory one level above the C output directory.
+add_custom_command(
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/boot/GenerateEntryPoint.mos
+
+    WORKING_DIRECTORY ${OMC_BOOTSTRAP_BINARY_DIR}
+
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${OMC_BOOTSTRAP_C_DIR}
+    COMMAND ${CMAKE_COMMAND} -E env OPENMODELICA_BACKEND_STUBS=1
+            ${OMC_BOOTSTRAP_OMC} -g=MetaModelica
+            ${CMAKE_CURRENT_SOURCE_DIR}/boot/GenerateEntryPoint.mos
+
+    OUTPUT ${OMC_BOOTSTRAP_C_DIR}/_main.c
+    COMMENT "Generating _main.c for the bootstrapping sources"
+)
+
+
+# OpenModelicaBootstrappingHeader.h declares the records the runtime shares with
+# the compiler. boot/CMakeLists.txt copies the submodule's copy back into
+# Compiler/ at configure time, so it has to be refreshed along with the C.
+# GenerateOMCHeader.mos loads its inputs by relative path and writes
+# OpenModelicaBootstrappingHeader.h.new next to them, so it has to run in
+# Compiler/; the .new file is removed again right after.
+# The header is nothing but record descriptions, no SourceInfo and therefore no
+# paths or timestamps, so OPENMODELICA_BACKEND_STUBS makes no difference here.
+add_custom_command(
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/GenerateOMCHeader.mos
+            ${CMAKE_CURRENT_SOURCE_DIR}/FrontEnd/Absyn.mo
+            ${CMAKE_CURRENT_SOURCE_DIR}/Script/GlobalScript.mo
+            ${CMAKE_CURRENT_SOURCE_DIR}/FrontEnd/Values.mo
+            ${CMAKE_CURRENT_SOURCE_DIR}/Util/ErrorTypes.mo
+            ${CMAKE_CURRENT_SOURCE_DIR}/Util/Config.mo
+            ${CMAKE_CURRENT_SOURCE_DIR}/Util/FMI.mo
+            ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFType.mo
+            ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFExpression.mo
+            ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFDimension.mo
+
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+
+    COMMAND ${OMC_BOOTSTRAP_OMC} -g=MetaModelica ${CMAKE_CURRENT_SOURCE_DIR}/GenerateOMCHeader.mos
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${CMAKE_CURRENT_SOURCE_DIR}/OpenModelicaBootstrappingHeader.h.new
+            ${OMC_BOOTSTRAP_TARBALL_INCLUDE_DIR}/OpenModelicaBootstrappingHeader.h
+    COMMAND ${CMAKE_COMMAND} -E remove -f ${CMAKE_CURRENT_SOURCE_DIR}/OpenModelicaBootstrappingHeader.h.new
+
+    OUTPUT ${OMC_BOOTSTRAP_TARBALL_INCLUDE_DIR}/OpenModelicaBootstrappingHeader.h
+    BYPRODUCTS ${CMAKE_CURRENT_SOURCE_DIR}/OpenModelicaBootstrappingHeader.h.new
+    COMMENT "Generating OpenModelicaBootstrappingHeader.h for the bootstrapping sources"
+)
+
+
+# Generate only. Useful on its own to check that the snapshot can be produced
+# without touching the submodule working tree.
+add_custom_target(generate-bootstrap-sources
+                  DEPENDS ${OMC_BOOTSTRAP_C_FILES}
+                          ${OMC_BOOTSTRAP_C_DIR}/_main.c
+                          ${OMC_BOOTSTRAP_TARBALL_INCLUDE_DIR}/OpenModelicaBootstrappingHeader.h
+                  COMMENT "Generated the bootstrapping sources in ${OMC_BOOTSTRAP_C_DIR}.")
+
+# omc pulls in DEPENDENCY_UPDATE, and with it every interface this pass reads.
+add_dependencies(generate-bootstrap-sources omc DEPENDENCY_UPDATE)
+
+
+add_custom_target(update-bootstrap-sources
+                  COMMAND ${CMAKE_COMMAND}
+                          -DBOOTSTRAP_C_DIR=${OMC_BOOTSTRAP_C_DIR}
+                          -DBOOTSTRAP_HEADER=${OMC_BOOTSTRAP_TARBALL_INCLUDE_DIR}/OpenModelicaBootstrappingHeader.h
+                          -DBOMC_DIR=${OMC_BOOTSTRAP_BOMC_DIR}
+                          -P ${CMAKE_CURRENT_SOURCE_DIR}/.cmake/sync_bootstrap_sources.cmake
+                  COMMENT "Updating OMCompiler/Compiler/boot/bomc from the generated bootstrapping sources")
+
+add_dependencies(update-bootstrap-sources generate-bootstrap-sources)

--- a/OMCompiler/Compiler/.cmake/mm_compile.in.mos
+++ b/OMCompiler/Compiler/.cmake/mm_compile.in.mos
@@ -2,8 +2,8 @@ echo(false);
 mm_output_dir := "@MM_OUTPUT_DIR@";
 mm_src_file := "@MM_INPUT_SOURCE_DIR@/@MM_PACKAGE_NAME@.mo";
 
-out_c_src_dir := "@MM_OUTPUT_DIR@/c_files/";
-out_log_file := "@MM_OUTPUT_DIR@/c_files/@MM_PACKAGE_NAME@.log";
+out_c_src_dir := "@MM_C_OUTPUT_DIR@/";
+out_log_file := "@MM_C_OUTPUT_DIR@/@MM_PACKAGE_NAME@.log";
 
 class_strname := "@MM_PACKAGE_NAME@";
 class_typename := $TypeName(@MM_PACKAGE_NAME@);

--- a/OMCompiler/Compiler/.cmake/sync_bootstrap_sources.cmake
+++ b/OMCompiler/Compiler/.cmake/sync_bootstrap_sources.cmake
@@ -1,0 +1,73 @@
+# Copies a freshly generated set of bootstrapping sources into the working tree
+# of the OMBootstrapping submodule (OMCompiler/Compiler/boot/bomc).
+#
+# Run through cmake -P by the update-bootstrap-sources target, see
+# .cmake/bootstrap_sources.cmake. Expects:
+#   BOOTSTRAP_C_DIR   directory holding the generated *.c / *.h
+#   BOOTSTRAP_HEADER  generated OpenModelicaBootstrappingHeader.h
+#   BOMC_DIR          the submodule working tree to update
+
+cmake_minimum_required(VERSION 3.14)
+
+# Part of the snapshot but not generated: hand written external stubs for the
+# functions bomc does not link (BackendDAEEXT and friends). Keep them.
+set(HAND_WRITTEN_SOURCES FakeBoostrappingExternals.c)
+
+foreach(var BOOTSTRAP_C_DIR BOOTSTRAP_HEADER BOMC_DIR)
+  if("${${var}}" STREQUAL "")
+    message(FATAL_ERROR "${var} was not passed to sync_bootstrap_sources.cmake.")
+  endif()
+endforeach()
+
+if(NOT EXISTS ${BOMC_DIR}/.git)
+  message(FATAL_ERROR
+    "${BOMC_DIR} is not a git checkout. Initialize the submodule first:\n"
+    "  git submodule update --init OMCompiler/Compiler/boot/bomc")
+endif()
+
+file(GLOB generated_sources ${BOOTSTRAP_C_DIR}/*.c ${BOOTSTRAP_C_DIR}/*.h)
+if(NOT generated_sources)
+  message(FATAL_ERROR "No generated sources found in ${BOOTSTRAP_C_DIR}.")
+endif()
+if(NOT EXISTS ${BOOTSTRAP_HEADER})
+  message(FATAL_ERROR "${BOOTSTRAP_HEADER} does not exist.")
+endif()
+
+set(dest_build_dir ${BOMC_DIR}/bootstrap-sources/build)
+set(dest_include_dir ${BOMC_DIR}/tarball-include)
+file(MAKE_DIRECTORY ${dest_build_dir})
+file(MAKE_DIRECTORY ${dest_include_dir})
+
+set(generated_names "")
+foreach(source ${generated_sources})
+  get_filename_component(name ${source} NAME)
+  list(APPEND generated_names ${name})
+endforeach()
+
+# Drop what the compiler no longer generates, otherwise a removed or renamed
+# MetaModelica package leaves its C behind and bomc keeps compiling it.
+file(GLOB existing_sources ${dest_build_dir}/*.c ${dest_build_dir}/*.h)
+set(removed_count 0)
+foreach(source ${existing_sources})
+  get_filename_component(name ${source} NAME)
+  if(NOT name IN_LIST generated_names AND NOT name IN_LIST HAND_WRITTEN_SOURCES)
+    message(STATUS "Removing stale ${name}")
+    file(REMOVE ${source})
+    math(EXPR removed_count "${removed_count} + 1")
+  endif()
+endforeach()
+
+file(COPY ${generated_sources} DESTINATION ${dest_build_dir})
+file(COPY ${BOOTSTRAP_HEADER} DESTINATION ${dest_include_dir})
+
+list(LENGTH generated_sources copied_count)
+message(STATUS "Copied ${copied_count} files to ${dest_build_dir} (removed ${removed_count} stale).")
+message(STATUS "")
+message(STATUS "Note: bootstrap-sources/Makefile.sources is left untouched. It only feeds the")
+message(STATUS "autotools bootstrap-from-tarball, which is on its way out; the CMake build of")
+message(STATUS "bomc globs bootstrap-sources/build/*.c and does not read it.")
+message(STATUS "")
+message(STATUS "Next steps:")
+message(STATUS "  1. Commit the changes in ${BOMC_DIR} and open a PR against OMBootstrapping.")
+message(STATUS "  2. Re-run cmake and rebuild to check that bomc builds from the new sources.")
+message(STATUS "  3. Point the submodule at the merged commit in a PR against OpenModelica.")

--- a/OMCompiler/Compiler/.cmake/template_compilation.cmake
+++ b/OMCompiler/Compiler/.cmake/template_compilation.cmake
@@ -29,6 +29,7 @@ macro(omc_add_template_target)
     # message(STATUS "${template_file} : ${depends_on}")
 
     get_filename_component(file_name_no_ext ${template_file} NAME_WLE)
+    get_filename_component(file_name ${template_file} NAME)
     get_filename_component(source_dir ${template_file} DIRECTORY)
     # Mirror the template's own directory (Template, susan_codegen, ...) under
     # the generated-mo root, so the tree matches the source layout.
@@ -48,7 +49,14 @@ macro(omc_add_template_target)
         # regenerated after the Susan binary is (re)built.
         DEPENDS ${template_file} ${depends_on} ${TPL_EXTRA_DEPENDS}
         COMMAND ${CMAKE_COMMAND} -E make_directory ${output_dir}
-        COMMAND ${OMC_EXE} -d=failtrace --tplOutputDir=${output_dir} ${template_file} > ${output_log_file} || (cat ${output_log_file} && false)
+        # Susan copies the template path it is given verbatim into the generated
+        # .mo (Tpl.sourceInfo("...", line, column)), and from there it ends up in
+        # the C generated for the compiler. Pass it relative to the working
+        # directory set above so that stays "CodegenC.tpl" instead of the absolute
+        # path of whoever ran the build; the bootstrapping snapshot produced by
+        # .cmake/bootstrap_sources.cmake has to be the same no matter where it was
+        # generated.
+        COMMAND ${OMC_EXE} -d=failtrace --tplOutputDir=${output_dir} ${file_name} > ${output_log_file} || (cat ${output_log_file} && false)
 
         OUTPUT ${output_mo_file}
         COMMENT "Generating ${output_mo_file} from ${template_file}"

--- a/OMCompiler/Compiler/CMakeLists.txt
+++ b/OMCompiler/Compiler/CMakeLists.txt
@@ -105,7 +105,12 @@ macro(add_compile_script mo_source_file)
 
     set(MM_PACKAGE_NAME ${file_name_no_ext})
     set(MM_INPUT_SOURCE_DIR ${source_dir})
+    # MM_OUTPUT_DIR is where the interfaces (and the dependency information derived
+    # from them) live, MM_C_OUTPUT_DIR is where the translated C ends up. They are
+    # separate because .cmake/bootstrap_sources.cmake reuses the interfaces of this
+    # build but writes its C somewhere else.
     set(MM_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
+    set(MM_C_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/c_files)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/.cmake/mm_compile.in.mos ${CMAKE_CURRENT_BINARY_DIR}/${file_name_no_ext}.compile.mos)
 endmacro(add_compile_script)
 
@@ -368,6 +373,11 @@ endif()
 #   target_link_options(omc PRIVATE -Wl,--stack,33554432)
 # endif()
 
+
+# Defines generate-bootstrap-sources / update-bootstrap-sources, the way to
+# refresh the pre-translated C sources bomc is built from. Neither target is part
+# of 'all'. Needs the omc target above and the interfaces of this build.
+include(${CMAKE_CURRENT_SOURCE_DIR}/.cmake/bootstrap_sources.cmake)
 
 
 ### INSTALLATION

--- a/OMCompiler/Compiler/FrontEnd/Static.mo
+++ b/OMCompiler/Compiler/FrontEnd/Static.mo
@@ -3633,7 +3633,14 @@ algorithm
            DAE.ICONST(info.columnNumberStart),
            DAE.ICONST(info.lineNumberEnd),
            DAE.ICONST(info.columnNumberEnd),
-           DAE.RCONST(info.lastModification)
+           // Deliberately not info.lastModification. This record is constant folded
+           // into the generated C, so the mtime of the source file would be baked in
+           // as a literal and the output would depend on when the file happened to be
+           // checked out. Nothing ever reads the field back off a sourceInfo() value
+           // (the mtime of a *class* is read from its Absyn.CLASS instead, see
+           // reloadClass and getTimeStamp in CevalScript), so pin it to 0.0.
+           // See OpenModelica#14399.
+           DAE.RCONST(0.0)
         };
         outExp := DAE.METARECORDCALL(Absyn.QUALIFIED("SourceInfo",Absyn.IDENT("SOURCEINFO")),args,{"fileName","isReadOnly","lineNumberStart","columnNumberStart","lineNumberEnd","columnNumberEnd","lastEditTime"},0,{});
       then (inCache,outExp,DAE.PROP(DAE.T_SOURCEINFO_DEFAULT,DAE.C_CONST()));


### PR DESCRIPTION
### Related Issues

Fixes https://github.com/OpenModelica/OpenModelica/issues/16443
Fixes https://github.com/OpenModelica/OpenModelica/issues/14399.

### Purpose

* Add a CMake target to update bootstrap-sources
  ```bash
  cmake --build build_cmake --target update-bootstrap-sources
  ```
* Update bootstrap-sources submodule with this branch
* Made sources a bit more diff-friendly 

```diff
- #define _OMC_LIT6_data "//OpenModelica/OMCompiler/Compiler/Script/CevalScript.mo"
+ #define _OMC_LIT6_data "CevalScript.mo"
```

```diff
- #define _OMC_LIT68_data "Configured 2026-08-19 12:00:49 using arguments:  '--disable-option-checking' '--prefix=//OpenModelica/install' 'CC=gcc' 'CXX=g++' 'FC=gfortran' 'CFLAGS=-Os' '--with-cppruntime' '--without-omc' '--without-omlibrary' '--with-omniORB' '--enable-modelica3d' '--without-hwloc' '--with-ombuilddir=//OpenModelica/build' '--cache-file=/dev/null' '--srcdir=.'"
+ #define _OMC_LIT68_data "Configured  using arguments: "
```

### Approach

* New CMake custom targets to generate and update bootstrap-sources
* Updated template path generated by Susan
* Set `SOURCEINFO.lastModified` to `DAE.RCONST(0.0)`

### TODO

- [ ] Merge https://github.com/OpenModelica/OMBootstrapping/pull/18, update this PR and then merge this
