### PR TITLE
wasm-jit: C parity for two FMI tests

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/daskr/src/solver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/daskr/src/solver.rs
@@ -99,7 +99,9 @@ pub type JacFn = unsafe fn(
 );
 
 /// Root (constraint) function: `(neq, t, y, yprime, nrt, rval, rpar, ipar)`.
-/// Fills `rval[0..nrt]` with the values whose zeros are sought.
+/// Fills `rval[0..nrt]` with the values whose zeros are sought. A nonzero return
+/// abandons the call with `IDID` = [`IDID_RT_ABORT`] (C's runtime `longjmp`s out
+/// of the root function instead).
 pub type RtFn = unsafe fn(
     neq: *mut i32,
     t: *mut f64,
@@ -109,7 +111,11 @@ pub type RtFn = unsafe fn(
     rval: *mut f64,
     rpar: *mut f64,
     ipar: *mut i32,
-);
+) -> i32;
+
+/// Not one of DDASKR's own codes.
+pub const IDID_RT_ABORT: i32 = -34;
+const IRT_ABORT: i32 = -3;
 
 /// Krylov Jacobian/preconditioner setup `jac`:
 /// `(res, ires, neq, t, y, yprime, rewt, savr, wk, h, cj, wp, iwp, ier, rpar, ipar)`.
@@ -866,7 +872,8 @@ pub unsafe fn dummy_rt(
     _rval: *mut f64,
     _rpar: *mut f64,
     _ipar: *mut i32,
-) {
+) -> i32 {
+    0
 }
 
 /// Krylov nonlinear-solver driver (placeholder until the Krylov path is ported).
