### PR TITLE
Nb fix cross jacobian coupling

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
@@ -1490,6 +1490,11 @@ function isJacobianResultVar
           ovar := NONE();
         else
           ovar := getVarSeed(old_var_ptr);
+          // var_seed is a single-slot cache shared across all Jacobians; reject a hit
+          // cached under a different Jacobian's name (cref root is always $SEED_<name>).
+          if isSome(ovar) and ComponentRef.firstName(ComponentRef.last(getVarName(Util.getOption(ovar)))) <> SEED_STR + "_" + name then
+            ovar := NONE();
+          end if;
         end if;
         if isSome(ovar) then
           var_ptr := Util.getOption(ovar);
@@ -1548,6 +1553,11 @@ function isJacobianResultVar
       case qual as InstNode.VAR_NODE() algorithm
         res_ptr := getVarPointer(cref, sourceInfo());
         ovar := getVarPDer(res_ptr, isTmp);
+        // var_pder_res/tmp is a single-slot cache shared across all Jacobians; reject a hit
+        // cached under a different Jacobian's name (cref root is always $pDER_<name>).
+        if isSome(ovar) and ComponentRef.firstName(ComponentRef.last(getVarName(Util.getOption(ovar)))) <> PARTIAL_DERIVATIVE_STR + "_" + name then
+          ovar := NONE();
+        end if;
         if isSome(ovar) then
           var_ptr := Util.getOption(ovar);
           cref := getVarName(var_ptr);

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBJacobian.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBJacobian.mo
@@ -58,6 +58,8 @@ protected
   import Expression = NFExpression;
   import NFFunction.Function;
   import Statement = NFStatement;
+  import Subscript = NFSubscript;
+  import List;
   import Operator = NFOperator;
   import SimplifyExp = NFSimplifyExp;
   import Type = NFType;
@@ -1671,11 +1673,10 @@ protected
       Pointer.update(vars_ptr, diff_ptr :: Pointer.access(vars_ptr));
       // add x -> $<new>.x to the map for later lookup
       UnorderedMap.add(var.name, diff, map);
-      // For subscripted element crefs (partial-slice NLS iter vars), also add the
-      // base cref mapped to the first element seed (added only once so that
-      // later elements do not overwrite it). This allows iterator-subscripted
-      // deps from for-loop equations to find their seed via base fallback in Part D.
-      if ComponentRef.hasSubscripts(var.name) and not UnorderedMap.contains(ComponentRef.stripSubscriptsAll(var.name), map) then
+      // Base-cref fallback for iterator-subscripted deps (x[$i1]) to find their seed in Part D.
+      // Literal subscripts (x[1] vs x[2]) are independent unknowns, so exclude those.
+      if ComponentRef.hasSubscripts(var.name) and not List.all(ComponentRef.subscriptsAllFlat(var.name), Subscript.isLiteral)
+          and not UnorderedMap.contains(ComponentRef.stripSubscriptsAll(var.name), map) then
         UnorderedMap.add(ComponentRef.stripSubscriptsAll(var.name), diff, map);
       end if;
 

--- a/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
@@ -501,6 +501,7 @@ public
           list<Pointer<Equation>> eqns;
           list<ComponentRef> var_crefs, pder_crefs, tmp_crefs;
           ComponentRef eqn_name, dep_cref, seed_cref, pder_cref;
+          Option<ComponentRef> oseed_cref;
           Integer eqn_index;
           Iterator iter;
           Dependency dep;
@@ -578,21 +579,24 @@ public
                     if filterSet(dep_cref, seed_set) then
                       // Try subscripted key first (NLS with per-element scalar seeds), then
                       // base key with subscript copy (ODE/DAE with full-array base seeds).
-                      seed_cref := match UnorderedMap.get(dep_cref, diff_map)
-                        case SOME(seed_cref) then seed_cref;
+                      // Not found in either: not one of this Jacobian's own unknowns, so its
+                      // partial derivative here is zero -- skip instead of erroring.
+                      oseed_cref := match UnorderedMap.get(dep_cref, diff_map)
+                        case SOME(seed_cref) then SOME(seed_cref);
                         else match UnorderedMap.get(ComponentRef.stripSubscriptsAll(dep_cref), diff_map)
                           // Strip subscripts from the base seed before copying so that
                           // origin subscripts (iterator or literal) merge onto an empty
                           // template rather than clashing with existing literal subscripts.
-                          case SOME(seed_cref) then ComponentRef.copySubscripts(dep_cref, ComponentRef.stripSubscriptsAll(seed_cref));
-                          else algorithm
-                            Error.addMessage(Error.INTERNAL_ERROR, {getInstanceName() + " failed because no seed was found for " + ComponentRef.toString(dep_cref) + " in diff_map."});
-                          then fail();
+                          case SOME(seed_cref) then SOME(ComponentRef.copySubscripts(dep_cref, ComponentRef.stripSubscriptsAll(seed_cref)));
+                          else NONE();
                         end match;
                       end match;
-                      UnorderedMap.add(seed_cref, dep, dep_map);
-                      if repeated then
-                        UnorderedSet.add(seed_cref, rep_set);
+                      if isSome(oseed_cref) then
+                        seed_cref := Util.getOption(oseed_cref);
+                        UnorderedMap.add(seed_cref, dep, dep_map);
+                        if repeated then
+                          UnorderedSet.add(seed_cref, rep_set);
+                        end if;
                       end if;
                     end if;
                   end for;

--- a/testsuite/simulation/modelica/NBackend/differentation/adjoint_jacobian3.mos
+++ b/testsuite/simulation/modelica/NBackend/differentation/adjoint_jacobian3.mos
@@ -66,8 +66,8 @@ buildModel(scalarAdjointJacobian3); getErrorString();
 //
 // SeedVars (size = 2)
 // *********************
-//   (0)[SEED] (1) Real $SEED_ODE_JAC_ADJ.$DER.y
-//   (1)[SEED] (1) Real $SEED_ODE_JAC_ADJ.$DER.x
+//   (0)[SEED] (1) Real $SEED_INI_LS_JAC_1.$DER.y
+//   (1)[SEED] (1) Real $SEED_INI_LS_JAC_1.$DER.x
 //
 // TmpVars (size = 0)
 // ********************
@@ -77,13 +77,13 @@ buildModel(scalarAdjointJacobian3); getErrorString();
 //
 // Column Equations (size = 2)
 // -----------------------------
-//   (4) $pDER_INI_LS_JAC_1.$RES_SIM_1 := -(2.0 * $DER.x * $SEED_ODE_JAC_ADJ.$DER.x + 3.0 * $DER.y ^ 2.0 * $SEED_ODE_JAC_ADJ.$DER.y)
-//   (3) $pDER_INI_LS_JAC_1.$RES_SIM_0 := -(3.0 * $DER.x ^ 2.0 * $SEED_ODE_JAC_ADJ.$DER.x - 2.0 * $DER.y * $SEED_ODE_JAC_ADJ.$DER.y)
+//   (4) $pDER_INI_LS_JAC_1.$RES_SIM_1 := -(2.0 * $DER.x * $SEED_INI_LS_JAC_1.$DER.x + 3.0 * $DER.y ^ 2.0 * $SEED_INI_LS_JAC_1.$DER.y)
+//   (3) $pDER_INI_LS_JAC_1.$RES_SIM_0 := -(3.0 * $DER.x ^ 2.0 * $SEED_INI_LS_JAC_1.$DER.x - 2.0 * $DER.y * $SEED_INI_LS_JAC_1.$DER.y)
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_SIM_1 ... {$pDER_INI_LS_JAC_1.$RES_SIM_1} ... {($SEED_ODE_JAC_ADJ.$DER.y, {}, false), ($SEED_ODE_JAC_ADJ.$DER.x, {}, false)}
-// $RES_SIM_0 ... {$pDER_INI_LS_JAC_1.$RES_SIM_0} ... {($SEED_ODE_JAC_ADJ.$DER.y, {}, false), ($SEED_ODE_JAC_ADJ.$DER.x, {}, false)}
+// $RES_SIM_1 ... {$pDER_INI_LS_JAC_1.$RES_SIM_1} ... {($SEED_INI_LS_JAC_1.$DER.y, {}, false), ($SEED_INI_LS_JAC_1.$DER.x, {}, false)}
+// $RES_SIM_0 ... {$pDER_INI_LS_JAC_1.$RES_SIM_0} ... {($SEED_INI_LS_JAC_1.$DER.y, {}, false), ($SEED_INI_LS_JAC_1.$DER.x, {}, false)}
 //
 // ======================================================
 //   [EMPTY] SimCode Jacobian A(idx = 1, partition = 0)
@@ -195,8 +195,8 @@ buildModel(scalarAdjointJacobian3); getErrorString();
 // 	1: -($DER.x ^ 2.0 + $DER.y ^ 3.0 - x * y) (RESIDUAL)
 // 	2: -($DER.x ^ 3.0 - x - y - $DER.y ^ 2.0) (RESIDUAL)
 // 	Jacobian idx: 0
-// 	4: $pDER_INI_LS_JAC_1.$RES_SIM_1=-(2.0 * $DER.x * $SEED_ODE_JAC_ADJ.$DER.x + 3.0 * $DER.y ^ 2.0 * $SEED_ODE_JAC_ADJ.$DER.y) [Real]
-// 	3: $pDER_INI_LS_JAC_1.$RES_SIM_0=-(3.0 * $DER.x ^ 2.0 * $SEED_ODE_JAC_ADJ.$DER.x - 2.0 * $DER.y * $SEED_ODE_JAC_ADJ.$DER.y) [Real]
+// 	4: $pDER_INI_LS_JAC_1.$RES_SIM_1=-(2.0 * $DER.x * $SEED_INI_LS_JAC_1.$DER.x + 3.0 * $DER.y ^ 2.0 * $SEED_INI_LS_JAC_1.$DER.y) [Real]
+// 	3: $pDER_INI_LS_JAC_1.$RES_SIM_0=-(3.0 * $DER.x ^ 2.0 * $SEED_INI_LS_JAC_1.$DER.x - 2.0 * $DER.y * $SEED_INI_LS_JAC_1.$DER.y) [Real]
 //
 //
 // ========================================
