### PR TITLE
Fix three gaps found by library testing

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -731,7 +731,9 @@ void partestRust(partition) {
   // cSources/fmuCSources check generated C files or FMU sources - wasm-jit does not use C
   // 63bit/antlr: the port's Integer is i32 and its parser is winnow, not ANTLR
   // stackoverflow: Rust aborts on stack overflow, MMC unwinds out of the SEGV handler
-  String suitesArg = ' -suites=-cpp,-hpcom,-metamodelica,-63bit,-antlr,-cSources,-fmuCSources,-stackoverflow'
+  // wasm: off everywhere else - these tests select the wasm-jit/wasm target
+  // themselves, which only this build has.
+  String suitesArg = ' -suites=-cpp,-hpcom,-metamodelica,-63bit,-antlr,-cSources,-fmuCSources,-stackoverflow,+wasm'
   // wasmtime reserves ~4 GiB of address space per wasm memory, and shrinking that
   // reservation to fit an RLIMIT_AS costs the bounds-check-free fast path.
   String asLimit = params.RUST_PARTEST_SIMCODETARGET == 'wasm-jit'

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -2669,8 +2669,22 @@ algorithm
   flatModel.variables := list(evaluateBindingConnOp(c, sets, setsArray, variables, ctable, replacements) for c in flatModel.variables);
   flatModel.equations := evaluateEquationsConnOp(flatModel.equations, sets, setsArray, variables, ctable, replacements);
   flatModel.initialEquations := evaluateEquationsConnOp(flatModel.initialEquations, sets, setsArray, variables, ctable, replacements);
-  // TODO: Implement evaluation for algorithm sections.
+  flatModel.algorithms := evaluateAlgorithmsConnOp(flatModel.algorithms, sets, setsArray, variables, ctable, replacements);
+  flatModel.initialAlgorithms := evaluateAlgorithmsConnOp(flatModel.initialAlgorithms, sets, setsArray, variables, ctable, replacements);
 end evaluateConnectionOperators;
+
+function evaluateAlgorithmsConnOp
+  input output list<Algorithm> algorithms;
+  input ConnectionSets.Sets sets;
+  input array<list<Connector>> setsArray;
+  input UnorderedMap<ComponentRef, Variable> variables;
+  input CardinalityTable.Table ctable;
+  input Option<StreamFlowAlias.Replacements> replacements;
+algorithm
+  algorithms := Algorithm.mapExpList(algorithms,
+    function ConnectEquations.evaluateOperators(sets = sets, setsArray = setsArray,
+      variables = variables, ctable = ctable, replacements = replacements));
+end evaluateAlgorithmsConnOp;
 
 function evaluateBindingConnOp
   input output Variable var;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -3427,7 +3427,11 @@ fn emit_fmu(
     })();
     if let Err(e) = &outcome {
         if openmodelica_util::Error::getNumErrorMessages() == errs_before {
-            record_error(format!("CodegenWasmJit: cannot build FMI {} {kind} FMU: {e:#}", fmi_version()));
+            record_error(format!(
+                "CodegenWasmJit: cannot build FMI {} {kind} FMU: {}",
+                fmi_version(),
+                with_engine_detail(e)
+            ));
         }
     }
     outcome

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -2753,6 +2753,8 @@ fn emit_shared_external_call(
         Cell { ptr: u32, ty: SigTy, out: Option<Target> },
         /// A Fortran array: copy back if it is an output, then release any scratch.
         F77Array { handle: u32, ptr: u32, is_out: bool },
+        /// C's `<record>_external`: copy its fields into `out`, then free it.
+        CRecord { ptr: u32, fields: Arc<Vec<(ArcStr, SigTy)>>, out: Target },
     }
     let fortran = sig.lang == ExtLang::Fortran77;
     let native = is_native_external(&sig.name);
