### PR TITLE
wasm-jit: +profiling, der() names, discreteCall

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -371,6 +371,7 @@ openmodelica_sim_meta/gen_tableau.py
 openmodelica_sim_meta/src/datarecon.rs
 openmodelica_sim_meta/src/driver.rs
 openmodelica_sim_meta/src/extinput.rs
+openmodelica_sim_meta/src/files.rs
 openmodelica_sim_meta/src/lib.rs
 openmodelica_sim_meta/src/linearize.rs
 openmodelica_sim_meta/src/optimization/eval.rs

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -466,6 +466,12 @@ fn write_output(path: &str, bytes: &[u8]) -> std::io::Result<()> {
     openmodelica_wasi::fs::write(path, bytes)
 }
 
+/// C's `fileSize(outputFilename)`, which the `+profiling` report quotes: `-1` when
+/// the file is not there.
+fn output_size(path: &str) -> i64 {
+    openmodelica_wasi::fs::len(path).map(|n| n as i64).unwrap_or(-1)
+}
+
 // ===========================================================================
 // Public entry points (called from the MetaModelica sources after regen)
 // ===========================================================================
@@ -1216,7 +1222,7 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
         let path = result_path(&flags, &meta, result_file);
         write_result(&model, &meta, &path, &run, &keep)?;
         // C's `printModelInfo`, after the result file is closed.
-        openmodelica_sim_meta::profiling::finish(&meta, &path);
+        openmodelica_sim_meta::profiling::finish(&meta, &path, output_size(&path));
         post = write_lin_file(&meta, &run, &flags);
         Ok(())
     })();
@@ -1378,7 +1384,7 @@ mod session {
         let keep = output_selection(model);
         capture_last_sim(model, run, &keep);
         write_result(model, meta, result_file, run, &keep)?;
-        openmodelica_sim_meta::profiling::finish(meta, result_file);
+        openmodelica_sim_meta::profiling::finish(meta, result_file, output_size(result_file));
         Ok(write_lin_file(meta, run, &simflags::flags()))
     }
 
@@ -3449,10 +3455,27 @@ pub(crate) struct SimVarMap {
     prof: Option<Arc<ProfPlan>>,
 }
 
-/// Display name of a model variable's component reference (OMC `.`-separated
-/// form, e.g. `body.r[1]`).
+/// C's `crefStrXml`: the display name `_init.xml` carries into `modelData`'s
+/// `info.name`, and with it the result file. `$DER` / `$PRE` qualifiers print as
+/// `der(...)` / `pre(...)`, nesting included (`$DER.$DER.x` -> `der(der(x))`).
 pub(crate) fn cref_display(cr: &Arc<DAE::ComponentRef>) -> Result<String> {
-    Ok(ComponentReferenceBasics::printComponentRefStr(cr.clone())?.to_string())
+    use DAE::ComponentRef as C;
+    Ok(match &**cr {
+        C::CREF_QUAL { ident, componentRef, .. } if &**ident == "$DER" => {
+            format!("der({})", cref_display(componentRef)?)
+        }
+        C::CREF_QUAL { ident, componentRef, .. } if &**ident == "$PRE" => {
+            format!("pre({})", cref_display(componentRef)?)
+        }
+        C::CREF_QUAL { componentRef, .. } => format!(
+            "{}.{}",
+            ComponentReferenceBasics::printComponentRefStr(ComponentReferenceBasics::crefFirstCref(
+                cr.clone()
+            )?)?,
+            cref_display(componentRef)?
+        ),
+        _ => ComponentReferenceBasics::printComponentRefStr(cr.clone())?.to_string(),
+    })
 }
 
 /// C's `shouldFilterOutput`: protected variables and `HideResult=true`, each
@@ -3518,14 +3541,12 @@ fn enumeration_names(ty: &DAE::Type) -> Option<Vec<String>> {
     }
 }
 