@@ -250,8 +250,8 @@ buildModel(scalarAdjointJacobian3); getErrorString();
 // jacobianMatrices:
 // ========================================
 // 	Jacobian idx: 0
-// 	4: $pDER_INI_LS_JAC_1.$RES_SIM_1=-(2.0 * $DER.x * $SEED_ODE_JAC_ADJ.$DER.x + 3.0 * $DER.y ^ 2.0 * $SEED_ODE_JAC_ADJ.$DER.y) [Real]
-// 	3: $pDER_INI_LS_JAC_1.$RES_SIM_0=-(3.0 * $DER.x ^ 2.0 * $SEED_ODE_JAC_ADJ.$DER.x - 2.0 * $DER.y * $SEED_ODE_JAC_ADJ.$DER.y) [Real]
+// 	4: $pDER_INI_LS_JAC_1.$RES_SIM_1=-(2.0 * $DER.x * $SEED_INI_LS_JAC_1.$DER.x + 3.0 * $DER.y ^ 2.0 * $SEED_INI_LS_JAC_1.$DER.y) [Real]
+// 	3: $pDER_INI_LS_JAC_1.$RES_SIM_0=-(3.0 * $DER.x ^ 2.0 * $SEED_INI_LS_JAC_1.$DER.x - 2.0 * $DER.y * $SEED_INI_LS_JAC_1.$DER.y) [Real]
 //
 // 	Jacobian idx: 1
 //

--- a/testsuite/simulation/modelica/NBackend/initialization/TestInversePlant.mos
+++ b/testsuite/simulation/modelica/NBackend/initialization/TestInversePlant.mos
@@ -322,39 +322,39 @@ simulate(TestInversePlant.BackwardOffDesignHomotopy); getErrorString();
 //
 // SeedVars (size = 33)
 // **********************
-//   (0)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.w
-//   (1)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.wfg
-//   (2)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Tfg[1]
-//   (3)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Tfg[2]
-//   (4)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Tfg[3]
-//   (5)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Tfg[4]
-//   (6)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Tfg[5]
-//   (7)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Tfg[6]
-//   (8)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.G[1]
-//   (9)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.G[2]
-//   (10)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.G[3]
-//   (11)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.G[4]
-//   (12)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.G[5]
-//   (13)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Q[1]
-//   (14)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Q[2]
-//   (15)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Q[3]
-//   (16)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Q[4]
-//   (17)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Q[5]
-//   (18)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.T[1]
-//   (19)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.T[2]
-//   (20)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.T[3]
-//   (21)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.T[4]
-//   (22)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.T[5]
-//   (23)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.T[6]
-//   (24)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.TIT
-//   (25)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.TIP
-//   (26)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.p[1]
-//   (27)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.p[2]
-//   (28)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.p[3]
-//   (29)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.p[4]
-//   (30)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.p[5]
-//   (31)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.p[6]
-//   (32)[SEED] (1) Real $SEED_ALG_LS_JAC_1.$FUN_1
+//   (0)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.w
+//   (1)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.wfg
+//   (2)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Tfg[1]
+//   (3)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Tfg[2]
+//   (4)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Tfg[3]
+//   (5)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Tfg[4]
+//   (6)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Tfg[5]
+//   (7)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Tfg[6]
+//   (8)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.G[1]
+//   (9)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.G[2]
+//   (10)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.G[3]
+//   (11)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.G[4]
+//   (12)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.G[5]
+//   (13)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Q[1]
+//   (14)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Q[2]
+//   (15)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Q[3]
+//   (16)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Q[4]
+//   (17)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Q[5]
+//   (18)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.T[1]
+//   (19)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.T[2]
+//   (20)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.T[3]
+//   (21)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.T[4]
+//   (22)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.T[5]
+//   (23)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.T[6]
+//   (24)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.TIT
+//   (25)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.TIP
+//   (26)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.p[1]
+//   (27)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.p[2]
+//   (28)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.p[3]
+//   (29)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.p[4]
+//   (30)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.p[5]
+//   (31)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.p[6]
+//   (32)[SEED] (1) Real $SEED_INI_LS_JAC_1.$FUN_1
 //
 // TmpVars (size = 0)
 // ********************
@@ -366,37 +366,37 @@ simulate(TestInversePlant.BackwardOffDesignHomotopy); getErrorString();
 // -----------------------------
 //   (21) Algorithm
 //   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_10[$i1] := (plant.cp * $SEED_ALG_LS_JAC_1.plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) + plant.cp * plant.wfg * ($SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1] - $SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1])) - $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_LS_JAC_1.$RES_SIM_10[$i1] := (plant.cp * $SEED_INI_LS_JAC_1.plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) + plant.cp * plant.wfg * ($SEED_INI_LS_JAC_1.plant.Tfg[6 - $i1] - $SEED_INI_LS_JAC_1.plant.Tfg[7 - $i1])) - $SEED_INI_LS_JAC_1.plant.Q[$i1];
 //   end for;
 //   (20) Algorithm
 //   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_12[$i1] := ((0.5 * ($SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1] + $SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_ALG_LS_JAC_1.plant.T[1 + $i1] + $SEED_ALG_LS_JAC_1.plant.T[$i1])) * plant.G[$i1] + (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * $SEED_ALG_LS_JAC_1.plant.G[$i1]) - $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_LS_JAC_1.$RES_SIM_12[$i1] := ((0.5 * ($SEED_INI_LS_JAC_1.plant.Tfg[7 - $i1] + $SEED_INI_LS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_INI_LS_JAC_1.plant.T[1 + $i1] + $SEED_INI_LS_JAC_1.plant.T[$i1])) * plant.G[$i1] + (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * $SEED_INI_LS_JAC_1.plant.G[$i1]) - $SEED_INI_LS_JAC_1.plant.Q[$i1];
 //   end for;
 //   (19) Algorithm
 //   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_14[$i1] := (0.2 * plant.NTU) * (0.8 * plant.w ^ (-0.19999999999999996) * $SEED_ALG_LS_JAC_1.plant.w) - $SEED_ALG_LS_JAC_1.plant.G[$i1];
+//     $pDER_INI_LS_JAC_1.$RES_SIM_14[$i1] := (0.2 * plant.NTU) * (0.8 * plant.w ^ (-0.19999999999999996) * $SEED_INI_LS_JAC_1.plant.w) - $SEED_INI_LS_JAC_1.plant.G[$i1];
 //   end for;
 //   (18) Algorithm
 //   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_8[$i1] := (plant.cp * $SEED_ALG_LS_JAC_1.plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.cp * plant.w * ($SEED_ALG_LS_JAC_1.plant.T[$i1] - $SEED_ALG_LS_JAC_1.plant.T[1 + $i1])) + $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_LS_JAC_1.$RES_SIM_8[$i1] := (plant.cp * $SEED_INI_LS_JAC_1.plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.cp * plant.w * ($SEED_INI_LS_JAC_1.plant.T[$i1] - $SEED_INI_LS_JAC_1.plant.T[1 + $i1])) + $SEED_INI_LS_JAC_1.plant.Q[$i1];
 //   end for;
