### PR TITLE
web: tidy simulator UI, fix 3D orbit

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -1722,6 +1722,7 @@ function(omc_rust_setup_wasm)
         ${RUST_OMC_DIR}/wasm/simulator/examples/BouncingBall.mo
         ${RUST_OMC_DIR}/wasm/plot.js
         ${RUST_OMC_DIR}/wasm/theme.css
+        ${RUST_OMC_DIR}/wasm/ui.js
         ${RUST_OMC_DIR}/wasm/fmu-aot.js
         ${RUST_OMC_DIR}/wasm/fmu-aot-worker.js
         # Shared 3D animation view (anim/), used by both simulator pages.
@@ -1746,6 +1747,7 @@ function(omc_rust_setup_wasm)
         COMMAND ${CMAKE_COMMAND} -E copy
                 ${RUST_OMC_DIR}/wasm/plot.js
                 ${RUST_OMC_DIR}/wasm/theme.css
+                ${RUST_OMC_DIR}/wasm/ui.js
                 ${RUST_OMC_DIR}/wasm/fmu-aot.js
                 ${RUST_OMC_DIR}/wasm/fmu-aot-worker.js
                 ${_web_dir}/

--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -506,3 +506,4 @@ wasm/simulator/examples/BouncingBall.mo
 wasm/simulator/index.html
 wasm/simulator/omc-worker.js
 wasm/theme.css