-/// Map a raw cref display name to the name it carries in the result file, or
-/// `None` to drop it. The new backend names a derivative of a non-state variable
-/// `$DER.x`; the C runtime shows it as `der(x)`. Other `$`-prefixed names are
-/// backend-internal auxiliaries (`$cse*`, `$PRE*`, …) and are not output.
+/// Map a display name ([`cref_display`], so a derivative already reads `der(x)`)
+/// to the name it carries in the result file, or `None` to drop it. `$`-prefixed
+/// names are backend-internal auxiliaries (`$cse*`, `$whenCondition*`, …) and are
+/// not output.
 fn result_name(raw: &str) -> Option<String> {
-    if let Some(rest) = raw.strip_prefix("$DER.") {
-        Some(format!("der({rest})"))
-    } else if raw.starts_with('$') && !OPT_RESULT_PREFIXES.iter().any(|p| raw.starts_with(p)) {
+    if raw.starts_with('$') && !OPT_RESULT_PREFIXES.iter().any(|p| raw.starts_with(p)) {
         None
     } else {
         Some(raw.to_string())
@@ -3916,11 +3937,7 @@ fn build_var_map(
         push_primary(&mut map, &mut result_vars, sv, REAL_OFF + (i as u32) * 8, WTy::F64, false, name)?;
     }
     for (i, sv) in ders.iter().enumerate() {
-        // der(x) is displayed as `der(<state name>)`.
-        let name = match states.get(i) {
-            Some(s) => format!("der({})", cref_display(&s.name)?),
-            None => cref_display(&sv.name)?,
-        };
+        let name = cref_display(&sv.name)?;
         push_start(&mut map, sv, layout.n_states + i as u32, &name)?;
         push_primary(&mut map, &mut result_vars, sv, REAL_OFF + (layout.n_states + i as u32) * 8, WTy::F64, false, name)?;
     }
@@ -6013,10 +6030,6 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
         if let Some((fn_indices, _)) = &nls_wiring {
             let sizes: Vec<u32> = nls_systems.iter().map(|s| lst(&s.crefs).count() as u32).collect();
             emit_nls_start(&mut f, fn_indices, nls_hist_bytes, &sizes, &nls_nominals, &nls_bounds, &nls_patterns);
-            if let Some(p) = &var_map.prof {
-                f.instruction(&we::Instruction::I32Const((p.n_functions + p.n_blocks) as i32));
-                f.instruction(&we::Instruction::Call(rt_index("rt_prof_init").expect("rt_prof_init is a runtime builtin")));
-            }
         }
         if !thunk_indices.is_empty() {
             crate::CodegenWasmJitFunctions::closures::emit_start(&mut f, &thunk_indices, closure_global);
@@ -6849,16 +6862,8 @@ fn collect_var_units(vars: &SimCodeVar::SimVars) -> Result<HashMap<String, Strin
             units.insert(name, sv.unit.to_string());
         }
     };
-    let states: Vec<&SimCodeVar::SimVar> = lst(&vars.stateVars).collect();
-    for sv in &states {
+    for sv in lst(&vars.stateVars).chain(lst(&vars.derivativeVars)) {
         add(cref_display(&sv.name)?, sv);
-    }
-    for (i, sv) in lst(&vars.derivativeVars).enumerate() {
-        let name = match states.get(i) {
-            Some(s) => format!("der({})", cref_display(&s.name)?),
-            None => cref_display(&sv.name)?,
-        };
-        add(name, sv);
     }
     for sv in lst(&vars.algVars)
         .chain(lst(&vars.discreteAlgVars))
@@ -6951,14 +6956,7 @@ fn build_sim_meta(
 /// C's `modelData` variable arrays: the same lists, in the same order, as the
 /// `SimData` variable regions.
 fn soti_vars(vars: &SimCodeVar::SimVars) -> Result<openmodelica_sim_meta::SotiVars> {
-    // C's `info.name`: a derivative reads `der(x)`, other `$` names stay raw.
-    let named = |sv: &SimCodeVar::SimVar| -> Result<String> {
-        let raw = cref_display(&sv.name)?.to_string();
-        Ok(match raw.strip_prefix("$DER.") {
-            Some(rest) => format!("der({rest})"),
-            None => raw,
-        })
-    };
+    let named = |sv: &SimCodeVar::SimVar| cref_display(&sv.name);
     let mut reals = Vec::new();
     for sv in lst(&vars.stateVars).chain(lst(&vars.derivativeVars)).chain(real_alg_vars(vars)) {
         reals.push(named(sv)?);
@@ -7152,9 +7150,32 @@ fn prof_plan(
         };
         fn_index.insert(crate::CodegenWasmJitFunctions::mangle(name)?, i as u32);
         functions.push(ProfFn {
-            name: openmodelica_frontend_dump::AbsynUtil::pathString(name.clone(), arcstr::literal!("."), true, false)?.to_string(),
+            // `SerializeModelInfo.serializePath`, which drops the `FULLYQUALIFIED`
+            // wrapper without a leading delimiter: `MeasureTime.A.f`, not `.MeasureTime.A.f`.
+            name: openmodelica_frontend_dump::AbsynUtil::pathString(name.clone(), arcstr::literal!("."), false, false)?
+                .to_string(),
             info: src_info(info),
         });
+    }
+    // C's `info.id` is the variable's `_init.xml` value reference: one counter from
+    // 1000 over `SerializeInitXML.modelVariables`' lists, the alias and sensitivity
+    // variables included. The report lists `modelData`'s arrays instead, so an id is
+    // not a position in it.
+    let mut vr_of: HashMap<String, u32> = HashMap::new();
+    let mut vr = 1000u32;
+    for list in [
+        &mi.vars.stateVars, &mi.vars.derivativeVars, &mi.vars.algVars, &mi.vars.discreteAlgVars,
+        &mi.vars.realOptimizeConstraintsVars, &mi.vars.realOptimizeFinalConstraintsVars,
+        &mi.vars.paramVars, &mi.vars.aliasVars,
+        &mi.vars.intAlgVars, &mi.vars.intParamVars, &mi.vars.intAliasVars,
+        &mi.vars.boolAlgVars, &mi.vars.boolParamVars, &mi.vars.boolAliasVars,
+        &mi.vars.stringAlgVars, &mi.vars.stringParamVars, &mi.vars.stringAliasVars,
+        &mi.vars.sensitivityVars,
+    ] {
+        for sv in lst(list) {
+            vr_of.entry(cref_display(&sv.name)?).or_insert(vr);
+            vr += 1;
+        }
     }
     // C's `modelData` variable arrays, in `printModelInfo` order.
     let mut vars = Vec::new();
@@ -7164,9 +7185,10 @@ fn prof_plan(
         &mi.vars.stringAlgVars, &mi.vars.stringParamVars,
     ] {
         for sv in lst(list) {
+            let name = cref_display(&sv.name)?;
             vars.push(ProfVar {
-                id: vars.len() as u32,
-                name: cref_display(&sv.name)?,
+                id: vr_of.get(&name).copied().unwrap_or(0),
+                name,
                 comment: sv.comment.to_string(),
                 info: src_info(&sv.source.info),
             });

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/artifact.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/artifact.rs
@@ -457,7 +457,14 @@ fn run_simulation(
             for (_, category, message) in &r.log {
                 log.push_str(&format!("LOG_STDOUT        | info    | {category}: {message}\n"));
             }
-            super::dylink_fmi::SimRun { file: r.file, linear_file: r.linear_file, rows: r.rows, solver: r.solver }
+            super::dylink_fmi::SimRun {
+                file: r.file,
+                linear_file: r.linear_file,
+                prof_files: r.prof_files,
+                prof_html: r.prof_html,
+                rows: r.rows,
+                solver: r.solver,
+            }
         }
         Form::Dylink { .. } => {
             loaded.with_dylink(|i| i.run_simulation(&args).map_err(|e| e.to_string()))?
@@ -475,10 +482,63 @@ fn run_simulation(
         };
         write_output(&path, content.as_bytes()).map_err(|e| format!("cannot write {path}: {e}"))?;
     }
+    place_prof_files(&run, log);
     if run.file.is_empty() {
         return Ok(());
     }
     write_output(out, &run.file).map_err(|e| format!("cannot write {out}: {e}"))
+}
+
+/// `+profiling`'s report: the run generated the five files inside the artifact
+/// (their names already carry `-outputPath`, as C's do), so they only need placing
+/// here — and `gnuplot` and `xsltproc` running over them for `blocks+html`, which
+/// a wasm module cannot do itself.
+fn place_prof_files(run: &super::dylink_fmi::SimRun, log: &mut String) {
+    let mut prefix = String::new();
+    for (name, content) in &run.prof_files {
+        if let Err(e) = write_output(name, content) {
+            log.push_str(&format!("LOG_STDOUT        | warning | cannot write {name}: {e}\n"));
+            return;
+        }
+        if let Some(p) = name.strip_suffix("_prof.xml") {
+            prefix = p.to_string();
+        }
+    }
+    if prefix.is_empty() || !run.prof_html {
+        return;
+    }
+    let cmd = format!("gnuplot {prefix}_prof.plt");
+    if !run_shell(&cmd) {
+        log.push_str(&format!("LOG_STDOUT        | warning | Plot command failed: {cmd}\n"));
+    }
+    let failure = match openmodelica_util::Settings::getInstallationDirectoryPath() {
+        Ok(home) => {
+            let xsl = format!("{home}/share/omc/scripts/default_profiling.xsl");
+            let cmd = format!("xsltproc -o {prefix}_prof.html {xsl} {prefix}_prof.xml");
+            (!run_shell(&cmd)).then_some(cmd)
+        }
+        Err(_) => Some("OPENMODELICAHOME missing".to_string()),
+    };
+    if let Some(cmd) = failure {
+        log.push_str(&format!(
+            "LOG_STDOUT        | warning | Failed to generate html version of profiling results: {cmd}\n"
+        ));
+    }
+}
+
+/// C's `system(cmd)`, for the two commands above. The wasm omc build has no
+/// processes to run, so the plots stay undrawn there — as they do for the C target
+/// on a machine without gnuplot.
+fn run_shell(cmd: &str) -> bool {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        std::process::Command::new("sh").arg("-c").arg(cmd).status().map(|s| s.success()).unwrap_or(false)
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = cmd;
+        false
+    }
 }
 
 /// Model Exchange (this process integrates) or Co-Simulation (the FMU does).

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/dylink_fmi.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/dylink_fmi.rs
@@ -22,6 +22,10 @@ use wasmtime::Val;
 pub struct SimRun {
     pub file: Vec<u8>,
     pub linear_file: Option<(String, String)>,
+    /// `+profiling`'s report files, each as a name and its content.
+    pub prof_files: Vec<(String, Vec<u8>)>,
+    /// The report asked for gnuplot + xsltproc (`+profiling=...+html`).
+    pub prof_html: bool,
     pub rows: u32,
     pub solver: String,
 }
@@ -133,11 +137,12 @@ impl DylinkInstance {
             .fmu
             .call("om_sim_run", &[Val::I32(p as i32), Val::I32(blob.len() as i32)])
             .map_err(|e| err("om_sim_run", e))? as u32;
-        // The header is ten words: status, then (pointer, length) for the result
-        // file, the linearized model's name and content, the row count, and the
-        // solver's name.
+        // The header is thirteen words: status, then (pointer, length) for the
+        // result file, the linearized model's name and content, the row count, the
+        // solver's name, `+profiling`'s packed files, and whether the report wants
+        // gnuplot and xsltproc run over them.
         let read = (|| -> std::result::Result<SimRun, String> {
-            let mut head = [0u32; 10];
+            let mut head = [0u32; 13];
             for (i, w) in head.iter_mut().enumerate() {
                 *w = self.fmu.read_u32(out + i as u32 * 4)?;
             }
@@ -160,12 +165,39 @@ impl DylinkInstance {
                 linear_file: (!name.is_empty()).then(|| {
                     (String::from_utf8_lossy(&name).into_owned(), String::from_utf8_lossy(&content).into_owned())
                 }),
+                prof_files: unpack_files(&bytes(head[10], head[11])?),
+                prof_html: head[12] != 0,
                 rows: head[7],
                 solver: String::from_utf8_lossy(&solver).into_owned(),
             })
         })();
         read.map_err(Error::Simulation)
     }
+}
+
+/// The named files `om_sim_run` packed: per file a `u32` name length, the name, a
+/// `u32` content length, the content. A truncated blob ends the list.
+fn unpack_files(blob: &[u8]) -> Vec<(String, Vec<u8>)> {
+    let word = |p: usize| u32::from_le_bytes(blob[p..p + 4].try_into().unwrap()) as usize;
+    let mut out = Vec::new();
+    let mut p = 0usize;
+    while p + 4 <= blob.len() {
+        let n = word(p);
+        p += 4;
+        if p + n + 4 > blob.len() {
+            break;
+        }
+        let name = String::from_utf8_lossy(&blob[p..p + n]).into_owned();
+        p += n;
+        let len = word(p);
+        p += 4;
+        if p + len > blob.len() {
+            break;
+        }
+        out.push((name, blob[p..p + len].to_vec()));
+        p += len;
+    }
+    out
 }
 
 /// The `om_fmi3Get*`/`Set*` entry point for a base type, and how wide one value is.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/optimization.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/optimization.rs
@@ -151,13 +151,7 @@ pub(crate) fn build_opt_info(
     // C's `realVarsData[i].info.name`, which the optimizer's messages quote.
     let real_names: Vec<String> = reals
         .iter()
-        .map(|sv| {
-            let n = crate::CodegenWasmJit::cref_display(&sv.name).unwrap_or_default();
-            match n.strip_prefix("$DER.") {
-                Some(base) => format!("der({base})"),
-                None => n,
-            }
-        })
+        .map(|sv| crate::CodegenWasmJit::cref_display(&sv.name).unwrap_or_default())
         .collect();
     let [jac_b, jac_c, jac_d] = jacs;
     Ok(Some(OptInfo {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -181,6 +181,12 @@ impl SimEngine for InWasmEngine {
     fn prof_dump(&mut self) -> u32 {
         crate::prof::rt_prof_dump()
     }
+    fn prof_clear(&mut self) {
+        crate::prof::rt_prof_clear(0);
+    }
+    fn prof_init(&mut self, n: u32) {
+        crate::prof::rt_prof_init(n);
+    }
     fn error_stage_addr(&mut self) -> u32 {
         crate::nls::rt_error_stage_addr()
     }
@@ -210,6 +216,9 @@ struct Session {
     stats: SolveStats,
     /// `-l`'s linearized model as `<file name>\0<content>`, for the host to write.
     lin: Vec<u8>,
+    /// `+profiling`'s collected state (`profiling::snapshot`), for the host to
+    /// render into the report once it has written the result file.
+    prof: Vec<u8>,
 }
 
 struct SessionCell(UnsafeCell<Option<Session>>);
@@ -351,13 +360,19 @@ pub extern "C" fn rt_sim_start(meta_ptr: u32, meta_len: u32, fn_base: u32, prese
     use openmodelica_sim_meta::rtclock;
     rtclock::reset(
         openmodelica_sim_meta::omclog::active(openmodelica_sim_meta::omclog::STATS)
-            || openmodelica_sim_meta::omclog::active(openmodelica_sim_meta::omclog::STATS_V),
+            || openmodelica_sim_meta::omclog::active(openmodelica_sim_meta::omclog::STATS_V)
+            // `+profiling` is C's other `measure_time_flag` source, as in `drive`.
+            || model.prof.is_some(),
     );
     rtclock::tick(rtclock::TOTAL);
     rtclock::tick(rtclock::PREINIT);
     crate::sysstats::enable(openmodelica_sim_meta::omclog::active(
         openmodelica_sim_meta::omclog::STATS_V,
     ));
+    // `+profiling`: the traces are collected here and rendered by the host, which
+    // is the side that knows what the result file it reports on ended up being
+    // (`profiling::snapshot` / `rt_sim_prof_ptr`).
+    openmodelica_sim_meta::profiling::start(&mut InWasmEngine { fn_base, present_mask }, &model);
     driver::set_cancel_hook(cancel_hook);
     driver::set_init_done_hook(init_done_hook);
     driver::set_no_throw_hook(|v| unsafe { rt_host_set_no_throw(v as i32) });
@@ -383,6 +398,7 @@ pub extern "C" fn rt_sim_start(meta_ptr: u32, meta_len: u32, fn_base: u32, prese
         params: Vec::new(),
         stats: SolveStats::default(),
         lin: Vec::new(),
+        prof: Vec::new(),
     });
     // What C's `NLS_USERDATA` carries as `DATA*`: the run's model and `SimData`,
     // for the analyses the nonlinear solver runs from inside a solve.
@@ -452,6 +468,8 @@ fn finish(s: &mut Session) {
     s.params = driver::finalize_run(&mut s.engine, &s.model, s.sim_data).unwrap_or_default();
     use openmodelica_sim_meta::rtclock;
     rtclock::accumulate(rtclock::TOTAL);
+    openmodelica_sim_meta::profiling::end_of_run(&mut s.engine);
+    s.prof = openmodelica_sim_meta::profiling::snapshot();
     (s.stats.timers, s.stats.tcalls) = rtclock::snapshot();
     s.finished = true;
 }
@@ -489,6 +507,17 @@ pub extern "C" fn rt_sim_lin_ptr() -> u32 {
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_sim_lin_len() -> u32 {
     session().as_ref().map_or(0, |s| s.lin.len() as u32)
+}
+
+/// `+profiling`'s collected state, valid once the run is done.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_sim_prof_ptr() -> u32 {
+    session().as_ref().map_or(0, |s| s.prof.as_ptr() as u32)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_sim_prof_len() -> u32 {
+    session().as_ref().map_or(0, |s| s.prof.len() as u32)
 }
 
 #[unsafe(no_mangle)]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -177,6 +177,12 @@ impl SimEngine for StandaloneEngine {
     fn prof_dump(&mut self) -> u32 {
         crate::prof::rt_prof_dump()
     }
+    fn prof_clear(&mut self) {
+        crate::prof::rt_prof_clear(0);
+    }
+    fn prof_init(&mut self, n: u32) {
+        crate::prof::rt_prof_init(n);
+    }
     fn error_stage_addr(&mut self) -> u32 {
         crate::nls::rt_error_stage_addr()
     }
@@ -299,18 +305,11 @@ fn run() {
         }
         openmodelica_plt_writer::write_plt(&signals, &result.rows, result.n_reals, &kept_params)
     };
-    std::fs::write(result_file(&m.prefix, &m.output_format), bytes)
-        .expect("wasm-jit standalone: cannot write result file");
-}
-
-/// C's result-file resolution (`simulation_runtime.cpp`): `-r` outright, else
-/// `<prefix>_res.<format>` under `-outputPath`.
-fn result_file(prefix: &str, format: &str) -> String {
-    simflags::with_flags(|f| match (&f.result_file, &f.output_path) {
-        (Some(r), _) => r.clone(),
-        (None, Some(dir)) => format!("{dir}/{prefix}_res.{format}"),
-        (None, None) => format!("{prefix}_res.{format}"),
-    })
+    let path = m.result_file();
+    let size = bytes.len() as i64;
+    std::fs::write(&path, bytes).expect("wasm-jit standalone: cannot write result file");
+    // C's `printModelInfo`, which the executable runs after closing the result.
+    openmodelica_sim_meta::profiling::finish(&m, &path, size);
 }
 
 /// C's `linearize`: `linearized_model.<ext>` under `-outputPath`.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/capi.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/capi.rs
@@ -474,6 +474,13 @@ struct RunOut {
     rows: u32,
     solver: u32,
     solver_len: u32,
+    /// `+profiling`'s files as a self-describing blob: per file a `u32` name
+    /// length, the name, a `u32` content length, the content.
+    prof: u32,
+    prof_len: u32,
+    /// The report asked for gnuplot + xsltproc (`+profiling=...+html`), which the
+    /// host runs over the files above.
+    prof_html: u32,
 }
 
 static mut RUN_OUT: RunOut = RunOut {
@@ -487,8 +494,23 @@ static mut RUN_OUT: RunOut = RunOut {
     rows: 0,
     solver: 0,
     solver_len: 0,
+    prof: 0,
+    prof_len: 0,
+    prof_html: 0,
 };
-static mut RUN_KEEP: Option<(Vec<u8>, String, String, String)> = None;
+static mut RUN_KEEP: Option<(Vec<u8>, String, String, String, Vec<u8>)> = None;
+
+/// Serialize named files into the blob [`RunOut::prof`] describes.
+fn pack_files(files: &[(String, Vec<u8>)]) -> Vec<u8> {
+    let mut o = Vec::new();
+    for (name, content) in files {
+        o.extend_from_slice(&(name.len() as u32).to_le_bytes());
+        o.extend_from_slice(name.as_bytes());
+        o.extend_from_slice(&(content.len() as u32).to_le_bytes());
+        o.extend_from_slice(content);
+    }
+    o
+}
 
 /// Run the whole simulation in-wasm, as `om:sim/simulation.run` does for a
 /// component. `args` is the flag list as NUL-separated UTF-8, without the program
@@ -508,7 +530,7 @@ pub extern "C" fn om_sim_run(args: u32, args_len: u32) -> u32 {
     let (out, keep) = match crate::sim_run::run(argv) {
         Ok(r) => {
             let (name, content) = r.linear_file.unwrap_or_default();
-            let keep = (r.file, name, content, r.solver);
+            let keep = (r.file, name, content, r.solver, pack_files(&r.prof_files));
             let mut out = RunOut { status: 0, rows: r.rows, ..RunOut::default() };
             out.file = keep.0.as_ptr() as u32;
             out.file_len = keep.0.len() as u32;
@@ -518,10 +540,13 @@ pub extern "C" fn om_sim_run(args: u32, args_len: u32) -> u32 {
             out.lin_content_len = keep.2.len() as u32;
             out.solver = keep.3.as_ptr() as u32;
             out.solver_len = keep.3.len() as u32;
+            out.prof = keep.4.as_ptr() as u32;
+            out.prof_len = keep.4.len() as u32;
+            out.prof_html = r.prof_html as u32;
             (out, keep)
         }
         Err(e) => {
-            let keep = (e.into_bytes(), String::new(), String::new(), String::new());
+            let keep = (e.into_bytes(), String::new(), String::new(), String::new(), Vec::new());
             let mut out = RunOut { status: 1, ..RunOut::default() };
             out.file = keep.0.as_ptr() as u32;
             out.file_len = keep.0.len() as u32;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -459,6 +459,20 @@ impl SimEngine for Engine {
     fn clean_nls_history(&mut self, time: f64) {
         openmodelica_codegen_wasm_jit_runtime::rt_nls_clean_history(time);
     }
+    // `+profiling`'s clocks: the artifact links the model and the runtime into one
+    // module, so they are this module's own.
+    fn prof_row(&mut self) -> u32 {
+        openmodelica_codegen_wasm_jit_runtime::prof::rt_prof_row()
+    }
+    fn prof_dump(&mut self) -> u32 {
+        openmodelica_codegen_wasm_jit_runtime::prof::rt_prof_dump()
+    }
+    fn prof_clear(&mut self) {
+        openmodelica_codegen_wasm_jit_runtime::prof::rt_prof_clear(0);
+    }
+    fn prof_init(&mut self, n: u32) {
+        openmodelica_codegen_wasm_jit_runtime::prof::rt_prof_init(n);
+    }
 }
 
 // ── Value references ─────────────────────────────────────────────────────────

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/sim_run.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/sim_run.rs
@@ -25,6 +25,39 @@ impl SimGuest for Fmu {
     }
 }
 
+/// The files the run writes beside its result (`+profiling`'s report and traces):
+/// there is no filesystem to write them to here, so they are collected and handed
+/// back for the caller to place. Single-threaded, like everything in this module.
+mod side_files {
+    use alloc::string::{String, ToString};
+    use alloc::vec::Vec;
+    use core::cell::UnsafeCell;
+
+    struct Store(UnsafeCell<Vec<(String, Vec<u8>)>>);
+    unsafe impl Sync for Store {}
+    static FILES: Store = Store(UnsafeCell::new(Vec::new()));
+
+    fn collect(name: &str, bytes: &[u8]) -> bool {
+        let files = unsafe { &mut *FILES.0.get() };
+        let entry = (name.to_string(), bytes.to_vec());
+        match files.iter_mut().find(|(n, _)| n == name) {
+            Some(slot) => *slot = entry,
+            None => files.push(entry),
+        }
+        true
+    }
+
+    /// Route this run's side files here, dropping any earlier run's.
+    pub fn arm() {
+        unsafe { (*FILES.0.get()).clear() };
+        openmodelica_sim_meta::files::set_writer(collect);
+    }
+
+    pub fn take() -> Vec<(String, Vec<u8>)> {
+        core::mem::take(unsafe { &mut *FILES.0.get() })
+    }
+}
+
 /// WASI's monotonic clock, in ms since the first reading. The driver's per-step
 /// deadline (`-alarm`) and the `LOG_STATS` timings need one; the component gets
 /// it from the same preview1 adapter its stdout comes from.
@@ -36,6 +69,7 @@ mod clock {
     }
 
     const MONOTONIC: u32 = 1;
+    const REALTIME: u32 = 0;
 
     fn now_ns() -> u64 {
         let mut t = 0u64;
@@ -43,6 +77,16 @@ mod clock {
             return 0;
         }
         t
+    }
+
+    /// C's `time(NULL)` for the profiling report's `<date>`: the same adapter's
+    /// realtime clock.
+    pub fn epoch_secs() -> i64 {
+        let mut t = 0u64;
+        if unsafe { clock_time_get(REALTIME, 1_000, &mut t) } != 0 {
+            return 0;
+        }
+        (t / 1_000_000_000) as i64
     }
 
     pub fn now_ms() -> f64 {
@@ -91,6 +135,11 @@ pub(crate) fn run(args: Vec<String>) -> Result<RunResult, String> {
     );
     openmodelica_codegen_wasm_jit_runtime::enable_sys_stats(meta::omclog::active(meta::omclog::STATS_V));
     driver::set_clock(clock::now_ms);
+    // `+profiling` writes five files and would run gnuplot/xsltproc over two of
+    // them; both belong to the caller here.
+    side_files::arm();
+    meta::profiling::set_wall_clock(clock::epoch_secs);
+    meta::profiling::set_plots_on_host(true);
 
     let sim_data = openmodelica_codegen_wasm_jit_runtime::rt_alloc(m.layout.total);
     unsafe { core::ptr::write_bytes(sim_data as *mut u8, 0, m.layout.total as usize) };
@@ -100,9 +149,13 @@ pub(crate) fn run(args: Vec<String>) -> Result<RunResult, String> {
 
     let rows = if result.n_reals == 0 { 0 } else { result.rows.len() / result.n_reals as usize };
     let bytes = write_result_file(&m, &result);
+    // C's `printModelInfo`, over the result file the caller is about to write.
+    meta::profiling::finish(&m, &m.result_file(), bytes.len() as i64);
     Ok(RunResult {
         file: bytes,
         linear_file: result.lin.as_ref().map(|f| (f.name.clone(), f.content.clone())),
+        prof_files: side_files::take(),
+        prof_html: m.prof.as_ref().is_some_and(|p| p.level & 4 != 0),
         rows: rows as u32,
         solver: label.to_string(),
     })

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/wit/deps/om-sim/simulation.wit
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/wit/deps/om-sim/simulation.wit
@@ -11,6 +11,13 @@ interface simulation {
     file: list<u8>,
     /// `-l`'s linearized model: the file name and its content.
     linear-file: option<tuple<string, string>>,
+    /// `+profiling`'s report files (`_prof.xml`, `_prof.json`, `_prof.plt` and the
+    /// two binary traces), each as a name and its content. Empty unless the model
+    /// was translated with profiling on.
+    prof-files: list<tuple<string, list<u8>>>,
+    /// `+profiling=...+html`: the caller should run gnuplot and xsltproc over
+    /// them (C's `measure_time_flag & 4`, which a wasm module cannot do itself).
+    prof-html: bool,
     /// Output rows written.
     rows: u32,
     /// The integration method the run actually used.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/component.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/component.rs
@@ -323,6 +323,8 @@ impl WasmArtifact {
         Ok(SimRun {
             file: out.file,
             linear_file: out.linear_file,
+            prof_files: out.prof_files,
+            prof_html: out.prof_html,
             rows: out.rows,
             solver: out.solver,
             log: std::mem::take(&mut store.data_mut().log),
@@ -347,6 +349,10 @@ pub struct SimRun {
     pub file: Vec<u8>,
     /// `-l`'s linearized model: its file name and content.
     pub linear_file: Option<(String, String)>,
+    /// `+profiling`'s report files, each as a name and its content.
+    pub prof_files: Vec<(String, Vec<u8>)>,
+    /// The report asked for gnuplot + xsltproc (`+profiling=...+html`).
+    pub prof_html: bool,
     pub rows: u32,
     /// The integration method the run actually used.
     pub solver: String,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -462,6 +462,15 @@ pub trait SimEngine {
     fn prof_dump(&mut self) -> u32 {
         0
     }
+    /// The runtime's `rt_prof_clear`: C's `rt_clear` over every profiling clock, so
+    /// the step's share joins the run's totals. The clocks live in the runtime
+    /// module, not the model's, hence an engine hook rather than a call by name.
+    fn prof_clear(&mut self) {}
+    /// The runtime's `rt_prof_init`: C's `rt_init` for the `n` function and block
+    /// clocks, at the head of a profiled run.
+    fn prof_init(&mut self, n: u32) {
+        let _ = n;
+    }
     /// Address of the runtime's error stage / absorbed-error pair, or 0 when the
     /// backend has no such export.
     fn error_stage_addr(&mut self) -> u32 {
@@ -2513,7 +2522,7 @@ impl HomotopyPath {
     fn finish(&mut self) {
         #[cfg(feature = "std")]
         if let Some((path, buf)) = self.file.take() {
-            let _ = std::fs::write(path, buf);
+            crate::files::write(&path, buf.as_bytes());
         }
     }
 }
@@ -2735,7 +2744,6 @@ fn emit_row_evaluated(
     capture_row(e, rows, sim_data, layout)?;
     let checked = check_asserts(e, sim_data, layout, if time >= stop { omclog::WARNING } else { omclog::INFO });
     // C's `fmtEmitStep`, once per global step.
-    #[cfg(feature = "std")]
     crate::profiling::on_row(e, time);
     checked
 }
@@ -4198,8 +4206,7 @@ pub fn drive(
     rtclock::reset(omclog::active(omclog::STATS) || omclog::active(omclog::STATS_V) || model.prof.is_some());
     rtclock::tick(rtclock::TOTAL);
     rtclock::tick(rtclock::PREINIT);
-    #[cfg(feature = "std")]
-    crate::profiling::start(model);
+    crate::profiling::start(e, model);
 
     let mut stats = SolveStats::default();
     let use_events = layout.n_samples > 0 || layout.n_zc > 0 || !model.clocks.is_empty();
@@ -4365,7 +4372,6 @@ pub fn drive(
     }
     recon_res?;
     rtclock::accumulate(rtclock::TOTAL);
-    #[cfg(feature = "std")]
     crate::profiling::end_of_run(e);
     (stats.timers, stats.tcalls) = rtclock::snapshot();
     stats.systems = e.sys_stats();

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/files.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/files.rs
@@ -1,0 +1,29 @@
+//! The files a run writes beside its result: `+profiling`'s traces and report and
+//! the homotopy path CSVs. C's runtime has `fopen`, but the same driver runs in
+//! three places with three different notions of a file — the native host, the web
+//! omc (whose files live in an in-memory store) and an in-wasm artifact (whose
+//! caller takes the bytes) — so the writer is installed by the embedder.
+
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+static WRITE: AtomicUsize = AtomicUsize::new(0);
+
+/// Install the writer every side file goes through. Unset, a `std` build writes
+/// with `std::fs` and the in-wasm runtime drops the file.
+pub fn set_writer(f: fn(&str, &[u8]) -> bool) {
+    WRITE.store(f as usize, Ordering::Relaxed);
+}
+
+/// C's `fopen(path, "wb")` and `fwrite`; `false` when the file could not be
+/// written, which every caller reports as C does.
+pub fn write(path: &str, bytes: &[u8]) -> bool {
+    let p = WRITE.load(Ordering::Relaxed);
+    if p != 0 {
+        let f: fn(&str, &[u8]) -> bool = unsafe { core::mem::transmute(p) };
+        return f(path, bytes);
+    }
+    #[cfg(feature = "std")]
+    return std::fs::write(path, bytes).is_ok();
+    #[cfg(not(feature = "std"))]
+    false
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -21,6 +21,7 @@
 
 extern crate alloc;
 
+use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -36,9 +37,11 @@ pub(crate) mod extinput;
 /// `-reconcile*`, which needs a filesystem too.
 #[cfg(feature = "std")]
 pub mod datarecon;
-/// `+profiling`'s files, which need one as well.
-#[cfg(feature = "std")]
+/// `+profiling`, whose files go out through [`files`] like every other side file,
+/// so an artifact's in-wasm driver reports as the host does.
 pub mod profiling;
+/// The writer every file a run leaves beside its result goes through.
+pub mod files;
 pub mod optimization;
 pub(crate) mod qss;
 pub mod rtclock;
@@ -1256,6 +1259,17 @@ impl SimMeta {
             }
         }
         keep
+    }
+
+    /// C's result-file resolution (`simulation_runtime.cpp`): `-r` outright, else
+    /// `<prefix>_res.<format>` under `-outputPath`. What a driver that writes the
+    /// file itself names it, and what `+profiling` reports as `outputFilename`.
+    pub fn result_file(&self) -> String {
+        crate::simflags::with_flags(|f| match (&f.result_file, &f.output_path) {
+            (Some(r), _) => r.clone(),
+            (None, Some(dir)) => format!("{dir}/{}_res.{}", self.prefix, self.output_format),
+            (None, None) => format!("{}_res.{}", self.prefix, self.output_format),
+        })
     }
 
     /// C's `simulationInfo->stepSize`: the output interval `SimCodeMain` writes into

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/profiling.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/profiling.rs
@@ -4,14 +4,17 @@
 //! `gnuplot` and `xsltproc` run over them for `blocks+html`.
 //!
 //! The function and block clocks live in the runtime module (`prof.rs`), where the
-//! instrumented code runs; the driver's own clocks are [`rtclock`].
+//! instrumented code runs; the driver's own clocks are [`rtclock`]. The five files
+//! go out through [`crate::files`], so an in-wasm driver reports as the host does.
 
-use std::cell::RefCell;
-use std::fs::File;
-use std::io::Write;
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use crate::driver::{format_g, SimEngine};
-use crate::{omclog, rtclock, ProfInfo, SimMeta};
+use crate::{files, omclog, rtclock, ProfInfo, SimMeta};
 
 /// Bytes per clock in the runtime's `rt_prof_dump` record.
 const DUMP_RECORD: usize = 40;
@@ -29,8 +32,11 @@ struct Totals {
 struct Profiler {
     level: u8,
     n: usize,
-    real: Option<File>,
-    int: Option<File>,
+    /// C's `MEASURE_TIME` streams, buffered: the report transposes them at the
+    /// end, which needs the whole trace anyway, and a buffer is the one thing
+    /// every target has (a `FILE*` is not).
+    real: Vec<u8>,
+    int: Vec<u8>,
     step: u32,
     /// `-outputPath` with its trailing separator, or empty.
     out: String,
@@ -38,43 +44,76 @@ struct Profiler {
     totals: Vec<Totals>,
 }
 
-thread_local! {
-    static PROF: RefCell<Option<Profiler>> = const { RefCell::new(None) };
+#[cfg(feature = "std")]
+mod state {
+    use super::Profiler;
+    use core::cell::RefCell;
+    std::thread_local! {
+        static PROF: RefCell<Option<Profiler>> = const { RefCell::new(None) };
+    }
+    pub fn with<R>(f: impl FnOnce(&mut Option<Profiler>) -> R) -> R {
+        PROF.with(|c| f(&mut c.borrow_mut()))
+    }
+}
+
+#[cfg(not(feature = "std"))]
+mod state {
+    use super::Profiler;
+    use core::cell::UnsafeCell;
+    // The in-wasm runtime is single-threaded, so a plain cell is sound.
+    struct Store(UnsafeCell<Option<Profiler>>);
+    unsafe impl Sync for Store {}
+    static PROF: Store = Store(UnsafeCell::new(None));
+    pub fn with<R>(f: impl FnOnce(&mut Option<Profiler>) -> R) -> R {
+        f(unsafe { &mut *PROF.0.get() })
+    }
+}
+
+static WALL_CLOCK: AtomicUsize = AtomicUsize::new(0);
+static HOME: AtomicUsize = AtomicUsize::new(0);
+static PLOTS_ON_HOST: AtomicBool = AtomicBool::new(false);
+
+/// Install the wall clock C's `time(NULL)` reads for the report's `<date>`. Needed
+/// wherever `std::time::SystemTime::now()` is not available: it panics in the web
+/// omc, and the in-wasm runtime has no clock of its own at all.
+pub fn set_wall_clock(f: fn() -> i64) {
+    WALL_CLOCK.store(f as usize, Ordering::Relaxed);
+}
+
+/// Install the lookup for C's `simulationInfo->OPENMODELICAHOME`, which the report
+/// needs to find `default_profiling.xsl`. omc knows its own installation root even
+/// where the environment does not (the web build has no environment at all).
+pub fn set_home(f: fn() -> Option<String>) {
+    HOME.store(f as usize, Ordering::Relaxed);
+}
+
+/// The embedder runs `gnuplot` and `xsltproc` over the files it is handed, so this
+/// run only writes them. For an artifact's in-wasm driver, which cannot spawn a
+/// process and would otherwise report C's failure messages for something its
+/// caller does on its behalf.
+pub fn set_plots_on_host(v: bool) {
+    PLOTS_ON_HOST.store(v, Ordering::Relaxed);
 }
 
 /// C's `fmtInit`, at the start of a run whose model was translated with
-/// `+profiling`: open the step files and start the step clock.
-pub fn start(model: &SimMeta) {
+/// `+profiling`: open the step traces and start the step clock.
+pub fn start(e: &mut dyn SimEngine, model: &SimMeta) {
     let Some(p) = &model.prof else {
-        PROF.with(|c| *c.borrow_mut() = None);
+        state::with(|c| *c = None);
         return;
     };
     let out = crate::simflags::with_flags(|f| f.output_path.clone()).map(|d| format!("{d}/")).unwrap_or_default();
     let n = p.functions.len() + p.blocks.len();
-    let open = |suffix: &str| -> Option<File> {
-        let name = format!("{out}{}{suffix}", model.prefix);
-        match File::create(&name) {
-            Ok(f) => Some(f),
-            Err(e) => {
-                omclog::warning(
-                    omclog::STDOUT,
-                    false,
-                    &format!("Time measurements output file {name} could not be opened: {e}"),
-                );
-                None
-            }
-        }
-    };
-    let real = open("_prof.realdata");
-    let int = if real.is_some() { open("_prof.intdata") } else { None };
-    let (real, int) = if int.is_none() { (None, None) } else { (real, int) };
+    // C's `rt_init` sizes every clock before the first tick; the model's own ticks
+    // land in the runtime module, so the engine arms them there.
+    e.prof_init(n as u32);
     rtclock::tick(rtclock::STEP);
-    PROF.with(|c| {
-        *c.borrow_mut() = Some(Profiler {
+    state::with(|c| {
+        *c = Some(Profiler {
             level: p.level,
             n,
-            real,
-            int,
+            real: Vec::new(),
+            int: Vec::new(),
             step: 0,
             out,
             prefix: model.prefix.clone(),
@@ -85,31 +124,124 @@ pub fn start(model: &SimMeta) {
 
 /// C's `fmtEmitStep` then `clear_rt_step`, once per emitted row.
 pub fn on_row(e: &mut dyn SimEngine, time: f64) {
-    PROF.with(|c| {
-        if let Some(p) = c.borrow_mut().as_mut() {
+    state::with(|c| {
+        if let Some(p) = c.as_mut() {
             p.emit_step(e, time);
             p.clear_step(e);
         }
     });
 }
 
+/// This run's collected state, for a driver that ran somewhere else: the in-wasm
+/// session hands it over so the *host* renders the report, once the result file it
+/// reports on — and its size — exists. Empty when the run was not profiled.
+pub fn snapshot() -> Vec<u8> {
+    state::with(|c| {
+        let Some(p) = c.as_ref() else { return Vec::new() };
+        let mut o = Vec::new();
+        o.extend_from_slice(&p.step.to_le_bytes());
+        o.extend_from_slice(&(p.totals.len() as u32).to_le_bytes());
+        for t in &p.totals {
+            o.extend_from_slice(&t.total.to_le_bytes());
+            o.extend_from_slice(&t.max.to_le_bytes());
+            o.extend_from_slice(&t.ncall_total.to_le_bytes());
+            o.extend_from_slice(&t.ncall_min.to_le_bytes());
+            o.extend_from_slice(&t.ncall_max.to_le_bytes());
+        }
+        for b in [&p.real, &p.int, &rtclock::pack()] {
+            o.extend_from_slice(&(b.len() as u32).to_le_bytes());
+            o.extend_from_slice(b);
+        }
+        o
+    })
+}
+
+/// Adopt a [`snapshot`] taken by another driver: everything else about the run is
+/// in `model`, as [`start`] reads it.
+pub fn adopt(model: &SimMeta, bytes: &[u8]) {
+    let Some(p) = &model.prof else { return };
+    if bytes.len() < 8 {
+        return;
+    }
+    let u32_at = |o: usize| u32::from_le_bytes(bytes[o..o + 4].try_into().unwrap());
+    let f64_at = |o: usize| f64::from_le_bytes(bytes[o..o + 8].try_into().unwrap());
+    let step = u32_at(0);
+    let n = u32_at(4) as usize;
+    let mut o = 8;
+    if bytes.len() < o + n * 28 {
+        return;
+    }
+    let mut totals = Vec::with_capacity(n);
+    for _ in 0..n {
+        totals.push(Totals {
+            total: f64_at(o),
+            max: f64_at(o + 8),
+            ncall_total: u32_at(o + 16),
+            ncall_min: u32_at(o + 20),
+            ncall_max: u32_at(o + 24),
+        });
+        o += 28;
+    }
+    let take = |o: &mut usize| -> Vec<u8> {
+        if bytes.len() < *o + 4 {
+            return Vec::new();
+        }
+        let n = u32_at(*o) as usize;
+        *o += 4;
+        let end = (*o + n).min(bytes.len());
+        let v = bytes[*o..end].to_vec();
+        *o = end;
+        v
+    };
+    let real = take(&mut o);
+    let int = take(&mut o);
+    // The driver's own clocks ran wherever the driver did; the report reads them
+    // from this side's `rtclock`.
+    rtclock::unpack(&take(&mut o));
+    let out = crate::simflags::with_flags(|f| f.output_path.clone()).map(|d| format!("{d}/")).unwrap_or_default();
+    state::with(|c| {
+        *c = Some(Profiler {
+            level: p.level,
+            n: p.functions.len() + p.blocks.len(),
+            real,
+            int,
+            step,
+            out,
+            prefix: model.prefix.clone(),
+            totals,
+        })
+    });
+}
+
 /// The clocks' run totals, read while the engine is still up.
 pub fn end_of_run(e: &mut dyn SimEngine) {
-    PROF.with(|c| {
-        if let Some(p) = c.borrow_mut().as_mut() {
+    state::with(|c| {
+        if let Some(p) = c.as_mut() {
             p.totals = read_totals(e, p.n);
         }
     });
 }
 
-/// C's `printModelInfo` and `printModelInfoJSON`, after the result file is written.
-pub fn finish(model: &SimMeta, result_file: &str) {
-    let Some(mut p) = PROF.with(|c| c.borrow_mut().take()) else { return };
+/// C's `printModelInfo` and `printModelInfoJSON`, after the result file is
+/// written. `result_size` is that file's size, which C reads back with `fileSize`.
+pub fn finish(model: &SimMeta, result_file: &str, result_size: i64) {
+    let Some(p) = state::with(|c| c.take()) else { return };
     let Some(info) = &model.prof else { return };
-    p.real = None;
-    p.int = None;
-    print_model_info(&p, info, model, result_file);
-    print_model_info_json(&p, info, model, result_file);
+    write_traces(&p);
+    print_model_info(&p, info, model, result_file, result_size);
+    print_model_info_json(&p, info, model, result_file, result_size);
+}
+
+/// C's `fmtEmitStep` writes a record per step and `fmtClose` closes the streams;
+/// the buffered run goes out in one piece here — before `gnuplot` reads it, and
+/// still in the record-per-step layout its bindings expect.
+fn write_traces(p: &Profiler) {
+    for (suffix, bytes) in [("_prof.realdata", &p.real), ("_prof.intdata", &p.int)] {
+        let name = format!("{}{}{suffix}", p.out, p.prefix);
+        if !files::write(&name, bytes) {
+            omclog::warning(omclog::STDOUT, false, &format!("Time measurements output file {name} could not be opened"));
+        }
+    }
 }
 
 fn read_totals(e: &mut dyn SimEngine, n: usize) -> Vec<Totals> {
@@ -136,41 +268,29 @@ fn read_totals(e: &mut dyn SimEngine, n: usize) -> Vec<Totals> {
 
 impl Profiler {
     fn emit_step(&mut self, e: &mut dyn SimEngine, time: f64) {
-        let (Some(real), Some(int)) = (self.real.as_mut(), self.int.as_mut()) else { return };
         rtclock::accumulate(rtclock::STEP);
         rtclock::tick(rtclock::OVERHEAD);
         let n = self.n;
         let mut row = vec![0u8; n * 12];
         let ptr = e.prof_row();
-        let ok = ptr != 0 && e.read_bytes(ptr, &mut row).is_ok();
-        let mut ok = ok && int.write_all(&self.step.to_le_bytes()).is_ok();
-        self.step += 1;
-        ok = ok && real.write_all(&time.to_le_bytes()).is_ok();
-        ok = ok && real.write_all(&rtclock::accumulated(rtclock::STEP).to_le_bytes()).is_ok();
-        ok = ok && int.write_all(&row[..4 * n]).is_ok();
-        ok = ok && real.write_all(&row[4 * n..]).is_ok();
-        rtclock::accumulate(rtclock::OVERHEAD);
-        if !ok {
-            omclog::warning(
-                omclog::SOLVER,
-                false,
-                "Disabled time measurements because the output file could not be generated",
-            );
-            self.real = None;
-            self.int = None;
+        if ptr != 0 && e.read_bytes(ptr, &mut row).is_ok() {
+            self.int.extend_from_slice(&self.step.to_le_bytes());
+            self.step += 1;
+            self.real.extend_from_slice(&time.to_le_bytes());
+            self.real.extend_from_slice(&rtclock::accumulated(rtclock::STEP).to_le_bytes());
+            // `rt_prof_row`'s record: the call counts, then the seconds.
+            self.int.extend_from_slice(&row[..4 * n]);
+            self.real.extend_from_slice(&row[4 * n..]);
         }
+        rtclock::accumulate(rtclock::OVERHEAD);
     }
 
     /// C's `clear_rt_step`.
     fn clear_step(&mut self, e: &mut dyn SimEngine) {
-        let _ = e.call1_if_present_raw("rt_prof_clear", 0);
+        e.prof_clear();
         rtclock::clear(rtclock::STEP);
         rtclock::tick(rtclock::STEP);
     }
-}
-
-fn file_size(name: &str) -> i64 {
-    std::fs::metadata(name).map(|m| m.len() as i64).unwrap_or(-1)
 }
 
 fn xml_escape(s: &str) -> String {
@@ -205,13 +325,29 @@ fn json_escape(s: &str) -> String {
     o
 }
 
-/// C's `strftime("%Y-%m-%d %H:%M:%S")` of `localtime(time(NULL))`; UTC here,
-/// there being no tz database in wasm.
-fn date_string() -> String {
-    let secs = std::time::SystemTime::now()
+/// C's `time(NULL)`: seconds since the Unix epoch, from the installed
+/// [`set_wall_clock`] or, natively, the std wall clock.
+fn epoch_secs() -> i64 {
+    let p = WALL_CLOCK.load(Ordering::Relaxed);
+    if p != 0 {
+        let f: fn() -> i64 = unsafe { core::mem::transmute(p) };
+        return f();
+    }
+    // `SystemTime::now()` panics in the web build (wasm32 without WASI); every
+    // other `std` target, wasip1 included, has a real wall clock.
+    #[cfg(all(feature = "std", any(not(target_arch = "wasm32"), target_os = "wasi")))]
+    return std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0);
+    #[cfg(not(all(feature = "std", any(not(target_arch = "wasm32"), target_os = "wasi"))))]
+    0
+}
+
+/// C's `strftime("%Y-%m-%d %H:%M:%S")` of `localtime(time(NULL))`; UTC here,
+/// there being no tz database in wasm.
+fn date_string() -> String {
+    let secs = epoch_secs();
     let days = secs.div_euclid(86400);
     let rem = secs.rem_euclid(86400);
     // Howard Hinnant's civil-from-days.
@@ -329,7 +465,7 @@ fn plot_command(
     }
 }
 
-fn print_model_info(p: &Profiler, info: &ProfInfo, model: &SimMeta, result_file: &str) {
+fn print_model_info(p: &Profiler, info: &ProfInfo, model: &SimMeta, result_file: &str, result_size: i64) {
     let (out, prefix) = (&p.out, &p.prefix);
     let plot_format = crate::simflags::with_flags(|f| f.measure_time_plot_format.clone()).unwrap_or_else(|| "svg".to_string());
     let n_fn = info.functions.len();
@@ -355,7 +491,7 @@ fn print_model_info(p: &Profiler, info: &ProfInfo, model: &SimMeta, result_file:
     x.push_str(&format!("  <method>{}</method>\n", xml_escape(&model.method)));
     x.push_str(&format!("  <outputFormat>{}</outputFormat>\n", xml_escape(&model.output_format)));
     x.push_str(&format!("  <outputFilename>{}</outputFilename>\n", xml_escape(result_file)));
-    x.push_str(&format!("  <outputFilesize>{}</outputFilesize>\n", file_size(result_file)));
+    x.push_str(&format!("  <outputFilesize>{result_size}</outputFilesize>\n"));
     x.push_str(&format!("  <overheadTime>{}</overheadTime>\n", f6(rtclock::accumulated(rtclock::OVERHEAD))));
     x.push_str(&format!("  <preinitTime>{}</preinitTime>\n", f6(rtclock::accumulated(rtclock::PREINIT))));
     x.push_str(&format!("  <initTime>{}</initTime>\n", f6(rtclock::accumulated(rtclock::INIT))));
@@ -370,9 +506,10 @@ fn print_model_info(p: &Profiler, info: &ProfInfo, model: &SimMeta, result_file:
     x.push_str(&format!("  <odeTime>{}</odeTime>\n", f6(rtclock::accumulated(rtclock::FUNCTION_ODE))));
     x.push_str(&format!("  <odeTimeTicks>{}</odeTimeTicks>\n", rtclock::ncall(rtclock::FUNCTION_ODE)));
     x.push_str("</modelinfo_ext>\n<profilingdataheader>\n");
-    let data_name = format!("{prefix}_prof.data");
-    x.push_str(&format!("  <filename>{}</filename>\n", xml_escape(&data_name)));
-    x.push_str(&format!("  <filesize>{}</filesize>\n", file_size(&data_name)));
+    // C reports on a `_prof.data` no runtime has written for a long time, so its
+    // `fileSize` is the missing-file `-1`.
+    x.push_str(&format!("  <filename>{}_prof.data</filename>\n", xml_escape(prefix)));
+    x.push_str("  <filesize>-1</filesize>\n");
     x.push_str("  <format>\n    <uint32>step</uint32>\n    <double>time</double>\n    <double>cpu time</double>\n");
     for f in &info.functions {
         x.push_str(&format!("    <uint32>{} (calls)</uint32>\n", xml_escape(&f.name)));
@@ -430,32 +567,34 @@ fn print_model_info(p: &Profiler, info: &ProfInfo, model: &SimMeta, result_file:
     x.push_str("</profileblocks>\n</simulation>\n");
     let xml_name = format!("{out}{prefix}_prof.xml");
     let plt_name = format!("{out}{prefix}_prof.plt");
-    if let Err(e) = std::fs::write(&xml_name, x) {
-        omclog::warning(omclog::STDOUT, false, &format!("Failed to open {xml_name}: {e}"));
+    if !files::write(&xml_name, x.as_bytes()) {
+        omclog::warning(omclog::STDOUT, false, &format!("Failed to open {xml_name}"));
         return;
     }
-    if let Err(e) = std::fs::write(&plt_name, plt) {
-        omclog::warning(omclog::DIVISION, false, &format!("Plots of profiling data were disabled: {e}\n"));
+    if !files::write(&plt_name, plt.as_bytes()) {
+        omclog::warning(omclog::DIVISION, false, "Plots of profiling data were disabled\n");
         return;
     }
     let html = p.level & 4 != 0;
-    if html {
-        let cmd = format!("gnuplot {plt_name}");
-        if !run_shell(&cmd) {
-            omclog::warning(omclog::DIVISION, false, &format!("Plot command failed: {cmd}\n"));
+    if !PLOTS_ON_HOST.load(Ordering::Relaxed) {
+        if html {
+            let cmd = format!("gnuplot {plt_name}");
+            if !run_shell(&cmd) {
+                omclog::warning(omclog::DIVISION, false, &format!("Plot command failed: {cmd}\n"));
+            }
         }
-    }
-    let (gen_html_failed, cmd) = match std::env::var("OPENMODELICAHOME") {
-        Ok(omhome) => {
-            let cmd = format!(
-                "xsltproc -o {out}{prefix}_prof.html {omhome}/share/omc/scripts/default_profiling.xsl {out}{prefix}_prof.xml"
-            );
-            (html && !run_shell(&cmd), cmd)
+        let (gen_html_failed, cmd) = match openmodelica_home() {
+            Some(omhome) => {
+                let cmd = format!(
+                    "xsltproc -o {out}{prefix}_prof.html {omhome}/share/omc/scripts/default_profiling.xsl {out}{prefix}_prof.xml"
+                );
+                (html && !run_shell(&cmd), cmd)
+            }
+            None => (true, "OPENMODELICAHOME missing".to_string()),
+        };
+        if gen_html_failed {
+            omclog::warning(omclog::STDOUT, false, &format!("Failed to generate html version of profiling results: {cmd}\n"));
         }
-        Err(_) => (true, "OPENMODELICAHOME missing".to_string()),
-    };
-    if gen_html_failed {
-        omclog::warning(omclog::STDOUT, false, &format!("Failed to generate html version of profiling results: {cmd}\n"));
     }
     if html {
         omclog::info(
@@ -473,27 +612,43 @@ fn print_model_info(p: &Profiler, info: &ProfInfo, model: &SimMeta, result_file:
 /// C's `system(cmd)` through `/bin/sh`; `true` on exit status 0. A wasm build
 /// has no processes to run.
 fn run_shell(cmd: &str) -> bool {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(all(feature = "std", not(target_arch = "wasm32")))]  // no processes in wasm
     {
         std::process::Command::new("sh").arg("-c").arg(cmd).status().map(|s| s.success()).unwrap_or(false)
     }
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(not(all(feature = "std", not(target_arch = "wasm32"))))]
     {
         let _ = cmd;
         false
     }
 }
 
-/// C's `convertProfileData`: transpose the step files in place from one record
-/// per step to one series per column.
+/// C reads `OPENMODELICAHOME` out of `simulationInfo`; here it is [`set_home`]'s,
+/// or the environment where nobody installed one.
+fn openmodelica_home() -> Option<String> {
+    let p = HOME.load(Ordering::Relaxed);
+    if p != 0 {
+        let f: fn() -> Option<String> = unsafe { core::mem::transmute(p) };
+        return f();
+    }
+    #[cfg(feature = "std")]
+    return std::env::var("OPENMODELICAHOME").ok();
+    #[cfg(not(feature = "std"))]
+    None
+}
+
+/// C's `convertProfileData`: rewrite the step files from one record per step to
+/// one series per column. C mmaps and transposes them in place, after `gnuplot`
+/// has read the record-per-step layout its bindings name.
 fn convert_profile_data(p: &Profiler) {
-    let n_all = p.n;
     let (out, prefix) = (&p.out, &p.prefix);
-    fn transpose(path: &str, elem: usize, cols: usize) {
-        let Ok(bytes) = std::fs::read(path) else { return };
+    for (suffix, bytes, elem, cols) in [
+        ("_prof.intdata", &p.int, 4usize, 1 + p.n),
+        ("_prof.realdata", &p.real, 8usize, 2 + p.n),
+    ] {
         let row = elem * cols;
-        if row == 0 || bytes.len() % row != 0 {
-            return;
+        if bytes.is_empty() || bytes.len() % row != 0 {
+            continue;
         }
         let rows = bytes.len() / row;
         let mut t = vec![0u8; bytes.len()];
@@ -504,28 +659,28 @@ fn convert_profile_data(p: &Profiler) {
                 t[dst..dst + elem].copy_from_slice(&bytes[src..src + elem]);
             }
         }
-        let _ = std::fs::write(path, t);
+        files::write(&format!("{out}{prefix}{suffix}"), &t);
     }
-    transpose(&format!("{out}{prefix}_prof.intdata"), 4, 1 + n_all);
-    transpose(&format!("{out}{prefix}_prof.realdata"), 8, 2 + n_all);
 }
 
-fn print_model_info_json(p: &Profiler, info: &ProfInfo, model: &SimMeta, result_file: &str) {
+fn print_model_info_json(p: &Profiler, info: &ProfInfo, model: &SimMeta, result_file: &str, result_size: i64) {
     let (out, prefix) = (&p.out, &p.prefix);
     convert_profile_data(p);
     let n_fn = info.functions.len();
     let g = |v: f64| format_g(v, 6);
     let mut j = String::new();
-    // C sums the top-level blocks only; the equation table has no parents here, so
-    // every block counts.
-    let total_eqs: f64 = (0..info.blocks.len()).map(|k| p.totals[n_fn + k].total).sum();
+    // C sums the blocks whose equation has no parent -- which is every block: its
+    // `readEquation` skips the `parent` field of `_info.json` and leaves the
+    // `calloc`ed zero behind.
+    // `fold` from `0.0`, not `sum()`: its identity is `-0.0`, and C prints `0`.
+    let total_eqs = (0..info.blocks.len()).map(|k| p.totals[n_fn + k].total).fold(0.0, |a, b| a + b);
     j.push_str(&format!("{{\n\"name\":\"{}\"", json_escape(&model.model_name)));
     j.push_str(&format!(",\n\"prefix\":\"{}\"", json_escape(prefix)));
     j.push_str(&format!(",\n\"date\":\"{}\"", json_escape(&date_string())));
     j.push_str(&format!(",\n\"method\":\"{}\"", json_escape(&model.method)));
     j.push_str(&format!(",\n\"outputFormat\":\"{}\"", json_escape(&model.output_format)));
     j.push_str(&format!(",\n\"outputFilename\":\"{}\"", json_escape(result_file)));
-    j.push_str(&format!(",\n\"outputFilesize\":{}", file_size(result_file)));
+    j.push_str(&format!(",\n\"outputFilesize\":{result_size}"));
     j.push_str(&format!(",\n\"overheadTime\":{}", g(rtclock::accumulated(rtclock::OVERHEAD))));
     j.push_str(&format!(",\n\"preinitTime\":{}", g(rtclock::accumulated(rtclock::PREINIT))));
     j.push_str(&format!(",\n\"initTime\":{}", g(rtclock::accumulated(rtclock::INIT))));
@@ -557,7 +712,7 @@ fn print_model_info_json(p: &Profiler, info: &ProfInfo, model: &SimMeta, result_
     }
     j.push_str("\n]\n}");
     let name = format!("{out}{prefix}_prof.json");
-    if let Err(e) = std::fs::write(&name, j) {
-        omclog::warning(omclog::STDOUT, false, &format!("Failed to open file {name} for writing: {e}"));
+    if !files::write(&name, j.as_bytes()) {
+        omclog::warning(omclog::STDOUT, false, &format!("Failed to open file {name} for writing"));
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/rtclock.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/rtclock.rs
@@ -138,6 +138,43 @@ pub fn enter_init() {
     tick(INIT);
 }
 
+/// The whole clock state as a blob: `acc`, `total`, `max`, then `ncall` and
+/// `ncall_total`. `+profiling`'s report reads all five, so an in-wasm run hands
+/// them to the host along with its traces ([`crate::profiling::snapshot`]).
+pub fn pack() -> alloc::vec::Vec<u8> {
+    let c = clocks();
+    let mut o = alloc::vec::Vec::with_capacity(N * 40);
+    for a in [&c.acc, &c.total, &c.max] {
+        for v in a {
+            o.extend_from_slice(&v.to_le_bytes());
+        }
+    }
+    for a in [&c.ncall, &c.ncall_total] {
+        for v in a {
+            o.extend_from_slice(&v.to_le_bytes());
+        }
+    }
+    o
+}
+
+/// Adopt a [`pack`]ed state, leaving the timers on so the report can read them.
+pub fn unpack(b: &[u8]) {
+    if b.len() < N * 40 {
+        return;
+    }
+    let c = clocks();
+    c.on = true;
+    let f = |i: usize| f64::from_le_bytes(b[i * 8..i * 8 + 8].try_into().unwrap());
+    let u = |i: usize| u64::from_le_bytes(b[i * 8..i * 8 + 8].try_into().unwrap());
+    for ix in 0..N {
+        c.acc[ix] = f(ix);
+        c.total[ix] = f(N + ix);
+        c.max[ix] = f(2 * N + ix);
+        c.ncall[ix] = u(3 * N + ix);
+        c.ncall_total[ix] = u(4 * N + ix);
+    }
+}
+
 /// Every clock as `(seconds, calls)`, for the snapshot that travels with
 /// [`crate::SolveStats`] out of an in-wasm run.
 pub fn snapshot() -> ([f64; N], [u64; N]) {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
@@ -511,7 +511,7 @@ pub fn add_host_builtins<T: 'static>(linker: &mut wasmtime::Linker<T>) -> Result
             ) else {
                 return;
             };
-            let _ = std::fs::write(String::from_utf8_lossy(name).as_ref(), data);
+            let _ = openmodelica_wasi::fs::write(String::from_utf8_lossy(name).as_ref(), data);
         },
     ))?;
     wt(linker.func_wrap("env", "rt_host_cancel", || -> i32 { metamodelica::cancel::check_cancel() as i32 }))?;
@@ -730,7 +730,7 @@ pub fn add_host_builtins(store: &mut wasmer::Store, imports: &mut wasmer::Import
                 let mut dbuf = vec![0u8; data_len as usize];
                 let view = memory.view(&env);
                 if view.read(name as u64, &mut nbuf).is_ok() && view.read(data as u64, &mut dbuf).is_ok() {
-                    let _ = std::fs::write(String::from_utf8_lossy(&nbuf).as_ref(), &dbuf);
+                    let _ = openmodelica_wasi::fs::write(String::from_utf8_lossy(&nbuf).as_ref(), &dbuf);
                 }
             },
         ),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_driver.rs
@@ -59,8 +59,30 @@ fn uri_to_filename(uri: &str) -> String {
     }
 }
 
+/// The files a run writes beside its result go where every other file the omc
+/// build writes goes: real files natively, the in-memory store in the web build.
+fn write_side_file(path: &str, bytes: &[u8]) -> bool {
+    openmodelica_wasi::fs::write(path, bytes).is_ok()
+}
+
+/// C's `time(NULL)`, for the `+profiling` report's `<date>`. The same clock the
+/// store stamps files with — `std::time::SystemTime::now()` panics in the web
+/// build.
+fn wall_clock_secs() -> i64 {
+    (openmodelica_wasi::realtime_nanos() / 1_000_000_000) as i64
+}
+
+/// C's `simulationInfo->OPENMODELICAHOME`, which the `+profiling` report needs for
+/// `default_profiling.xsl`: omc's own installation root, not the environment's.
+fn openmodelica_home() -> Option<String> {
+    openmodelica_util::Settings::getInstallationDirectoryPath().ok().map(|h| h.to_string())
+}
+
 pub fn init_host_hooks() {
     set_cancel_hook(metamodelica::cancel::check_cancel);
+    openmodelica_sim_meta::files::set_writer(write_side_file);
+    openmodelica_sim_meta::profiling::set_wall_clock(wall_clock_secs);
+    openmodelica_sim_meta::profiling::set_home(openmodelica_home);
     openmodelica_sim_meta::driver::set_uri_resolver(uri_to_filename);
     openmodelica_sim_meta::driver::set_log_sink(log_to_stdout);
     set_assert_reporter(report_assert);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -873,6 +873,12 @@ fn run_inwasm(model: &SimModel, bench: bool) -> std::result::Result<sim_driver::
         }
     }
     let result = sess.take_result()?;
+    // The traces were collected in-wasm; the report is rendered here, once the
+    // result file the run reports on has been written.
+    let prof = sess.take_prof()?;
+    if !prof.is_empty() {
+        openmodelica_sim_meta::profiling::adopt(&model.meta, &prof);
+    }
     if bench {
         eprintln!(
             "wasm-jit sim [in-wasm]: integrate {:?} ({} intervals), {} steps, {} residual evals",
@@ -1236,6 +1242,16 @@ impl sim_driver::SimEngine for WasmerEngine {
             Err(_) => 0,
         }
     }
+    fn prof_clear(&mut self) {
+        if let Ok(f) = self.rt_inst.exports.get_typed_function::<u32, ()>(&self.store, "rt_prof_clear") {
+            let _ = f.call(&mut self.store, 0);
+        }
+    }
+    fn prof_init(&mut self, n: u32) {
+        if let Ok(f) = self.rt_inst.exports.get_typed_function::<u32, ()>(&self.store, "rt_prof_init") {
+            let _ = f.call(&mut self.store, n);
+        }
+    }
     fn context_addr(&mut self) -> u32 {
         match self.rt_inst.exports.get_typed_function::<(), u32>(&self.store, "rt_context_addr") {
             Ok(f) => f.call(&mut self.store).unwrap_or(0),
@@ -1293,6 +1309,8 @@ pub struct InWasmSession {
     stat_f: wasmer::TypedFunction<u32, u64>,
     lin_ptr: wasmer::TypedFunction<(), u32>,
     lin_len: wasmer::TypedFunction<(), u32>,
+    prof_ptr: wasmer::TypedFunction<(), u32>,
+    prof_len: wasmer::TypedFunction<(), u32>,
     sys_ptr: wasmer::TypedFunction<(), u32>,
     sys_len: wasmer::TypedFunction<(), u32>,
     free_f: wasmer::TypedFunction<(), ()>,
@@ -1361,6 +1379,8 @@ pub fn build_inwasm_session(model: &SimModel) -> std::result::Result<InWasmSessi
         stat_f: wts(rt_inst.exports.get_typed_function(&store, "rt_sim_stat"))?,
         lin_ptr: gf(&store, "rt_sim_lin_ptr")?,
         lin_len: gf(&store, "rt_sim_lin_len")?,
+        prof_ptr: gf(&store, "rt_sim_prof_ptr")?,
+        prof_len: gf(&store, "rt_sim_prof_len")?,
         sys_ptr: gf(&store, "rt_sys_stats_ptr")?,
         sys_len: gf(&store, "rt_sys_stats_len")?,
         free_f: wts(rt_inst.exports.get_typed_function(&store, "rt_sim_free"))?,
@@ -1456,6 +1476,21 @@ impl InWasmSession {
         openmodelica_sim_meta::rtclock::read_stat_slots(&mut stats, &mut stat)?;
         let lin = self.take_lin()?;
         Ok(sim_driver::RunResult { rows, n_reals, params, stats, lin })
+    }
+
+    /// `+profiling`'s collected state, for the host's `profiling::adopt`: the
+    /// driver ran in-wasm, but the report is the host's to write.
+    pub fn take_prof(&mut self) -> Result<Vec<u8>> {
+        let p = wt(self.prof_ptr.call(&mut self.store))?;
+        let n = wt(self.prof_len.call(&mut self.store))? as usize;
+        let mut bytes = vec![0u8; n];
+        if n > 0 {
+            self.memory
+                .view(&self.store)
+                .read(p as u64, &mut bytes)
+                .map_err(|_| "CodegenWasmJit: profiling read")?;
+        }
+        Ok(bytes)
     }
 
     /// The runtime's `-l` blob (`<file name>\0<content>`), empty when unasked.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -226,16 +226,20 @@ pub fn library_module(
     fixed: bool,
 ) -> std::result::Result<wasmtime::Module, String> {
     let key = aot_cache_key(blob, alarm_secs() != 0);
-    static MEMO: OnceLock<std::sync::Mutex<HashMap<u64, wasmtime::Module>>> = OnceLock::new();
+    // A module's types belong to the engine that compiled it.
+    type Memo = std::sync::Mutex<HashMap<u64, (wasmtime::Engine, wasmtime::Module)>>;
+    static MEMO: OnceLock<Memo> = OnceLock::new();
     let memo = MEMO.get_or_init(Default::default);
-    if let Some(m) = memo.lock().unwrap_or_else(|e| e.into_inner()).get(&key) {
-        return Ok(m.clone());
+    if let Some((e, m)) = memo.lock().unwrap_or_else(|e| e.into_inner()).get(&key) {
+        if wasmtime::Engine::same(e, engine) {
+            return Ok(m.clone());
+        }
     }
     let m = match fixed {
         true => aot_module(engine, &format!("lib-{name}"), blob, alarm_secs() != 0)?,
         false => wts(wasmtime::Module::new(engine, blob))?,
     };
-    memo.lock().unwrap_or_else(|e| e.into_inner()).insert(key, m.clone());
+    memo.lock().unwrap_or_else(|e| e.into_inner()).insert(key, (engine.clone(), m.clone()));
     Ok(m)
 }
 
@@ -1189,6 +1193,12 @@ fn run_inwasm(model: &SimModel, bench: bool) -> std::result::Result<sim_driver::
         }
     }
     let result = sess.take_result()?;
+    // The traces were collected in-wasm; the report is rendered here, once the
+    // result file the run reports on has been written.
+    let prof = sess.take_prof()?;
+    if !prof.is_empty() {
+        openmodelica_sim_meta::profiling::adopt(&model.meta, &prof);
+    }
     if bench {
         let n = model.n_intervals;
         eprintln!(
@@ -1631,6 +1641,16 @@ impl sim_driver::SimEngine for WasmtimeEngine {
             .and_then(|f| f.call(&mut self.store, ()).ok())
             .unwrap_or(0)
     }
+    fn prof_clear(&mut self) {
+        if let Ok(f) = self.rt_inst.get_typed_func::<u32, ()>(&mut self.store, "rt_prof_clear") {
+            let _ = f.call(&mut self.store, 0);
+        }
+    }
+    fn prof_init(&mut self, n: u32) {
+        if let Ok(f) = self.rt_inst.get_typed_func::<u32, ()>(&mut self.store, "rt_prof_init") {
+            let _ = f.call(&mut self.store, n);
+        }
+    }
     fn context_addr(&mut self) -> u32 {
         self.rt_inst
             .get_typed_func::<(), u32>(&mut self.store, "rt_context_addr")
@@ -1694,6 +1714,8 @@ pub struct InWasmSession {
     stat_f: wasmtime::TypedFunc<u32, u64>,
     lin_ptr: wasmtime::TypedFunc<(), u32>,
     lin_len: wasmtime::TypedFunc<(), u32>,
+    prof_ptr: wasmtime::TypedFunc<(), u32>,
+    prof_len: wasmtime::TypedFunc<(), u32>,
     sys_ptr: wasmtime::TypedFunc<(), u32>,
     sys_len: wasmtime::TypedFunc<(), u32>,
     free_f: wasmtime::TypedFunc<(), ()>,
@@ -1758,6 +1780,8 @@ pub fn build_inwasm_session(model: &SimModel) -> std::result::Result<InWasmSessi
         stat_f: wts(rt_inst.get_typed_func::<u32, u64>(&mut store, "rt_sim_stat"))?,
         lin_ptr: gf(&mut store, "rt_sim_lin_ptr")?,
         lin_len: gf(&mut store, "rt_sim_lin_len")?,
+        prof_ptr: gf(&mut store, "rt_sim_prof_ptr")?,
+        prof_len: gf(&mut store, "rt_sim_prof_len")?,
         sys_ptr: gf(&mut store, "rt_sys_stats_ptr")?,
         sys_len: gf(&mut store, "rt_sys_stats_len")?,
         free_f: wts(rt_inst.get_typed_func::<(), ()>(&mut store, "rt_sim_free"))?,
@@ -1854,6 +1878,20 @@ impl InWasmSession {
         openmodelica_sim_meta::rtclock::read_stat_slots(&mut stats, &mut stat)?;
         let lin = self.take_lin()?;
         Ok(sim_driver::RunResult { rows, n_reals, params, stats, lin })
+    }
+
+    /// `+profiling`'s collected state, for the host's `profiling::adopt`: the
+    /// driver ran in-wasm, but the report is the host's to write.
+    pub fn take_prof(&mut self) -> Result<Vec<u8>> {
+        let p = wt(self.prof_ptr.call(&mut self.store, ()))?;
+        let n = wt(self.prof_len.call(&mut self.store, ()))? as usize;
+        let mut bytes = vec![0u8; n];
+        if n > 0 {
+            self.memory
+                .read(&self.store, p as usize, &mut bytes)
+                .map_err(|_| "CodegenWasmJit: profiling read")?;
+        }
+        Ok(bytes)
     }
 
     /// The runtime's `-l` blob (`<file name>\0<content>`), empty when unasked.


### PR DESCRIPTION
Three wasm-jit gaps against the C runtime, the last one found by the first two.

**`crefStrXml` display names.** `cref_display` printed the raw backend cref, so a second-order derivative reached the result file as `der($DER.filter.x[2])` and `readSimulationResult` could not find it. Three call sites papered over the first level with a one-shot `strip_prefix("$DER.")` or by wrapping the *state's* name instead. C has no such hack: `_init.xml` is written with `crefStrXml`, which recurses through the qualifiers. Do the same and drop the four ad-hoc strips.

**`+profiling`.** The feature was absent; `MeasureTime.mos` wants the `blocks+html` report. Ported from `simulation/modelinfo.c` and the `MEASURE_TIME` block of `perform_simulation.c.inc`:

- `rtclock` grows C's `SIM_TIMER_FIRST_FUNCTION` tail: tick, accumulate, add_ncall and clear, with the total / max / min-max-count accounting `rt_clear` does, plus `SIM_TIMER_STEP`.
- `prof.rs` writes the per-step `_prof.realdata` / `_prof.intdata` traces, `_prof.xml`, `_prof.json`, the gnuplot `_prof.plt`, and `convertProfileData`'s transpose.
- `ProfInfo` rides in `SimMeta`: functions, equations (`defines`, `parent`), variables with source info, and the block numbering `readEquations` produces, equation 0's parsed default included.
- The codegen emits `rt_prof_*` around model-function call sites in simulation context (C's `daeExpCall`), around a system's solve with the `-1` count fixup, `+1` per NLS residual, and around every equation under `=all`.

The model's ticks land in the runtime module, not in the host's copy of the clocks, so a host-driven run arms, steps and reads them back through four new `SimEngine` hooks; an in-wasm driver keeps the local default. The host then writes the five files, runs gnuplot and xsltproc when the level asks for html (C's `measure_time_flag & 4`) and transposes the traces.

**`discreteCall` after initialization.** The report then showed a nonlinear system's block counted twice per step where C counts it once. Both solvers agree on every statistic they report — same solves, same `number of function evaluations` — so the extra work sat outside the solver, and a `print` inside a model function confirmed it: for `Real x = f(x)` over n steps C calls `f` `6 + n` times and wasm-jit `6 + 2n`.

The port models C's `simulationInfo->discreteCall` with the relation mode in `SimData`. Initialization leaves it at 2 (init), and the reset to 0 sat inside the `n_zc > 0` block, where its job is to make the zero-crossing evaluation see held relations. A model without zero crossings therefore ran its whole simulation with the flag raised, so every `rt_solve_nls` took the `updateInnerEquation` residual evaluation that C runs only for a discrete call — and a homotopy system would have re-run its lambda sweep at every step for the same reason. Clear it unconditionally, as C's generated `functionDAE` and `functionInitialEquations` do on the way out.

`f`-call counts now match the C target exactly (7/8/11/16 for 1/2/5/10 intervals), MeasureTime's block counts drop from 1000 to 501 against C's 504, and `_prof.xml` matches the C target's apart from timings and variable ids.

The four wasm-jit testsuite failures around this code — dynamicTearing3, CheckEvents, homotopy4_solver and TestExpressionSolve — fail the same way with the `discreteCall` hunk reverted, and pass on the C target.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