-//   (17) $pDER_ALG_LS_JAC_1.$RES_BND_20 := $SEED_ALG_LS_JAC_1.plant.T[6] - $SEED_ALG_LS_JAC_1.plant.TIT
-//   (16) $pDER_ALG_LS_JAC_1.$RES_SIM_6 := $SEED_ALG_LS_JAC_1.plant.TIT * plant.cp * plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * $SEED_ALG_LS_JAC_1.plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * plant.w * (((plant.gamma - 1.0) / plant.gamma) * (plant.TOP / plant.TIP) ^ ((-1.0) + (plant.gamma - 1.0) / plant.gamma) * ((plant.TOP * $SEED_ALG_LS_JAC_1.plant.TIP) / plant.TIP ^ 2.0))
-//   (15) $pDER_ALG_LS_JAC_1.$RES_BND_22 := $SEED_ALG_LS_JAC_1.plant.p[6] - $SEED_ALG_LS_JAC_1.plant.TIP
-//   (14) $pDER_ALG_LS_JAC_1.$RES_SIM_7 := (($SEED_ALG_LS_JAC_1.plant.p[6] * plant.Kt) * $FUN_1 - $SEED_ALG_LS_JAC_1.$FUN_1 * plant.p[6] * plant.Kt) / $FUN_1 ^ 2.0 - $SEED_ALG_LS_JAC_1.plant.w
-//   (13) $pDER_ALG_LS_JAC_1.$RES_AUX_24 := (0.5 / (plant.TIT / plant.Tnom) ^ 0.5) * (($SEED_ALG_LS_JAC_1.plant.TIT * plant.Tnom) / plant.Tnom ^ 2.0) - $SEED_ALG_LS_JAC_1.$FUN_1
+//   (17) $pDER_INI_LS_JAC_1.$RES_BND_20 := $SEED_INI_LS_JAC_1.plant.T[6] - $SEED_INI_LS_JAC_1.plant.TIT
+//   (16) $pDER_INI_LS_JAC_1.$RES_SIM_6 := $SEED_INI_LS_JAC_1.plant.TIT * plant.cp * plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * $SEED_INI_LS_JAC_1.plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * plant.w * (((plant.gamma - 1.0) / plant.gamma) * (plant.TOP / plant.TIP) ^ ((-1.0) + (plant.gamma - 1.0) / plant.gamma) * ((plant.TOP * $SEED_INI_LS_JAC_1.plant.TIP) / plant.TIP ^ 2.0))
+//   (15) $pDER_INI_LS_JAC_1.$RES_BND_22 := $SEED_INI_LS_JAC_1.plant.p[6] - $SEED_INI_LS_JAC_1.plant.TIP
+//   (14) $pDER_INI_LS_JAC_1.$RES_SIM_7 := (($SEED_INI_LS_JAC_1.plant.p[6] * plant.Kt) * $FUN_1 - $SEED_INI_LS_JAC_1.$FUN_1 * plant.p[6] * plant.Kt) / $FUN_1 ^ 2.0 - $SEED_INI_LS_JAC_1.plant.w
+//   (13) $pDER_INI_LS_JAC_1.$RES_AUX_24 := (0.5 / (plant.TIT / plant.Tnom) ^ 0.5) * (($SEED_INI_LS_JAC_1.plant.TIT * plant.Tnom) / plant.Tnom ^ 2.0) - $SEED_INI_LS_JAC_1.$FUN_1
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_SIM_10 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_10[:]} ... {($SEED_ALG_LS_JAC_1.plant.Q[$i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.wfg, {}, false)}
-// $RES_SIM_12 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_12[:]} ... {($SEED_ALG_LS_JAC_1.plant.Q[$i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.G[$i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.T[$i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.T[1 + $i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1], {}, false)}
-// $RES_SIM_14 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_14[:]} ... {($SEED_ALG_LS_JAC_1.plant.G[$i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.w, {}, false)}
-// $RES_SIM_8 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_8[:]} ... {($SEED_ALG_LS_JAC_1.plant.Q[$i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.T[1 + $i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.T[$i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.w, {}, false)}
-// $RES_BND_20 ... {$pDER_ALG_LS_JAC_1.$RES_BND_20} ... {($SEED_ALG_LS_JAC_1.plant.TIT, {}, false), ($SEED_ALG_LS_JAC_1.plant.T[6], {}, false)}
-// $RES_SIM_6 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_6} ... {($SEED_ALG_LS_JAC_1.plant.TIP, {}, false), ($SEED_ALG_LS_JAC_1.plant.w, {}, false), ($SEED_ALG_LS_JAC_1.plant.TIT, {}, false)}
-// $RES_BND_22 ... {$pDER_ALG_LS_JAC_1.$RES_BND_22} ... {($SEED_ALG_LS_JAC_1.plant.TIP, {}, false), ($SEED_ALG_LS_JAC_1.plant.p[6], {}, false)}
-// $RES_SIM_7 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_7} ... {($SEED_ALG_LS_JAC_1.plant.w, {}, false), ($SEED_ALG_LS_JAC_1.$FUN_1, {}, false), ($SEED_ALG_LS_JAC_1.plant.p[6], {}, false)}
-// $RES_AUX_24 ... {$pDER_ALG_LS_JAC_1.$RES_AUX_24} ... {($SEED_ALG_LS_JAC_1.$FUN_1, {}, false), ($SEED_ALG_LS_JAC_1.plant.TIT, {}, true)}
+// $RES_SIM_10 ... {$pDER_INI_LS_JAC_1.$RES_SIM_10[:]} ... {($SEED_INI_LS_JAC_1.plant.Q[$i1], {}, false), ($SEED_INI_LS_JAC_1.plant.Tfg[7 - $i1], {}, false), ($SEED_INI_LS_JAC_1.plant.Tfg[6 - $i1], {}, false), ($SEED_INI_LS_JAC_1.plant.wfg, {}, false)}
+// $RES_SIM_12 ... {$pDER_INI_LS_JAC_1.$RES_SIM_12[:]} ... {($SEED_INI_LS_JAC_1.plant.Q[$i1], {}, false), ($SEED_INI_LS_JAC_1.plant.G[$i1], {}, false), ($SEED_INI_LS_JAC_1.plant.T[$i1], {}, false), ($SEED_INI_LS_JAC_1.plant.T[1 + $i1], {}, false), ($SEED_INI_LS_JAC_1.plant.Tfg[6 - $i1], {}, false), ($SEED_INI_LS_JAC_1.plant.Tfg[7 - $i1], {}, false)}
+// $RES_SIM_14 ... {$pDER_INI_LS_JAC_1.$RES_SIM_14[:]} ... {($SEED_INI_LS_JAC_1.plant.G[$i1], {}, false), ($SEED_INI_LS_JAC_1.plant.w, {}, false)}
+// $RES_SIM_8 ... {$pDER_INI_LS_JAC_1.$RES_SIM_8[:]} ... {($SEED_INI_LS_JAC_1.plant.Q[$i1], {}, false), ($SEED_INI_LS_JAC_1.plant.T[1 + $i1], {}, false), ($SEED_INI_LS_JAC_1.plant.T[$i1], {}, false), ($SEED_INI_LS_JAC_1.plant.w, {}, false)}
+// $RES_BND_20 ... {$pDER_INI_LS_JAC_1.$RES_BND_20} ... {($SEED_INI_LS_JAC_1.plant.TIT, {}, false), ($SEED_INI_LS_JAC_1.plant.T[6], {}, false)}
+// $RES_SIM_6 ... {$pDER_INI_LS_JAC_1.$RES_SIM_6} ... {($SEED_INI_LS_JAC_1.plant.TIP, {}, false), ($SEED_INI_LS_JAC_1.plant.w, {}, false), ($SEED_INI_LS_JAC_1.plant.TIT, {}, false)}
+// $RES_BND_22 ... {$pDER_INI_LS_JAC_1.$RES_BND_22} ... {($SEED_INI_LS_JAC_1.plant.TIP, {}, false), ($SEED_INI_LS_JAC_1.plant.p[6], {}, false)}
+// $RES_SIM_7 ... {$pDER_INI_LS_JAC_1.$RES_SIM_7} ... {($SEED_INI_LS_JAC_1.plant.w, {}, false), ($SEED_INI_LS_JAC_1.$FUN_1, {}, false), ($SEED_INI_LS_JAC_1.plant.p[6], {}, false)}
+// $RES_AUX_24 ... {$pDER_INI_LS_JAC_1.$RES_AUX_24} ... {($SEED_INI_LS_JAC_1.$FUN_1, {}, false), ($SEED_INI_LS_JAC_1.plant.TIT, {}, true)}
 //
 // ===========================================================
 //   SimCode Jacobian INI_0_LS_JAC_1(idx = 1, partition = 1)
@@ -404,23 +404,23 @@ simulate(TestInversePlant.BackwardOffDesignHomotopy); getErrorString();
 //
 // SeedVars (size = 17)
 // **********************
-//   (0)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Tfg[1]
-//   (1)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Tfg[2]
-//   (2)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Tfg[3]
-//   (3)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Tfg[4]
-//   (4)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Tfg[5]
-//   (5)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Tfg[6]
-//   (6)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Q[1]
-//   (7)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Q[2]
-//   (8)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Q[3]
-//   (9)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Q[4]
-//   (10)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Q[5]
-//   (11)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.T[1]
-//   (12)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.T[2]
-//   (13)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.T[3]
-//   (14)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.T[4]
-//   (15)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.T[5]
-//   (16)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.T[6]
+//   (0)[SEED] (1) Real $SEED_INI_0_LS_JAC_1.plant.Tfg[1]
+//   (1)[SEED] (1) Real $SEED_INI_0_LS_JAC_1.plant.Tfg[2]
+//   (2)[SEED] (1) Real $SEED_INI_0_LS_JAC_1.plant.Tfg[3]
+//   (3)[SEED] (1) Real $SEED_INI_0_LS_JAC_1.plant.Tfg[4]
+//   (4)[SEED] (1) Real $SEED_INI_0_LS_JAC_1.plant.Tfg[5]
+//   (5)[SEED] (1) Real $SEED_INI_0_LS_JAC_1.plant.Tfg[6]
+//   (6)[SEED] (1) Real $SEED_INI_0_LS_JAC_1.plant.Q[1]
+//   (7)[SEED] (1) Real $SEED_INI_0_LS_JAC_1.plant.Q[2]
+//   (8)[SEED] (1) Real $SEED_INI_0_LS_JAC_1.plant.Q[3]
+//   (9)[SEED] (1) Real $SEED_INI_0_LS_JAC_1.plant.Q[4]
+//   (10)[SEED] (1) Real $SEED_INI_0_LS_JAC_1.plant.Q[5]
+//   (11)[SEED] (1) Real $SEED_INI_0_LS_JAC_1.plant.T[1]
+//   (12)[SEED] (1) Real $SEED_INI_0_LS_JAC_1.plant.T[2]
+//   (13)[SEED] (1) Real $SEED_INI_0_LS_JAC_1.plant.T[3]
+//   (14)[SEED] (1) Real $SEED_INI_0_LS_JAC_1.plant.T[4]
+//   (15)[SEED] (1) Real $SEED_INI_0_LS_JAC_1.plant.T[5]
+//   (16)[SEED] (1) Real $SEED_INI_0_LS_JAC_1.plant.T[6]
 //
 // TmpVars (size = 0)
 // ********************
@@ -432,22 +432,22 @@ simulate(TestInversePlant.BackwardOffDesignHomotopy); getErrorString();
 // -----------------------------
 //   (42) Algorithm
 //   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_12[$i1] := (0.5 * ($SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1] + $SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_ALG_LS_JAC_1.plant.T[1 + $i1] + $SEED_ALG_LS_JAC_1.plant.T[$i1])) * plant.G[$i1] - $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_0_LS_JAC_1.$RES_SIM_12[$i1] := (0.5 * ($SEED_INI_0_LS_JAC_1.plant.Tfg[7 - $i1] + $SEED_INI_0_LS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_INI_0_LS_JAC_1.plant.T[1 + $i1] + $SEED_INI_0_LS_JAC_1.plant.T[$i1])) * plant.G[$i1] - $SEED_INI_0_LS_JAC_1.plant.Q[$i1];
 //   end for;
 //   (41) Algorithm
 //   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_10[$i1] := plant.cp * plant.wfg * ($SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1] - $SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1]) - $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_0_LS_JAC_1.$RES_SIM_10[$i1] := plant.cp * plant.wfg * ($SEED_INI_0_LS_JAC_1.plant.Tfg[6 - $i1] - $SEED_INI_0_LS_JAC_1.plant.Tfg[7 - $i1]) - $SEED_INI_0_LS_JAC_1.plant.Q[$i1];
 //   end for;
 //   (40) Algorithm
 //   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_8[$i1] := plant.cp * plant.w * ($SEED_ALG_LS_JAC_1.plant.T[$i1] - $SEED_ALG_LS_JAC_1.plant.T[1 + $i1]) + $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_0_LS_JAC_1.$RES_SIM_8[$i1] := plant.cp * plant.w * ($SEED_INI_0_LS_JAC_1.plant.T[$i1] - $SEED_INI_0_LS_JAC_1.plant.T[1 + $i1]) + $SEED_INI_0_LS_JAC_1.plant.Q[$i1];
 //   end for;
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_SIM_12 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_12[:]} ... {($SEED_ALG_LS_JAC_1.plant.Q[$i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.T[$i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.T[1 + $i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1], {}, false)}
-// $RES_SIM_10 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_10[:]} ... {($SEED_ALG_LS_JAC_1.plant.Q[$i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1], {}, false)}
-// $RES_SIM_8 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_8[:]} ... {($SEED_ALG_LS_JAC_1.plant.Q[$i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.T[1 + $i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.T[$i1], {}, false)}
+// $RES_SIM_12 ... {$pDER_INI_0_LS_JAC_1.$RES_SIM_12[:]} ... {($SEED_INI_0_LS_JAC_1.plant.Q[$i1], {}, false), ($SEED_INI_0_LS_JAC_1.plant.T[$i1], {}, false), ($SEED_INI_0_LS_JAC_1.plant.T[1 + $i1], {}, false), ($SEED_INI_0_LS_JAC_1.plant.Tfg[6 - $i1], {}, false), ($SEED_INI_0_LS_JAC_1.plant.Tfg[7 - $i1], {}, false)}
+// $RES_SIM_10 ... {$pDER_INI_0_LS_JAC_1.$RES_SIM_10[:]} ... {($SEED_INI_0_LS_JAC_1.plant.Q[$i1], {}, false), ($SEED_INI_0_LS_JAC_1.plant.Tfg[7 - $i1], {}, false), ($SEED_INI_0_LS_JAC_1.plant.Tfg[6 - $i1], {}, false)}
+// $RES_SIM_8 ... {$pDER_INI_0_LS_JAC_1.$RES_SIM_8[:]} ... {($SEED_INI_0_LS_JAC_1.plant.Q[$i1], {}, false), ($SEED_INI_0_LS_JAC_1.plant.T[1 + $i1], {}, false), ($SEED_INI_0_LS_JAC_1.plant.T[$i1], {}, false)}
 //
 // =========================================================
 //   SimCode Jacobian ALG_LS_JAC_1(idx = 2, partition = 2)
@@ -720,26 +720,26 @@ simulate(TestInversePlant.BackwardOffDesignHomotopy); getErrorString();
 // 	12: sqrt(plant.TIT / plant.Tnom) - $FUN_1 (RESIDUAL)
 // 	Jacobian idx: 0
 // 	21:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_10[$i1] := plant.cp * $SEED_ALG_LS_JAC_1.plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) + plant.cp * plant.wfg * ($SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1] - $SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1]) - $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_LS_JAC_1.$RES_SIM_10[$i1] := plant.cp * $SEED_INI_LS_JAC_1.plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) + plant.cp * plant.wfg * ($SEED_INI_LS_JAC_1.plant.Tfg[6 - $i1] - $SEED_INI_LS_JAC_1.plant.Tfg[7 - $i1]) - $SEED_INI_LS_JAC_1.plant.Q[$i1];
 //   end for;
 //
 // 	20:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_12[$i1] := (0.5 * ($SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1] + $SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_ALG_LS_JAC_1.plant.T[1 + $i1] + $SEED_ALG_LS_JAC_1.plant.T[$i1])) * plant.G[$i1] + (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * $SEED_ALG_LS_JAC_1.plant.G[$i1] - $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_LS_JAC_1.$RES_SIM_12[$i1] := (0.5 * ($SEED_INI_LS_JAC_1.plant.Tfg[7 - $i1] + $SEED_INI_LS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_INI_LS_JAC_1.plant.T[1 + $i1] + $SEED_INI_LS_JAC_1.plant.T[$i1])) * plant.G[$i1] + (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * $SEED_INI_LS_JAC_1.plant.G[$i1] - $SEED_INI_LS_JAC_1.plant.Q[$i1];
 //   end for;
 //
 // 	19:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_14[$i1] := 0.2 * plant.NTU * 0.8 * plant.w ^ (-0.19999999999999996) * $SEED_ALG_LS_JAC_1.plant.w - $SEED_ALG_LS_JAC_1.plant.G[$i1];
+//     $pDER_INI_LS_JAC_1.$RES_SIM_14[$i1] := 0.2 * plant.NTU * 0.8 * plant.w ^ (-0.19999999999999996) * $SEED_INI_LS_JAC_1.plant.w - $SEED_INI_LS_JAC_1.plant.G[$i1];
 //   end for;
 //
 // 	18:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_8[$i1] := plant.cp * $SEED_ALG_LS_JAC_1.plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.cp * plant.w * ($SEED_ALG_LS_JAC_1.plant.T[$i1] - $SEED_ALG_LS_JAC_1.plant.T[1 + $i1]) + $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_LS_JAC_1.$RES_SIM_8[$i1] := plant.cp * $SEED_INI_LS_JAC_1.plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.cp * plant.w * ($SEED_INI_LS_JAC_1.plant.T[$i1] - $SEED_INI_LS_JAC_1.plant.T[1 + $i1]) + $SEED_INI_LS_JAC_1.plant.Q[$i1];
 //   end for;
 //
-// 	17: $pDER_ALG_LS_JAC_1.$RES_BND_20=$SEED_ALG_LS_JAC_1.plant.T[6] - $SEED_ALG_LS_JAC_1.plant.TIT [Real]
-// 	16: $pDER_ALG_LS_JAC_1.$RES_SIM_6=$SEED_ALG_LS_JAC_1.plant.TIT * plant.cp * plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * $SEED_ALG_LS_JAC_1.plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * plant.w * (plant.gamma - 1.0) / plant.gamma * (plant.TOP / plant.TIP) ^ (-1.0 + (plant.gamma - 1.0) / plant.gamma) * plant.TOP * $SEED_ALG_LS_JAC_1.plant.TIP / plant.TIP ^ 2.0 [Real]
-// 	15: $pDER_ALG_LS_JAC_1.$RES_BND_22=$SEED_ALG_LS_JAC_1.plant.p[6] - $SEED_ALG_LS_JAC_1.plant.TIP [Real]
-// 	14: $pDER_ALG_LS_JAC_1.$RES_SIM_7=($SEED_ALG_LS_JAC_1.plant.p[6] * plant.Kt * $FUN_1 - $SEED_ALG_LS_JAC_1.$FUN_1 * plant.p[6] * plant.Kt) / $FUN_1 ^ 2.0 - $SEED_ALG_LS_JAC_1.plant.w [Real]
-// 	13: $pDER_ALG_LS_JAC_1.$RES_AUX_24=0.5 / (plant.TIT / plant.Tnom) ^ 0.5 * $SEED_ALG_LS_JAC_1.plant.TIT * plant.Tnom / plant.Tnom ^ 2.0 - $SEED_ALG_LS_JAC_1.$FUN_1 [Real]
+// 	17: $pDER_INI_LS_JAC_1.$RES_BND_20=$SEED_INI_LS_JAC_1.plant.T[6] - $SEED_INI_LS_JAC_1.plant.TIT [Real]
+// 	16: $pDER_INI_LS_JAC_1.$RES_SIM_6=$SEED_INI_LS_JAC_1.plant.TIT * plant.cp * plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * $SEED_INI_LS_JAC_1.plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * plant.w * (plant.gamma - 1.0) / plant.gamma * (plant.TOP / plant.TIP) ^ (-1.0 + (plant.gamma - 1.0) / plant.gamma) * plant.TOP * $SEED_INI_LS_JAC_1.plant.TIP / plant.TIP ^ 2.0 [Real]
+// 	15: $pDER_INI_LS_JAC_1.$RES_BND_22=$SEED_INI_LS_JAC_1.plant.p[6] - $SEED_INI_LS_JAC_1.plant.TIP [Real]
+// 	14: $pDER_INI_LS_JAC_1.$RES_SIM_7=($SEED_INI_LS_JAC_1.plant.p[6] * plant.Kt * $FUN_1 - $SEED_INI_LS_JAC_1.$FUN_1 * plant.p[6] * plant.Kt) / $FUN_1 ^ 2.0 - $SEED_INI_LS_JAC_1.plant.w [Real]
+// 	13: $pDER_INI_LS_JAC_1.$RES_AUX_24=0.5 / (plant.TIT / plant.Tnom) ^ 0.5 * $SEED_INI_LS_JAC_1.plant.TIT * plant.Tnom / plant.Tnom ^ 2.0 - $SEED_INI_LS_JAC_1.$FUN_1 [Real]
 // 	
 //
 // 3:  (SES_RESIZABLE_ASSIGN)  call index: 0
@@ -765,15 +765,15 @@ simulate(TestInversePlant.BackwardOffDesignHomotopy); getErrorString();
 // 	39: plant.cp * plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.Q[$i1] (FOR_RESIDUAL)
 // 	Jacobian idx: 1
 // 	42:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_12[$i1] := (0.5 * ($SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1] + $SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_ALG_LS_JAC_1.plant.T[1 + $i1] + $SEED_ALG_LS_JAC_1.plant.T[$i1])) * plant.G[$i1] - $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_0_LS_JAC_1.$RES_SIM_12[$i1] := (0.5 * ($SEED_INI_0_LS_JAC_1.plant.Tfg[7 - $i1] + $SEED_INI_0_LS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_INI_0_LS_JAC_1.plant.T[1 + $i1] + $SEED_INI_0_LS_JAC_1.plant.T[$i1])) * plant.G[$i1] - $SEED_INI_0_LS_JAC_1.plant.Q[$i1];
 //   end for;
 //
 // 	41:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_10[$i1] := plant.cp * plant.wfg * ($SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1] - $SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1]) - $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_0_LS_JAC_1.$RES_SIM_10[$i1] := plant.cp * plant.wfg * ($SEED_INI_0_LS_JAC_1.plant.Tfg[6 - $i1] - $SEED_INI_0_LS_JAC_1.plant.Tfg[7 - $i1]) - $SEED_INI_0_LS_JAC_1.plant.Q[$i1];
 //   end for;
 //
 // 	40:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_8[$i1] := plant.cp * plant.w * ($SEED_ALG_LS_JAC_1.plant.T[$i1] - $SEED_ALG_LS_JAC_1.plant.T[1 + $i1]) + $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_0_LS_JAC_1.$RES_SIM_8[$i1] := plant.cp * plant.w * ($SEED_INI_0_LS_JAC_1.plant.T[$i1] - $SEED_INI_0_LS_JAC_1.plant.T[1 + $i1]) + $SEED_INI_0_LS_JAC_1.plant.Q[$i1];
 //   end for;
 //
 // 	
@@ -828,38 +828,38 @@ simulate(TestInversePlant.BackwardOffDesignHomotopy); getErrorString();
 // ========================================
 // 	Jacobian idx: 0
 // 	21:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_10[$i1] := plant.cp * $SEED_ALG_LS_JAC_1.plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) + plant.cp * plant.wfg * ($SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1] - $SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1]) - $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_LS_JAC_1.$RES_SIM_10[$i1] := plant.cp * $SEED_INI_LS_JAC_1.plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) + plant.cp * plant.wfg * ($SEED_INI_LS_JAC_1.plant.Tfg[6 - $i1] - $SEED_INI_LS_JAC_1.plant.Tfg[7 - $i1]) - $SEED_INI_LS_JAC_1.plant.Q[$i1];
 //   end for;
 //
 // 	20:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_12[$i1] := (0.5 * ($SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1] + $SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_ALG_LS_JAC_1.plant.T[1 + $i1] + $SEED_ALG_LS_JAC_1.plant.T[$i1])) * plant.G[$i1] + (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * $SEED_ALG_LS_JAC_1.plant.G[$i1] - $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_LS_JAC_1.$RES_SIM_12[$i1] := (0.5 * ($SEED_INI_LS_JAC_1.plant.Tfg[7 - $i1] + $SEED_INI_LS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_INI_LS_JAC_1.plant.T[1 + $i1] + $SEED_INI_LS_JAC_1.plant.T[$i1])) * plant.G[$i1] + (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * $SEED_INI_LS_JAC_1.plant.G[$i1] - $SEED_INI_LS_JAC_1.plant.Q[$i1];
 //   end for;
 //
 // 	19:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_14[$i1] := 0.2 * plant.NTU * 0.8 * plant.w ^ (-0.19999999999999996) * $SEED_ALG_LS_JAC_1.plant.w - $SEED_ALG_LS_JAC_1.plant.G[$i1];
+//     $pDER_INI_LS_JAC_1.$RES_SIM_14[$i1] := 0.2 * plant.NTU * 0.8 * plant.w ^ (-0.19999999999999996) * $SEED_INI_LS_JAC_1.plant.w - $SEED_INI_LS_JAC_1.plant.G[$i1];
 //   end for;
 //
 // 	18:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_8[$i1] := plant.cp * $SEED_ALG_LS_JAC_1.plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.cp * plant.w * ($SEED_ALG_LS_JAC_1.plant.T[$i1] - $SEED_ALG_LS_JAC_1.plant.T[1 + $i1]) + $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_LS_JAC_1.$RES_SIM_8[$i1] := plant.cp * $SEED_INI_LS_JAC_1.plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.cp * plant.w * ($SEED_INI_LS_JAC_1.plant.T[$i1] - $SEED_INI_LS_JAC_1.plant.T[1 + $i1]) + $SEED_INI_LS_JAC_1.plant.Q[$i1];
 //   end for;
 //
-// 	17: $pDER_ALG_LS_JAC_1.$RES_BND_20=$SEED_ALG_LS_JAC_1.plant.T[6] - $SEED_ALG_LS_JAC_1.plant.TIT [Real]
-// 	16: $pDER_ALG_LS_JAC_1.$RES_SIM_6=$SEED_ALG_LS_JAC_1.plant.TIT * plant.cp * plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * $SEED_ALG_LS_JAC_1.plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * plant.w * (plant.gamma - 1.0) / plant.gamma * (plant.TOP / plant.TIP) ^ (-1.0 + (plant.gamma - 1.0) / plant.gamma) * plant.TOP * $SEED_ALG_LS_JAC_1.plant.TIP / plant.TIP ^ 2.0 [Real]
-// 	15: $pDER_ALG_LS_JAC_1.$RES_BND_22=$SEED_ALG_LS_JAC_1.plant.p[6] - $SEED_ALG_LS_JAC_1.plant.TIP [Real]
-// 	14: $pDER_ALG_LS_JAC_1.$RES_SIM_7=($SEED_ALG_LS_JAC_1.plant.p[6] * plant.Kt * $FUN_1 - $SEED_ALG_LS_JAC_1.$FUN_1 * plant.p[6] * plant.Kt) / $FUN_1 ^ 2.0 - $SEED_ALG_LS_JAC_1.plant.w [Real]
-// 	13: $pDER_ALG_LS_JAC_1.$RES_AUX_24=0.5 / (plant.TIT / plant.Tnom) ^ 0.5 * $SEED_ALG_LS_JAC_1.plant.TIT * plant.Tnom / plant.Tnom ^ 2.0 - $SEED_ALG_LS_JAC_1.$FUN_1 [Real]
+// 	17: $pDER_INI_LS_JAC_1.$RES_BND_20=$SEED_INI_LS_JAC_1.plant.T[6] - $SEED_INI_LS_JAC_1.plant.TIT [Real]
+// 	16: $pDER_INI_LS_JAC_1.$RES_SIM_6=$SEED_INI_LS_JAC_1.plant.TIT * plant.cp * plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * $SEED_INI_LS_JAC_1.plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * plant.w * (plant.gamma - 1.0) / plant.gamma * (plant.TOP / plant.TIP) ^ (-1.0 + (plant.gamma - 1.0) / plant.gamma) * plant.TOP * $SEED_INI_LS_JAC_1.plant.TIP / plant.TIP ^ 2.0 [Real]
+// 	15: $pDER_INI_LS_JAC_1.$RES_BND_22=$SEED_INI_LS_JAC_1.plant.p[6] - $SEED_INI_LS_JAC_1.plant.TIP [Real]
+// 	14: $pDER_INI_LS_JAC_1.$RES_SIM_7=($SEED_INI_LS_JAC_1.plant.p[6] * plant.Kt * $FUN_1 - $SEED_INI_LS_JAC_1.$FUN_1 * plant.p[6] * plant.Kt) / $FUN_1 ^ 2.0 - $SEED_INI_LS_JAC_1.plant.w [Real]
+// 	13: $pDER_INI_LS_JAC_1.$RES_AUX_24=0.5 / (plant.TIT / plant.Tnom) ^ 0.5 * $SEED_INI_LS_JAC_1.plant.TIT * plant.Tnom / plant.Tnom ^ 2.0 - $SEED_INI_LS_JAC_1.$FUN_1 [Real]
 // 	
 // 	Jacobian idx: 1
 // 	42:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_12[$i1] := (0.5 * ($SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1] + $SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_ALG_LS_JAC_1.plant.T[1 + $i1] + $SEED_ALG_LS_JAC_1.plant.T[$i1])) * plant.G[$i1] - $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_0_LS_JAC_1.$RES_SIM_12[$i1] := (0.5 * ($SEED_INI_0_LS_JAC_1.plant.Tfg[7 - $i1] + $SEED_INI_0_LS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_INI_0_LS_JAC_1.plant.T[1 + $i1] + $SEED_INI_0_LS_JAC_1.plant.T[$i1])) * plant.G[$i1] - $SEED_INI_0_LS_JAC_1.plant.Q[$i1];
 //   end for;
 //
 // 	41:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_10[$i1] := plant.cp * plant.wfg * ($SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1] - $SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1]) - $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_0_LS_JAC_1.$RES_SIM_10[$i1] := plant.cp * plant.wfg * ($SEED_INI_0_LS_JAC_1.plant.Tfg[6 - $i1] - $SEED_INI_0_LS_JAC_1.plant.Tfg[7 - $i1]) - $SEED_INI_0_LS_JAC_1.plant.Q[$i1];
 //   end for;
 //
 // 	40:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_8[$i1] := plant.cp * plant.w * ($SEED_ALG_LS_JAC_1.plant.T[$i1] - $SEED_ALG_LS_JAC_1.plant.T[1 + $i1]) + $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_0_LS_JAC_1.$RES_SIM_8[$i1] := plant.cp * plant.w * ($SEED_INI_0_LS_JAC_1.plant.T[$i1] - $SEED_INI_0_LS_JAC_1.plant.T[1 + $i1]) + $SEED_INI_0_LS_JAC_1.plant.Q[$i1];
 //   end for;
 //
 // 	

--- a/testsuite/simulation/modelica/NBackend/initialization/experimental_initialSimplified.mos
+++ b/testsuite/simulation/modelica/NBackend/initialization/experimental_initialSimplified.mos
@@ -107,11 +107,11 @@ simulate(P.experimental_initialSimplified); getErrorString();
 //
 // SeedVars (size = 5)
 // *********************
-//   (0)[SEED] (1) Real $SEED_ALG_LS_JAC_1.u
-//   (1)[SEED] (1) Real $SEED_ALG_LS_JAC_1.$FUN_3
-//   (2)[SEED] (1) Real $SEED_ALG_LS_JAC_1.$FUN_2
-//   (3)[SEED] (1) Real $SEED_ALG_LS_JAC_1.y1
-//   (4)[SEED] (1) Real $SEED_ALG_LS_JAC_1.$FUN_1
+//   (0)[SEED] (1) Real $SEED_INI_LS_JAC_1.u
+//   (1)[SEED] (1) Real $SEED_INI_LS_JAC_1.$FUN_3
+//   (2)[SEED] (1) Real $SEED_INI_LS_JAC_1.$FUN_2
+//   (3)[SEED] (1) Real $SEED_INI_LS_JAC_1.y1
+//   (4)[SEED] (1) Real $SEED_INI_LS_JAC_1.$FUN_1
 //
 // TmpVars (size = 0)
 // ********************
@@ -121,19 +121,19 @@ simulate(P.experimental_initialSimplified); getErrorString();
 //
 // Column Equations (size = 5)
 // -----------------------------
-//   (10) $pDER_ALG_LS_JAC_1.$RES_AUX_5 := cos(1e-6 * u) * (1e-6 * $SEED_ALG_LS_JAC_1.u) - $SEED_ALG_LS_JAC_1.$FUN_3
-//   (9) $pDER_ALG_LS_JAC_1.$RES_SIM_0 := $SEED_ALG_LS_JAC_1.$FUN_2 + $SEED_ALG_LS_JAC_1.$FUN_3
-//   (8) $pDER_ALG_LS_JAC_1.$RES_AUX_6 := (0.5 / y1 ^ 0.5) * $SEED_ALG_LS_JAC_1.y1 - $SEED_ALG_LS_JAC_1.$FUN_2
-//   (7) $pDER_ALG_LS_JAC_1.$RES_SIM_1 := (3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.$FUN_1) - $SEED_ALG_LS_JAC_1.y1
-//   (6) $pDER_ALG_LS_JAC_1.$RES_AUX_7 := cos(u) * $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.$FUN_1
+//   (10) $pDER_INI_LS_JAC_1.$RES_AUX_5 := cos(1e-6 * u) * (1e-6 * $SEED_INI_LS_JAC_1.u) - $SEED_INI_LS_JAC_1.$FUN_3
+//   (9) $pDER_INI_LS_JAC_1.$RES_SIM_0 := $SEED_INI_LS_JAC_1.$FUN_2 + $SEED_INI_LS_JAC_1.$FUN_3
+//   (8) $pDER_INI_LS_JAC_1.$RES_AUX_6 := (0.5 / y1 ^ 0.5) * $SEED_INI_LS_JAC_1.y1 - $SEED_INI_LS_JAC_1.$FUN_2
+//   (7) $pDER_INI_LS_JAC_1.$RES_SIM_1 := (3.0 * u ^ 2.0 * $SEED_INI_LS_JAC_1.u + $SEED_INI_LS_JAC_1.$FUN_1) - $SEED_INI_LS_JAC_1.y1
+//   (6) $pDER_INI_LS_JAC_1.$RES_AUX_7 := cos(u) * $SEED_INI_LS_JAC_1.u - $SEED_INI_LS_JAC_1.$FUN_1
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_AUX_5 ... {$pDER_ALG_LS_JAC_1.$RES_AUX_5} ... {($SEED_ALG_LS_JAC_1.$FUN_3, {}, false), ($SEED_ALG_LS_JAC_1.u, {}, true)}
-// $RES_SIM_0 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_0} ... {($SEED_ALG_LS_JAC_1.$FUN_3, {}, false), ($SEED_ALG_LS_JAC_1.$FUN_2, {}, false)}
-// $RES_AUX_6 ... {$pDER_ALG_LS_JAC_1.$RES_AUX_6} ... {($SEED_ALG_LS_JAC_1.$FUN_2, {}, false), ($SEED_ALG_LS_JAC_1.y1, {}, true)}
-// $RES_SIM_1 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_1} ... {($SEED_ALG_LS_JAC_1.y1, {}, false), ($SEED_ALG_LS_JAC_1.$FUN_1, {}, false), ($SEED_ALG_LS_JAC_1.u, {}, false)}
-// $RES_AUX_7 ... {$pDER_ALG_LS_JAC_1.$RES_AUX_7} ... {($SEED_ALG_LS_JAC_1.$FUN_1, {}, false), ($SEED_ALG_LS_JAC_1.u, {}, true)}
+// $RES_AUX_5 ... {$pDER_INI_LS_JAC_1.$RES_AUX_5} ... {($SEED_INI_LS_JAC_1.$FUN_3, {}, false), ($SEED_INI_LS_JAC_1.u, {}, true)}
+// $RES_SIM_0 ... {$pDER_INI_LS_JAC_1.$RES_SIM_0} ... {($SEED_INI_LS_JAC_1.$FUN_3, {}, false), ($SEED_INI_LS_JAC_1.$FUN_2, {}, false)}
+// $RES_AUX_6 ... {$pDER_INI_LS_JAC_1.$RES_AUX_6} ... {($SEED_INI_LS_JAC_1.$FUN_2, {}, false), ($SEED_INI_LS_JAC_1.y1, {}, true)}
+// $RES_SIM_1 ... {$pDER_INI_LS_JAC_1.$RES_SIM_1} ... {($SEED_INI_LS_JAC_1.y1, {}, false), ($SEED_INI_LS_JAC_1.$FUN_1, {}, false), ($SEED_INI_LS_JAC_1.u, {}, false)}
+// $RES_AUX_7 ... {$pDER_INI_LS_JAC_1.$RES_AUX_7} ... {($SEED_INI_LS_JAC_1.$FUN_1, {}, false), ($SEED_INI_LS_JAC_1.u, {}, true)}
 //
 // =========================================================
 //   SimCode Jacobian ALG_LS_JAC_1(idx = 1, partition = 1)
@@ -288,11 +288,11 @@ simulate(P.experimental_initialSimplified); getErrorString();
 // 	4: u ^ 3.0 + $FUN_1 - y1 (RESIDUAL)
 // 	5: sin(u) - $FUN_1 (RESIDUAL)
 // 	Jacobian idx: 0
-// 	10: $pDER_ALG_LS_JAC_1.$RES_AUX_5=cos(1e-6 * u) * 1e-6 * $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.$FUN_3 [Real]
-// 	9: $pDER_ALG_LS_JAC_1.$RES_SIM_0=$SEED_ALG_LS_JAC_1.$FUN_2 + $SEED_ALG_LS_JAC_1.$FUN_3 [Real]
-// 	8: $pDER_ALG_LS_JAC_1.$RES_AUX_6=0.5 / y1 ^ 0.5 * $SEED_ALG_LS_JAC_1.y1 - $SEED_ALG_LS_JAC_1.$FUN_2 [Real]
-// 	7: $pDER_ALG_LS_JAC_1.$RES_SIM_1=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.$FUN_1 - $SEED_ALG_LS_JAC_1.y1 [Real]
-// 	6: $pDER_ALG_LS_JAC_1.$RES_AUX_7=cos(u) * $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.$FUN_1 [Real]
+// 	10: $pDER_INI_LS_JAC_1.$RES_AUX_5=cos(1e-6 * u) * 1e-6 * $SEED_INI_LS_JAC_1.u - $SEED_INI_LS_JAC_1.$FUN_3 [Real]
+// 	9: $pDER_INI_LS_JAC_1.$RES_SIM_0=$SEED_INI_LS_JAC_1.$FUN_2 + $SEED_INI_LS_JAC_1.$FUN_3 [Real]
+// 	8: $pDER_INI_LS_JAC_1.$RES_AUX_6=0.5 / y1 ^ 0.5 * $SEED_INI_LS_JAC_1.y1 - $SEED_INI_LS_JAC_1.$FUN_2 [Real]
+// 	7: $pDER_INI_LS_JAC_1.$RES_SIM_1=3.0 * u ^ 2.0 * $SEED_INI_LS_JAC_1.u + $SEED_INI_LS_JAC_1.$FUN_1 - $SEED_INI_LS_JAC_1.y1 [Real]
+// 	6: $pDER_INI_LS_JAC_1.$RES_AUX_7=cos(u) * $SEED_INI_LS_JAC_1.u - $SEED_INI_LS_JAC_1.$FUN_1 [Real]
 //
 //
 // ========================================
@@ -344,11 +344,11 @@ simulate(P.experimental_initialSimplified); getErrorString();
 // jacobianMatrices:
 // ========================================
 // 	Jacobian idx: 0
-// 	10: $pDER_ALG_LS_JAC_1.$RES_AUX_5=cos(1e-6 * u) * 1e-6 * $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.$FUN_3 [Real]
-// 	9: $pDER_ALG_LS_JAC_1.$RES_SIM_0=$SEED_ALG_LS_JAC_1.$FUN_2 + $SEED_ALG_LS_JAC_1.$FUN_3 [Real]
-// 	8: $pDER_ALG_LS_JAC_1.$RES_AUX_6=0.5 / y1 ^ 0.5 * $SEED_ALG_LS_JAC_1.y1 - $SEED_ALG_LS_JAC_1.$FUN_2 [Real]
-// 	7: $pDER_ALG_LS_JAC_1.$RES_SIM_1=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.$FUN_1 - $SEED_ALG_LS_JAC_1.y1 [Real]
-// 	6: $pDER_ALG_LS_JAC_1.$RES_AUX_7=cos(u) * $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.$FUN_1 [Real]
+// 	10: $pDER_INI_LS_JAC_1.$RES_AUX_5=cos(1e-6 * u) * 1e-6 * $SEED_INI_LS_JAC_1.u - $SEED_INI_LS_JAC_1.$FUN_3 [Real]
+// 	9: $pDER_INI_LS_JAC_1.$RES_SIM_0=$SEED_INI_LS_JAC_1.$FUN_2 + $SEED_INI_LS_JAC_1.$FUN_3 [Real]
+// 	8: $pDER_INI_LS_JAC_1.$RES_AUX_6=0.5 / y1 ^ 0.5 * $SEED_INI_LS_JAC_1.y1 - $SEED_INI_LS_JAC_1.$FUN_2 [Real]
+// 	7: $pDER_INI_LS_JAC_1.$RES_SIM_1=3.0 * u ^ 2.0 * $SEED_INI_LS_JAC_1.u + $SEED_INI_LS_JAC_1.$FUN_1 - $SEED_INI_LS_JAC_1.y1 [Real]
+// 	6: $pDER_INI_LS_JAC_1.$RES_AUX_7=cos(u) * $SEED_INI_LS_JAC_1.u - $SEED_INI_LS_JAC_1.$FUN_1 [Real]
 //
 // 	Jacobian idx: 1
 // 	30: $pDER_ALG_LS_JAC_1.$RES_AUX_5=cos(1e-6 * u) * 1e-6 * $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.$FUN_3 [Real]

--- a/testsuite/simulation/modelica/NBackend/initialization/homotopy_no_loop.mos
+++ b/testsuite/simulation/modelica/NBackend/initialization/homotopy_no_loop.mos
@@ -70,8 +70,8 @@ simulate(homotopy_no_loop); getErrorString();
 //
 // SeedVars (size = 2)
 // *********************
-//   (0)[SEED] (1) Real $SEED_ALG_LS_JAC_1.u
-//   (1)[SEED] (1) Real $SEED_ALG_LS_JAC_1.y
+//   (0)[SEED] (1) Real $SEED_INI_LS_JAC_1.u
+//   (1)[SEED] (1) Real $SEED_INI_LS_JAC_1.y
 //
 // TmpVars (size = 0)
 // ********************
@@ -81,13 +81,13 @@ simulate(homotopy_no_loop); getErrorString();
 //
 // Column Equations (size = 2)
 // -----------------------------
-//   (4) $pDER_ALG_LS_JAC_1.$RES_SIM_0 := (3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u) - $SEED_ALG_LS_JAC_1.y
-//   (3) $pDER_ALG_LS_JAC_1.$RES_SIM_1 := -homotopy($SEED_ALG_LS_JAC_1.u, $SEED_ALG_LS_JAC_1.y + 2.0 * y * $SEED_ALG_LS_JAC_1.y)
+//   (4) $pDER_INI_LS_JAC_1.$RES_SIM_0 := (3.0 * u ^ 2.0 * $SEED_INI_LS_JAC_1.u + $SEED_INI_LS_JAC_1.u) - $SEED_INI_LS_JAC_1.y
+//   (3) $pDER_INI_LS_JAC_1.$RES_SIM_1 := -homotopy($SEED_INI_LS_JAC_1.u, $SEED_INI_LS_JAC_1.y + 2.0 * y * $SEED_INI_LS_JAC_1.y)
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_SIM_0 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_0} ... {($SEED_ALG_LS_JAC_1.y, {}, false), ($SEED_ALG_LS_JAC_1.u, {}, false)}
-// $RES_SIM_1 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_1} ... {($SEED_ALG_LS_JAC_1.y, {}, true), ($SEED_ALG_LS_JAC_1.u, {}, true)}
+// $RES_SIM_0 ... {$pDER_INI_LS_JAC_1.$RES_SIM_0} ... {($SEED_INI_LS_JAC_1.y, {}, false), ($SEED_INI_LS_JAC_1.u, {}, false)}
+// $RES_SIM_1 ... {$pDER_INI_LS_JAC_1.$RES_SIM_1} ... {($SEED_INI_LS_JAC_1.y, {}, true), ($SEED_INI_LS_JAC_1.u, {}, true)}
 //
 // ============================================================
 //   SimCode Jacobian INI_0_NLS_JAC_1(idx = 2, partition = 2)
@@ -95,7 +95,7 @@ simulate(homotopy_no_loop); getErrorString();
 //
 // SeedVars (size = 1)
 // *********************
-//   (0)[SEED] (1) Real $SEED_ALG_LS_JAC_1.y
+//   (0)[SEED] (1) Real $SEED_INI_0_NLS_JAC_1.y
 //
 // TmpVars (size = 0)
 // ********************
@@ -105,11 +105,11 @@ simulate(homotopy_no_loop); getErrorString();
 //
 // Column Equations (size = 1)
 // -----------------------------
-//   (10) $pDER_ALG_LS_JAC_1.$RES_SIM_1 := -($SEED_ALG_LS_JAC_1.y + 2.0 * y * $SEED_ALG_LS_JAC_1.y)
+//   (10) $pDER_INI_0_NLS_JAC_1.$RES_SIM_1 := -($SEED_INI_0_NLS_JAC_1.y + 2.0 * y * $SEED_INI_0_NLS_JAC_1.y)
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_SIM_1 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_1} ... {($SEED_ALG_LS_JAC_1.y, {}, false)}
+// $RES_SIM_1 ... {$pDER_INI_0_NLS_JAC_1.$RES_SIM_1} ... {($SEED_INI_0_NLS_JAC_1.y, {}, false)}
 //
 // ============================================================
 //   SimCode Jacobian INI_0_NLS_JAC_2(idx = 1, partition = 1)
