### PR TITLE
wasm FMU: declare system libraries, do not pack

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -1734,6 +1734,9 @@ pub(crate) struct ExtLibraries {
     pub wasm: Vec<ExtLibrary>,
     /// In link order, for a native host to fall back to.
     pub native: Vec<String>,
+    /// The system libraries among them: named by soname, with no file behind them
+    /// that an export could ship. Also in `native`, which only ever dlopens.
+    pub native_system: Vec<String>,
     /// The static archives and object files among them, likewise in link order.
     pub archives: Vec<String>,
     /// `#include` lines for the C sources a `Library` named, which the C target
@@ -1790,6 +1793,10 @@ pub(crate) fn resolve_ext_libraries(
                 match find_native_library(&lib, &dirs) {
                     Some(NativeLib::Shared(path)) => out.native.push(path),
                     Some(NativeLib::Archive(path)) => out.archives.push(path),
+                    Some(NativeLib::System(soname)) => {
+                        out.native.push(soname.clone());
+                        out.native_system.push(soname);
+                    }
                     None => (),
                 }
             }
@@ -2015,6 +2022,9 @@ enum NativeLib {
     Shared(String),
     /// A static archive or an object file, which [`ExtArchives`] has to link first.
     Archive(String),
+    /// A soname no search directory held a file for, so only the platform's own
+    /// loader can find it: a system dependency, not a file an export can ship.
+    System(String),
 }
 
 fn is_link_input(name: &str) -> bool {
@@ -2058,7 +2068,7 @@ fn find_native_library(spec: &str, dirs: &[String]) -> Option<NativeLib> {
             return found(p);
         }
     }
-    (spec != name).then(|| NativeLib::Shared(format!("{prefix}{name}{suffix}")))
+    (spec != name).then(|| NativeLib::System(format!("{prefix}{name}{suffix}")))
 }
 
 /// `<dir><name>` or `<dir>lib<name>`, the two spellings a `Library="foo"`
