### PR TITLE
Fix compiler warnings in OMSI

### DIFF
--- a/OMCompiler/SimulationRuntime/OMSI/solver/src/solver_api.c
+++ b/OMCompiler/SimulationRuntime/OMSI/solver/src/solver_api.c
@@ -713,15 +713,15 @@ void solver_print_data (solver_data*    solver,
         case solver_true:
             lin_callbacks = solver->solver_callbacks;
             length += snprintf(buffer+length, MAX_BUFFER_SIZE-length,
-                    "\t\t get_A_element set: \t %s \t ( Address: %p )\n", lin_callbacks->get_A_element?"yes":"no", lin_callbacks->get_A_element);
+                    "\t\t get_A_element set: \t %s\n", lin_callbacks->get_A_element?"yes":"no");
             length += snprintf(buffer+length, MAX_BUFFER_SIZE-length,
-                    "\t\t set_A_element set: \t %s \t ( Address: %p )\n", lin_callbacks->set_A_element?"yes":"no", lin_callbacks->set_A_element);
+                    "\t\t set_A_element set: \t %s\n", lin_callbacks->set_A_element?"yes":"no");
             length += snprintf(buffer+length, MAX_BUFFER_SIZE-length,
-                    "\t\t get_b_element set: \t %s \t ( Address: %p )\n", lin_callbacks->get_b_element?"yes":"no", lin_callbacks->get_b_element);
+                    "\t\t get_b_element set: \t %s\n", lin_callbacks->get_b_element?"yes":"no");
             length += snprintf(buffer+length, MAX_BUFFER_SIZE-length,
-                    "\t\t set_b_element set: \t %s \t ( Address: %p )\n", lin_callbacks->set_b_element?"yes":"no", lin_callbacks->set_b_element);
+                    "\t\t set_b_element set: \t %s\n", lin_callbacks->set_b_element?"yes":"no");
             length += snprintf(buffer+length, MAX_BUFFER_SIZE-length,
-                    "\t\t solve_eq_system set: \t %s \t ( Address: %p )\n", lin_callbacks->solve_eq_system?"yes":"no", lin_callbacks->solve_eq_system);
+                    "\t\t solve_eq_system set: \t %s\n", lin_callbacks->solve_eq_system?"yes":"no");
             break;
         default:
 


### PR DESCRIPTION
- Don't print the addresses of callbacks in solver_print_data, since function pointers can't be cast to void* in a portable way and the address doesn't really provide much information anyway.