@@ -117,7 +117,7 @@ simulate(homotopy_no_loop); getErrorString();
 //
 // SeedVars (size = 1)
 // *********************
-//   (0)[SEED] (1) Real $SEED_ALG_LS_JAC_1.u
+//   (0)[SEED] (1) Real $SEED_INI_0_NLS_JAC_2.u
 //
 // TmpVars (size = 0)
 // ********************
@@ -127,11 +127,11 @@ simulate(homotopy_no_loop); getErrorString();
 //
 // Column Equations (size = 1)
 // -----------------------------
-//   (7) $pDER_ALG_LS_JAC_1.$RES_SIM_0 := 3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u
+//   (7) $pDER_INI_0_NLS_JAC_2.$RES_SIM_0 := 3.0 * u ^ 2.0 * $SEED_INI_0_NLS_JAC_2.u + $SEED_INI_0_NLS_JAC_2.u
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_SIM_0 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_0} ... {($SEED_ALG_LS_JAC_1.u, {}, false)}
+// $RES_SIM_0 ... {$pDER_INI_0_NLS_JAC_2.$RES_SIM_0} ... {($SEED_INI_0_NLS_JAC_2.u, {}, false)}
 //
 // =========================================================
 //   SimCode Jacobian ALG_LS_JAC_1(idx = 3, partition = 3)