@@ -2301,12 +2311,16 @@ fn wasm_exports(bytes: &[u8]) -> impl Iterator<Item = &str> {
 
 /// `resources/native_externals.txt`: the platform libraries to load and the
 /// functions to serve from them, in the form `openmodelica_ext_native_marshal`
-/// parses. `libs` are file names under `binaries/<platform>/`.
-fn native_externals_table(sigs: &[ExtCallSig], libs: &[String]) -> String {
+/// parses. `libs` are file names under `binaries/<platform>/`; `system` are the
+/// sonames the FMU does not ship, which its loader opens through the platform's.
+fn native_externals_table(sigs: &[ExtCallSig], libs: &[String], system: &[String]) -> String {
     use openmodelica_wasm_jit::sig::ExtLang;
     let mut out = String::new();
     for l in libs {
         out.push_str(&format!("lib {l}\n"));
+    }
+    for l in system {
+        out.push_str(&format!("extlib {l}\n"));
     }
     for sig in sigs {
         let mut code = String::new();
@@ -2328,6 +2342,38 @@ fn native_externals_table(sigs: &[ExtCallSig], libs: &[String]) -> String {
         out.push('\n');
     }
     out
+}
+
+/// `sources/buildDescription.xml` declaring the libraries the FMU does not ship
+/// (FMI 3.0 `<Library external="true"/>`). `system` are sonames; `name` carries the
+/// linker name, as the schema's examples spell it.
+fn external_build_description(model_id: &str, system: &[String]) -> String {
+    let platform = native_fmu::host_platform().map(|p| format!(" platform=\"{}\"", p.fmi)).unwrap_or_default();
+    let mut out = String::from(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+         <fmiBuildDescription fmiVersion=\"3.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" \
+         xsi:noNamespaceSchemaLocation=\"https://raw.githubusercontent.com/modelica/fmi-standard/v3.0.2/schema/fmi3BuildDescription.xsd\">\n",
+    );
+    out.push_str(&format!("  <BuildConfiguration modelIdentifier=\"{}\"{platform}>\n", xml_escape(model_id)));
+    for soname in system {
+        let name = soname
+            .strip_prefix(std::env::consts::DLL_PREFIX)
+            .unwrap_or(soname)
+            .strip_suffix(std::env::consts::DLL_SUFFIX)
+            .unwrap_or(soname);
+        out.push_str(&format!(
+            "    <Library name=\"{}\" external=\"true\" description=\"a Library annotation named it; \
+             resolved as {} by the loader of the platform running the FMU\"/>\n",
+            xml_escape(name),
+            xml_escape(soname),
+        ));
+    }
+    out.push_str("  </BuildConfiguration>\n</fmiBuildDescription>\n");
+    out
+}
+
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;").replace('"', "&quot;")
 }
 
 /// The dylink stub module defining the host-served externals: each stores its
@@ -2403,6 +2449,8 @@ struct NativeExternals {
     stub: Vec<u8>,
     /// (file name under `binaries/<platform>/`, contents)
     libs: Vec<(String, Vec<u8>)>,
+    /// Sonames declared but not shipped, for `sources/buildDescription.xml`.
+    system: Vec<String>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -2428,7 +2476,13 @@ fn native_externals(model: &SimModel, kind: &str) -> Result<Option<NativeExterna
         "CodegenWasmJit: unresolved host-served externals"
     })?;
     let mut libs = Vec::new();
+    let mut system = Vec::new();
     for path in &files {
+        // Declared, not shipped: no file behind the soname to pack.
+        if model.ext_native_system.iter().any(|s| s == path) {
+            system.push(path.clone());
+            continue;
+        }
         let name = std::path::Path::new(path).file_name().map(|n| n.to_string_lossy().into_owned()).unwrap_or_default();
         let bytes = std::fs::read(path).map_err(|e| {
             record_error(format!("CodegenWasmJit: cannot read `{path}`: {e}"));
@@ -2436,9 +2490,10 @@ fn native_externals(model: &SimModel, kind: &str) -> Result<Option<NativeExterna
         })?;
         libs.push((name, bytes));
     }
-    let table = native_externals_table(&model.ext_native, &libs.iter().map(|(n, _)| n.clone()).collect::<Vec<_>>());
+    let table =
+        native_externals_table(&model.ext_native, &libs.iter().map(|(n, _)| n.clone()).collect::<Vec<_>>(), &system);
     let stub = native_ext_stub(&model.ext_native, &table)?;
-    Ok(Some(NativeExternals { table, stub, libs }))
+    Ok(Some(NativeExternals { table, stub, libs, system }))
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -3314,6 +3369,9 @@ fn emit_fmu(
         }
         if let Some(n) = &natives {
             entries.push((NATIVE_TABLE.to_string(), n.table.clone().into_bytes()));
+            if version == "3.0" && !n.system.is_empty() {
+                entries.push(("sources/buildDescription.xml".to_string(), external_build_description(&model_id, &n.system).into_bytes()));
+            }
         }
         // What `Modelica.Utilities.Files.loadResource` named; C's `SimCodeMain`
         // copies the same set.
@@ -6334,6 +6392,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
         ext_native,
         ext_builtin,
         ext_native_libs: ext_libs.native,
+        ext_native_system: ext_libs.native_system,
         ext_archives,
         ext_includes,
         ext_lib_notes,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ext_native/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ext_native/src/lib.rs
@@ -142,16 +142,22 @@ impl Natives {
         utilities::publish();
         let mut handles: Vec<*mut c_void> = Vec::new();
         // A library may need one loaded after it; keep trying until a pass loads none.
-        let mut pending: Vec<String> = table.libs.clone();
+        // A shipped library is opened from the FMU, a system one (`extlib`) by the
+        // soname alone, so the platform's loader searches its own path for it.
+        let mut pending: Vec<(String, bool)> = table
+            .libs
+            .iter()
+            .map(|l| (lib_dir.join(l).to_string_lossy().into_owned(), false))
+            .chain(table.system_libs.iter().map(|l| (l.clone(), true)))
+            .collect();
         loop {
             let before = pending.len();
-            let mut failed: Vec<(String, String)> = Vec::new();
-            for lib in std::mem::take(&mut pending) {
-                let path = lib_dir.join(&lib);
-                let c = CString::new(path.to_string_lossy().into_owned()).map_err(|_| "NUL in a library path")?;
+            let mut failed: Vec<(String, bool, String)> = Vec::new();
+            for (lib, system) in std::mem::take(&mut pending) {
+                let c = CString::new(lib.clone()).map_err(|_| "NUL in a library path")?;
                 let h = unsafe { libc::dlopen(c.as_ptr(), libc::RTLD_GLOBAL | libc::RTLD_LAZY) };
                 if h.is_null() {
-                    failed.push((lib, dl_error()));
+                    failed.push((lib, system, dl_error()));
                 } else {
                     handles.push(h);
                 }
@@ -162,11 +168,18 @@ impl Natives {
             if failed.len() == before {
                 return Err(failed
                     .into_iter()
-                    .map(|(l, e)| format!("cannot load `{l}`: {e}"))
+                    .map(|(l, system, e)| match system {
+                        true => format!(
+                            "cannot load `{l}`: {e}\n  The FMU does not ship it: \
+                             sources/buildDescription.xml declares it external, so it has to be \
+                             installed on this machine."
+                        ),
+                        false => format!("cannot load `{l}`: {e}"),
+                    })
                     .collect::<Vec<_>>()
                     .join("\n"));
             }
-            pending = failed.into_iter().map(|(l, _)| l).collect();
+            pending = failed.into_iter().map(|(l, system, _)| (l, system)).collect();
         }
         let mut fns = Vec::with_capacity(table.fns.len());
         for sig in &table.fns {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ext_native_marshal/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ext_native_marshal/src/lib.rs
@@ -56,7 +56,11 @@ pub struct Sig {
 /// `resources/native_externals.txt`: the libraries to load, then the functions.
 #[derive(Clone, Debug, Default)]
 pub struct Table {
+    /// Shipped inside the FMU, opened from its `binaries/<platform>/`.
     pub libs: Vec<String>,
+    /// Named but not shipped (FMI 3.0 `<Library external="true"/>`): a system
+    /// library, opened by soname so the platform's loader finds it.
+    pub system_libs: Vec<String>,
     pub fns: Vec<Sig>,
 }
 
@@ -89,9 +93,11 @@ fn parse_ty(code: &str) -> Result<Ty, String> {
 ///
 /// ```text
 /// lib libfoo.so
+/// extlib libpython3.8.so
 /// fn wa_split C - R *R *I
 /// ```
 ///
+/// An `extlib` line names a library the FMU does not ship, opened by soname.
 /// A `fn` line is the name, the language (`C`/`F`), the return type or `-`, then
 /// each argument, `*` marking an `_Out_`. Types are the wasm-jit `SigTy` codes.
 pub fn parse(text: &str) -> Result<Table, String> {
@@ -100,6 +106,7 @@ pub fn parse(text: &str) -> Result<Table, String> {
         let mut words = line.split_whitespace();
         match words.next() {
             Some("lib") => t.libs.push(words.collect::<Vec<_>>().join(" ")),
+            Some("extlib") => t.system_libs.push(words.collect::<Vec<_>>().join(" ")),
             Some("fn") => {
                 let name = words.next().ok_or("native externals: `fn` without a name")?.to_string();
                 let fortran = words.next() == Some("F");
@@ -314,7 +321,8 @@ mod tests {
 
     #[test]
     fn table_round_trip() {
-        let t = parse("# libs\nlib libfoo.so\nfn wa_split C - R *R *I\nfn greet C S S I [R\n").unwrap();
+        let t = parse("# libs\nlib libfoo.so\nextlib libpython3.8.so\nfn wa_split C - R *R *I\nfn greet C S S I [R\n").unwrap();
+        assert_eq!(t.system_libs, ["libpython3.8.so"]);
         assert_eq!(t.libs, vec!["libfoo.so".to_string()]);
         assert_eq!(t.fns.len(), 2);
         let f = &t.fns[0];

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -38,6 +38,9 @@ pub struct SimModel {
     /// library defines: a native host dlopens them and calls in through libffi.
     /// Empty in the browser.
     pub ext_native_libs: Vec<String>,
+    /// The system libraries among `ext_native_libs`: an export declares these
+    /// rather than shipping them.
+    pub ext_native_system: Vec<String>,
     /// The archives and object files among them ([`ExtArchives`]).
     pub ext_archives: Option<ExtArchives>,
     pub ext_includes: Option<ExtIncludes>,


### PR DESCRIPTION
A `Library` annotation naming a library no search directory holds a file for resolves to a bare soname, which is what `dlopen` needs the platform's own loader to find. The FMU export then handed that soname to `fs::read` to pack into `binaries/<platform>/` and failed:

    Internal error CodegenWasmJit: cannot read `libpython3.8.so`:
    No such file or directory (os error 2)

Buildings' `Library={"ModelicaBuildingsPython_3_8", "python3.8"}` is the shape: the first ships with the library, the second is a system dependency. Resolving by soname rather than by path is exactly what distinguishes the two, so `NativeLib::System` now carries that and the export declares such a library instead of shipping it:

| where | shipped library | system library |
|---|---|---|
| `resources/native_externals.txt` | `lib <name>` | `extlib <soname>` | | `binaries/<platform>/` | packed | absent |
| `sources/buildDescription.xml` | - | `<Library external="true"/>` |

`external="true"` in an FMI 3.0 build description is the standard's only way to name a dependency the importer has to provide. The generated file validates against fmi3BuildDescription.xsd.

The FMU's loader opens an `extlib` entry by soname, letting the platform search its own path, and says so when one is missing rather than reporting it as a library the FMU failed to unpack.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
