### PR TITLE
wasm-jit: model-error unwinding parity with C

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -4649,18 +4649,49 @@ fn emit_nls_recoverable_return(ctx: &mut FnCtx) -> Result<()> {
     Ok(())
 }
 
-/// Trap on a model error whose message String handle is already on the stack — C's
-/// `assertCommonVar`: no dumped condition, `omc_dummyFileInfo`.
+/// C's `assertCommonVar` for a model error whose message String handle is on the
+/// stack. Where a solver or the step catches the unwind, the evaluation returns with
+/// its outputs untouched, as [`emit_nls_recoverable_return`] does.
 fn emit_model_error(ctx: &mut FnCtx) -> Result<()> {
-    emit_str_literal(ctx, b"")?; // file
-    for _ in 0..5 {
-        ctx.emit(we::Instruction::I32Const(0)); // line/col start+end, isReadOnly
+    use we::Instruction as I;
+    // C's `FUNCTION_CONTEXT` arm is `omc_assert(threadData, omc_dummyFileInfo, msg)`,
+    // which a simulation binds to `omc_assert_simulation` — `emit_assert`'s two arms.
+    if ctx.sim.is_none() {
+        let msg = ctx.alloc_temp(WTy::I32);
+        ctx.emit(I::LocalSet(msg));
+        let mut report_args = |ctx: &mut FnCtx| -> Result<()> {
+            ctx.emit(I::LocalGet(msg));
+            emit_str_literal(ctx, b"")?; // file
+            for _ in 0..5 {
+                ctx.emit(I::I32Const(0)); // line/col start+end, isReadOnly
+            }
+            ctx.emit(I::I32Const(0)); // no condition: never suppressed
+            emit_initial_flag(ctx);
+            emit_sim_data_or_zero(ctx);
+            Ok(())
+        };
+        ctx.emit(I::Call(rt_index("rt_nls_recovering")?));
+        ctx.emit(I::If(we::BlockType::Empty));
+        report_args(ctx)?;
+        ctx.emit(I::Call(rt_index("rt_nls_assert_failed")?));
+        release_heap_locals(ctx)?;
+        push_outputs(ctx);
+        ctx.emit(I::Return);
+        ctx.emit(I::End);
+        report_args(ctx)?;
+        ctx.emit(I::Call(env_extra_index("rt_assert")?));
+        ctx.emit(I::Drop); // a model error is never suppressed
+        emit_assert_unwind(ctx);
+        return Ok(());
     }
-    ctx.emit(we::Instruction::I32Const(0)); // no condition: never suppressed
-    emit_initial_flag(ctx);
     emit_sim_data_or_zero(ctx);
-    ctx.emit(we::Instruction::Call(env_extra_index("rt_assert")?));
-    ctx.emit(we::Instruction::Drop);
+    emit_initial_flag(ctx);
+    ctx.emit(I::Call(rt_index("rt_assert_common")?));
+    ctx.emit(I::If(we::BlockType::Empty));
+    release_heap_locals(ctx)?;
+    push_outputs(ctx);
+    ctx.emit(I::Return);
+    ctx.emit(I::End);
     emit_assert_unwind(ctx);
     Ok(())
 }
@@ -4746,22 +4777,6 @@ fn emit_math_domain_guard(ctx: &mut FnCtx, name: &str, arg: &Arc<DAE::Exp>, d: &
     ctx.emit(I::Call(rt_index("rt_concat")?));
     emit_str_literal(ctx, d.tail.as_bytes())?;
     ctx.emit(I::Call(rt_index("rt_concat")?));
-    let msg = ctx.alloc_temp(WTy::I32);
-    ctx.emit(I::LocalTee(msg));
-    // C's `assertCommonVar` warns and throws; a solver or the step catches the
-    // throw, so the evaluation returns instead of trapping.
-    match ctx.sim.as_ref().map(|s| s.data_local) {
-        Some(data) => ctx.emit(I::LocalGet(data)),
-        None => ctx.emit(I::I32Const(0)),
-    }
-    emit_initial_flag(ctx);
-    ctx.emit(I::Call(rt_index("rt_assert_common")?));
-    ctx.emit(I::If(we::BlockType::Empty));
-    release_heap_locals(ctx)?;
-    push_outputs(ctx);
-    ctx.emit(I::Return);
-    ctx.emit(I::End);
-    ctx.emit(I::LocalGet(msg));
     emit_model_error(ctx)?;
     ctx.emit(I::End);
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -119,8 +119,8 @@ pub(crate) fn note_runtime_error(msg: &str) {
     host_runtime_error();
 }
 
-/// [`note_runtime_error`] for a throw whose message C suppresses (a nonlinear
-/// solver's, with `LOG_NLS` off): the run still ends on it.
+/// [`note_runtime_error`] without the log line: the message is already logged, or C
+/// suppresses it (a nonlinear solver's, with `LOG_NLS` off). The run still ends on it.
 pub(crate) fn note_runtime_error_flag() {
     openmodelica_sim_meta::driver::note_runtime_error_flag();
     host_runtime_error();
@@ -143,8 +143,7 @@ fn host_runtime_error() {}
 #[cfg(not(all(target_arch = "wasm32", not(feature = "host_log"), not(feature = "standalone"))))]
 pub(crate) fn omc_assert(msg: &str) -> ! {
     omclog::error(omclog::ASSERT, false, msg);
-    openmodelica_sim_meta::driver::note_runtime_error_flag();
-    host_runtime_error();
+    note_runtime_error_flag();
     trap()
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -321,14 +321,13 @@ pub extern "C" fn rt_nls_assert_failed(
 
 /// C's `assertCommonVar` (a math builtin's domain guard): `omc_assert_warning`
 /// heads the `LOG_ASSERT` block and `throwStreamPrintWithEquationIndexes` adds the
-/// message and unwinds. Returns non-zero where the unwind is caught — a solver
-/// residual or the step — so the caller returns; the model-error path reports a
-/// fatal one. `msg` is this call's to release.
+/// message, both before `getBestJumpBuffer` picks the jump buffer — so a fatal
+/// violation reports exactly as a caught one does. Returns non-zero where a solver
+/// residual or the step catches it, so the caller returns instead of unwinding.
+/// `msg` is this call's to release.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_assert_common(msg: i32, sim_data: i32, initial: i32) -> i32 {
-    if !error_caught() {
-        return 0;
-    }
+    let caught = error_caught();
     if throw_reports() {
         use openmodelica_sim_meta::TIME_OFF;
         let time = if sim_data != 0 { unsafe { load_f64(sim_data as u32 + TIME_OFF) } } else { 0.0 };
@@ -341,13 +340,20 @@ pub extern "C" fn rt_assert_common(msg: i32, sim_data: i32, initial: i32) -> i32
                 crate::omclog::f(time, 0, 6)
             ),
         );
-        crate::omclog::debug(crate::omclog::ASSERT, false, &rt_string(msg));
+        if throw_logged() {
+            crate::omclog::debug(crate::omclog::ASSERT, false, &rt_string(msg));
+        }
     }
-    rt_nls_note_assert();
     if msg != 0 {
         crate::rt_release(msg as u32);
     }
-    1
+    if caught {
+        rt_nls_note_assert();
+        return 1;
+    }
+    // The flag is what makes the caller's unwind report as an assertion, not a crash.
+    crate::note_runtime_error_flag();
+    0
 }
 
 /// C's stage switch in `va_omc_assert_simulation_withEquationIndexes`.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -1767,10 +1767,10 @@ fn assert_block(info: &AssertInfo, cond: &str, time: f64, initial: bool) -> Stri
     // An equation `assert()` always names its condition, and C prints it with the
     // message as one message's second line — including for a backend-generated
     // variable, whose `FILE_INFO` is empty (`$finalCon$…`'s min/max guard). Without
-    // a condition it is C's `FUNCTION_CONTEXT` `omc_assert` (position and message
-    // only) or `assertCommonVar` (the math-domain guards, neither).
+    // a condition it is C's `FUNCTION_CONTEXT` `omc_assert`: the message, under the
+    // position where there is one (`omc_dummyFileInfo` has none).
     if cond.is_empty() {
-        return if info.file.is_empty() { head } else { format!("{pos}\n{}", info.msg) };
+        return if info.file.is_empty() { info.msg.clone() } else { format!("{pos}\n{}", info.msg) };
     }
     let body = format!("(({cond})) --> \"{}\"", info.msg);
     if info.file.is_empty() {
@@ -1781,16 +1781,9 @@ fn assert_block(info: &AssertInfo, cond: &str, time: f64, initial: bool) -> Stri
 
 pub fn log_assert_block(info: &AssertInfo, cond: &str, time: f64, initial: bool) {
     let block = assert_block(info, cond, time, initial);
-    // C's `assertCommonVar` (the math-domain guards, no condition and no source
-    // position): the warning names the time, a debug line carries the message.
-    if cond.is_empty() && info.file.is_empty() {
-        omclog::warning(omclog::ASSERT, false, &block);
-        omclog::debug(omclog::ASSERT, false, &info.msg);
-        return;
-    }
-    // C's generated guard for a backend variable warns (`omc_assert_warning`); one
-    // with a source position is a model `assert()`, which is an error.
-    if info.file.is_empty() {
+    // C's generated guard for a backend variable warns (`omc_assert_warning`); a
+    // model `assert()` and `omc_assert`'s conditionless message are both errors.
+    if info.file.is_empty() && !cond.is_empty() {
         omclog::warning(omclog::ASSERT, false, &block);
         return;
     }


### PR DESCRIPTION
Two error-unwinding gaps against `SimulationRuntime/c`, found via `simulation/modelica/asserts/powAssert1.mos` and
`simulation/modelica/events/CheckEvents.mos`.

C's `getBestJumpBuffer` routes a model error to `simulationJumpBuffer` for every error stage but `ERROR_EVENTHANDLING`, which unwinds to `globalJumpBuffer` — past `perform_simulation.c.inc`'s `MMC_CATCH_INTERNAL`. So a throw raised inside `handleEvents` ends the run at once, with no retry and none of the catch's "terminated by an assert" line.

`StepRetry::undo` decided retryability from `RUNTIME_ERROR` alone, which any model throw sets, so `powAssert1` logged its `Invalid root` twice and the second attempt escaped as a bare `wasm trap: unreachable`. `GLOBAL_THROW` now records a model throw leaving an `ERROR_EVENTHANDLING` region — `event_update` and `fire_time_event`, the two mirrors of C's single assignment site.

`emit_math_domain_guard` called `emit_nls_recoverable_return` before the message was built, so a `sqrt`/`log`/`asin` violation inside the DASSL residual silently set `ires = -1`. C's `assertCommonVar` warns and throws either way, so the message is now built first and handed to `rt_model_error`: `omc_assert_warning` names the time, then `throwStreamPrint` carries the message under `throwPrintsMessage`'s gate, and the return value says whether the caller must unwind.

Only the simulation arm goes there. C's `FUNCTION_CONTEXT` arm is `omc_assert(threadData, omc_dummyFileInfo, msg)`, and in wasm-jit that stays on `rt_assert`, whose recorded assertion is what `-d=gen`'s function evaluation turns into the error buffer's `Error: Model error: ...` line.

| suite | result |
| --- | --- |
| `simulation/modelica/asserts` | 14/14 |
| `simulation/modelica/events` | 35/35 |
| `simulation/modelica/nonlinear_system` | 50/50 | | `simulation/modelica/built_in_functions` | 21/22 (`MeasureTime`, pre-existing `+profiling` gap) |

Also byte-identical to `omc` for a fatal init-time domain error and for `-d=gen` function evaluation, and a `platforms={"wasm"}` FMU with domain guards still validates.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
