### PR TITLE
Add `Parameters` context menu to Element Browser tree nodes

### DIFF
--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -1516,7 +1516,7 @@ void Element::createActions()
   connect(mpShowElementAction, SIGNAL(triggered()), SLOT(showElement()));
   // Parameters Action
   mpParametersAction = new QAction(Helper::parameters, mpGraphicsView);
-  mpParametersAction->setStatusTip(tr("Shows the component parameters"));
+  mpParametersAction->setStatusTip(Helper::parametersTip);
   connect(mpParametersAction, SIGNAL(triggered()), SLOT(showParameters()));
   // Todo: Connect /robbr
   // Attributes Action
@@ -2208,7 +2208,7 @@ void Element::showParameters()
       && mpGraphicsView->getModelWidget()->getModelInstance() && mpGraphicsView->getModelWidget()->getModelInstance()->getRootParentElement()) {
     inherited = mpGraphicsView->getModelWidget()->getModelInstance()->getRootParentElement()->isExtend();
   }
-  ElementParameters *pElementParameters = new ElementParameters(mpModelComponent, mpGraphicsView, inherited, false, 0, 0, 0, pMainWindow);
+  ElementParameters *pElementParameters = new ElementParameters(mpModelComponent, mpGraphicsView, inherited, false, false, 0, 0, 0, pMainWindow);
   pMainWindow->hideProgressBar();
   pMainWindow->getStatusBar()->clearMessage();
   pElementParameters->exec();