@@ -2879,6 +2881,23 @@ fn emit_shared_external_call(
             SigTy::Ptr => push_value(ctx, "an external-object", WTy::I32)?,
             // A record still crosses as the runtime object, not C's `<record>_external`.
             SigTy::Record { .. } if !is_out && !fortran => push_value(ctx, "a record", WTy::I32)?,
+            // C writes a `<record>_external` (the fields' C types, no runtime
+            // header), so it gets a scratch one and the fields are copied back.
+            SigTy::Record { fields, .. } if !fortran => {
+                let size = openmodelica_wasm_jit::sig::c_record_layout(fields, 4).size.max(1);
+                ctx.emit(we::Instruction::I32Const(size as i32));
+                ctx.emit(we::Instruction::Call(rt_index("rt_alloc")?));
+                let ptr = ctx.alloc_temp(WTy::I32);
+                ctx.emit(we::Instruction::LocalSet(ptr));
+                // `rt_alloc` reuses freed blocks.
+                ctx.emit(we::Instruction::LocalGet(ptr));
+                ctx.emit(we::Instruction::I32Const(0));
+                ctx.emit(we::Instruction::I32Const(size as i32));
+                ctx.emit(we::Instruction::MemoryFill(0));
+                ctx.emit(we::Instruction::LocalGet(ptr));
+                let out = output_target(ctx, ext_arg_output_index(a), cref)?;
+                cleanups.push(Cleanup::CRecord { ptr, fields: fields.clone(), out });
+            }
             other => {
                 openmodelica_wasm_jit::set_engine_error_detail(format!(
                     "  {}, external `{}`: {other:?} cannot be passed to a shared-memory {}",
@@ -2918,6 +2937,11 @@ fn emit_shared_external_call(
                     ctx.emit(we::Instruction::LocalGet(*ptr));
                     ctx.emit(we::Instruction::I32Const(0));
                     ctx.emit(we::Instruction::Call(rt_index("rt_f77_arr_out")?));
+                }
+                // The call did not return, so nothing is copied back out of it.
+                Cleanup::CRecord { ptr, .. } => {
+                    ctx.emit(we::Instruction::LocalGet(*ptr));
+                    ctx.emit(we::Instruction::Call(rt_index("rt_free")?));
                 }
             }
         }
@@ -2986,6 +3010,32 @@ fn emit_shared_external_call(
                 ctx.emit(we::Instruction::LocalGet(*ptr));
                 ctx.emit(we::Instruction::I32Const(i32::from(*is_out)));
                 ctx.emit(we::Instruction::Call(rt_index("rt_f77_arr_out")?));
+            }
+            Cleanup::CRecord { ptr, fields, out } => {
+                let c = openmodelica_wasm_jit::sig::c_record_layout(fields, 4);
+                let rec = match &out.out_sty {
+                    SigTy::Record { path, .. } => path.as_str(),
+                    _ => "the output record",
+                };
+                for (i, (name, fty)) in fields.iter().enumerate() {
+                    if !matches!(fty, SigTy::Real | SigTy::Int | SigTy::Bool) {
+                        // As C's `recordMemberCopyToFromExternal` refuses a String.
+                        openmodelica_wasm_jit::set_engine_error_detail(format!(
+                            "  {}, external `{}`: cannot read output field `{name}` of `{rec}` back \
+                             from C - only Real, Integer and Boolean record members are copied",
+                            fn_path(),
+                            sig.name,
+                        ));
+                        return Err("CodegenWasmJit: unsupported external output record field");
+                    }
+                    ctx.emit(we::Instruction::LocalGet(*ptr));
+                    field_load(ctx, fty.wty(), c.offsets[i]);
+                    let vt = ctx.alloc_temp(fty.wty());
+                    ctx.emit(we::Instruction::LocalSet(vt));
+                    store_fresh_into_field(ctx, out.out_idx, fields, name, vt)?;
+                }
+                ctx.emit(we::Instruction::LocalGet(*ptr));
+                ctx.emit(we::Instruction::Call(rt_index("rt_free")?));
             }
         }
     }
@@ -6171,6 +6221,32 @@ pub(crate) fn push_qual_subs(subs: &Arc<List<Arc<DAE::Subscript>>>, s: &mut Stri
 }
 
 /// If `exp` is a constant index (`ICONST`/enum literal), its 1-based value.
