### PR TITLE
Export a Co-Simulation FMU in DAE mode

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -5292,12 +5292,13 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
         types.ty().function([we::ValType::I32], [we::ValType::I32]);
         Some((residual_type, load_type, strict_type))
     };
-    // `evaluateDAEResiduals(SimData*, stage)`: (i32,i32) -> (), for a DAE-mode model.
-    let dae_fn_type = (!dae_eqs.is_empty()).then(|| {
+    // `evaluateDAEResiduals(SimData*, stage)`: (i32,i32) -> (). Emitted (empty for an
+    // explicit-ODE model) either way, so the shared FMI adapter can import it.
+    let dae_fn_type = {
         let ti = types.len();
         types.ty().function([we::ValType::I32, we::ValType::I32], []);
         ti
-    });
+    };
     // `functionUpdateSynchronous`/`functionEquationsSynchronous`: (i32,i32) -> ().
     let sync_fn_type = {
         let ti = types.len();
@@ -5914,15 +5915,12 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
         });
         idx
     };
-    // Emitted only for a DAE-mode model: its absence is how the standalone export and
-    // the FMU adapters know the model is an explicit ODE.
-    let dae_residuals_idx = match dae_fn_type {
-        None => None,
-        Some(ty) => {
-            let idx = import_base + bodies.len() as u32;
-            splits.push(build_split_fn("evaluateDAEResiduals", &dae_units(&dae_eqs), 2, ty, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks)?);
-            Some(idx)
-        }
+    // `layout.dae_mode()`, not this function's presence, is what tells a driver
+    // which form the model is in.
+    let dae_residuals_idx = {
+        let idx = import_base + bodies.len() as u32;
+        splits.push(build_split_fn("evaluateDAEResiduals", &dae_units(&dae_eqs), 2, dae_fn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks)?);
+        idx
     };
     // C's `symbolicInlineSystem`. Emitted (empty without `--symSolver`) either way,
     // so every module's entry points sit at the same indices.
@@ -6019,9 +6017,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     functions.function(sync_fn_type); // functionUpdateSynchronous: (i32, i32) -> ()
     functions.function(sync_fn_type); // functionEquationsSynchronous: (i32, i32) -> ()
     functions.function(eqfn_type); // functionRemovedInitialEquations: (i32) -> ()
-    if let Some(ti) = dae_fn_type {
-        functions.function(ti); // evaluateDAEResiduals: (i32, i32) -> ()
-    }
+    functions.function(dae_fn_type); // evaluateDAEResiduals: (i32, i32) -> ()
     functions.function(eqfn_type); // symbolicInlineSystem: (i32) -> ()
     if recon_dae_idx.is_some() {
         functions.function(eqfn_type); // functionDAE: (i32) -> ()
@@ -6214,9 +6210,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     exports.export("functionInitSynchronous", we::ExportKind::Func, sync_init);
     exports.export("functionUpdateSynchronous", we::ExportKind::Func, sync_update);
     exports.export("functionEquationsSynchronous", we::ExportKind::Func, sync_eqs);
-    if let Some(idx) = dae_residuals_idx {
-        exports.export("evaluateDAEResiduals", we::ExportKind::Func, idx);
-    }
+    exports.export("evaluateDAEResiduals", we::ExportKind::Func, dae_residuals_idx);
     exports.export("symbolicInlineSystem", we::ExportKind::Func, sym_inline_idx);
     if error_tag_type.is_some() {
         for (k, (name, _)) in guarded.iter().enumerate() {
@@ -6295,9 +6289,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
     names.push((sync_init, "functionInitSynchronous".to_string()));
     names.push((sync_update, "functionUpdateSynchronous".to_string()));
     names.push((sync_eqs, "functionEquationsSynchronous".to_string()));
-    if let Some(idx) = dae_residuals_idx {
-        names.push((idx, "evaluateDAEResiduals".to_string()));
-    }
+    names.push((dae_residuals_idx, "evaluateDAEResiduals".to_string()));
     names.push((sym_inline_idx, "symbolicInlineSystem".to_string()));
     for s in &splits {
         for k in 0..s.count {
@@ -10750,22 +10742,17 @@ mod link_tests {
         // emitter always exports them, so the stub must too or the merge leaves
         // unresolved `model.*` imports. Taken from the canonical list rather than
         // copied, so adding an entry point cannot leave this stub behind.
-        // `evaluateDAEResiduals` is left out with `simulate`: the standalone runtime
-        // imports neither with this shape (the DAE residual takes two arguments and
-        // only a `--daeMode` model has one).
+        // `simulate` aside, the entry points that are not `fn(SimData*)`.
         let two_arg = [
             openmodelica_sim_meta::driver::MODEL_FN_UPDATE_SYNC,
             openmodelica_sim_meta::driver::MODEL_FN_EQS_SYNC,
             openmodelica_sim_meta::driver::MODEL_FN_ZC,
+            openmodelica_sim_meta::driver::MODEL_FN_DAE,
         ];
         let one_arg: Vec<&str> = openmodelica_sim_meta::driver::MODEL_FNS
             .iter()
             .copied()
-            .filter(|n| {
-                *n != "simulate"
-                    && *n != openmodelica_sim_meta::driver::MODEL_FN_DAE
-                    && !two_arg.contains(n)
-            })
+            .filter(|n| *n != "simulate" && !two_arg.contains(n))
             .collect();
 
         let mut funcs = we::FunctionSection::new();

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/Cargo.lock
@@ -561,6 +561,7 @@ dependencies = [
  "libm",
  "minpack",
  "openmodelica_lapack",
+ "openmodelica_mat_writer",
  "openmodelica_sim_meta",
 ]
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -44,6 +44,8 @@ unsafe extern "C" {
     fn functionZeroCrossings(sim_data: u32, gout: u32);
     fn functionUpdateSynchronous(sim_data: u32, base_idx: u32);
     fn functionEquationsSynchronous(sim_data: u32, idx: u32);
+    // `--daeMode`'s residual, exported (empty) by every model so this resolves.
+    fn evaluateDAEResiduals(sim_data: u32, eval_stage: u32);
     fn om_meta_ptr() -> u32;
     fn om_meta_len() -> u32;
 }
@@ -426,9 +428,8 @@ impl SimEngine for Engine {
                 driver::MODEL_FN_ZC => functionZeroCrossings(a, b),
                 driver::MODEL_FN_UPDATE_SYNC => functionUpdateSynchronous(a, b),
                 driver::MODEL_FN_EQS_SYNC => functionEquationsSynchronous(a, b),
-                // Importing `evaluateDAEResiduals` would leave every non-DAE model
-                // with an unresolved `model.*` import.
-                _ => return Err("fmi3-me: --daeMode models cannot be exported as an FMU"),
+                driver::MODEL_FN_DAE => evaluateDAEResiduals(a, b),
+                _ => return Err(UNKNOWN_MODEL_FN),
             }
         }
         Ok(())

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -4434,10 +4434,23 @@ algorithm
     FMUType := "me";
   end if;
   if Flags.getConfigBool(Flags.DAE_MODE) then
-    success := false;
-    outValue := Values.STRING("");
-    Error.addMessage(Error.FMU_EXPORT_DAE_MODE_NOT_SUPPORTED, {});
-    return;
+    // Model Exchange has to answer with state derivatives, which a DAE-mode model
+    // has none of. Co-Simulation integrates the model itself, and of the two
+    // runtimes that do so only the wasm one handles the residual form.
+    if isWasmFMU and FMUType == "me_cs" then
+      Error.addMessage(Error.FMU_EXPORT_DAE_MODE_ME_DROPPED, {});
+      FMUType := "cs";
+    elseif FMI.isFMIMEType(FMUType) then
+      success := false;
+      outValue := Values.STRING("");
+      Error.addMessage(Error.FMU_EXPORT_DAE_MODE_ME, {FMUType});
+      return;
+    elseif not isWasmFMU then
+      success := false;
+      outValue := Values.STRING("");
+      Error.addMessage(Error.FMU_EXPORT_DAE_MODE_C_CS, {});
+      return;
+    end if;
   end if;
 
   // NOTE: The FMUs use fileNamePrefix for the internal name when it would be expected to be fileNamePrefix that decides the .fmu filename
@@ -4833,9 +4846,20 @@ algorithm
     FMUType := "me";
   end if;
   if Flags.getConfigBool(Flags.DAE_MODE) then
-    outValue := Values.STRING("");
-    Error.addMessage(Error.FMU_EXPORT_DAE_MODE_NOT_SUPPORTED, {});
-    return;
+    // As in callTranslateModelFMU, which has to make the same choice: the
+    // `fmuTranslationFor` lookup below is keyed on the interface.
+    if isWasmFMU and FMUType == "me_cs" then
+      Error.addMessage(Error.FMU_EXPORT_DAE_MODE_ME_DROPPED, {});
+      FMUType := "cs";
+    elseif FMI.isFMIMEType(FMUType) then
+      outValue := Values.STRING("");
+      Error.addMessage(Error.FMU_EXPORT_DAE_MODE_ME, {FMUType});
+      return;
+    elseif not isWasmFMU then
+      outValue := Values.STRING("");
+      Error.addMessage(Error.FMU_EXPORT_DAE_MODE_C_CS, {});
+      return;
+    end if;
   end if;
 
   // NOTE: The FMUs use fileNamePrefix for the internal name when it would be expected to be fileNamePrefix that decides the .fmu filename

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -1341,10 +1341,14 @@ public constant ErrorTypes.Message DUPLICATE_VARIABLE_ERROR = ErrorTypes.MESSAGE
   "Duplicate elements:\n %s.");
 public constant ErrorTypes.Message ENCRYPTION_NOT_SUPPORTED = ErrorTypes.MESSAGE(7026, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   "File not Found: %s. Compile OpenModelica with Encryption support.");
-public constant ErrorTypes.Message FMU_EXPORT_DAE_MODE_NOT_SUPPORTED = ErrorTypes.MESSAGE(7027, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
-  "DAE mode (--daeMode) is not supported for FMU export. Please remove the --daeMode flag.");
+public constant ErrorTypes.Message FMU_EXPORT_DAE_MODE_ME = ErrorTypes.MESSAGE(7027, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
+  "DAE mode (--daeMode) is not supported for FMI Model Exchange export (fmuType=\"%s\"), which requires the state derivatives a DAE-mode model does not have. Export a Co-Simulation FMU instead, or remove the --daeMode flag.");
 public constant ErrorTypes.Message USER_CANCELLED = ErrorTypes.MESSAGE(7028, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   "Operation cancelled by user.");
+public constant ErrorTypes.Message FMU_EXPORT_DAE_MODE_ME_DROPPED = ErrorTypes.MESSAGE(7031, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
+  "DAE mode (--daeMode) has no Model Exchange interface, which would require the state derivatives a DAE-mode model does not have. Exporting Co-Simulation only.");
+public constant ErrorTypes.Message FMU_EXPORT_DAE_MODE_C_CS = ErrorTypes.MESSAGE(7030, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
+  "DAE mode (--daeMode) is not supported by the C simulation runtime, so it cannot build a Co-Simulation FMU either. Export with platforms={\"wasm\"}, whose runtime does support it, or remove the --daeMode flag.");
 public constant ErrorTypes.Message FMU_EXPORT_WASM_FMI1 = ErrorTypes.MESSAGE(7029, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   "The wasm FMU export does not serve the deprecated FMI 1.0. Ask for version=\"2.0\" or version=\"3.0\", or drop \"wasm\" from platforms to export a C FMU.");
 

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/dae_fmu_export_error.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/dae_fmu_export_error.mos
@@ -13,12 +13,20 @@ annotation(__OpenModelica_commandLineOptions = \"--daeMode\");
 end DaeModeModel;
 "); getErrorString();
 
+// Model Exchange needs the state derivatives a DAE-mode model does not have.
 buildModelFMU(DaeModeModel, version = "2.0", fmuType = "me"); getErrorString();
+
+// Co-Simulation integrates the model itself, but the C runtime cannot do it in
+// DAE mode either; only platforms={"wasm"} can.
+buildModelFMU(DaeModeModel, version = "2.0", fmuType = "cs"); getErrorString();
 
 // Result:
 // true
 // ""
 // ""
-// "Error: DAE mode (--daeMode) is not supported for FMU export. Please remove the --daeMode flag.
+// "Error: DAE mode (--daeMode) is not supported for FMI Model Exchange export (fmuType=\"me\"), which requires the state derivatives a DAE-mode model does not have. Export a Co-Simulation FMU instead, or remove the --daeMode flag.
+// "
+// ""
+// "Error: DAE mode (--daeMode) is not supported by the C simulation runtime, so it cannot build a Co-Simulation FMU either. Export with platforms={\"wasm\"}, whose runtime does support it, or remove the --daeMode flag.
 // "
 // endResult


### PR DESCRIPTION
#15227 rejected FMU export outright under --daeMode, to replace a C compilation failure with a clear diagnostic. Its reasoning - FMI is based on an ODE formulation - holds only for Model Exchange, which has to answer fmi3GetContinuousStateDerivatives with state derivatives a DAE-mode model does not have. Co-Simulation integrates the model itself behind fmi3DoStep; nothing DAE-specific crosses the interface.

So the check now asks what is actually out of reach:

| fmuType | C target | wasm target |
|---|---|---|
| me | error | error |
| cs | error (C runtime) | exported |
| me_cs | error | warning, exported as cs |

Downgrading me_cs rather than refusing it keeps the one artifact that serves plain simulation, ME and CS usable for the two faces that still work. Both callTranslateModelFMU and callBuildModelFMU make the same choice, because the fmuTranslationFor lookup that reuses a kept translation is keyed on the interface.

The wasm runtime already ran DAE mode: openmodelica_sim_meta's driver routes every stage through evaluateDAEResiduals under layout.dae_mode(), and the Co-Simulation driver is in that same crate. Only the adapter was in the way - being compiled once and shared across models, it could not import a function that only DAE-mode models export. Every model kernel now exports evaluateDAEResiduals, empty for an explicit ODE, as symbolicInlineSystem is already emitted either way.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