--- a/OMEdit/OMEditLIB/Element/ElementProperties.cpp
+++ b/OMEdit/OMEditLIB/Element/ElementProperties.cpp
@@ -149,7 +149,7 @@ void FinalEachToolButton::showParameterMenu()
 Parameter::Parameter(ModelInstance::Element *pElement, bool defaultValue, ElementParameters *pElementParameters)
 {
   mpModelInstanceElement = pElement;
-  mExtendName = mpModelInstanceElement->getTopLevelExtendName();
+  mExtendName = mpModelInstanceElement->getTopLevelParentElementName();
   mInherited = defaultValue;
   mpElementParameters = pElementParameters;
   auto &dialogAnnotation = mpModelInstanceElement->getAnnotation()->getDialogAnnotation();
@@ -913,13 +913,13 @@ void Parameter::editClassButtonClicked()
   if (mpElementParameters && mpElementParameters->hasElement()) {
     // if we fail to find the type
     if ((mpModelInstanceElement == NULL) ||
-        (mpModelInstanceElement->getTopLevelExtendElement() == NULL) ||
-        (mpModelInstanceElement->getTopLevelExtendElement()->getParentModel() == NULL) ||
-        (mpModelInstanceElement->getTopLevelExtendElement()->getParentModel()->getName() == QString())) {
+        (mpModelInstanceElement->getTopLevelParentElement() == NULL) ||
+        (mpModelInstanceElement->getTopLevelParentElement()->getParentModel() == NULL) ||
+        (mpModelInstanceElement->getTopLevelParentElement()->getParentModel()->getName() == QString())) {
       QMessageBox::critical(MainWindow::instance(), QString("%1 - %2").arg(Helper::applicationName, Helper::error), tr("Unable to find the redeclare class."), QMessageBox::Ok);
       return;
     }
-    classPath = mpModelInstanceElement->getTopLevelExtendElement()->getParentModel()->getName();
+    classPath = mpModelInstanceElement->getTopLevelParentElement()->getParentModel()->getName();
   } else {
     classPath = mpElementParameters->getElementParentClassName();
   }
@@ -958,7 +958,7 @@ void Parameter::editClassButtonClicked()
     mpModelInstanceElement->setModel(pNewModel);
     MainWindow::instance()->getProgressBar()->setRange(0, 0);
     MainWindow::instance()->showProgressBar();
-    ElementParameters *pElementParameters = new ElementParameters(mpModelInstanceElement, mpElementParameters->getGraphicsView(), mpElementParameters->isInherited(),
+    ElementParameters *pElementParameters = new ElementParameters(mpModelInstanceElement, mpElementParameters->getGraphicsView(), mpElementParameters->isInherited(), true,
                                                                   true, pDefaultElementModifier, pReplaceableConstrainedByModifier, pElementModifier, mpElementParameters);
     MainWindow::instance()->hideProgressBar();
     MainWindow::instance()->getStatusBar()->clearMessage();
@@ -1321,9 +1321,9 @@ QVBoxLayout *ParametersScrollArea::getLayout()
  * \param pElementModifier
  * \param pParent
  */
-ElementParameters::ElementParameters(ModelInstance::Element *pElement, GraphicsView *pGraphicsView, bool inherited, bool nested,
-                                     ModelInstance::Modifier *pDefaultElementModifier,
-                                     ModelInstance::Modifier *pReplaceableConstrainedByModifier, ModelInstance::Modifier *pElementModifier, QWidget *pParent)
+ElementParameters::ElementParameters(ModelInstance::Element *pElement, GraphicsView *pGraphicsView, bool inherited, bool nested, bool subDialog,
+                                     ModelInstance::Modifier *pDefaultElementModifier, ModelInstance::Modifier *pReplaceableConstrainedByModifier,
+                                     ModelInstance::Modifier *pElementModifier, QWidget *pParent)
   : QDialog(pParent)
 {
   mpElement = pElement;
@@ -1336,6 +1336,7 @@ ElementParameters::ElementParameters(ModelInstance::Element *pElement, GraphicsV
   }
   mInherited = inherited;
   mNested = nested;
+  mSubDialog = subDialog;
   mpDefaultElementModifier = pDefaultElementModifier;
   mpReplaceableConstrainedByModifier = pReplaceableConstrainedByModifier;
   mpElementModifier = pElementModifier;
@@ -2306,7 +2307,7 @@ void ElementParameters::updateElementParameters()
       }
     }
 
-    if (mNested) {
+    if (mSubDialog) {
       if (modifiersList.isEmpty()) {
         mModification.clear();
       } else {
@@ -2334,9 +2335,9 @@ void ElementParameters::updateElementParameters()
                 }
                 pParentElement = pParentElement->getParentModel() ? pParentElement->getParentModel()->getParentElement() : nullptr;
               }
-              pOMCProxy->setExtendsModifierValue(className, mpElement->getTopLevelExtendName(), "_", modifiers);
+              pOMCProxy->setExtendsModifierValue(className, mpElement->getTopLevelParentElementName(), "_", modifiers);
             } else {
-              pOMCProxy->setExtendsModifierValue(className, mpElement->getTopLevelExtendName(), mpElement->getQualifiedName(), modifiers);
+              pOMCProxy->setExtendsModifierValue(className, mpElement->getTopLevelParentElementName(), mpElement->getQualifiedName(), modifiers);
             }
           } else {
             pOMCProxy->setElementModifierValue(className, mpElement->getQualifiedName(), modifiers);

--- a/OMEdit/OMEditLIB/Element/ElementProperties.h
+++ b/OMEdit/OMEditLIB/Element/ElementProperties.h
@@ -254,7 +254,7 @@ class ElementParameters : public QDialog
 {
   Q_OBJECT
 public:
-  ElementParameters(ModelInstance::Element *pElement, GraphicsView *pGraphicsView, bool inherited, bool nested, ModelInstance::Modifier *pDefaultElementModifier,
+  ElementParameters(ModelInstance::Element *pElement, GraphicsView *pGraphicsView, bool inherited, bool nested, bool subDialog, ModelInstance::Modifier *pDefaultElementModifier,
                     ModelInstance::Modifier *pReplaceableConstrainedByModifier, ModelInstance::Modifier *pElementModifier, QWidget *pParent = 0);
   ~ElementParameters();
   QString getElementQualifiedName() const;
@@ -268,7 +268,6 @@ public:
   bool isElementArray() const {return mpElement->getDimensions().isArray();}
   QString getElementDimensions() const {return mpElement->getDimensions().getTypedDimensionsString();}
   bool isInherited() const {return mInherited;}
-  bool isNested() const {return mNested;}
   bool skipFocusOutEvent() const {return mSkipFocusOutEvent;}
   QString getModification() const {return mModification;}
   Parameter* findParameter(const QString &parameter, Qt::CaseSensitivity caseSensitivity = Qt::CaseSensitive) const;
@@ -277,8 +276,9 @@ public:
 private:
   ModelInstance::Element *mpElement;
   GraphicsView *mpGraphicsView;
-  bool mInherited;
-  bool mNested;
+  bool mInherited = false;
+  bool mNested = false;
+  bool mSubDialog = false;
   bool mSkipFocusOutEvent = false;
   ModelInstance::Modifier *mpDefaultElementModifier;
   ModelInstance::Modifier *mpReplaceableConstrainedByModifier;

--- a/OMEdit/OMEditLIB/Modeling/ElementTreeWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ElementTreeWidget.cpp
@@ -38,12 +38,14 @@
  */
 
 #include "ElementTreeWidget.h"
+#include "Element/ElementProperties.h"
 #include "ItemDelegate.h"
 #include "Util/Helper.h"
 #include "MainWindow.h"
 #include "Modeling/ModelWidgetContainer.h"
 
 #include <QGridLayout>
+#include <QMenu>
 #include <QStringBuilder>
 
 /*!
@@ -93,6 +95,7 @@ QString makeTooltip(const QString &restriction, const QString &name, const QStri
 ElementTreeItem::ElementTreeItem(ModelInstance::Element *pElement, ElementTreeItem *pParentElementTreeItem)
 {
   mpParentElementTreeItem = pParentElementTreeItem;
+  mpModelInstanceElement = pElement;
   if (pElement->isExtend()) {
     mName = pElement->getType();
     mNameStructure = mpParentElementTreeItem->getNameStructure().isEmpty() ? mName : mpParentElementTreeItem->getNameStructure() + "." + mName;
@@ -556,6 +559,134 @@ ElementTreeView::ElementTreeView(ElementWidget *pElementWidget)
   setIndentation(Helper::treeIndentation);
   setUniformRowHeights(true);
   setHeaderHidden(true);
+  setContextMenuPolicy(Qt::CustomContextMenu);
+  connect(this, &ElementTreeView::customContextMenuRequested, this, &ElementTreeView::showContextMenu);
+}
+
+/*!
+ * \brief ElementTreeView::showContextMenu
+ * Shows the context menu for the ElementTreeItem.
+ * \param pos
+ */
+void ElementTreeView::showContextMenu(const QPoint &pos)
+{
+  QModelIndex index = indexAt(pos);
+  if (!index.isValid()) {
+    return;
+  }
+  QModelIndex sourceIndex = mpElementWidget->getElementTreeProxyModel()->mapToSource(index);
+  auto *pElementTreeItem = static_cast<ElementTreeItem*>(sourceIndex.internalPointer());
+  if (!pElementTreeItem) {
+    return;
+  }
+
+  auto *pModelInstanceElement = pElementTreeItem->getModelInstanceElement();
+  if (!pModelInstanceElement || !pModelInstanceElement->isComponent() || !pModelInstanceElement->getModel()) {
+    return;
+  }
+  ModelWidget *pModelWidget = MainWindow::instance()->getModelWidgetContainer()->getCurrentModelWidget();
+  if (!(pModelWidget &&
+        ((pModelWidget->getIconGraphicsView() && pModelWidget->getIconGraphicsView()->isVisible()) ||
+         (pModelWidget->getDiagramGraphicsView() && pModelWidget->getDiagramGraphicsView()->isVisible())))) {
+    return;
+  }
+  QMenu menu(this);
+  QAction *pParametersAction = menu.addAction(Helper::parameters);
+  pParametersAction->setStatusTip(Helper::parametersTip);
+  connect(pParametersAction, &QAction::triggered, this, [pElementTreeItem, pModelInstanceElement, pModelWidget]() {
+    // the element is inherited if its top level parent element is an extends clause.
+    bool inherited = false;
+    ModelInstance::Element *pTopLevelParentElement = pModelInstanceElement->getTopLevelParentElement();
+    if (pTopLevelParentElement && pTopLevelParentElement->isExtend()) {
+      inherited = true;
+    }
+    MainWindow *pMainWindow = MainWindow::instance();
+
+    if (pElementTreeItem->isTopLevel()) {
+      // Top-level node: same as Element::showParameters() — all modifier arguments null, nested=false.
+      pMainWindow->getStatusBar()->showMessage(tr("Opening %1 %2 parameters window").arg(pModelInstanceElement->getModel()->getName()).arg(pModelInstanceElement->getName()));
+      pMainWindow->getProgressBar()->setRange(0, 0);
+      pMainWindow->showProgressBar();
+      ElementParameters *pElementParameters = new ElementParameters(pModelInstanceElement, pModelWidget->getDiagramGraphicsView(),
+                                                                    inherited, false, false, 0, 0, 0, pMainWindow);
+      pMainWindow->hideProgressBar();
+      pMainWindow->getStatusBar()->clearMessage();
+      pElementParameters->exec();
+      pElementParameters->deleteLater();
+    } else {
+      // Sub-level node: replicate Parameter::editClassButtonClicked() pattern.
+      QString type = pModelInstanceElement->getType();
+      ModelInstance::Modifier *pReplaceableConstrainedByModifier = nullptr;
+      if (pModelInstanceElement->getReplaceable()) {
+        pReplaceableConstrainedByModifier = pModelInstanceElement->getReplaceable()->getModifier();
+      }
+
+      // Create pElementModifier via modifierToJSON round-trip (matching editClassButtonClicked pattern)
+      ModelInstance::Modifier *pElementModifier = nullptr;
+      if (pTopLevelParentElement && pTopLevelParentElement->isComponent() && pTopLevelParentElement->getModifier()) {
+        pElementModifier = pTopLevelParentElement->getModifier()->getModifier(pModelInstanceElement->getName(), true);
+      }
+      if (!pTopLevelParentElement ||
+          !pTopLevelParentElement->getParentModel() ||
+          pTopLevelParentElement->getParentModel()->getName().isEmpty()) {
+        return;
+      }
+      QString classPath = pTopLevelParentElement->getParentModel()->getName();
+      const QString qualifiedType = pMainWindow->getOMCProxy()->qualifyPath(classPath, type);
+      // Merge with constrainedby modifier if applicable.
+      QString modifier;
+      if (pReplaceableConstrainedByModifier && pElementModifier) {
+        QVector<const ModelInstance::Modifier*> modifiers;
+        modifiers.append(pReplaceableConstrainedByModifier);
+        modifiers.append(pElementModifier);
+        ModelInstance::Modifier *pMergedModifier = ModelInstance::Modifier::mergeModifiersIntoOne(modifiers, pModelInstanceElement->getParentModel());
+        modifier = pMergedModifier->toString();
+        delete pMergedModifier;
+      }
+      // Get the model instance from OMC with the modifier applied.
+      ModelInstance::Model *pCurrentModel = pModelInstanceElement->getModel();
+      const QJsonObject newModelJSON = pMainWindow->getOMCProxy()->getModelInstance(qualifiedType, pModelInstanceElement->getQualifiedName(), modifier);
+      if (!newModelJSON.isEmpty()) {
+        // Create pDefaultElementModifier from the element's own modifier.
+        QString defaultModifier;
+        if (pModelInstanceElement->getModifier()) {
+          defaultModifier = pModelInstanceElement->getModifier()->toString();
+        }
+        ModelInstance::Modifier *pDefaultElementModifier = nullptr;
+        if (!defaultModifier.isEmpty()) {
+          const QJsonObject defaultModifierJSON = pMainWindow->getOMCProxy()->modifierToJSON(defaultModifier);
+          pDefaultElementModifier = new ModelInstance::Modifier("", QJsonValue(defaultModifierJSON), pModelInstanceElement->getParentModel());
+        }
+        // Create new Model and set on element.
+        ModelInstance::Model *pNewModel = new ModelInstance::Model(newModelJSON, pModelInstanceElement);
+        pModelInstanceElement->setModel(pNewModel);
+        pMainWindow->getStatusBar()->showMessage(tr("Opening %1 %2 parameters window").arg(pModelInstanceElement->getModel()->getName()).arg(pModelInstanceElement->getName()));
+        pMainWindow->getProgressBar()->setRange(0, 0);
+        pMainWindow->showProgressBar();
+        ElementParameters *pElementParameters = new ElementParameters(pModelInstanceElement, pModelWidget->getDiagramGraphicsView(), inherited, true, false,
+                                                                      pDefaultElementModifier, pReplaceableConstrainedByModifier, pElementModifier, pMainWindow);
+        pMainWindow->hideProgressBar();
+        pMainWindow->getStatusBar()->clearMessage();
+        int answer = pElementParameters->exec();
+        pElementParameters->deleteLater();
+        /* Cleanup: if the user accepted the dialog, delete the old model; if rejected, restore the old model and delete the new one.
+         * In accepted case the new model will be deleted as part of updating the model instance so we only delete the current model.
+         * In rejected case we set to the current model and delete the new model.
+         */
+        if (answer == QDialog::Accepted) {
+          delete pCurrentModel;
+        } else {
+          pModelInstanceElement->setModel(pCurrentModel);
+          delete pNewModel;
+        }
+
+        if (pDefaultElementModifier) {
+          delete pDefaultElementModifier;
+        }
+      }
+    }
+  });
+  menu.exec(viewport()->mapToGlobal(pos));
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Modeling/ElementTreeWidget.h
+++ b/OMEdit/OMEditLIB/Modeling/ElementTreeWidget.h
@@ -65,7 +65,9 @@ public:
   bool isTopLevel() const;
   QString getName() const {return mName;}
   QString getNameStructure() const {return mNameStructure;}
+  ModelInstance::Element* getModelInstanceElement() const {return mpModelInstanceElement;}
 private:
+  ModelInstance::Element *mpModelInstanceElement = nullptr;
   ElementTreeItem *mpParentElementTreeItem = 0;
   bool mIsRootItem = false;
   QList<ElementTreeItem*> mChildren;
@@ -122,6 +124,8 @@ public:
   ElementTreeView(ElementWidget *pElementWidget);
 private:
   ElementWidget *mpElementWidget;
+private slots:
+  void showContextMenu(const QPoint &pos);
 };
 
 class ElementWidget : public QWidget

--- a/OMEdit/OMEditLIB/Modeling/Model.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Model.cpp
@@ -949,11 +949,24 @@ namespace ModelInstance
     }
   }
 
-  Modifier *Modifier::getModifier(const QString &modifier) const
+  /*!
+   * \brief Modifier::getModifier
+   * Returns the Modifier with the given name.\n
+   * \param modifier - the name of the modifier to search for.
+   * \param recursive - if true then search recursively in sub modifiers.
+   * \return
+   */
+  Modifier *Modifier::getModifier(const QString &modifier, bool recursive) const
   {
     foreach (auto *pModifier, mModifiers) {
       if (pModifier->getName().compare(modifier) == 0) {
         return pModifier;
+      }
+      if (recursive) {
+        Modifier *pSubModifier = pModifier->getModifier(modifier, recursive);
+        if (pSubModifier) {
+          return pSubModifier;
+        }
       }
     }
     return 0;
@@ -2079,7 +2092,6 @@ namespace ModelInstance
       mDymolaCheckBox.deserialize(jsonObject.value("__Dymola_checkBox"));
     }
 
-
     if (jsonObject.contains("choice")) {
       const auto& choicesArray = jsonObject.value("choice").toArray();
       mChoices.reserve(choicesArray.size());
@@ -2154,7 +2166,12 @@ namespace ModelInstance
     deserialize_impl(jsonObject);
   }
 
-  Element *Element::getTopLevelExtendElement() const
+  /*!
+   * \brief Element::getTopLevelParentElement
+   * Returns the top level parent element of the model where this element is located.
+   * \return
+   */
+  Element *Element::getTopLevelParentElement() const
   {
     Element *pElement = mpParentModel->getParentElement();
     while (pElement && pElement->getParentModel() && pElement->getParentModel()->getParentElement()) {
@@ -2195,13 +2212,13 @@ namespace ModelInstance
   }
 
   /*!
-   * \brief Element::getTopLevelExtendName
-   * Returns the top level extend name where the element is located.
+   * \brief Element::getTopLevelParentElementName
+   * Returns the name of the top level parent element of the model where this element is located.
    * \return
    */
-  QString Element::getTopLevelExtendName() const
+  QString Element::getTopLevelParentElementName() const
   {
-    Element *pElement = getTopLevelExtendElement();
+    Element *pElement = getTopLevelParentElement();
 
     if (pElement && pElement->getModel()) {
       return pElement->getModel()->getName();
@@ -2306,13 +2323,7 @@ namespace ModelInstance
 
   Replaceable *Element::getReplaceable() const
   {
-    if (mpPrefixes) {
-      return mpPrefixes.get()->getReplaceable();
-    } else if (mpModel) {
-      return mpModel->getReplaceable();
-    } else {
-      return nullptr;
-    }
+    return mpPrefixes ? mpPrefixes.get()->getReplaceable() : nullptr;
   }
 
   bool Element::isRedeclare() const

--- a/OMEdit/OMEditLIB/Modeling/Model.h
+++ b/OMEdit/OMEditLIB/Modeling/Model.h
@@ -506,7 +506,7 @@ private:
     QString toString(bool skipTopLevel = false, bool includeComment = false, bool onlyType = false, bool skipDisplayUnit = false) const;
     static Modifier *mergeModifiersIntoOne(QVector<const Modifier *> extendsModifiers, Model *pParentModel);
     static void mergeModifiers(Modifier *pModifier1, const Modifier *pModifier2);
-    Modifier *getModifier(const QString &modifier) const;
+    Modifier *getModifier(const QString &modifier, bool recursive = false) const;
     QPair<QString, bool> getModifierValue(const QString &modifier) const;
     bool hasModifier(const QString &modifier) const;
     const QVector<Modifier*> &getModifiers() const {return mModifiers;}
@@ -708,8 +708,8 @@ private:
     void deserialize(const QJsonObject &jsonObject);
 
     Model *getParentModel() const {return mpParentModel;}
-    QString getTopLevelExtendName() const;
-    Element *getTopLevelExtendElement() const;
+    QString getTopLevelParentElementName() const;
+    Element *getTopLevelParentElement() const;
     void setModel(Model *pModel) {mpModel = pModel;}
     Model *getModel() const {return mpModel;}
     Modifier *getModifier() const {return mpModifier;}

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -3206,7 +3206,7 @@ bool GraphicsView::updateElementConnectorSizingParameter(GraphicsView *pGraphics
       } else {
         QString modifierKey = QString("%1.%2").arg(pElement->getRootParentElement()->getName()).arg(parameter);
         if (pElement->isInheritedElement() && pElement->getModelComponent()) {
-          MainWindow::instance()->getOMCProxy()->setExtendsModifierValueOld(className, pElement->getModelComponent()->getTopLevelExtendName(),
+          MainWindow::instance()->getOMCProxy()->setExtendsModifierValueOld(className, pElement->getModelComponent()->getTopLevelParentElementName(),
                                                                             modifierKey, QString::number(numberOfElementConnections));
         } else {
           MainWindow::instance()->getOMCProxy()->setElementModifierValueOld(className, modifierKey, QString::number(numberOfElementConnections));
@@ -4146,9 +4146,9 @@ void GraphicsView::showParameters()
       if (mpModelWidget->getModelInstance()->getRootParentElement()) {
         inherited = mpModelWidget->getModelInstance()->getRootParentElement()->isExtend();
       }
-      pElementParameters = new ElementParameters(mpModelWidget->getModelInstance()->getParentElement(), this, inherited, false, 0, 0, 0, MainWindow::instance());
+      pElementParameters = new ElementParameters(mpModelWidget->getModelInstance()->getParentElement(), this, inherited, false, false, 0, 0, 0, MainWindow::instance());
     } else {
-      pElementParameters = new ElementParameters(0, this, false, false, 0, 0, 0, MainWindow::instance());
+      pElementParameters = new ElementParameters(0, this, false, false, false, 0, 0, 0, MainWindow::instance());
     }
     MainWindow::instance()->hideProgressBar();
     MainWindow::instance()->getStatusBar()->clearMessage();

--- a/OMEdit/OMEditLIB/Util/Helper.cpp
+++ b/OMEdit/OMEditLIB/Util/Helper.cpp
@@ -190,6 +190,7 @@ QString Helper::removeItem;
 QString Helper::general;
 QString Helper::output;
 QString Helper::parameters;
+QString Helper::parametersTip;
 QString Helper::inputs;
 QString Helper::name;
 QString Helper::startScript;
@@ -514,6 +515,7 @@ void Helper::initHelperVariables()
   Helper::general = tr("General");
   Helper::output = tr("Output");
   Helper::parameters = tr("Parameters");
+  Helper::parametersTip = tr("Shows the component parameters");
   Helper::inputs = tr("Inputs");
   Helper::name = tr("Name:");
   Helper::startScript = tr("Start Script:");

--- a/OMEdit/OMEditLIB/Util/Helper.h
+++ b/OMEdit/OMEditLIB/Util/Helper.h
@@ -196,6 +196,7 @@ public:
   static QString general;
   static QString output;
   static QString parameters;
+  static QString parametersTip;
   static QString inputs;
   static QString name;
   static QString startScript;


### PR DESCRIPTION
Add a context menu to the ElementTreeView that opens the ElementParameters dialog for the selected component element. Top-level nodes use the `Element::showParameters()` path, while sub-level (nested) nodes replicate the `Parameter::editClassButtonClicked()` flow so modifiers can be edited at any depth in the hierarchy. Revert change done #14439. Do not look for replaceable in the prefixes of component type.