+wasm/ui.js

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/anim/anim-view.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/anim/anim-view.js
@@ -20,7 +20,7 @@ export class AnimView {
     root.className = 'anim';
     root.hidden = true;
     root.innerHTML = `
-      <div class="anim-view">
+      <div class="anim-view" title="Drag to rotate · right-drag to pan · wheel to zoom">
         <div class="anim-views">
           <button data-view="iso" title="Isometric">Iso</button>
           <button data-view="side" title="Side (look −Z; x→ right, y↑ up)">Side</button>

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/anim/animation.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/anim/animation.js
@@ -45,14 +45,21 @@ function scaleFor(kind, length, width, height) {
   }
 }
 
-// Camera presets matching OMEdit (AbstractAnimationWindow::cameraPosition*): `dir`
-// is the world direction from the target toward the camera, `up` the camera up.
-// Side is OMEdit's default for Modelica models (x right, y up, z toward viewer).
+// OrbitControls orbits about one axis, read from `camera.up` when it is constructed.
+// A camera exactly on that axis is the frame's singularity: azimuth is a no-op and
+// the polar angle only moves one way, so nothing may come closer to it than POLE.
+const UP = [0, 1, 0];
+const POLE = 0.02;
+
+// Camera presets matching OMEdit (AbstractAnimationWindow::cameraPosition*), as the
+// spherical angles OrbitControls works in: polar `phi` from +Y, azimuth `theta` from
+// +Z toward +X. Top's azimuth keeps OMEdit's +Z-right, +X-up screen orientation.
+const HALF_PI = Math.PI / 2;
 const VIEWS = {
-  iso:   { dir: [0.57735, 0.57735, 0.57735], up: [-0.409, 0.816, -0.409] },
-  side:  { dir: [0, 0, 1], up: [0, 1, 0] },   // look -Z
-  front: { dir: [1, 0, 0], up: [0, 1, 0] },   // look -X
-  top:   { dir: [0, 1, 0], up: [1, 0, 0] },   // look -Y
+  iso:   { theta: Math.PI / 4, phi: Math.acos(1 / Math.sqrt(3)) },
+  side:  { theta: 0,           phi: HALF_PI },   // look -Z
+  front: { theta: HALF_PI,     phi: HALF_PI },   // look -X
+  top:   { theta: -HALF_PI,    phi: POLE },      // look -Y
 };
 const DEFAULT_VIEW = 'side';
 
@@ -62,17 +69,20 @@ export class Animator {
     this.scene = new THREE.Scene();
     this.scene.background = new THREE.Color(0xf2f2f2);   // OMEdit's animation clear colour
     this.camera = new THREE.PerspectiveCamera(45, 1, 1e-3, 1e5);
-    this.camera.up.set(0, 0, 1);
+    this.camera.up.set(...UP);
 
     this.renderer = new THREE.WebGLRenderer({ antialias: true });
     this.renderer.setPixelRatio(window.devicePixelRatio || 1);
     container.appendChild(this.renderer.domElement);
     Object.assign(this.renderer.domElement.style, { width: '100%', height: '100%', display: 'block' });
 
+    // After camera.up: OrbitControls reads it once, to fix the orbit axis.
     this.controls = new OrbitControls(this.camera, this.renderer.domElement);
     // No damping (which would need a continuous rAF loop); instead re-render on
     // every control change so orbiting works whether or not playback is running.
     this.controls.enableDamping = false;
+    this.controls.minPolarAngle = POLE;
+    this.controls.maxPolarAngle = Math.PI - POLE;
     this.controls.addEventListener('change', () => this.renderOnce());
 
     this.scene.add(new THREE.HemisphereLight(0xffffff, 0x9a9a9a, 1.1));
@@ -81,11 +91,12 @@ export class Animator {
     this.unit = buildUnitGeometries();
     this.meshes = [];
     this.times = null; this.data = null; this.stride = 0; this.nshapes = 0;
-    this.center = new THREE.Vector3(); this.radius = 1; this.extents = [1, 1, 1];
+    this.center = new THREE.Vector3(); this.radius = 1;
 
     this.time = 0; this.playing = false; this.speed = 1; this.loop = false;
     this._last = 0; this._raf = null; this._scratch = null;
     this._tmpScale = new THREE.Matrix4();
+    this._sph = new THREE.Spherical(); this._offset = new THREE.Vector3();
     this.onTime = null;
     this._loop = this._loop.bind(this);
     this._onResize = () => this.resize();
@@ -130,22 +141,41 @@ export class Animator {
     const mesh = new THREE.Mesh(g, new THREE.MeshStandardMaterial(
       { vertexColors: true, roughness: 0.6, metalness: 0.15, side: THREE.DoubleSide }));
     mesh.userData.owned = true;                 // owns its geometry (dispose on clear)
+    g.computeBoundingSphere();     // reach from the file's origin, for _computeBounds
+    const bs = g.boundingSphere;
+    mesh.userData.reach = bs ? bs.center.length() + bs.radius : 0;
     return mesh;
   }
 
+  // The framing bounds. A shape's position is its *base* — the geometry runs from
+  // there to `length` along local +Z, half the other dimensions radially — so the
+  // box takes both ends of the axis and the radius carries the radial half-extent.
   _computeBounds() {
-    const bb = new THREE.Box3(), p = new THREE.Vector3();
-    const rows = this.times ? this.times.length : 0;
+    const bb = new THREE.Box3(), p = new THREE.Vector3(), e = new THREE.Vector3();
+    const d = this.data, rows = this.times ? this.times.length : 0;
+    let pad = 0;
     for (let f = 0; f < rows; f++)
       for (let s = 0; s < this.nshapes; s++) {
+        const mesh = this.meshes[s];
+        if (!mesh) continue;                    // not rendered, so not framed
         const o = (f * this.nshapes + s) * this.stride;
-        bb.expandByPoint(p.set(this.data[o + 10], this.data[o + 11], this.data[o + 12]));
+        const kind = d[o] | 0;
+        const l = Math.abs(d[o + 13]), w = Math.abs(d[o + 14]), h = Math.abs(d[o + 15]);
+        bb.expandByPoint(p.set(d[o + 10], d[o + 11], d[o + 12]));
+        if (kind === KIND.CAD) {
+          // File coordinates, arbitrary shape: a sphere of the mesh's own reach.
+          pad = Math.max(pad, (mesh.userData.reach || 0) * (d[o + 16] ? Math.max(l, w, h) : 1));
+          continue;
+        }
+        // Local +Z in world coordinates is row 3 of the poke matrix (see _applyShape).
+        bb.expandByPoint(e.set(d[o + 7], d[o + 8], d[o + 9]).multiplyScalar(l).add(p));
+        pad = Math.max(pad, kind === KIND.SPHERE ? l / 2
+                          : kind === KIND.BOX || kind === KIND.BEAM ? Math.hypot(w, h) / 2
+                          : w / 2);
       }
     if (bb.isEmpty()) bb.setFromCenterAndSize(new THREE.Vector3(), new THREE.Vector3(1, 1, 1));
-    const size = bb.getSize(new THREE.Vector3());
     bb.getCenter(this.center);
-    this.extents = [size.x, size.y, size.z];
-    this.radius = Math.max(size.length() * 0.5, 0.05);
+    this.radius = Math.max(bb.getSize(e).length() * 0.5 + pad, 0.05);
   }
 
   // Re-apply the current view, re-fitting the distance to the scene.
@@ -154,10 +184,9 @@ export class Animator {
   setView(name) {
     const v = VIEWS[name] || VIEWS[DEFAULT_VIEW];
     this._view = VIEWS[name] ? name : DEFAULT_VIEW;
-    const dir = new THREE.Vector3(...v.dir).normalize();
     const dist = this.radius / Math.tan((this.camera.fov * Math.PI / 180) / 2) * 1.3;
-    this.camera.up.set(...v.up);
-    this.camera.position.copy(this.center).addScaledVector(dir, dist);
+    this._sph.set(dist, v.phi, v.theta);
+    this.camera.position.copy(this.center).add(this._offset.setFromSpherical(this._sph));
     this.camera.near = dist / 100; this.camera.far = dist * 100;
     this.camera.updateProjectionMatrix();
     this.controls.target.copy(this.center);

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/README.md
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/README.md
@@ -64,9 +64,11 @@ launcher gives that one icon a white chip instead of recolouring the artwork.
 
 ## Results
 
-Samples are recorded for every numeric variable that can change, and the run
-writes the usual OpenModelica `.mat` through WASI, which the page offers as a
-download — the same file OMPlot and `omc-diff` read for a simulated model.
+Samples are recorded for every numeric variable that can change. The download
+button in the header writes the usual OpenModelica `.mat` through WASI and hands
+it over — the same file OMPlot and `omc-diff` read for a simulated model. It is
+written when asked for rather than after every run, since serialising the whole
+result is the expensive part and most runs are only ever plotted.
 
 Inputs are expressions in `t` (`sin(2*PI*t)`, `t < 1 ? 0 : 1`) evaluated by the
 driver wherever the solver asks for a value; parameters are constants applied

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/index.html
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/index.html
@@ -15,9 +15,12 @@
 
   /* FMU summary, or the drop target when nothing is loaded yet. */
   .info { padding:2px 12px 12px; }
-  .drop { margin:10px 12px; border:1.5px dashed var(--border); border-radius:8px;
-    padding:28px 16px; text-align:center; color:var(--muted); font-size:14px; }
-  .drop.over { border-color:var(--accent); color:var(--fg); background:#2d2d30; }
+  /* A button, so click and Enter open the file dialog. */
+  .drop { display:block; width:calc(100% - 24px); margin:10px 12px; background:transparent;
+    border:1.5px dashed var(--border); border-radius:8px; cursor:pointer;
+    padding:28px 16px; text-align:center; white-space:normal;
+    color:var(--muted); font:inherit; font-size:14px; }
+  .drop:hover, .drop.over { border-color:var(--accent); color:var(--fg); background:#2d2d30; }
   .drop b { color:var(--fg); font-weight:600; }
   .kv { display:grid; grid-template-columns:auto 1fr; gap:3px 10px; font-size:13.5px; }
   .kv dt { color:var(--muted); }
@@ -26,14 +29,9 @@
     padding:0 5px; margin-right:4px; font-size:12px; color:var(--teal); }
   .tag.off { color:var(--muted); opacity:.55; }
   .grid2 .wide { grid-column:2 / -1; }
-  .grid2 label.chk:not([hidden]) { color:var(--fg); display:flex; align-items:center; gap:7px; white-space:normal; cursor:pointer; font-size:13px; }
-  .grid2 label.chk input { width:auto; margin:0; }
+  /* .chk is shared (theme.css); the settings grid only relaxes its nowrap. */
+  .grid2 label.chk { white-space:normal; font-size:13px; }
   input:disabled { color:var(--muted); }
-  #nativePanel { padding:0 2px 6px; }
-  #nativePanel .chk-group { display:flex; flex-direction:column; gap:6px; margin-bottom:8px; }
-  #nativePanel .chk { display:flex; align-items:center; gap:7px; color:var(--fg); font-size:13px; cursor:pointer; }
-  #nativePanel .chk input { width:auto; margin:0; }
-  #nativePanel .modal-hint { color:var(--muted); font-size:12px; margin:8px 0 0; }
 
   #icPanel { flex:1 1 auto; overflow-y:auto; min-height:80px; }
   .ic-grid { padding:8px 12px 12px; display:grid; grid-template-columns:repeat(auto-fill,minmax(230px,1fr)); gap:7px 18px; }
@@ -85,30 +83,21 @@
   <span class="status" id="status">Open an FMI 3.0 wasm FMU to begin.</span>
   <input type="file" id="file" accept=".fmu,application/zip" hidden />
   <button class="ghost" id="open">Open FMU…</button>
+  <button class="ghost" id="nativeBtn" title="Compile this FMU's component for native platforms and repack it" hidden disabled>Native binaries…</button>
   <button class="ghost" id="figToggle" title="Switch between the FMU's figures and all recorded variables" hidden>All variables</button>
   <button id="run" disabled>Simulate</button>
-  <a class="ghost" id="download" hidden download>Download result</a>
+  <button class="ghost icon-only" id="download" hidden><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12"/><path d="M7 10l5 5 5-5"/><path d="M3 20h18"/></svg></button>
 </header>
 
 <main>
   <div class="left">
     <div class="section-label">FMU</div>
     <div class="info" id="info">
-      <div class="drop" id="drop">
-        <b>Drop an .fmu here</b><br />
+      <button type="button" class="drop" id="drop">
+        <b>Drop an .fmu here, or click to browse</b><br />
         FMI 3.0 Co-Simulation or Model Exchange with a<br />
         <code>binaries/wasm32-wasip2</code> component (FMI-LS-WASM).
-      </div>
-    </div>
-
-    <div class="section-label" id="nativeLabel" hidden>Add native binaries</div>
-    <div id="nativePanel" hidden>
-      <div class="chk-group" id="nativePlatforms"></div>
-      <button class="ghost" id="nativeGo" disabled>Build native FMU</button>
-      <p class="modal-hint">Compiles this FMU's component ahead of time for the
-      platforms you tick and repacks it with the matching FMI 3.0 loader library,
-      so importers that cannot run WebAssembly load it too. Nothing is uploaded —
-      the compiler runs here.</p>
+      </button>
     </div>
 
     <div class="section-label">Inputs, parameters and start values</div>
@@ -151,11 +140,33 @@
   </div>
 </main>
 
+<div class="modal-backdrop" id="nativeBackdrop" hidden>
+  <div class="modal" role="dialog" aria-label="Add native binaries" aria-modal="true">
+    <div class="modal-head">
+      <span>Add native binaries</span>
+      <button class="icon-btn" data-close title="Close" aria-label="Close">✕</button>
+    </div>
+    <div class="modal-body">
+      <label>Platforms</label>
+      <div class="chk-group" id="nativePlatforms"></div>
+      <p class="modal-hint">Compiles this FMU's component ahead of time for the
+      platforms you tick and repacks it with the matching FMI 3.0 loader library,
+      so importers that cannot run WebAssembly load it too. Nothing is uploaded —
+      the compiler runs here.</p>
+    </div>
+    <div class="modal-foot">
+      <button class="ghost" data-close>Cancel</button>
+      <button id="nativeGo" disabled>Build FMU</button>
+    </div>
+  </div>
+</div>
+
 <script type="module">
 import { loadFmu, readResource, findComponent, writeZip } from './fmu.js';
 import { loaderIndex, loaderBytes, compileForPlatform } from '../fmu-aot.js';
 import { Session } from './session.js';
 import { COLORS, createCharts, escapeHtml, unitHTML } from '../plot.js';
+import { bindModal, downloadBlob } from '../ui.js';
 import { AnimView } from '../anim/anim-view.js';
 import { buildAnimData, attachCadMeshes } from '../anim/anim-core.js';
 
@@ -177,7 +188,7 @@ let running = false, cancelled = false, logCount = 0;
 let lastRec = null;     // the most recent simulation record, for re-rendering
 let viewMode = 'auto';  // 'auto' -> figures when the FMU has them, else all vars
 let animView = null;    // shared 3D animation panel, if the FMU carries a <Visualization>
-let downloadUrl = null; // object URL of the last result file
+let resultName = null;  // the last run's result file, or null when there is none
 
 const setStatus = (text, cls = '') => { statusEl.textContent = text; statusEl.className = 'status ' + cls; };
 const num = (v, d) => { const n = parseFloat(v); return isFinite(n) ? n : d; };
@@ -232,6 +243,7 @@ const session = new Session({
 
 // --- loading ----------------------------------------------------------------
 openBtn.onclick = () => fileEl.click();
+dropEl.onclick = () => fileEl.click();     // a real button, so Enter works too
 fileEl.onchange = () => { if (fileEl.files[0]) openFile(fileEl.files[0]); fileEl.value = ''; };
 
 for (const ev of ['dragenter', 'dragover']) {
@@ -245,6 +257,7 @@ document.addEventListener('drop', (e) => { const f = e.dataTransfer.files[0]; if
 async function openFile(file) {
   if (running) return;
   runBtn.disabled = true;
+  hideResultFile();
   setStatus(`Loading ${file.name}…`, 'busy');
   try {
     const buf = await file.arrayBuffer();
@@ -259,11 +272,12 @@ async function openFile(file) {
     renderFields();
     applyDefaults();
     runBtn.disabled = false;
-    nativeGo.disabled = !nativeGroup.querySelector('input:checked');
+    syncNativeDialog();
     setStatus(`${fmu.md.modelName || file.name} loaded in ${ms} ms — the FMU reports FMI ${probe.fmiVersion}.`);
   } catch (e) {
     fmu = null;
     runBtn.disabled = true;
+    syncNativeDialog();
     setStatus(`${file.name}: ${e.message}`, 'err');
     log('host', `load failed: ${e.stack || e.message}`);
   }
@@ -410,6 +424,8 @@ runBtn.onclick = () => {
     session.terminate();
     fmu = null;
     runBtn.disabled = true;
+    hideResultFile();
+    syncNativeDialog();
   }
 };
 
@@ -433,6 +449,7 @@ async function run() {
   if (!(opts.stepSize > 0)) { setStatus('Step size must be positive.', 'err'); return; }
 
   running = true; cancelled = false;
+  hideResultFile();
   runBtn.textContent = 'Cancel'; runBtn.className = 'cancel';
   openBtn.disabled = true;
   setStatus('Simulating…', 'busy');
@@ -442,7 +459,7 @@ async function run() {
     const ms = Math.round(performance.now() - t0);
     renderCharts(rec);
     renderAnimation(rec);
-    await offerResultFile();
+    offerResultFile();
     if (rec.summary.cancelled) {
       setStatus(`Cancelled at t = ${(+rec.time.at(-1).toPrecision(6))} — ${rec.time.length} samples kept.`);
       return;
@@ -489,23 +506,33 @@ function toRecord(result) {
   };
 }
 
-/// Write the result file — through the driver's WASI, like every other
-/// simulation — and offer it for download.
-async function offerResultFile() {
-  const name = `${(fmu.md.modelName || 'result').replace(/[^\w.-]+/g, '_')}_res.mat`;
-  try {
-    const bytes = await session.mat(`/${name}`);
-    if (!bytes) return;
-    if (downloadUrl) URL.revokeObjectURL(downloadUrl);
-    downloadUrl = URL.createObjectURL(new Blob([bytes], { type: 'application/octet-stream' }));
-    downloadEl.href = downloadUrl;
-    downloadEl.download = name;
-    downloadEl.hidden = false;
-    downloadEl.textContent = `Download ${name}`;
-  } catch (e) {
-    log('warning', `the result file could not be written: ${e.message}`);
-  }
+// Written on demand: serialising the whole result is the expensive part.
+function offerResultFile() {
+  resultName = `${(fmu.md.modelName || 'result').replace(/[^\w.-]+/g, '_')}_res.mat`;
+  downloadEl.hidden = false;
+  downloadEl.title = downloadEl.ariaLabel = `Download ${resultName}`;
 }
+
+function hideResultFile() {
+  resultName = null;
+  downloadEl.hidden = true;
+}
+
+downloadEl.onclick = async () => {
+  if (!resultName || downloadEl.disabled) return;
+  downloadEl.disabled = true;
+  try {
+    const bytes = await session.mat(`/${resultName}`);
+    if (!bytes || !bytes.length) throw new Error('the driver wrote no result file');
+    downloadBlob(resultName, bytes);
+    setStatus(`${resultName} — ${bytes.length} bytes.`, 'ok');
+  } catch (e) {
+    setStatus(`The result file could not be written: ${e.message}`, 'err');
+    log('warning', `the result file could not be written: ${e.message}`);
+  } finally {
+    downloadEl.disabled = false;
+  }
+};
 
 // --- charts -----------------------------------------------------------------
 const haveFigures = () => !!(fmu && fmu.md.figures && fmu.md.figures.length);
@@ -635,26 +662,36 @@ const PLATFORM_NAMES = {
   'x86_64-windows': 'Windows x86-64', 'aarch64-windows': 'Windows ARM64',
   'x86_64-darwin': 'macOS x86-64', 'aarch64-darwin': 'macOS ARM64',
 };
-const nativeGo = el('nativeGo'), nativeGroup = el('nativePlatforms');
+const nativeBtn = el('nativeBtn'), nativeGo = el('nativeGo'), nativeGroup = el('nativePlatforms');
 let loaders = [];
+
+const nativeDialog = bindModal(el('nativeBackdrop'));
+nativeBtn.onclick = () => nativeDialog.open();
 
 (async () => {
   loaders = await loaderIndex();
   if (!loaders.length) return;
   nativeGroup.replaceChildren(...loaders.map((e) => {
     const box = Object.assign(document.createElement('input'), { type: 'checkbox', value: e.platform });
-    box.onchange = () => { nativeGo.disabled = !fmu || !nativeGroup.querySelector('input:checked'); };
+    box.onchange = syncNativeDialog;
     const label = Object.assign(document.createElement('label'), { className: 'chk' });
     label.append(box, ' ' + (PLATFORM_NAMES[e.platform] || e.platform));
     return label;
   }));
-  el('nativeLabel').hidden = el('nativePanel').hidden = false;
+  nativeBtn.hidden = false;
+  syncNativeDialog();
 })();
+
+function syncNativeDialog() {
+  nativeBtn.disabled = !fmu;
+  nativeGo.disabled = !fmu || !nativeGroup.querySelector('input:checked');
+}
 
 nativeGo.onclick = async () => {
   const picked = [...nativeGroup.querySelectorAll('input:checked')].map((c) => c.value);
   if (!fmu || !picked.length) return;
-  nativeGo.disabled = true;
+  nativeDialog.close();
+  nativeGo.disabled = nativeBtn.disabled = true;
   const id = (fmu.md.cs || fmu.md.me).modelIdentifier;
   try {
     const component = findComponent(fmu.files, fmu.md);
@@ -669,17 +706,13 @@ nativeGo.onclick = async () => {
       files.set(`resources/${platform}.cwasm`, cwasm);
     }
     const blob = await writeZip(files);
-    const a = Object.assign(document.createElement('a'), {
-      href: URL.createObjectURL(blob), download: `${id}-native.fmu`,
-    });
-    a.click();
-    URL.revokeObjectURL(a.href);
-    setStatus(`${id}-native.fmu — ${picked.join(', ')} (${blob.size} bytes).`);
+    downloadBlob(`${id}-native.fmu`, blob);
+    setStatus(`${id}-native.fmu — ${picked.join(', ')} (${blob.size} bytes).`, 'ok');
   } catch (e) {
     setStatus(`Native build failed: ${e.message}`, 'err');
     log('host', e.stack || e.message);
   } finally {
-    nativeGo.disabled = false;
+    syncNativeDialog();
   }
 };
 

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/index.html
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/index.html
@@ -46,21 +46,9 @@
   .stepper button:last-child { border-radius:0 4px 4px 0; }
   .stepper button:hover { background:#2d2d30; }
 
-  /* Simulation-settings dialog (opened by the cogwheel). */
-  .modal-backdrop { position:fixed; inset:0; z-index:50; display:grid; place-items:center;
-    background:#0008; padding:16px; }
-  .modal-backdrop[hidden] { display:none; }
-  .modal { background:var(--panel); border:1px solid var(--border); border-radius:10px;
-    width:min(460px,100%); box-shadow:0 14px 44px #000a; }
-  .modal-head { display:flex; align-items:center; justify-content:space-between;
-    padding:12px 14px; border-bottom:1px solid var(--border); font-weight:650; color:var(--fg); }
-  .modal-body { padding:14px; display:grid; grid-template-columns:auto 1fr; gap:12px 14px; align-items:center; }
-  .modal-body > label { color:var(--muted); }
-  .modal-body select { background:#1b1b1b; color:var(--fg); border:1px solid var(--border);
-    border-radius:4px; padding:3px 6px; font:inherit; }
-  .modal-body select:disabled { opacity:.5; }
   /* Settings dialog: label above control, two fields per row, so the solver names
-     and the tolerance stepper each get half the dialog instead of competing for it. */
+     and the tolerance stepper each get half the dialog instead of competing for it.
+     The modal frame itself is shared (theme.css). */
   #settingsBackdrop .modal { width:min(520px,100%); }
   .settings { grid-template-columns:repeat(2,minmax(0,1fr)); align-items:end; }
   .settings .fld { display:flex; flex-direction:column; gap:5px; min-width:0; }
@@ -68,12 +56,6 @@
   .settings label { color:var(--muted); font-size:13px; }
   .settings label .flag { font-family:ui-monospace,Menlo,Consolas,monospace; font-size:11.5px; opacity:.65; white-space:nowrap; }
   .settings select { padding:6px 8px; font-size:15px; }
-  .chk-group { display:flex; flex-direction:column; gap:6px; }
-  .chk { display:flex; align-items:center; gap:7px; color:var(--fg); }
-  .chk input { width:auto; }
-  .modal-foot { display:flex; justify-content:flex-end; gap:8px;
-    padding:12px 14px; border-top:1px solid var(--border); }
-  .modal-hint { grid-column:1 / -1; color:var(--muted); font-size:12px; margin:0; }
 
   #icPanel { max-height:34%; overflow-y:auto; }
   /* Auto-fill into as many columns as fit (PID has many parameters to tune). */
@@ -132,6 +114,7 @@
   </button>
   <button id="exportFmu" class="ghost" disabled title="Export an FMI 3.0 wasm FMU of the active model">Export FMU</button>
   <button id="run" disabled>Run</button>
+  <button id="downloadRes" class="ghost icon-only" hidden><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12"/><path d="M7 10l5 5 5-5"/><path d="M3 20h18"/></svg></button>
 </header>
 
 <main>
@@ -171,7 +154,7 @@
   <div class="modal" role="dialog" aria-label="Simulation settings" aria-modal="true">
     <div class="modal-head">
       <span>Simulation settings</span>
-      <button class="icon-btn" id="settingsClose" title="Close" aria-label="Close">✕</button>
+      <button class="icon-btn" data-close title="Close" aria-label="Close">✕</button>
     </div>
     <div class="modal-body settings">
       <div class="fld"><label for="stop">Stop time</label>
@@ -205,7 +188,7 @@
   <div class="modal" role="dialog" aria-label="Export FMU" aria-modal="true">
     <div class="modal-head">
       <span>Export FMU</span>
-      <button class="icon-btn" id="exportClose" title="Close" aria-label="Close">✕</button>
+      <button class="icon-btn" data-close title="Close" aria-label="Close">✕</button>
     </div>
     <div class="modal-body">
       <label>Interfaces</label>
@@ -221,7 +204,7 @@
       <p class="modal-hint" id="csOnlyHint" hidden>Co-Simulation on its own is translated separately, so that export takes as long as a compile: it needs the output derivatives <code>fmi3GetOutputDerivatives</code> answers from, which only a pure Co-Simulation translation carries.</p>
     </div>
     <div class="modal-foot">
-      <button class="ghost" id="exportCancel">Cancel</button>
+      <button class="ghost" data-close>Cancel</button>
       <button id="exportGo">Export</button>
     </div>
   </div>
@@ -231,6 +214,7 @@
 import { AnimView } from '../anim/anim-view.js';
 import { COLORS, createCharts, escapeHtml, unitHTML } from '../plot.js';
 import { attachFmuAot } from '../fmu-aot.js';
+import { bindModal, downloadBlob } from '../ui.js';
 // The omc compiler runs in Web Workers (omc-worker.js), not on this thread, so
 // compile/simulate never freezes the UI. Two are spawned: a plain one that is
 // ready fast, and a second that installs the MSL in the background and takes
@@ -258,7 +242,7 @@ const chartsEl = el('charts'), chartsEmpty = el('chartsEmpty');
 const charts = createCharts(chartsEl);
 const icGrid = el('icGrid'), icEmpty = el('icEmpty'), tolEl = el('tol'), toggleBtn = el('viewToggle');
 const exSel = el('examples'), docBody = el('docBody');
-const settingsBtn = el('settingsBtn'), settingsBackdrop = el('settingsBackdrop'), settingsClose = el('settingsClose');
+const settingsBtn = el('settingsBtn'), downloadResBtn = el('downloadRes');
 const rightEl = el('right');
 
 // Documentation collapse/expand, driven from inside the widget: a chevron in the
@@ -391,15 +375,24 @@ function promote() {
   log('promoted MSL worker to primary');
   retireW1();
 }
-function retireW1() {
+async function retireW1() {
   // Not while a job is on it: terminating a worker mid-call leaves the page
   // waiting on a reply that can never come. An export holds w1 through
   // activeExportWorker rather than jobWorker, and retires it when it finishes.
-  if (primaryWorker !== w1 && w1 && jobWorker !== w1 && activeExportWorker !== w1) {
-    log('terminating w1');
-    if (builtWorker === w1) { builtModel = null; builtWorker = null; }   // its model is gone → next run rebuilds
-    w1.terminate(); w1 = null;
+  if (primaryWorker === w1 || !w1 || jobWorker === w1 || activeExportWorker === w1) return;
+  const dying = w1, model = builtModel;
+  // The result file lives in this worker, but the plot the user is looking at
+  // outlives it — so copy the file out first.
+  if (builtWorker === dying && resultReady && !resultCache) {
+    const got = await fetchResultFile(dying, model).catch(() => null);
+    // A run started while that was in flight: its result replaces this one.
+    if (got && resultReady && builtWorker === dying) resultCache = got;
   }
+  if (w1 !== dying || jobWorker === dying || activeExportWorker === dying) return;   // raced
+  log('terminating w1');
+  if (builtWorker === dying) { builtModel = null; builtWorker = null; }   // its model is gone → next run rebuilds
+  dying.terminate(); w1 = null;
+  syncResultDownload();
 }
 
 // A user model needs the MSL if it is a library copy, imports/extends Modelica,
@@ -448,6 +441,8 @@ let copyName = null;          // top-level name of the current library copy (cop
 let preloaded = null;         // a class already loaded by copyClass (skip the first redundant loadSource)
 let freshModel = true;        // true until a model's own experiment settings have been read back from a run
 let animView = null;          // the shared 3D animation panel (lazily created on first use)
+let resultReady = false;      // the built worker's VFS holds a complete `<model>_res.mat`
+let resultCache = null;       // { name, bytes } — kept when the worker holding it had to go
 
 // Only the parameters the user actually edited. Sending the whole grid back would
 // re-seed every start value from the last run's row 0, and the flag string is
@@ -541,6 +536,7 @@ async function run(kind) {                       // 'full' | 'resim'
     return;
   }
   running = true; runningKind = kind; setRunUI(true);
+  resultReady = false; resultCache = null; syncResultDownload();
   const tRun = beginOp(kind === 'resim' ? 'Re-simulation failed' : 'Simulation failed');
   let runMs = 0;
   log('run', kind, 'mode', mode);
@@ -596,6 +592,7 @@ async function run(kind) {                       // 'full' | 'resim'
     if (kind !== 'resim' && snap.options) { seedFromOptions(snap.options); freshModel = false; }
     if (kind !== 'resim') buildInitialConditions();   // docs already rendered pre-simulation
     renderCharts();
+    resultReady = true; syncResultDownload();
     await fetchAnim(builtWorker);      // 3D scene, if the model enabled -d=visxml
     const figNote = (modelFigures && modelFigures.length && viewMode !== 'all') ? ' · figures' : '';
     const drv = DRIVER_MODE !== null ? ` (${DRIVER_MODE ? 'in-wasm' : 'host'} driver)` : '';
@@ -620,6 +617,34 @@ async function run(kind) {                       // 'full' | 'resim'
     if (pendingKind) { const k = pendingKind; pendingKind = null; run(k); }
   }
 }
+
+// Read back on demand from the worker, or from retireW1's copy once that worker is
+// gone. Offered only for a run that finished: a failed one leaves a truncated file.
+function syncResultDownload() {
+  const name = resultCache ? resultCache.name
+             : (resultReady && builtModel && builtWorker) ? `${builtModel}_res.mat` : null;
+  downloadResBtn.hidden = !name;
+  if (name) downloadResBtn.title = downloadResBtn.ariaLabel = `Download ${name}`;
+}
+
+async function fetchResultFile(worker, model) {
+  if (!worker || !model) return null;
+  const r = await call(worker, 'resultFile', { name: model });
+  if (!r.ok) throw new Error(r.error);
+  return { name: r.filename, bytes: r.bytes };
+}
+
+downloadResBtn.addEventListener('click', async () => {
+  if (downloadResBtn.disabled) return;
+  downloadResBtn.disabled = true;
+  try {
+    const r = resultCache || await fetchResultFile(builtWorker, builtModel);
+    if (!r) return;
+    downloadBlob(r.name, r.bytes);
+    setStatus(`${r.name} — ${r.bytes.length} bytes.`);
+  } catch (e) { setStatus('' + e, 'err'); }
+  finally { downloadResBtn.disabled = false; }
+});
 
 // Run ↔ Cancel: while a job is running the button turns into a red Cancel.
 function setRunUI(busy) {
@@ -655,6 +680,7 @@ async function selectExample(ex) {
   beginOp('Loading the example failed');
   currentExample = ex;
   builtModel = null; builtWorker = null; lastText = null; preloaded = null; freshModel = true;
+  snap = null; resultReady = false; resultCache = null; syncResultDownload();
   showBuilding();
   if (ex.library) {
     // A genuine editable copy via copyClass: a self-contained top-level class with
@@ -922,12 +948,8 @@ function setChartsCursor(t) {
 }
 
 // --- settings dialog --------------------------------------------------------
-function openSettings() { settingsBackdrop.hidden = false; }
-function closeSettings() { settingsBackdrop.hidden = true; }
-settingsBtn.addEventListener('click', openSettings);
-settingsClose.addEventListener('click', closeSettings);
-settingsBackdrop.addEventListener('click', (e) => { if (e.target === settingsBackdrop) closeSettings(); });
-window.addEventListener('keydown', (e) => { if (e.key === 'Escape' && !settingsBackdrop.hidden) closeSettings(); });
+const settingsDialog = bindModal(el('settingsBackdrop'));
+settingsBtn.addEventListener('click', () => settingsDialog.open());
 
 // --- wiring -----------------------------------------------------------------
 let debounce;
@@ -946,12 +968,6 @@ tolEl.addEventListener('change', () => { const v = parseFloat(tolEl.value); if (
 runBtn.addEventListener('click', () => { if (running) cancelRun(); else run('full'); });
 
 const exportBtn = el('exportFmu');
-function downloadBlob(name, bytes) {
-  const url = URL.createObjectURL(new Blob([bytes], { type: 'application/octet-stream' }));
-  const a = document.createElement('a');
-  a.href = url; a.download = name; document.body.appendChild(a); a.click(); a.remove();
-  setTimeout(() => URL.revokeObjectURL(url), 2000);
-}
 let exporting = false;
 async function exportFmu({ fmuType, method, platforms }) {
   if (running || exporting) return;
@@ -994,21 +1010,18 @@ function syncExportDialog() {
   csSolver.disabled = !fmiCs.checked;
   el('exportGo').disabled = !(fmiMe.checked || fmiCs.checked);
 }
-function openExport() { if (!exportBtn.disabled) { syncExportDialog(); exportBackdrop.hidden = false; } }
-function closeExport() { exportBackdrop.hidden = true; }
+const exportDialog = bindModal(exportBackdrop, {
+  onOpen: () => { if (exportBtn.disabled) return false; syncExportDialog(); },
+});
 fmiCs.addEventListener('change', syncExportDialog);
 fmiMe.addEventListener('change', syncExportDialog);
 // While exporting the button cancels; otherwise it opens the dialog.
-exportBtn.addEventListener('click', () => { if (exporting) requestExportCancel(); else openExport(); });
-el('exportClose').addEventListener('click', closeExport);
-el('exportCancel').addEventListener('click', closeExport);
-exportBackdrop.addEventListener('click', (e) => { if (e.target === exportBackdrop) closeExport(); });
-window.addEventListener('keydown', (e) => { if (e.key === 'Escape' && !exportBackdrop.hidden) closeExport(); });
+exportBtn.addEventListener('click', () => { if (exporting) requestExportCancel(); else exportDialog.open(); });
 el('exportGo').addEventListener('click', () => {
   const fmuType = fmiMe.checked && fmiCs.checked ? 'me_cs' : (fmiCs.checked ? 'cs' : 'me');
   const method = fmiCs.checked ? csSolver.value : undefined;
   const platforms = [...el('fmuPlatforms').querySelectorAll('input:checked')].map((c) => c.value);
-  closeExport();
+  exportDialog.close();
   exportFmu({ fmuType, method, platforms });
 });
 toggleBtn.addEventListener('click', () => { viewMode = (viewMode === 'all') ? 'auto' : 'all'; renderCharts();

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/omc-worker.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/omc-worker.js
@@ -473,6 +473,19 @@ self.onmessage = async (ev) => {
         reply({ ok: true, filename: (a.name || 'model') + '.fmu', bytes: buf }, [buf.buffer]);
         break;
       }
+      case 'resultFile': {
+        // runResumable already wrote it, so this is a read, not a re-simulation.
+        const info = omc_sim_info();
+        const model = (info && info.model) || a.name;
+        if (!model) return reply({ ok: false, error: 'no simulation has been run' });
+        const file = model + '_res.mat';
+        const bytes = wasiReadFile(file);
+        if (!bytes || !bytes.length) return reply({ ok: false, error: 'no result file at ' + file });
+        // Copy out of wasm memory before transferring (wasiReadFile may view it).
+        const buf = bytes.slice();
+        reply({ ok: true, filename: file, bytes: buf }, [buf.buffer]);
+        break;
+      }
       case 'eval':
         reply(await evalWithDownloads(a.src, status));
         break;

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/theme.css
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/theme.css
@@ -25,6 +25,11 @@ header .status { color:var(--muted); flex:1; min-width:0; overflow:hidden;
 header .status.err { color:var(--err); }
 header .status.busy { color:var(--accent); }
 header .status.ok { color:var(--teal); }
+/* One height for every header control: a text button is otherwise sized by its line
+   box (so it scales with its own font-size) and an icon button by its svg. Horizontal
+   padding stays per-class; the flex centring places the content in the fixed box. */
+header button { height:34px; display:inline-flex; align-items:center; justify-content:center; }
+header button[hidden] { display:none; }
 
 /* The plain-button look. :hover stays at one class of specificity (the disabled
    rule below it wins by order, not by :not) so a page whose controls are
@@ -40,10 +45,33 @@ button.cancel:hover:not(:disabled){ background:#c42b0e; }
 button.ghost { background:transparent; border:1px solid var(--border); color:var(--fg); padding:6px 12px; font-size:13px; }
 button.ghost:hover:not(:disabled){ background:#2d2d30; }
 button.ghost.icon-only { padding:6px 9px; display:inline-flex; align-items:center; }
+button.ghost.icon-only[hidden] { display:none; }
 button.ghost.icon-only svg { width:16px; height:16px; display:block; }
 .icon-btn { background:transparent; border:0; color:var(--muted); font-size:17px; line-height:1;
   cursor:pointer; padding:4px 8px; }
 .icon-btn:hover { color:var(--fg); }
+
+/* Modal dialog: a centred card over a dimmed page, used for the settings and
+   export/native-build dialogs. A page adds its own width/body layout on top. */
+.modal-backdrop { position:fixed; inset:0; z-index:50; display:grid; place-items:center;
+  background:#0008; padding:16px; }
+.modal-backdrop[hidden] { display:none; }
+.modal { background:var(--panel); border:1px solid var(--border); border-radius:10px;
+  width:min(460px,100%); box-shadow:0 14px 44px #000a; }
+.modal-head { display:flex; align-items:center; justify-content:space-between;
+  padding:12px 14px; border-bottom:1px solid var(--border); font-weight:650; color:var(--fg); }
+.modal-body { padding:14px; display:grid; grid-template-columns:auto 1fr; gap:12px 14px; align-items:center; }
+.modal-body > label { color:var(--muted); }
+.modal-body select { background:#1b1b1b; color:var(--fg); border:1px solid var(--border);
+  border-radius:4px; padding:3px 6px; font:inherit; }
+.modal-body select:disabled { opacity:.5; }
+.modal-foot { display:flex; justify-content:flex-end; gap:8px;
+  padding:12px 14px; border-top:1px solid var(--border); }
+.modal-hint { grid-column:1 / -1; color:var(--muted); font-size:12px; margin:0; }
+.chk-group { display:flex; flex-direction:column; gap:6px; }
+.chk { display:flex; align-items:center; gap:7px; color:var(--fg); cursor:pointer; }
+.chk[hidden] { display:none; }              /* [hidden] is a UA rule, which display:flex would beat */
+.chk input { width:auto; margin:0; }
 
 .section-label { font-size:11px; text-transform:uppercase; letter-spacing:.06em;
   color:var(--muted); padding:9px 12px 4px; flex:0 0 auto; }

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/ui.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/ui.js
@@ -1,0 +1,31 @@
+// Small DOM helpers shared by the web clients.
+
+// Hand `bytes` to the browser as a download named `name`. The object URL is
+// revoked once the browser has had time to start the save.
+export function downloadBlob(name, bytes) {
+  const url = URL.createObjectURL(new Blob([bytes], { type: 'application/octet-stream' }));
+  const a = Object.assign(document.createElement('a'), { href: url, download: name });
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 2000);
+}
+
+// Wire a `.modal-backdrop`: anything inside it marked `data-close` (the ✕ and
+// Cancel), a click on the backdrop itself and Escape all dismiss the dialog.
+// `onOpen` may return false to refuse to open.
+export function bindModal(backdrop, { onOpen = null, onClose = null } = {}) {
+  const close = () => {
+    if (backdrop.hidden) return;
+    backdrop.hidden = true;
+    if (onClose) onClose();
+  };
+  const open = () => {
+    if (onOpen && onOpen() === false) return;
+    backdrop.hidden = false;
+  };
+  for (const b of backdrop.querySelectorAll('[data-close]')) b.addEventListener('click', close);
+  backdrop.addEventListener('click', (e) => { if (e.target === backdrop) close(); });
+  window.addEventListener('keydown', (e) => { if (e.key === 'Escape') close(); });
+  return { open, close, get isOpen() { return !backdrop.hidden; } };
+}


### PR DESCRIPTION
fmi-simulator: "Add native binaries" moves out of the sidebar into a `Native binaries…` button beside `Open FMU…`, which opens a dialog holding the platform ticks. The result download becomes an icon button whose hover text names the file, and the `.mat` is written when asked for rather than after every run — serialising the whole result was being paid even for runs that were only ever plotted. The drop target is a real button, so clicking it or pressing Enter opens the file dialog.

simulator: the same download button, backed by a new `resultFile` worker command. The run already wrote `<model>_res.mat` into the VFS, so this is a read, not a re-simulation (0.3 ms for 109 kB). It survives the MSL worker being promoted: the file lives in the worker that ran the model, so `retireW1` copies it out before terminating that worker, and the download stays available for as long as the plot on screen.

Header controls now share one height. A text button was otherwise sized by its line box, which scales with its own font-size, and an icon button by its svg — so ghost/primary/icon came out 33.5/36.5/30px tall.

3D animation: rotation was dead in every view but one. OrbitControls reads its orbit axis from `camera.up` once, in its constructor, where the camera was Z-up; the view presets then set a Y-up camera, putting the default Side view exactly on the orbit pole, where azimuth is a no-op and the polar angle only moves one way. The presets are now the spherical angles OrbitControls itself works in, about a fixed +Y axis — MultiBody's default gravity axis, and the up of OMEdit's side view — with the polar angle clamped clear of both poles. The camera directions and screen orientations they produce are unchanged.

The framing bounds summed only shape positions, so a scene such as a lone rod got its radius clamped to the 0.05 floor and the camera started inside the geometry. The box now takes both ends of each shape's axis and the radius carries the radial half-extent.

Shared: the modal frame, `.chk`/`.chk-group` and a new `ui.js` (`downloadBlob`, `bindModal`) move out of the two pages, replacing three copies of the ✕/backdrop/Escape wiring. An author `display:flex` beats the UA's `[hidden]` rule, so each shared class that sets `display` needs an explicit `[hidden] { display:none }`.

New `wasm/` page assets have to be listed in `.cmake/rust_src_files.txt` as well as the web target's dependency and copy commands, or the bundle fails to assemble.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