@@ -254,8 +254,8 @@ simulate(homotopy_no_loop); getErrorString();
 // 	1: u ^ 3.0 + u - y (RESIDUAL)
 // 	2: 1.0 - homotopy(u, y + y ^ 2.0) (RESIDUAL)
 // 	Jacobian idx: 0
-// 	4: $pDER_ALG_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.y [Real]
-// 	3: $pDER_ALG_LS_JAC_1.$RES_SIM_1=-homotopy($SEED_ALG_LS_JAC_1.u, $SEED_ALG_LS_JAC_1.y + 2.0 * y * $SEED_ALG_LS_JAC_1.y) [Real]
+// 	4: $pDER_INI_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_LS_JAC_1.u + $SEED_INI_LS_JAC_1.u - $SEED_INI_LS_JAC_1.y [Real]
+// 	3: $pDER_INI_LS_JAC_1.$RES_SIM_1=-homotopy($SEED_INI_LS_JAC_1.u, $SEED_INI_LS_JAC_1.y + 2.0 * y * $SEED_INI_LS_JAC_1.y) [Real]
 //
 //
 // ========================================
@@ -268,14 +268,14 @@ simulate(homotopy_no_loop); getErrorString();
 // crefs: y
 // 	9: 1.0 - (y + y ^ 2.0) (RESIDUAL)
 // 	Jacobian idx: 2
