### PR TITLE
CodegenC: resolve cross-Jacobian seed crefs by retrying under the current Jacobian's name

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
+++ b/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
@@ -1900,6 +1900,21 @@ algorithm
   end match;
 end crefStripSubs;
 
+public function crefRenameSeedRoot
+"Replaces a seed cref's root ident ($SEED_<jacName>.rest) with $SEED_<newJacName>"
+  input DAE.ComponentRef inCref;
+  input String newJacName;
+  output DAE.ComponentRef outCref;
+algorithm
+  outCref := match inCref
+    case DAE.CREF_IDENT()
+      then ComponentReferenceBasics.makeCrefIdent("$SEED_" + newJacName, inCref.identType, inCref.subscriptLst);
+
+    case DAE.CREF_QUAL()
+      then ComponentReferenceBasics.makeCrefQual("$SEED_" + newJacName, inCref.identType, inCref.subscriptLst, inCref.componentRef);
+  end match;
+end crefRenameSeedRoot;
+
 public function crefStripSubsExceptModelSubs
 "Removes all subscript of a componentref expcept for model subscripts"
   input DAE.ComponentRef inCref;

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -4942,7 +4942,7 @@ template jacCrefs(ComponentRef cr, Context context, Integer ix, Text &sub)
   "Generates code for jacobian variables."
 ::=
  match context
-   case JACOBIAN_CONTEXT(jacHT=SOME(jacHT)) then
+   case JACOBIAN_CONTEXT(name=jacName, jacHT=SOME(jacHT)) then
      match simVarFromHT(cr, jacHT)
      case v as SIMVAR(varKind=BackendDAE.JAC_VAR()) then
        if stringEq(sub, "") then 'jacobian->resultVars[<%index%>]<%crefCCommentWithVariability(v)%>'
@@ -4964,7 +4964,13 @@ template jacCrefs(ComponentRef cr, Context context, Integer ix, Text &sub)
        case v as SIMVAR(varKind=BackendDAE.SEED_VAR()) then
          if stringEq(sub, "") then 'jacobian->seedVars[<%v.index%>]<%crefCCommentWithVariability(v)%>'
          else '(&(jacobian->seedVars[<%v.index%>]))<%&sub%><%crefCCommentWithVariability(v)%>'
-       else crefOld(cr, ix)
+       else
+         // Still not found: seed cached under a different Jacobian's name. Retry with the root renamed to this Jacobian.
+         match simVarFromHT(crefRenameSeedRoot(crefStripSubs(cr), jacName), jacHT)
+         case v as SIMVAR(varKind=BackendDAE.SEED_VAR()) then
+           if stringEq(sub, "") then 'jacobian->seedVars[<%v.index%>]<%crefCCommentWithVariability(v)%>'
+           else '(&(jacobian->seedVars[<%v.index%>]))<%&sub%><%crefCCommentWithVariability(v)%>'
+         else crefOld(cr, ix)
 end jacCrefs;
 
 template jacSparsityIndex(ComponentRef cr, Context context)

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -3966,6 +3966,12 @@ package ComponentReference
     output DAE.ComponentRef outComponentRef;
   end crefStripSubs;
 
+  function crefRenameSeedRoot
+    input DAE.ComponentRef inComponentRef;
+    input String newJacName;
+    output DAE.ComponentRef outComponentRef;
+  end crefRenameSeedRoot;
+
   function crefTypeFull
     input DAE.ComponentRef inRef;
     output DAE.Type res;


### PR DESCRIPTION
NBackend's makeSeedVar cache can hand back a seed cref cached under a different Jacobian's name when several Jacobians seed the same shared variable, producing an undeclared identifier in generated C (seen with AixLib.Electrical.AC.ThreePhasesUnbalanced Transformer/Line models). jacCrefs now retries the jac_map lookup with the seed's root renamed to the Jacobian actually being generated before falling back to crefOld.

