### PR TITLE
Causalize only public connectors for FMU export

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -2597,8 +2597,9 @@ protected
   ComponentRef fc;
 algorithm
   // crefs of all flow connector members (to tell a generated zero-flow equation
-  // apart from a genuine `x = 0` model equation)
-  flowCrefs := list(v.name for v guard Variable.isFlow(v) in flatModel.variables);
+  // apart from a genuine `x = 0` model equation). Only public ones: a protected
+  // connector is an internal wiring node, not an FMU boundary.
+  flowCrefs := list(v.name for v guard Variable.isFlow(v) and Variable.isPublic(v) in flatModel.variables);
   if listEmpty(flowCrefs) then return; end if;
 
   // collect and drop the `flow = 0` equations of unconnected flows.

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/Makefile
@@ -12,6 +12,7 @@ fmi3_arrays_start_vector.mos \
 fmi3_attributes_01.mos \
 fmi3_binary_extobj.mos \
 fmi3_builddescription.mos \
+fmi3_causalize_protected.mos \
 fmi3_clocks.mos \
 fmi3_directional_derivatives.mos \
 fmi3_fmustate.mos \

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_causalize_protected.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_causalize_protected.mos
@@ -1,0 +1,22 @@
+// name: fmi3_causalize_protected.mos
+// keywords: FMI 3.0 export flange causalization protected connector
+// status: correct
+// teardown_command: rm -rf CauerLowPassOPV.fmutmp/ CauerLowPassOPV.log CauerLowPassOPV_*
+//
+// FMI 3.0 flange causalization (issue #15686) exposes an unconnected acausal
+// connector as a causal FMU boundary, dropping its `flow = 0` equation. Only a
+// *public* connector is a boundary: CauerLowPassOPV wires its op-amps together
+// through 19 protected pins, and causalizing those dropped 19 equations without
+// giving the backend a known input in return ("Too few equations,
+// under-determined system. The model has 221 equation(s) and 240 variable(s)").
+
+loadModel(Modelica, {"4.1.0"}); getErrorString();
+
+translateModelFMU(Modelica.Electrical.Analog.Examples.CauerLowPassOPV, version="3.0", fmuType="me"); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// endResult


### PR DESCRIPTION
FMI 3.0 flange causalization (#15686) exposes an unconnected acausal connector as a causal FMU boundary: the flow becomes an input, the potential an output, and the generated `flow = 0` equation is dropped.

It applied to every connector, protected ones included. A protected connector is an internal wiring node, not a boundary, and reclassifying one does not give the backend a known input in return - so the equation went and the unknown stayed. `Modelica.Electrical.Analog.Examples. CauerLowPassOPV` wires its five op-amps together through 19 protected pins and has been failing to export since:

    Error: Too few equations, under-determined system.
    The model has 221 equation(s) and 240 variable(s).

Not wasm-specific: `translateModelFMU(version="3.0", fmuType="me")` fails the same way for the C target.

`generateTopLevelIOs`, which exposes local IOs, already required `Visibility.PUBLIC` for the same reason.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