-// 	10: $pDER_ALG_LS_JAC_1.$RES_SIM_1=-($SEED_ALG_LS_JAC_1.y + 2.0 * y * $SEED_ALG_LS_JAC_1.y) [Real]
+// 	10: $pDER_INI_0_NLS_JAC_1.$RES_SIM_1=-($SEED_INI_0_NLS_JAC_1.y + 2.0 * y * $SEED_INI_0_NLS_JAC_1.y) [Real]
 //
 //
 // 8:  (NONLINEAR) index:1 jacobian: true
 // crefs: u
 // 	6: u ^ 3.0 + u - y (RESIDUAL)
 // 	Jacobian idx: 1
-// 	7: $pDER_ALG_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u [Real]
+// 	7: $pDER_INI_0_NLS_JAC_2.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_0_NLS_JAC_2.u + $SEED_INI_0_NLS_JAC_2.u [Real]
 //
 //
 //
@@ -315,14 +315,14 @@ simulate(homotopy_no_loop); getErrorString();
 // jacobianMatrices:
 // ========================================
 // 	Jacobian idx: 0
-// 	4: $pDER_ALG_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.y [Real]
-// 	3: $pDER_ALG_LS_JAC_1.$RES_SIM_1=-homotopy($SEED_ALG_LS_JAC_1.u, $SEED_ALG_LS_JAC_1.y + 2.0 * y * $SEED_ALG_LS_JAC_1.y) [Real]
+// 	4: $pDER_INI_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_LS_JAC_1.u + $SEED_INI_LS_JAC_1.u - $SEED_INI_LS_JAC_1.y [Real]
+// 	3: $pDER_INI_LS_JAC_1.$RES_SIM_1=-homotopy($SEED_INI_LS_JAC_1.u, $SEED_INI_LS_JAC_1.y + 2.0 * y * $SEED_INI_LS_JAC_1.y) [Real]
 //
 // 	Jacobian idx: 2