+/// A constant subscript outside the array's range, e.g. the `T[0]` scalarizing
+/// `for i in 1:n loop ... T[i-1] ...` leaves in a branch the model never takes. C
+/// emits that access too, so it lowers to the run-time error instead of failing the
+/// translation. Leaves a value of the element type on the stack.
+fn emit_sim_const_index_error(ctx: &mut FnCtx, cref: &DAE::ComponentRef, key: &str) -> Result<Option<WTy>> {
+    let Some((base, subs)) = array_ref_of(cref)? else { return Ok(None) };
+    let Some(group) = ctx.sim()?.array_groups.get(&base).cloned() else { return Ok(None) };
+    if subs.len() != group.dims.len() {
+        return Ok(None);
+    }
+    let outside = subs
+        .iter()
+        .zip(&group.dims)
+        .any(|(e, d)| matches!(const_index_value(e), Some(i) if i < 1 || i > *d as i32));
+    if !outside {
+        return Ok(None);
+    }
+    let dims = group.dims.iter().map(|d| d.to_string()).collect::<Vec<_>>().join(",");
+    emit_runtime_error(ctx, &format!("Index out of bounds: `{key}` of array of size [{dims}]"))?;
+    match group.wty {
+        WTy::F64 => ctx.emit(we::Instruction::F64Const(0.0.into())),
+        WTy::I32 => ctx.emit(we::Instruction::I32Const(0)),
+    }
+    Ok(Some(group.wty))
+}
+
 fn const_index_value(exp: &DAE::Exp) -> Option<i32> {
     match exp {
         DAE::Exp::ICONST { integer } => Some(*integer),
@@ -6729,6 +6805,9 @@ fn compile_sim_cref_read(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Op
             }
             if try_emit_empty_sim_array(ctx, cref)? {
                 return Ok(Some(WTy::I32));
+            }
+            if let Some(wty) = emit_sim_const_index_error(ctx, cref, &key)? {
+                return Ok(Some(wty));
             }
             crate::CodegenWasmJit::record_error(format!(
                 "CodegenWasmJit: simulation reference to unknown variable `{key}`"

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -44,6 +44,11 @@ rtest special directives added to help creating testcases:
   them can deselect it: `partest/runtests.pl -suites=-metamodelica,-63bit`.
   Run `runtests.pl -h` for the suites and their defaults. The directive must be
   in the test's header, i.e. before the first line of code.
+* suite: wasm — says that the test selects the `wasm-jit` or `wasm` simCodeTarget
+  itself (rather than running under whatever target the run was given). Only the
+  Rust omc implements those targets, so the suite is off by default and the Rust
+  partest turns it on with `-suites=+wasm`. `rtest test.mos` runs such a test
+  regardless, as it does for the other tag suites.
 * suite: disabled — says that the test is not part of the testsuite, i.e. that it
   is listed in its makefile as a failing, not compiling, not simulating or manual
   test rather than in `TESTFILES`. Such a test is expected to fail, and some of

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/Makefile
@@ -22,7 +22,8 @@ fmi3_msl_engine1a.mos \
 fmi3_terminals_alias_nb.mos \
 fmi3_terminals_alias.mos \
 fmi3_terminals.mos \
-fmi3_types.mos
+fmi3_types.mos \
+fmi3_wasm_output_record.mos
 
 # Dependency files that are not .mo .mos or Makefile
 # Add them here or they will be cleaned.

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_wasm_output_record.mo
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_wasm_output_record.mo
@@ -1,0 +1,28 @@
+model ExtOutputRecord
+  record State
+    Real T;
+    Real p;
+    Integer phase;
+  end State;
+
+  function setState "Fill a record the C side writes through a pointer"
+    input Real p;
+    input Real h;
+    input String medium;
+    output State state;
+    external "C" om_set_state(p, h, state, medium)
+    annotation (Include="
+/* C's `<record>_external`: the members' C types packed from offset 0, with none
+   of the runtime record object's header. */
+typedef struct { double T; double p; int phase; } om_state_external;
+
+void om_set_state(double p, double h, om_state_external* s, const char* medium) {
+  s->T = h / 4200.0;
+  s->p = p;
+  s->phase = h > 250000.0 ? 2 : 1;
+}
+");
+  end setState;
+
+  State st = setState(1e5, 1e5 * time + 2e5, "water");
+end ExtOutputRecord;

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_wasm_output_record.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_wasm_output_record.mos
@@ -1,0 +1,59 @@
+// name: fmi3_wasm_output_record.mos
+// keywords: FMI 3.0 export wasm external record output
+// status: correct
+// suite: wasm
+// teardown_command: rm -rf ExtOutputRecord.fmu ExtOutputRecord_res.mat plain_res.mat diff_output_record* om-wasm-include-* ExtOutputRecord*.log plain*
+//
+// An `_Out_` record argument of an `external "C"` function. C writes a
+// `<record>_external` struct - the members' C types from offset 0, without the
+// runtime record object's header - which the caller copies back afterwards
+// (C's `<record>_copy_from_external`). The wasm FMU serves the external from
+// inside the simulation's own memory, where wasm-jit had no case for an output
+// record; the plain simulation is unaffected, resolving it through the host.
+// ExternalMedia's setState_ph has this shape.
+
+setCommandLineOptions("--simCodeTarget=wasm-jit"); getErrorString();
+loadFile("fmi3_wasm_output_record.mo"); getErrorString();
+
+// The plain simulation serves the external from the host, which already copied an
+// output record back; the reference for the run below.
+simulate(ExtOutputRecord, stopTime=1.0, numberOfIntervals=10, fileNamePrefix="plain"); getErrorString();
+
+setCommandLineOptions("--fmuDirectory=true"); getErrorString();
+buildModelFMU(ExtOutputRecord, fileNamePrefix="ExtOutputRecord", fmuType="me_cs", version="3.0", platforms={"wasm"}); getErrorString();
+
+// The artifact serves it from inside the simulation's own memory instead.
+simulate(ExtOutputRecord, stopTime=1.0, numberOfIntervals=10, resimulateExecutable="ExtOutputRecord.fmu"); getErrorString();
+
+// Both routes have to fill the record identically.
+diffSimulationResults("ExtOutputRecord_res.mat", "plain_res.mat", "diff_output_record", 1e-9, 1e-9);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "plain_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 10, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'plain', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// true
+// ""
+// "ExtOutputRecord.fmu"
+// "Notification: Building FMU for platform 'wasm' (1/1).
+// Notification: Finished FMU for platform 'wasm' (1/1).
+// "
+// record SimulationResult
+//     resultFile = "ExtOutputRecord.fmu_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 10, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ExtOutputRecord', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// (true, {})
+// endResult

--- a/testsuite/partest/runtests.pl
+++ b/testsuite/partest/runtests.pl
@@ -86,7 +86,7 @@ my $osname = $^O;
 # it belongs to are enabled. 'disabled' is such a tag: a test carrying it is not
 # part of the testsuite at all, see %suite_enabled.
 my @category_suites = qw(default cpp cppmsl tearing hpcom);
-my @tag_suites = qw(metamodelica 63bit antlr cSources fmuCSources stackoverflow disabled);
+my @tag_suites = qw(metamodelica 63bit antlr cSources fmuCSources stackoverflow wasm disabled);
 my %suite_enabled = (
   default      => 1,  # Everything not claimed by another category.
   cpp          => 1,  # */cppruntime/*
@@ -100,6 +100,10 @@ my %suite_enabled = (
   fmuCSources  => 1,  # Inspects sources/ inside an FMU, which only the C export has.
   stackoverflow => 1, # Recurses until the stack runs out; needs MMC's SEGV-handler
                       # recovery, which the Rust port has no equivalent of.
+  wasm         => 0,  # Selects the wasm-jit/wasm target itself, so it only runs
+                      # where that target exists: the Rust omc, which JIT-compiles
+                      # the model in-process. The C omc's CodegenWasmJit is a stub
+                      # that fails, so the suite is opt-in rather than off-by-build.
   # Not part of the testsuite: the tests a makefile lists as failing, not
   # compiling, not simulating or needing a manual setup. They are the tests that
   # fail, hang or eat the machine, so they are opt-in and rtest skips them too

--- a/testsuite/simulation/modelica/arrays/ConstantSubscriptOutOfRange.mos
+++ b/testsuite/simulation/modelica/arrays/ConstantSubscriptOutOfRange.mos
@@ -1,0 +1,56 @@
+// name: ConstantSubscriptOutOfRange
+// keywords: array subscript scalarization
+// status: correct
+// teardown_command: rm -rf ConstantSubscriptOutOfRange_* ConstantSubscriptOutOfRange ConstantSubscriptOutOfRange.log ConstantSubscriptOutOfRange.wasm
+//
+// Scalarizing `for i in 1:n loop ... T[i-1] ...` leaves `T[0]` in the `i == 1`
+// instance, in a branch guarded so that it never runs (`i >= k` is false there,
+// and k is not evaluated at compile time so the branch survives). The C code
+// generator addresses the element relative to the first one and never executes it;
+// wasm-jit needs a storage slot per element and used to reject the model with
+// "Internal error CodegenWasmJit: simulation reference to unknown variable `T[0]`".
+// It now lowers such an access to the run-time out-of-bounds error instead, which
+// this model never reaches.
+
+loadString("
+model ConstantSubscriptOutOfRange
+  parameter Integer n = 3;
+  parameter Integer k = 2 annotation(Evaluate = false);
+  Boolean u = time > 0.5;
+  Real T[n](each start = 300, each fixed = true);
+  Real d[n];
+equation
+  for i in 1:n loop
+    if i == k and u then
+      d[i] = -T[i];
+    elseif i >= k and u then
+      d[i] = T[i - 1] - T[i];
+    else
+      d[i] = 0;
+    end if;
+  end for;
+  for i in 1:n loop
+    der(T[i]) = d[i];
+  end for;
+end ConstantSubscriptOutOfRange;
+"); getErrorString();
+
+simulate(ConstantSubscriptOutOfRange, stopTime = 1.0, numberOfIntervals = 4); getErrorString();
+
+val(T[1], 1.0);
+val(T[3], 1.0);
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "ConstantSubscriptOutOfRange_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 4, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ConstantSubscriptOutOfRange', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 300.0
+// 272.9381694276217
+// endResult

--- a/testsuite/simulation/modelica/arrays/Makefile
+++ b/testsuite/simulation/modelica/arrays/Makefile
@@ -32,6 +32,7 @@ Bug3916.mos \
 ConstructFunc.mos \
 crefIndex.mos \
 DimConvert.mos \
+ConstantSubscriptOutOfRange.mos \
 DynamicSubscriptAliasArray.mos \
 gc.mos \
 gc2980.mos \

--- a/testsuite/simulation/modelica/inStream/Makefile
+++ b/testsuite/simulation/modelica/inStream/Makefile
@@ -14,6 +14,7 @@ Test10.mos \
 Test11.mos \
 Test12.mos \
 Test13.mos \
+TestAlgorithmSection.mos \
 
 
 # test that currently fail. Move up when fixed.

--- a/testsuite/simulation/modelica/inStream/TestAlgorithmSection.mos
+++ b/testsuite/simulation/modelica/inStream/TestAlgorithmSection.mos
@@ -1,0 +1,62 @@
+// name: TestAlgorithmSection
+// keywords: inStream, algorithm section, stream connector
+// status: correct
+// teardown_command: rm -rf TestAlgSect* Top_* Top.c Top.o Top.exe Top.log Top Top.libs Top.makefile Top_records.c output.log
+//
+// NFFlatten.evaluateConnectionOperators used to skip algorithm sections, so an
+// inStream() written in one survived flattening and reached code generation. The
+// C target emitted a call to a function that does not exist ("call to undeclared
+// function 'inStream'"); wasm-jit reported it as an unsupported builtin.
+
+loadString("
+connector FP
+  Real p;
+  flow Real m_flow;
+  stream Real rho;
+end FP;
+
+model Sink
+  FP port;
+  Real v;
+algorithm
+  v := port.m_flow * inStream(port.rho);
+equation
+  port.p = 1e5;
+  port.rho = 1.2;
+end Sink;
+
+model Src
+  FP port;
+equation
+  port.rho = 1.0;
+  port.m_flow = -0.5;
+end Src;
+
+model Top
+  Sink s;
+  Src r;
+equation
+  connect(r.port, s.port);
+end Top;
+"); getErrorString();
+
+simulate(Top, stopTime=1.0, numberOfIntervals=2); getErrorString();
+
+// inStream() of the only other connector in the set is that connector's value:
+// flow enters s, so inStream(s.port.rho) is r.port.rho = 1.0, and the algorithm
+// computes s.port.m_flow * 1.0 = 0.5.
+val(s.v, 1.0);
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "Top_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 2, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Top', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 0.5
+// endResult


### PR DESCRIPTION
**`external "C"` output records (ExternalMedia).** C passes such an argument as a `<record>_external`: the members' C types from offset 0, with none of the runtime record object's header, filled by the callee and copied back through `<record>_copy_from_external`. wasm-jit passed an *input* record straight through as the runtime object and had no case at all for an output one, so a wasm FMU export gave "unsupported shared-memory external argument type". The call now gets a scratch C-layout cell and the fields are copied back after it. Non-scalar members are refused with the reason, as C refuses a String member. Only the FMU was affected: the plain simulation serves the external from the host, which already did this.

**A constant subscript outside an array (TransiEnt).** Scalarizing `for i in 1:n loop ... T[i-1] ...` leaves `T[0]` in the `i == 1` instance, in a branch guarded so it never runs. C addresses the element relative to the first one and never executes it; wasm-jit needs a slot per element and rejected the model with "simulation reference to unknown variable `T[0]`". It now lowers to the run-time out-of-bounds error.

**`inStream()` in an algorithm section (BuildingSystems).** `evaluateConnectionOperators` handled variables, equations and initial equations, and left a TODO for algorithm sections - so an `inStream()` written in one reached code generation. Not target-specific: C emitted a call to a function nothing defines, failing at the C compiler with "call to undeclared function 'inStream'".

The FMU export error path now reports the engine detail it was dropping, which is the line naming the argument that could not be passed.

Each test fails without its fix. Verified against the C target on the library models: TransiEnt and BuildingSystems agree with it to 1e-6, and the ExternalMedia artifact agrees with the plain simulation to 1e-8.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