@@ -2175,7 +2182,10 @@ pub(crate) unsafe fn drchek(
     if job == 1 {
         // Evaluate R at initial T; check for zeros.
         ddatrp(*tn, at!(rwork, 51), y, yp, *neq, *kold, phi, psi);
-        rt(neq, lt0, y, yp, nrt, r0, rpar, ipar);
+        if rt(neq, lt0, y, yp, nrt, r0, rpar, ipar) != 0 {
+            *irt = IRT_ABORT;
+            return;
+        }
         at!(iwork, 36) = 1;
         let mut zroot = false;
         for i in 1..=*nrt {
@@ -2193,7 +2203,10 @@ pub(crate) unsafe fn drchek(
         for i in 1..=*neq {
             at!(y, i) += temp2 * at2!(phi, i, 2, *neq);
         }
-        rt(neq, lt0, y, yp, nrt, r0, rpar, ipar);
+        if rt(neq, lt0, y, yp, nrt, r0, rpar, ipar) != 0 {
+            *irt = IRT_ABORT;
+            return;
+        }
         at!(iwork, 36) += 1;
         zroot = false;
         for i in 1..=*nrt {
@@ -2212,7 +2225,10 @@ pub(crate) unsafe fn drchek(
         } else {
             // A root was found last step: evaluate R0 = R(T0).
             ddatrp(*tn, at!(rwork, 51), y, yp, *neq, *kold, phi, psi);
-            rt(neq, lt0, y, yp, nrt, r0, rpar, ipar);
+            if rt(neq, lt0, y, yp, nrt, r0, rpar, ipar) != 0 {
+                *irt = IRT_ABORT;
+                return;
+            }
             at!(iwork, 36) += 1;
             let mut zroot = false;
             for i in 1..=*nrt {
@@ -2235,7 +2251,10 @@ pub(crate) unsafe fn drchek(
                         at!(y, i) += temp2 * at2!(phi, i, 2, *neq);
                     }
                 }
-                rt(neq, lt0, y, yp, nrt, r0, rpar, ipar);
+                if rt(neq, lt0, y, yp, nrt, r0, rpar, ipar) != 0 {
+                    *irt = IRT_ABORT;
+                    return;
+                }
                 at!(iwork, 36) += 1;
                 for i in 1..=*nrt {
                     if at!(r0, i).abs() > 0.0 {
@@ -2279,7 +2298,10 @@ pub(crate) unsafe fn drchek(
             }
         }
         ddatrp(*tn, t1, y, yp, *neq, *kold, phi, psi);
-        rt(neq, &mut t1, y, yp, nrt, r1, rpar, ipar);
+        if rt(neq, &mut t1, y, yp, nrt, r1, rpar, ipar) != 0 {
+            *irt = IRT_ABORT;
+            return;
+        }
         at!(iwork, 36) += 1;
 
         // Search for a root in (T0, T1) via DROOTS.
@@ -2292,7 +2314,10 @@ pub(crate) unsafe fn drchek(
                 break;
             }
             ddatrp(*tn, xx, y, yp, *neq, *kold, phi, psi);
-            rt(neq, &mut xx, y, yp, nrt, rx, rpar, ipar);
+            if rt(neq, &mut xx, y, yp, nrt, rx, rpar, ipar) != 0 {
+                *irt = IRT_ABORT;
+                return;
+            }
             at!(iwork, 36) += 1;
         }
         at!(rwork, 51) = xx;
@@ -2940,6 +2965,10 @@ pub unsafe fn ddaskr(
                 1, rt, &mut nrt_l, &mut neq_l, t, tout, y, yprime, rw(lphi), rw(39), iw(8), rw(lr0),
                 rw(lr1), rw(lrx), jroot, &mut irt, rw(9), at!(info, 3), rwork, iwork, rpar, ipar,
             );
+            if irt == IRT_ABORT {
+                *idid = IDID_RT_ABORT;
+                l590!();
+            }
             if irt < 0 {
                 xerrwd("DASKR--  R IS ILL-DEFINED.  ZERO VALUES WERE FOUND AT TWO", 31, 1, 0, 0, 0, 0, 0.0, 0.0);
                 xerrwd("         VERY CLOSE T VALUES, AT T = R1", 31, 1, 0, 0, 0, 1, at!(rwork, 51), 0.0);
@@ -2961,6 +2990,10 @@ pub unsafe fn ddaskr(
                 rw(lr0), rw(lr1), rw(lrx), jroot, &mut irt, rw(9), at!(info, 3), rwork, iwork, rpar,
                 ipar,
             );
+            if irt == IRT_ABORT {
+                *idid = IDID_RT_ABORT;
+                l590!();
+            }
             if irt < 0 {
                 xerrwd("DASKR--  R IS ILL-DEFINED.  ZERO VALUES WERE FOUND AT TWO", 31, 1, 0, 0, 0, 0, 0.0, 0.0);
                 xerrwd("         VERY CLOSE T VALUES, AT T = R1", 31, 1, 0, 0, 0, 1, at!(rwork, 51), 0.0);
@@ -3187,6 +3220,10 @@ pub unsafe fn ddaskr(
                 rw(lr0), rw(lr1), rw(lrx), jroot, &mut irt, rw(9), at!(info, 3), rwork, iwork, rpar,
                 ipar,
             );
+            if irt == IRT_ABORT {
+                *idid = IDID_RT_ABORT;
+                l590!();
+            }
             if irt == 1 {
                 at!(iwork, 37) = 1;
                 *idid = 5;

--- a/OMCompiler/Compiler/OpenModelica.rs/daskr/tests/solver_cref.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/daskr/tests/solver_cref.rs
@@ -173,8 +173,9 @@ unsafe fn jac_r(_t: *mut f64, _y: *mut f64, _yp: *mut f64, pd: *mut f64, _d: *mu
 unsafe extern "C" fn rt_c(_neq: *mut i32, _t: *mut f64, y: *mut f64, _yp: *mut f64, _nrt: *mut i32, rval: *mut f64, _rp: *mut f64, _ip: *mut i32) {
     *rval.add(0) = *y.add(0);
 }
-unsafe fn rt_r(_neq: *mut i32, _t: *mut f64, y: *mut f64, _yp: *mut f64, _nrt: *mut i32, rval: *mut f64, _rp: *mut f64, _ip: *mut i32) {
+unsafe fn rt_r(_neq: *mut i32, _t: *mut f64, y: *mut f64, _yp: *mut f64, _nrt: *mut i32, rval: *mut f64, _rp: *mut f64, _ip: *mut i32) -> i32 {
     *rval.add(0) = *y.add(0);
+    0
 }
 
 // C dummies matching the typed ABIs.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -301,7 +301,7 @@ fn sim_models() -> &'static Mutex<HashMap<String, Arc<SimModel>>> {
 struct FmuKernel {
     model: Arc<SimModel>,
     /// Reaches the kernel's embedded metadata, so a different one cannot reuse it.
-    method: String,
+    cs_method: String,
 }
 
 /// Kept by [`translateFmu`] so the export that follows links this kernel rather
@@ -535,7 +535,7 @@ pub fn translateModel(simCode: SimCode::SimCode) -> Result<()> {
     let prefix = simCode.fileNamePrefix.to_string();
     let _ = std::fs::remove_file(format!("{prefix}.wasm"));
     let errs_before = openmodelica_util::Error::getNumErrorMessages();
-    let outcome = build_sim_model(&simCode, false, ExtHost::SIM).and_then(|model| {
+    let outcome = build_sim_model(&simCode, false, ExtHost::SIM, "").and_then(|model| {
         write_output(&format!("{prefix}.wasm"), &model.wasm).map_err(|_| "CodegenWasmJit: write failed")?;
         sim_models().lock().unwrap_or_else(|e| e.into_inner()).insert(prefix.clone(), Arc::new(model));
         Ok(())
@@ -1657,7 +1657,7 @@ use openmodelica_wasm_jit::RUNTIME_WASIP1;
 /// `wasm-merge` is an external tool, absent in the omc wasm build.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn emit_standalone_module(sim_code: &SimCode::SimCode) -> Result<Vec<u8>> {
-    let model = build_sim_model(sim_code, false, ExtHost::Wasm)?;
+    let model = build_sim_model(sim_code, false, ExtHost::Wasm, "")?;
     merge_standalone(&model.wasm)
 }
 
@@ -3116,21 +3116,13 @@ fn cad_basename(uri: &str) -> &str {
     uri.rsplit(['/', '\\']).next().unwrap_or(uri)
 }
 
-/// The integration method the export settles on, onto the settings the lowering
-/// reads. C's FMU reads `-s` from `_flags.json` at run time; this one is linked
-/// against one solver, so the flag has to reach the export.
-fn settle_fmu_method(sim_code: &mut SimCode::SimCode, simulation_flags_json: &str, kind: &str) {
-    let Some(settings) = sim_code.simulationSettingsOpt.as_mut() else { return };
+/// C's `FMI2CS_initializeSolverData`: `-s` from `_flags.json`, euler otherwise.
+/// The model's own method stays for the artifact's plain-simulation face.
+fn fmu_cs_method(simulation_flags_json: &str, kind: &str) -> String {
     match fmi_flag(simulation_flags_json, "s") {
-        Some(s) => settings.method = ArcStr::from(s.as_str()),
-        // A wasm FMU's embedded driver has the solvers a simulation has, so a
-        // Co-Simulation export keeps the model's own method and falls back to
-        // DASKR for one the driver cannot step to a communication point. C
-        // defaults to euler only because `fmu_read_flags.c` knows no other.
-        None if kind != "ME" && !fmu_cs_solvers().contains(&settings.method.as_str()) => {
-            settings.method = ArcStr::from("dassl")
-        }
-        None => {}
+        Some(s) => s,
+        None if kind != "ME" => "euler".to_string(),
+        None => String::new(),
     }
 }
 
@@ -3138,8 +3130,10 @@ fn settle_fmu_method(sim_code: &mut SimCode::SimCode, simulation_flags_json: &st
 /// this `kind` can serve it. Shared linear memory across model + runtime +
 /// ModelicaExternalC, so `external "C"` calls pass real pointers rather than
 /// runtime handles — which is also why the simulation path cannot bind it.
-fn lower_fmu_kernel(sim_code: &SimCode::SimCode, kind: &str) -> Result<SimModel> {
-    let model = crate::CodegenWasmJitFunctions::with_shared_externals(|| build_sim_model(sim_code, true, ExtHost::Wasm))?;
+fn lower_fmu_kernel(sim_code: &SimCode::SimCode, kind: &str, cs_method: &str) -> Result<SimModel> {
+    let model = crate::CodegenWasmJitFunctions::with_shared_externals(|| {
+        build_sim_model(sim_code, true, ExtHost::Wasm, cs_method)
+    })?;
     if let Some(func) = first_external_import(&model.wasm) {
         if !external_c_available() {
             record_error(format!(
@@ -3155,13 +3149,13 @@ fn lower_fmu_kernel(sim_code: &SimCode::SimCode, kind: &str) -> Result<SimModel>
 }
 
 /// A CS FMU integrates itself, so an unservable method has to fail at export
-/// rather than at the importer's first do-step. Empty is the dassl default.
+/// rather than at the importer's first do-step.
 fn check_fmu_method(model: &SimModel, kind: &str) -> Result<()> {
-    if kind != "ME" && !model.method.is_empty() && !fmu_cs_solvers().contains(&model.method.as_str()) {
+    if kind != "ME" && !fmu_cs_solvers().contains(&model.meta.cs_method.as_str()) {
         record_error(format!(
             "CodegenWasmJit: a Co-Simulation wasm FMU cannot integrate with method=\"{}\". \
              Available: {}.",
-            model.method,
+            model.meta.cs_method,
             fmu_cs_solvers().join(", ")
         ));
         return Err("CodegenWasmJit: unusable Co-Simulation integration method");
@@ -3171,28 +3165,22 @@ fn check_fmu_method(model: &SimModel, kind: &str) -> Result<()> {
 
 /// The kernel to build this FMU around: the one [`translateFmu`] left behind if it
 /// was lowered the way this export needs, and a fresh lowering otherwise.
-fn fmu_kernel(sim_code: &SimCode::SimCode, kind: &str) -> Result<Arc<SimModel>> {
+fn fmu_kernel(sim_code: &SimCode::SimCode, kind: &str, cs_method: &str) -> Result<Arc<SimModel>> {
     let prefix = sim_code.fileNamePrefix.to_string();
-    let method = settled_method(sim_code);
     let cached = fmu_kernels().lock().unwrap_or_else(|e| e.into_inner()).get(&prefix).cloned();
-    if let Some(k) = cached.filter(|k| k.method == method) {
+    if let Some(k) = cached.filter(|k| k.cs_method == cs_method) {
         check_fmu_method(&k.model, kind)?;
         return Ok(k.model.clone());
     }
-    let model = Arc::new(lower_fmu_kernel(sim_code, kind)?);
+    let model = Arc::new(lower_fmu_kernel(sim_code, kind, cs_method)?);
     keep_fmu_kernel(&prefix, &model);
     Ok(model)
-}
-
-/// What [`settle_fmu_method`] left on the settings.
-fn settled_method(sim_code: &SimCode::SimCode) -> String {
-    sim_code.simulationSettingsOpt.as_ref().map(|s| s.method.to_string()).unwrap_or_default()
 }
 
 fn keep_fmu_kernel(prefix: &str, model: &Arc<SimModel>) {
     fmu_kernels().lock().unwrap_or_else(|e| e.into_inner()).insert(
         prefix.to_string(),
-        Arc::new(FmuKernel { model: model.clone(), method: model.method.clone() }),
+        Arc::new(FmuKernel { model: model.clone(), cs_method: model.meta.cs_method.clone() }),
     );
 }
 
@@ -3204,8 +3192,7 @@ pub fn translateFmu(sim_code: SimCode::SimCode, fmu_type: ArcStr, simulation_fla
     sync_engine_threading()?;
     sim_runtime::start_runtime_compile();
     let kind = fmu_kind(&fmu_type);
-    let mut sim_code = sim_code;
-    settle_fmu_method(&mut sim_code, &simulation_flags_json, kind);
+    let cs_method = fmu_cs_method(&simulation_flags_json, kind);
     let prefix = sim_code.fileNamePrefix.to_string();
     let _ = openmodelica_wasi::fs::remove_file(&format!("{prefix}.wasm"));
     let errs_before = openmodelica_util::Error::getNumErrorMessages();
@@ -3213,7 +3200,7 @@ pub fn translateFmu(sim_code: SimCode::SimCode, fmu_type: ArcStr, simulation_fla
         // Lowered the way the simulation path binds it, since that is what runs it.
         // With no `external "C"` this is the FMU kernel too: shared externals
         // change the lowering only where there are `ext` imports.
-        let model = Arc::new(build_sim_model(&sim_code, true, ExtHost::SIM)?);
+        let model = Arc::new(build_sim_model(&sim_code, true, ExtHost::SIM, &cs_method)?);
         check_fmu_method(&model, kind)?;
         write_output(&format!("{prefix}.wasm"), &model.wasm).map_err(|_| "CodegenWasmJit: write failed")?;
         sim_models().lock().unwrap_or_else(|e| e.into_inner()).insert(prefix.clone(), model.clone());
@@ -3243,7 +3230,7 @@ fn keep_translated_model(sim_code: &SimCode::SimCode, kernel: &Arc<SimModel>) ->
     let model = match kept {
         Some(m) => m,
         None if first_external_import(&kernel.wasm).is_none() => kernel.clone(),
-        None => Arc::new(build_sim_model(sim_code, true, ExtHost::SIM)?),
+        None => Arc::new(build_sim_model(sim_code, true, ExtHost::SIM, &kernel.meta.cs_method)?),
     };
     if model.prepared.lock().unwrap_or_else(|e| e.into_inner()).is_none()
         && let Ok(compiled) = sim_runtime::take_compiled_model(&model)
@@ -3277,8 +3264,7 @@ fn emit_fmu(
 ) -> Result<()> {
     sync_engine_threading()?;
     sim_runtime::start_runtime_compile();
-    let mut sim_code = sim_code;
-    settle_fmu_method(&mut sim_code, &simulation_flags_json, kind);
+    let cs_method = fmu_cs_method(&simulation_flags_json, kind);
     // Emitting the model takes seconds; a host that compiles the native platforms
     // out of process can spend them loading its compiler.
     if !requested_native_platforms().is_empty() {
@@ -3286,7 +3272,7 @@ fn emit_fmu(
     }
     let errs_before = openmodelica_util::Error::getNumErrorMessages();
     let outcome = (|| -> Result<()> {
-        let model = fmu_kernel(&sim_code, kind)?;
+        let model = fmu_kernel(&sim_code, kind, &cs_method)?;
         export_phase("FMU model kernel");
         let natives = native_externals(&model, kind)?;
         let bare = fmu_directory();
@@ -3295,7 +3281,7 @@ fn emit_fmu(
             export_phase("FMU translated model");
         }
         let cs = kind != "ME";
-        let sundials = cs && fmu_needs_sundials(&model.method);
+        let sundials = cs && (fmu_needs_sundials(&model.meta.cs_method) || fmu_needs_sundials(&model.method));
         // An unzipped export is for an OpenModelica importer: it holds the model
         // description and the model kernel and nothing else, and the host links
         // that kernel against an adapter it compiled once into
@@ -4817,7 +4803,12 @@ fn build_guard_fn(target: u32) -> we::Function {
     f
 }
 
-fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost) -> Result<SimModel> {
+fn build_sim_model(
+    sim_code: &SimCode::SimCode,
+    fmi_vrs: bool,
+    ext_host: ExtHost,
+    cs_method: &str,
+) -> Result<SimModel> {
     crate::CodegenWasmJitFunctions::set_record_decls(&sim_code.recordDecls)?;
     let mi = &sim_code.modelInfo;
     let vi = &mi.varInfo;
@@ -5591,7 +5582,7 @@ fn build_sim_model(sim_code: &SimCode::SimCode, fmi_vrs: bool, ext_host: ExtHost
         }
     }
     let meta = build_sim_meta(
-        &layout, &result_vars, settings, &model_name, &sim_code.fileNamePrefix, jac_a.clone(), &state_sets,
+        &layout, &result_vars, settings, cs_method, &model_name, &sim_code.fileNamePrefix, jac_a.clone(), &state_sets,
         fmi_vrs, zc_descriptions(&zero_crossings), rel_descriptions(&sim_code.relations),
         param_vars(vars)?, attr_log_entries(sim_code)?,
         removed_init_residuals(sim_code).iter().map(|e| dump_exp(e)).collect(),
@@ -6950,6 +6941,7 @@ fn build_sim_meta(
     layout: &SimLayout,
     result_vars: &[ResultVar],
     settings: &SimCode::SimulationSettings,
+    cs_method: &str,
     model_name: &str,
     prefix: &str,
     jac_a: Option<JacAInfo>,
@@ -6980,6 +6972,7 @@ fn build_sim_meta(
         stop_time: settings.stopTime.into_inner(),
         n_intervals: settings.numberOfIntervals.max(0) as u32,
         method: settings.method.to_string(),
+        cs_method: cs_method.to_string(),
         tolerance: settings.tolerance.into_inner(),
         output_format: settings.outputFormat.to_string(),
         prefix: prefix.to_string(),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -553,6 +553,22 @@ fn set_error_stage(e: &mut dyn SimEngine, addr: u32, stage: i32) -> StageSave {
     save
 }
 
+fn stage_hit(e: &dyn SimEngine, addr: u32) -> bool {
+    addr != 0 && read_i32(e, addr + 4).unwrap_or(0) != 0
+}
+
+fn clear_stage_hit(e: &mut dyn SimEngine, addr: u32) {
+    if addr != 0 {
+        let _ = write_i32(e, addr + 4, 0);
+    }
+}
+
+fn mark_stage_hit(e: &mut dyn SimEngine, addr: u32) {
+    if addr != 0 {
+        let _ = write_i32(e, addr + 4, 1);
+    }
+}
+
 /// Close the region [`set_error_stage`] opened: put `save` back, and report whether a
 /// model error was absorbed in it (C's `success == 0`).
 fn took_error_stage(e: &mut dyn SimEngine, addr: u32, save: StageSave) -> bool {
@@ -4699,8 +4715,9 @@ impl LambdaRamp {
 /// whose sign change is a state event. Writes the candidate `t`/`y` into SimData,
 /// evaluates the continuous equations (`functionODE`) so any algebraics a
 /// crossing depends on are current, then the emitted `functionZeroCrossings`, and
-/// reads the results back. Errors are stashed in `ResCtx::err` (the C-style
-/// callback cannot return a status).
+/// reads the results back. A trap is stashed in `ResCtx::err`. A model error
+/// aborts the call, as C's `longjmp` out of the root function does
+/// ([`Solved::RootThrew`]).
 unsafe fn dassl_rt(
     _neq: *mut i32,
     t: *mut f64,
@@ -4710,14 +4727,15 @@ unsafe fn dassl_rt(
     rval: *mut f64,
     _rpar: *mut f64,
     _ipar: *mut i32,
-) {
+) -> i32 {
     let ctx = RES_CTX.load(Ordering::Relaxed);
     if ctx.is_null() {
-        return;
+        return 1;
     }
     let ctx = unsafe { &mut *ctx };
     let e = unsafe { &mut *ctx.engine };
     let _clock = rtclock::Handover::new(rtclock::SOLVER, rtclock::EVENT);
+    let hit_before = stage_hit(e, ctx.err_stage_addr);
     let run = (|| -> Result<()> {
         // A root probe may sit at an awkward candidate state where a nonlinear
         // system can't converge; keep that transient failure from leaking into the
@@ -4734,8 +4752,12 @@ unsafe fn dassl_rt(
         e.read_bytes(ctx.sim_data + ctx.zc_probe_off, rval_bytes)?;
         Ok(())
     })();
-    if let Err(err) = run {
-        ctx.err = Some(err);
+    match run {
+        Err(err) => {
+            ctx.err = Some(err);
+            1
+        }
+        Ok(()) => (!hit_before && stage_hit(e, ctx.err_stage_addr)) as i32,
     }
 }
 
@@ -6062,6 +6084,8 @@ enum Progress {
     Root,
     /// The per-call work quota ran out before the target; call again to continue.
     WorkQuota,
+    /// The root function raised a model error; see [`Solved::RootThrew`].
+    RootThrew,
     Failed(&'static str),
 }
 
@@ -6141,6 +6165,9 @@ impl DaskrState {
             return Progress::WorkQuota;
         }
         self.ev_retries = 0; // this target's integration is done (or failing)
+        if self.idid == solver::IDID_RT_ABORT {
+            return Progress::RootThrew;
+        }
         if self.idid < 0 {
             return Progress::Failed(report_dassl_failure(self.idid, *t));
         }
@@ -6253,6 +6280,7 @@ impl CvodeState {
                 self.work_retries += 1;
                 Progress::WorkQuota
             }
+            crate::sundials::Stop::Failed(crate::sundials::CV_RTFUNC_FAIL) => Progress::RootThrew,
             crate::sundials::Stop::Failed(_) => Progress::Failed("CodegenWasmJit: CVODE failed"),
             other => {
                 self.work_retries = 0;
@@ -6377,6 +6405,7 @@ impl IdaState {
                 );
                 Progress::WorkQuota
             }
+            crate::sundials::Stop::Failed(crate::sundials::IDA_RTFUNC_FAIL) => Progress::RootThrew,
             crate::sundials::Stop::Failed(_) => Progress::Failed("CodegenWasmJit: IDA failed"),
             other => {
                 self.work_retries = 0;
@@ -6694,6 +6723,10 @@ enum Solved {
     Stepped,
     /// A root function changed sign; `SolverCore::t` is where.
     Root,
+    /// The root function raised a model error. C's `dassl_step` catches that
+    /// `longjmp` with `retVal` still 0, so `simulationUpdate` evaluates the probe
+    /// point `SimData` was left at, and only its throw reaches the step's retry.
+    RootThrew(&'static str),
     Yielded,
     Cancelled,
 }
@@ -7183,11 +7216,16 @@ impl SolverCore {
             self.nje = ctx.nje;
             *did_step = true;
             // A wasm error in a callback outranks whatever the solver reported.
-            if let Some(err) = ctx.err.take() {
+            let err = ctx.err.take();
+            if let Progress::RootThrew = again {
+                return Ok(Solved::RootThrew(err.unwrap_or(ASSERT_ERR)));
+            }
+            if let Some(err) = err {
                 return Err(err);
             }
             match again {
                 Progress::WorkQuota => continue,
+                Progress::RootThrew => unreachable!(),
                 // An internal step below the target: only `-noEquidistantTimeGrid`
                 // makes it an output point, so otherwise integrate on, as C's
                 // `dassl_step` loop does while IDID == 1.
@@ -7436,6 +7474,17 @@ impl SolverCore {
                     }
                     Solved::Reached | Solved::Stepped => false,
                     Solved::Root => true,
+                    Solved::RootThrew(err) => {
+                        // C's `updateContinuousSystem` at the probe point; C carries on
+                        // if it does not throw, here the root function's throw is the step's.
+                        clear_stage_hit(e, ctx.err_stage_addr);
+                        let evaluated = eval_continuous(e, sim_data, layout);
+                        if err == ASSERT_ERR && !stage_hit(e, ctx.err_stage_addr) {
+                            mark_stage_hit(e, ctx.err_stage_addr);
+                        }
+                        evaluated?;
+                        return Err(err);
+                    }
                 };
                 self.write_states(e)?;
                 // C runs `simulationUpdate` on every accepted step, row due or not.
@@ -7680,7 +7729,7 @@ pub enum CsStep {
 /// `cvode_solver_initial` so the banner reaches the log either way. `defer` decides
 /// the root-finding line — see [`CsDriver::new`].
 pub fn log_cs_solver_setup(model: &SimModel, defer: CsDefer) {
-    let Ok(method) = resolve_solver_method(&model.method, model.layout.dae_mode()) else { return };
+    let Ok(method) = resolve_solver_method(model.cs_method(), model.layout.dae_mode()) else { return };
     // "No states present, continuing without ODE solver": C falls back to euler,
     // which has nothing to set up and nothing to say.
     if method != "cvode" || model.layout.n_states == 0 {
@@ -7704,7 +7753,7 @@ pub fn log_cs_solver_setup(model: &SimModel, defer: CsDefer) {
 
 impl CsDriver {
     /// Build over an already-initialized model at time `t`, integrating with the
-    /// method the FMU was exported with (`buildModelFMU`'s `method=`).
+    /// method the FMU was exported with ([`SimMeta::cs_method`]).
     ///
     /// The integrator watches event indicators only under [`CsDefer::Any`], the one
     /// mode whose master can be handed the crossing time (Event Mode with early
@@ -7720,7 +7769,7 @@ impl CsDriver {
     ) -> Result<Self> {
         daskr::auxiliary::xsetf(0);
         let layout = &model.layout;
-        let method = resolve_solver_method(&model.method, layout.dae_mode())?;
+        let method = resolve_solver_method(model.cs_method(), layout.dae_mode())?;
         // QSS runs a whole simulation of its own; C's `solver_main_step` throws
         // "Unhandled case" for it rather than stepping it.
         if method == "qss" {
@@ -9771,7 +9820,7 @@ impl GuessStepper {
                     frac = 1.0;
                 }
                 Ok(Solved::Cancelled) => return Err("CodegenWasmJit: simulation cancelled"),
-                Err(err) => {
+                Ok(Solved::RootThrew(err)) | Err(err) => {
                     iter += 1;
                     if iter > 10 {
                         omclog::warning(

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -1002,6 +1002,10 @@ pub struct SimMeta {
     pub n_intervals: u32,
     /// Integration method (`"dassl"`, `"euler"`, …; empty = the dassl default).
     pub method: String,
+    /// What a Co-Simulation `do-step` integrates with (C's
+    /// `FMI2CS_initializeSolverData`: `-s` from `_flags.json`, else euler).
+    /// Empty except for a CS export.
+    pub cs_method: String,
     /// Relative/absolute tolerance for the adaptive integrators.
     pub tolerance: f64,
     /// Result file format (`"mat"`, `"empty"`).
@@ -1147,6 +1151,10 @@ pub struct NlsVars {
 }
 
 impl SimMeta {
+    pub fn cs_method(&self) -> &str {
+        if self.cs_method.is_empty() { &self.method } else { &self.cs_method }
+    }
+
     /// [`ImportRoster`] for this model: the codegen resolves the `-iif` file against
     /// it and the driver applies the result, so both index the same list.
     pub fn import_roster(&self) -> ImportRoster<'_> {
@@ -1393,7 +1401,7 @@ impl SimMeta {
 // the crate dependency-free and trivially buildable for every target.
 
 const MAGIC: &[u8; 4] = b"OMSM";
-const VERSION: u32 = 16;
+const VERSION: u32 = 17;
 
 fn put_u32(o: &mut Vec<u8>, v: u32) {
     o.extend_from_slice(&v.to_le_bytes());
@@ -1506,6 +1514,7 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
     put_f64(&mut o, m.stop_time);
     put_u32(&mut o, m.n_intervals);
     put_str(&mut o, &m.method);
+    put_str(&mut o, &m.cs_method);
     put_f64(&mut o, m.tolerance);
     put_str(&mut o, &m.output_format);
     put_str(&mut o, &m.prefix);
@@ -1977,6 +1986,7 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
     let stop_time = r.f64()?;
     let n_intervals = r.u32()?;
     let method = r.string()?;
+    let cs_method = r.string()?;
     let tolerance = r.f64()?;
     let output_format = r.string()?;
     let prefix = r.string()?;
@@ -2285,7 +2295,7 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
         }
     };
     Ok(SimMeta {
-        layout, start_time, stop_time, n_intervals, method, tolerance, output_format, prefix,
+        layout, start_time, stop_time, n_intervals, method, cs_method, tolerance, output_format, prefix,
         model_name, vars, jac_a, state_sets, fmi_vrs, zc_desc, rel_desc, params, attr_log,
         removed_init_desc, nls_warnings, sample_index, soti, sens_params, nls_vars, n_lin_systems, dae, clocks, lin, opt, inputs, recon, prof,
     })
@@ -2308,6 +2318,7 @@ mod tests {
             stop_time: 1.0,
             n_intervals: 500,
             method: "dassl".to_string(),
+            cs_method: "euler".to_string(),
             tolerance: 1e-6,
             output_format: "mat".to_string(),
             prefix: "MyModel".to_string(),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/dassl.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/dassl.rs
@@ -348,17 +348,20 @@ unsafe fn root(
     rval: *mut f64,
     _rpar: *mut f64,
     _ipar: *mut i32,
-) {
-    let Some(ctx) = context() else { return };
+) -> i32 {
+    let Some(ctx) = context() else { return 1 };
     let (y, zc) = unsafe {
         (
             core::slice::from_raw_parts(y, ctx.n_states),
             core::slice::from_raw_parts_mut(rval, ctx.n_zc),
         )
     };
-    if let Err(e) = ctx.ode.eval_zc(unsafe { *t }, y, zc) {
-        ctx.failed.get_or_insert(e);
-        zc.fill(0.0);
+    match ctx.ode.eval_zc(unsafe { *t }, y, zc) {
+        Ok(()) => 0,
+        Err(e) => {
+            ctx.failed.get_or_insert(e);
+            1
+        }
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/sundials.rs
@@ -106,6 +106,7 @@ unsafe extern "C" fn err_handler(
 }
 /// `mxstep` internal steps taken without reaching `tout`; resuming continues.
 pub const CV_TOO_MUCH_WORK: c_int = -1;
+pub const CV_RTFUNC_FAIL: c_int = -12;
 
 unsafe extern "C" {
     /// `SUNComm` is a plain `int` without MPI, and `SUN_COMM_NULL` is 0.
@@ -442,6 +443,7 @@ pub type IdaJacFn = unsafe extern "C" fn(
 
 /// `mxstep` internal steps taken without reaching `tout`; resuming continues.
 pub const IDA_TOO_MUCH_WORK: c_int = -1;
+pub const IDA_RTFUNC_FAIL: c_int = -12;
 /// Error test failures on one step, corrector convergence failures, and a failed
 /// linear-solver setup — what `ida_solver_step` restarts from.
 pub const IDA_ERR_FAIL: c_int = -3;


### PR DESCRIPTION
## Root-function throws are reported like C

A model error raised inside DASSL's root function
(`function_ZeroCrossingsDASSL`, stage `ERROR_EVENTSEARCH`; CVODE and IDA alike) has no catch of its own in C. It longjmps out of DDASKR into `dassl_step`'s catch, which leaves `retVal == 0` and `localData[0]` at the probe point the root function had written. `performSimulation` therefore still runs `simulationUpdate`, whose `updateContinuousSystem` raises the same error once more, and only that second throw reaches the per-step catch that retries the step: the assertion block is printed twice per failed step. wasm-jit let DASKR carry on after the callback and reported once, at the retry.

* `daskr`'s `RtFn` returns a status; nonzero abandons the call with `IDID_RT_ABORT` (-34, not a DDASKR code) through `drchek`'s `IRT`. `CV_RTFUNC_FAIL`/`IDA_RTFUNC_FAIL` are the SUNDIALS equivalents.
* `dassl_rt` aborts on a trap or on a model error absorbed by the enclosing step region (its hit word, read before and after).
* `SolverCore` maps that to `Solved::RootThrew`: `integrate_to` evaluates the continuous system at the probe point (the second report), then hands the error to `drive`'s retry. C's continuation when that evaluation does not throw (with `currentTime` behind `localData`) is not mirrored.

Fixes `openmodelica/fmi/ModelExchange/2.0/testAssert.mos`.

## Co-Simulation integrates with `cs_method`

C's `FMI2CS_initializeSolverData` integrates a communication step with explicit Euler unless `-s` is in `resources/<prefix>_flags.json`, whatever method the model was translated with. #16444 made a CS wasm export keep the model's own method so the artifact's plain-simulation face stays the translated model; `omsimulator/DualMassOscillator_cs` (an OMSimulator master stepping two CS FMUs at 1e-5) then integrated with DASKR and came out 2.8 % off the C answer the test expects.

Both now travel in the embedded metadata: `SimMeta.method` stays the model's, read by `sim_run`, and `SimMeta.cs_method` (wire VERSION 17) is what a `do-step` integrates with. `fmu_cs_method` fills it as C does: the `s` flag, else `euler`, empty for ME. `CsDriver` and `log_cs_solver_setup` read `cs_method()`, `check_fmu_method` and the `FmuKernel` cache key on it, and the SUNDIALS adapter is chosen if either method needs it. `build_sim_model` takes the CS method as a parameter (`""` for a plain simulation).

Fixes `omsimulator/DualMassOscillator_cs.mos`; the result matches C to 1e-14.

Assisted-by: Claude Fable 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