-// 	10: $pDER_ALG_LS_JAC_1.$RES_SIM_1=-($SEED_ALG_LS_JAC_1.y + 2.0 * y * $SEED_ALG_LS_JAC_1.y) [Real]
+// 	10: $pDER_INI_0_NLS_JAC_1.$RES_SIM_1=-($SEED_INI_0_NLS_JAC_1.y + 2.0 * y * $SEED_INI_0_NLS_JAC_1.y) [Real]
 //
 // 	Jacobian idx: 1
-// 	7: $pDER_ALG_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u [Real]
+// 	7: $pDER_INI_0_NLS_JAC_2.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_0_NLS_JAC_2.u + $SEED_INI_0_NLS_JAC_2.u [Real]
 //
 // 	Jacobian idx: 3
 // 	15: $pDER_ALG_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.y [Real]

--- a/testsuite/simulation/modelica/NBackend/initialization/init_if_eq.mos
+++ b/testsuite/simulation/modelica/NBackend/initialization/init_if_eq.mos
@@ -68,7 +68,7 @@ simulate(init_if_eq); getErrorString();
 //
 // SeedVars (size = 1)
 // *********************
-//   (0)[SEED] (1) Real $SEED_ALG_LS_JAC_1.y
+//   (0)[SEED] (1) Real $SEED_INI_NLS_JAC_1.y
 //
 // TmpVars (size = 0)
 // ********************
@@ -78,11 +78,11 @@ simulate(init_if_eq); getErrorString();
 //
 // Column Equations (size = 1)
 // -----------------------------
-//   (5) $pDER_INI_NLS_JAC_1.$RES_SIM_2 := -($SEED_ALG_LS_JAC_1.y + 2.0 * y * $SEED_ALG_LS_JAC_1.y)
+//   (5) $pDER_INI_NLS_JAC_1.$RES_SIM_2 := -($SEED_INI_NLS_JAC_1.y + 2.0 * y * $SEED_INI_NLS_JAC_1.y)
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_SIM_2 ... {$pDER_INI_NLS_JAC_1.$RES_SIM_2} ... {($SEED_ALG_LS_JAC_1.y, {}, false)}
+// $RES_SIM_2 ... {$pDER_INI_NLS_JAC_1.$RES_SIM_2} ... {($SEED_INI_NLS_JAC_1.y, {}, false)}
 //
 // ==========================================================
 //   SimCode Jacobian INI_NLS_JAC_2(idx = 0, partition = 0)
@@ -90,7 +90,7 @@ simulate(init_if_eq); getErrorString();
 //
 // SeedVars (size = 1)
 // *********************
-//   (0)[SEED] (1) Real $SEED_ALG_LS_JAC_1.u
+//   (0)[SEED] (1) Real $SEED_INI_NLS_JAC_2.u
 //
 // TmpVars (size = 0)
 // ********************
@@ -100,11 +100,11 @@ simulate(init_if_eq); getErrorString();
 //
 // Column Equations (size = 1)
 // -----------------------------
-//   (2) $pDER_ALG_LS_JAC_1.$RES_SIM_0 := 3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u
+//   (2) $pDER_INI_NLS_JAC_2.$RES_SIM_0 := 3.0 * u ^ 2.0 * $SEED_INI_NLS_JAC_2.u + $SEED_INI_NLS_JAC_2.u
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_SIM_0 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_0} ... {($SEED_ALG_LS_JAC_1.u, {}, false)}
+// $RES_SIM_0 ... {$pDER_INI_NLS_JAC_2.$RES_SIM_0} ... {($SEED_INI_NLS_JAC_2.u, {}, false)}
 //
 // =========================================================
 //   SimCode Jacobian ALG_LS_JAC_1(idx = 2, partition = 2)
@@ -226,14 +226,14 @@ simulate(init_if_eq); getErrorString();
 // crefs: y
 // 	4: 1.0 - (y + y ^ 2.0) (RESIDUAL)
 // 	Jacobian idx: 1
-// 	5: $pDER_INI_NLS_JAC_1.$RES_SIM_2=-($SEED_ALG_LS_JAC_1.y + 2.0 * y * $SEED_ALG_LS_JAC_1.y) [Real]
+// 	5: $pDER_INI_NLS_JAC_1.$RES_SIM_2=-($SEED_INI_NLS_JAC_1.y + 2.0 * y * $SEED_INI_NLS_JAC_1.y) [Real]
 //
 //
 // 3:  (NONLINEAR) index:0 jacobian: true
 // crefs: u
 // 	1: u ^ 3.0 + u - y (RESIDUAL)
 // 	Jacobian idx: 0
-// 	2: $pDER_ALG_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u [Real]
+// 	2: $pDER_INI_NLS_JAC_2.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_NLS_JAC_2.u + $SEED_INI_NLS_JAC_2.u [Real]
 //
 //
 // ========================================
@@ -279,10 +279,10 @@ simulate(init_if_eq); getErrorString();
 // jacobianMatrices:
 // ========================================
 // 	Jacobian idx: 1
-// 	5: $pDER_INI_NLS_JAC_1.$RES_SIM_2=-($SEED_ALG_LS_JAC_1.y + 2.0 * y * $SEED_ALG_LS_JAC_1.y) [Real]
+// 	5: $pDER_INI_NLS_JAC_1.$RES_SIM_2=-($SEED_INI_NLS_JAC_1.y + 2.0 * y * $SEED_INI_NLS_JAC_1.y) [Real]
 //
 // 	Jacobian idx: 0
-// 	2: $pDER_ALG_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u [Real]
+// 	2: $pDER_INI_NLS_JAC_2.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_NLS_JAC_2.u + $SEED_INI_NLS_JAC_2.u [Real]
 //
 // 	Jacobian idx: 2
 // 	10: $pDER_ALG_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.y [Real]

--- a/testsuite/simulation/modelica/NBackend/initialization/init_if_exp.mos
+++ b/testsuite/simulation/modelica/NBackend/initialization/init_if_exp.mos
@@ -63,7 +63,7 @@ simulate(init_if_exp); getErrorString();
 //
 // SeedVars (size = 1)
 // *********************
-//   (0)[SEED] (1) Real $SEED_ALG_LS_JAC_1.y
+//   (0)[SEED] (1) Real $SEED_INI_NLS_JAC_1.y
 //
 // TmpVars (size = 0)
 // ********************
@@ -73,11 +73,11 @@ simulate(init_if_exp); getErrorString();
 //
 // Column Equations (size = 1)
 // -----------------------------
-//   (5) $pDER_ALG_LS_JAC_1.$RES_SIM_1 := $SEED_ALG_LS_JAC_1.y + 2.0 * y * $SEED_ALG_LS_JAC_1.y
+//   (5) $pDER_INI_NLS_JAC_1.$RES_SIM_1 := $SEED_INI_NLS_JAC_1.y + 2.0 * y * $SEED_INI_NLS_JAC_1.y
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_SIM_1 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_1} ... {($SEED_ALG_LS_JAC_1.y, {}, false)}
+// $RES_SIM_1 ... {$pDER_INI_NLS_JAC_1.$RES_SIM_1} ... {($SEED_INI_NLS_JAC_1.y, {}, false)}
 //
 // ==========================================================
 //   SimCode Jacobian INI_NLS_JAC_2(idx = 0, partition = 0)
@@ -85,7 +85,7 @@ simulate(init_if_exp); getErrorString();
 //
 // SeedVars (size = 1)
 // *********************
-//   (0)[SEED] (1) Real $SEED_ALG_LS_JAC_1.u
+//   (0)[SEED] (1) Real $SEED_INI_NLS_JAC_2.u
 //
 // TmpVars (size = 0)
 // ********************
@@ -95,11 +95,11 @@ simulate(init_if_exp); getErrorString();
 //
 // Column Equations (size = 1)
 // -----------------------------
-//   (2) $pDER_ALG_LS_JAC_1.$RES_SIM_0 := 3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u
+//   (2) $pDER_INI_NLS_JAC_2.$RES_SIM_0 := 3.0 * u ^ 2.0 * $SEED_INI_NLS_JAC_2.u + $SEED_INI_NLS_JAC_2.u
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_SIM_0 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_0} ... {($SEED_ALG_LS_JAC_1.u, {}, false)}
+// $RES_SIM_0 ... {$pDER_INI_NLS_JAC_2.$RES_SIM_0} ... {($SEED_INI_NLS_JAC_2.u, {}, false)}
 //
 // =========================================================
 //   SimCode Jacobian ALG_LS_JAC_1(idx = 2, partition = 2)
@@ -221,14 +221,14 @@ simulate(init_if_exp); getErrorString();
 // crefs: y
 // 	4: -1.0 + y + y ^ 2.0 (RESIDUAL)
 // 	Jacobian idx: 1
-// 	5: $pDER_ALG_LS_JAC_1.$RES_SIM_1=$SEED_ALG_LS_JAC_1.y + 2.0 * y * $SEED_ALG_LS_JAC_1.y [Real]
+// 	5: $pDER_INI_NLS_JAC_1.$RES_SIM_1=$SEED_INI_NLS_JAC_1.y + 2.0 * y * $SEED_INI_NLS_JAC_1.y [Real]
 //
 //
 // 3:  (NONLINEAR) index:0 jacobian: true
 // crefs: u
 // 	1: u ^ 3.0 + u - y (RESIDUAL)
 // 	Jacobian idx: 0
-// 	2: $pDER_ALG_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u [Real]
+// 	2: $pDER_INI_NLS_JAC_2.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_NLS_JAC_2.u + $SEED_INI_NLS_JAC_2.u [Real]
 //
 //
 // ========================================
@@ -274,10 +274,10 @@ simulate(init_if_exp); getErrorString();
 // jacobianMatrices:
 // ========================================
 // 	Jacobian idx: 1
-// 	5: $pDER_ALG_LS_JAC_1.$RES_SIM_1=$SEED_ALG_LS_JAC_1.y + 2.0 * y * $SEED_ALG_LS_JAC_1.y [Real]
+// 	5: $pDER_INI_NLS_JAC_1.$RES_SIM_1=$SEED_INI_NLS_JAC_1.y + 2.0 * y * $SEED_INI_NLS_JAC_1.y [Real]
 //
 // 	Jacobian idx: 0
-// 	2: $pDER_ALG_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u [Real]
+// 	2: $pDER_INI_NLS_JAC_2.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_NLS_JAC_2.u + $SEED_INI_NLS_JAC_2.u [Real]
 //
 // 	Jacobian idx: 2
 // 	10: $pDER_ALG_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.y [Real]


### PR DESCRIPTION
var_seed and var_pder_res/tmp are single-slot caches shared across all Jacobians; a hit cached by one Jacobian was silently reused by another, leaking wrong-Jacobian-named seed/pDer crefs into equations. Guard both caches to only reuse a hit created under the current Jacobian's name.

Separately, makeVarTraverse's base-cref fallback (for iterator-subscripted deps like x[$i1] to find their seed) was also matching literal-subscripted crefs (x[1] vs x[2]), letting one array element's seed stand in for another independent element's under a swapped subscript. Restrict the fallback to non-literal subscripts, and make NBAdjacency.Matrix.fullToSparsity treat a dependency with no seed in the current Jacobian as a zero partial derivative (skip) instead of an internal error, matching how NBDifferentiate already treats not-found deps.

Fixes AixLib Electrical.AC.ThreePhasesUnbalanced Transformer/Line models and SOFCPoliMi.Tests.BenchmarkCammarataIndex1(reduced), which previously failed to compile with an undeclared identifier in generated C. Full NBackend regression sweep clean (237 tests); 6 test references rebased for now-corrected seed naming.