### PR TITLE
Serve an external "C" a wasm library only wraps

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -1980,6 +1980,53 @@ pub(crate) fn missing_ext_symbols(ext_imports: &[ExtCallSig], libs: &[ExtLibrary
     ext_imports.iter().filter(|s| !defined.contains(s.name.as_str())).cloned().collect()
 }
 
+/// What a dylink library needs from outside: the functions it calls (`env`) and
+/// the ones whose address it takes (`GOT.func`).
+fn dylink_needs(bytes: &[u8]) -> Vec<String> {
+    use wasmparser::{Imports, TypeRef};
+    let mut out = Vec::new();
+    let mut add = |module: &str, name: &str, is_func: bool| {
+        if (module == "env" && is_func) || module == "GOT.func" {
+            out.push(name.to_string());
+        }
+    };
+    for payload in wasmparser::Parser::new(0).parse_all(bytes).flatten() {
+        let wasmparser::Payload::ImportSection(reader) = payload else { continue };
+        for group in reader.into_iter().flatten() {
+            match group {
+                Imports::Single(_, imp) => add(imp.module, imp.name, matches!(imp.ty, TypeRef::Func(_))),
+                Imports::Compact1 { module, items } => {
+                    for it in items.into_iter().flatten() {
+                        add(module, it.name, matches!(it.ty, TypeRef::Func(_)));
+                    }
+                }
+                Imports::Compact2 { module, names, ty } => {
+                    for n in names.into_iter().flatten() {
+                        add(module, n, matches!(ty, TypeRef::Func(_)));
+                    }
+                }
+            }
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Which of `needs` nothing in the wasm world defines; `--allow-undefined` lets a
+/// library link without them.
+fn unresolved_dylink_needs(needs: &[String], lib: &ExtLibrary, others: &[ExtLibrary]) -> Vec<String> {
+    let mut defined: HashSet<&str> = HashSet::new();
+    for bytes in others
+        .iter()
+        .map(|l| &l.bytes[..])
+        .chain([&lib.bytes[..], LIBC_PIC, EXTERNAL_C_DYLINK, LAPACK_DYLINK, openmodelica_wasm_jit::RUNTIME_WASM])
+    {
+        defined.extend(wasm_exports(bytes));
+    }
+    needs.iter().filter(|n| !defined.contains(n.as_str())).cloned().collect()
+}
+
 /// The `-L` directories of a linker flag string (`-Ldir`, `-L"dir"`, `-L dir`).
 /// It is a shell command line, so quotes group rather than belong to the path.
 fn ld_search_dirs(flags: &str) -> Vec<String> {
@@ -2386,6 +2433,15 @@ fn xml_escape(s: &str) -> String {
 /// parameters in a frame of 8-byte slots, calls the adapter's
 /// `om_ext_native_call(index, frame, table, table_len)` and loads the return value
 /// from the slot after them. The table text rides in the module's data.
+/// One 8-byte frame slot; wasm rejects an alignment hint larger than the access.
+fn slot_mem(offset: u32, wty: openmodelica_wasm_jit::sig::WTy) -> we::MemArg {
+    let align = match wty {
+        openmodelica_wasm_jit::sig::WTy::F64 => 3,
+        openmodelica_wasm_jit::sig::WTy::I32 => 2,
+    };
+    we::MemArg { offset: offset as u64, align, memory_index: 0 }
+}
+
 fn native_ext_stub(sigs: &[ExtCallSig], table: &str) -> Result<Vec<u8>> {
     let table_bytes = table.as_bytes();
     let frame_off = (table_bytes.len() as u32 + 7) & !7;
@@ -2415,7 +2471,7 @@ fn native_ext_stub(sigs: &[ExtCallSig], table: &str) -> Result<Vec<u8>> {
         exports.export(&sig.name, we::ExportKind::Func, i as u32 + 1);
         let mut f = we::Function::new(Vec::<(u32, we::ValType)>::new());
         for (p, t) in fs.params.iter().enumerate() {
-            let mem = we::MemArg { offset: (frame_off + 8 * p as u32) as u64, align: 3, memory_index: 0 };
+            let mem = slot_mem(frame_off + 8 * p as u32, t.wty());
             f.instruction(&we::Instruction::GlobalGet(0));
             f.instruction(&we::Instruction::LocalGet(p as u32));
             f.instruction(&match t.wty() {
@@ -2431,7 +2487,7 @@ fn native_ext_stub(sigs: &[ExtCallSig], table: &str) -> Result<Vec<u8>> {
         f.instruction(&we::Instruction::I32Const(table_bytes.len() as i32));
         f.instruction(&we::Instruction::Call(0));
         if let Some(r) = fs.results.first() {
-            let mem = we::MemArg { offset: (frame_off + 8 * fs.params.len() as u32) as u64, align: 3, memory_index: 0 };
+            let mem = slot_mem(frame_off + 8 * fs.params.len() as u32, r.wty());
             f.instruction(&we::Instruction::GlobalGet(0));
             f.instruction(&match r.wty() {
                 openmodelica_wasm_jit::sig::WTy::F64 => we::Instruction::F64Load(mem),
@@ -5062,7 +5118,19 @@ fn build_sim_model(
                 let missing = missing_ext_symbols(&ext_imports, &ext_libs.wasm);
                 if hook || !missing.is_empty() {
                     if let Some(l) = compile_include_library(&prefix, &sources, &dirs, &mp.cflags, &missing, &mut ext_lib_notes)? {
-                        ext_libs.wasm.push(l);
+                        // Sources that only wrap a platform library still compile,
+                        // and keeping the result would hide the functions from the
+                        // host fallback that can serve them.
+                        let unresolved = unresolved_dylink_needs(&dylink_needs(&l.bytes), &l, &ext_libs.wasm);
+                        if unresolved.is_empty() {
+                            ext_libs.wasm.push(l);
+                        } else {
+                            ext_lib_notes.push(format!(
+                                "the `Include` C sources compiled for wasm but need `{}`, which no \
+                                 wasm library defines; serving them from the host instead",
+                                unresolved.join("`, `")
+                            ));
+                        }
                     }
                 }
             }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/artifact.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/artifact.rs
@@ -424,8 +424,9 @@ pub fn run(
         Err(e) => return (Err(e), log),
     };
     log.push_str(&format!(
-        "LOG_STDOUT        | info    | wasm artifact loaded in {:.1} ms ({})\n",
-        loaded.load_ms, loaded.how
+        "LOG_STDOUT        | info    | wasm artifact loaded{} ({})\n",
+        took(loaded.load_ms),
+        loaded.how
     ));
     let flags = match super::install_sim_flags(simflags) {
         Ok(f) => f,
@@ -472,8 +473,10 @@ fn run_simulation(
     };
     let elapsed = ms(t);
     log.push_str(&format!(
-        "LOG_STDOUT        | info    | in-wasm simulation ({}) wrote {} rows in {:.1} ms\n",
-        run.solver, run.rows, elapsed
+        "LOG_STDOUT        | info    | in-wasm simulation ({}) wrote {} rows{}\n",
+        run.solver,
+        run.rows,
+        took(elapsed)
     ));
     if let Some((name, content)) = &run.linear_file {
         let path = match &flags.output_path {
@@ -608,9 +611,9 @@ fn run_fmi(
             }
             .map_err(|e| e.to_string())?;
             log.push_str(&format!(
-                "LOG_STDOUT        | info    | {} instantiated in {:.1} ms\n",
+                "LOG_STDOUT        | info    | {} instantiated{}\n",
                 kind.as_str(),
-                ms(t)
+                took(ms(t))
             ));
             let t = Instant::now();
             let (r, s) = drive(&mut inst, kind, md, &opts)?;
@@ -635,18 +638,18 @@ fn run_fmi(
                 Ok((r, s, ms(t)))
             })?;
             log.push_str(&format!(
-                "LOG_STDOUT        | info    | {} instantiated in {:.1} ms\n",
+                "LOG_STDOUT        | info    | {} instantiated{}\n",
                 kind.as_str(),
-                linked_ms
+                took(linked_ms)
             ));
             (r, s, e)
         }
     };
     log.push_str(&format!(
-        "LOG_STDOUT        | info    | {} run: {summary}, {} samples in {:.1} ms\n",
+        "LOG_STDOUT        | info    | {} run: {summary}, {} samples{}\n",
         kind.as_str(),
         recorder.len(),
-        elapsed
+        took(elapsed)
     ));
     if flags.noemit || flags.output_format.as_deref() == Some("empty") {
         return Ok(());
@@ -683,6 +686,15 @@ where
             );
             Ok((run.recorder, s))
         }
+    }
+}
+
+/// ` in 4.2 ms`, or nothing under the testsuite: these lines reach a `simulate()`
+/// record, where a timing would make the baseline depend on the clock.
+fn took(ms: f64) -> String {
+    match openmodelica_util::Testsuite::isRunning() {
+        Ok(true) => String::new(),
+        _ => format!(" in {ms:.1} ms"),
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ext_native/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ext_native/src/lib.rs
@@ -131,7 +131,7 @@ fn ffi_ty(ty: &Ty, out: bool) -> libffi::middle::Type {
         Ty::Scalar(Scalar::Real) => Type::f64(),
         // Every integer argument fills a 64-bit slot, correct for `int` and `long` alike.
         Ty::Scalar(_) => Type::i64(),
-        Ty::Str | Ty::Ptr | Ty::Array(_) => Type::pointer(),
+        Ty::Str | Ty::Ptr | Ty::Array(_) | Ty::Record(_) => Type::pointer(),
     }
 }
 
@@ -191,7 +191,9 @@ impl Natives {
                 Some(Ty::Scalar(Scalar::Real)) => (libffi::middle::Type::f64(), 8),
                 Some(Ty::Scalar(_)) => (libffi::middle::Type::i32(), 8),
                 Some(Ty::Str | Ty::Ptr) => (libffi::middle::Type::pointer(), 8),
-                Some(Ty::Array(_)) => return Err(format!("`{}` returns an array, which C cannot", sig.name)),
+                Some(Ty::Array(_) | Ty::Record(_)) => {
+                    return Err(format!("`{}` returns an array or record, which C cannot", sig.name))
+                }
             };
             fns.push(Resolved { sig: sig.clone(), addr, cif: libffi::middle::Cif::new(args, ret), ret_bytes });
         }
@@ -216,7 +218,7 @@ impl Natives {
         let mut cells: Vec<(usize, Box<Cell>)> = Vec::new();
         let mut next = args.iter();
         for (j, a) in sig.args.iter().enumerate() {
-            if a.out && !matches!(a.ty, Ty::Array(_)) {
+            if marshal::is_cell(a) {
                 let mut cell = Box::new(Cell(0));
                 slots.push(Cell(&mut *cell as *mut Cell as u64));
                 cells.push((j, cell));
@@ -233,7 +235,8 @@ impl Natives {
                     cstrings.push(c);
                     Cell(p)
                 }
-                (Ty::Array(_), Value::Bytes(b)) => {
+                // A record crosses the same way, as a pointer to the bytes.
+                (Ty::Array(_) | Ty::Record(_), Value::Bytes(b)) => {
                     let mut buf = b.clone();
                     // An empty array still needs an address.
                     buf.reserve(8);
@@ -279,6 +282,7 @@ impl Natives {
                     Value::Str(if p.is_null() { String::new() } else { unsafe { CStr::from_ptr(p) }.to_string_lossy().into_owned() })
                 }
                 Ty::Array(_) => return Err("an array cannot be a C result".into()),
+                Ty::Record(_) => return Err("a record cannot be a C result".into()),
             })
         };
         if let Some(ret) = &sig.ret {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ext_native_marshal/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ext_native_marshal/src/lib.rs
@@ -28,6 +28,9 @@ pub enum Ty {
     /// An external object.
     Ptr,
     Array(Scalar),
+    /// A pointer to C's `<record>_external` (the members' C types from offset 0);
+    /// the bytes are copied whole in both directions, so only the size is needed.
+    Record(u32),
 }
 
 impl Ty {
@@ -85,8 +88,35 @@ fn parse_ty(code: &str) -> Result<Ty, String> {
         "S" => Ok(Ty::Str),
         "P" => Ok(Ty::Ptr),
         c if c.starts_with('[') => Ok(Ty::Array(scalar(c.trim_start_matches('['))?)),
+        c if c.starts_with('{') => Ok(Ty::Record(record_size(c)?)),
         c => Ok(Ty::Scalar(scalar(c)?)),
     }
+}
+
+/// The size of C's `<record>_external` for `{path;name:code;…}`: each member at its
+/// natural alignment, the struct padded to the widest. A non-scalar member has no
+/// size both sides agree on (a pointer is 4 bytes in the kernel, 8 here).
+fn record_size(code: &str) -> Result<u32, String> {
+    let body = code.trim_start_matches('{').trim_end_matches('}');
+    let (mut off, mut align) = (0u32, 1u32);
+    for member in body.split(';').skip(1) {
+        let (name, ty) = member.split_once(':').ok_or_else(|| {
+            format!("native externals: record member `{member}` has no type in `{code}`")
+        })?;
+        let size = match ty {
+            "R" => 8,
+            "I" | "B" => 4,
+            _ => {
+                return Err(format!(
+                    "native externals: record member `{name}` of type `{ty}` cannot be copied to C \
+                     - only Real, Integer and Boolean members can"
+                ))
+            }
+        };
+        off = off.next_multiple_of(size) + size;
+        align = align.max(size);
+    }
+    Ok(off.next_multiple_of(align.max(1)))
 }
 
 /// The table's text form (see [`Table`]):
@@ -153,10 +183,11 @@ pub trait Guest {
     fn free(&mut self, addr: u32);
 }
 
-/// Whether the argument is passed as a cell the callee writes, and so is neither
-/// an input value nor a wasm result.
-fn is_cell(a: &Arg) -> bool {
-    a.out && !matches!(a.ty, Ty::Array(_))
+/// Whether the callee writes this argument through a scalar cell the caller
+/// allocates, and so is neither an input value nor a wasm result. An array or
+/// record crosses as a pointer, which *is* the value.
+pub fn is_cell(a: &Arg) -> bool {
+    a.out && !matches!(a.ty, Ty::Array(_) | Ty::Record(_))
 }
 
 /// The host's argument list, read out of the frame.
@@ -183,6 +214,11 @@ pub fn gather(sig: &Sig, frame: u32, g: &dyn Guest) -> Result<Vec<Value>, String
                 let h = g.load_i32(slot) as u32;
                 let bytes = if h == 0 { Vec::new() } else { g.read(g.array_data(h), g.array_total(h) * Ty::elem_size(*elem)) };
                 Value::Bytes(bytes)
+            }
+            // The slot holds the address of the kernel's scratch struct.
+            Ty::Record(size) => {
+                let p = g.load_i32(slot) as u32;
+                Value::Bytes(if p == 0 { Vec::new() } else { g.read(p, *size) })
             }
         });
     }
@@ -226,20 +262,30 @@ pub fn scatter(sig: &Sig, frame: u32, results: &[Value], g: &mut dyn Guest, scra
             store(g, cell, &a.ty, v, scratch)?;
         }
     }
+    // In argument order: that is the order the host returns them in.
     for (j, a) in sig.args.iter().enumerate() {
-        let Ty::Array(elem) = &a.ty else { continue };
         if !a.out {
             continue;
         }
-        let Value::Bytes(bytes) = next("output array")? else {
-            return Err(format!("native externals: `{}` returned a non-array for an output array", sig.name));
+        let (what, len, at) = match &a.ty {
+            Ty::Array(elem) => {
+                let h = g.load_i32(frame + 8 * j as u32) as u32;
+                ("array", g.array_total(h) * Ty::elem_size(*elem), g.array_data(h))
+            }
+            Ty::Record(size) => ("record", *size, g.load_i32(frame + 8 * j as u32) as u32),
+            _ => continue,
         };
-        let h = g.load_i32(frame + 8 * j as u32) as u32;
-        let len = g.array_total(h) * Ty::elem_size(*elem);
+        let Value::Bytes(bytes) = next(&format!("output {what}"))? else {
+            return Err(format!("native externals: `{}` returned a non-{what} for an output {what}", sig.name));
+        };
         if bytes.len() as u32 != len {
-            return Err(format!("native externals: `{}` returned {} bytes for an output array of {len}", sig.name, bytes.len()));
+            return Err(format!(
+                "native externals: `{}` returned {} bytes for an output {what} of {len}",
+                sig.name,
+                bytes.len()
+            ));
         }
-        g.write(g.array_data(h), bytes);
+        g.write(at, bytes);
     }
     Ok(())
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -377,14 +377,27 @@ fn ext_c_type(ty: &crate::sig::SigTy) -> Option<&'static str> {
 /// it carries the argument conversions ([`EXT_CALL_PREFIX`]).
 #[cfg(not(target_arch = "wasm32"))]
 pub fn external_symbol_or_wrapper(handles: &[usize], name: &str) -> Option<usize> {
-    use openmodelica_util::dynload::external_symbol_in;
-    if let Some(addr) = external_symbol_in(handles, &format!("{EXT_CALL_PREFIX}{name}")) {
+    external_symbol_or_wrapper_impl(handles, name, false)
+}
+
+/// [`external_symbol_or_wrapper`] restricted to `handles`: an export has to name
+/// the files it ships, and what the omc process happens to hold is not one.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn external_symbol_or_wrapper_shippable(handles: &[usize], name: &str) -> Option<usize> {
+    external_symbol_or_wrapper_impl(handles, name, true)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn external_symbol_or_wrapper_impl(handles: &[usize], name: &str, shippable: bool) -> Option<usize> {
+    use openmodelica_util::dynload::{external_symbol_in, symbol_in};
+    let find = |n: &str| if shippable { symbol_in(handles, n) } else { external_symbol_in(handles, n) };
+    if let Some(addr) = find(&format!("{EXT_CALL_PREFIX}{name}")) {
         return Some(addr);
     }
-    if let Some(addr) = external_symbol_in(handles, name) {
+    if let Some(addr) = find(name) {
         return Some(addr);
     }
-    let wrapper = external_symbol_in(handles, &format!("{EXT_ADDR_PREFIX}{name}"))?;
+    let wrapper = find(&format!("{EXT_ADDR_PREFIX}{name}"))?;
     // Safety: the generated wrapper is `void (*w(void))(void)`.
     let w: extern "C" fn() -> usize = unsafe { std::mem::transmute(wrapper) };
     Some(w()).filter(|a| *a != 0)

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -393,6 +393,8 @@ pub fn prepare_native_externals(model: &SimModel, sigs: &[crate::sig::ExtCallSig
 /// `Include` C source.
 #[derive(Default)]
 struct NativeExternals {
+    /// Only a symbol in `handles` counts: see `external_symbol_or_wrapper_shippable`.
+    shippable_only: bool,
     handles: Vec<usize>,
     /// The files behind `handles`, in load order.
     paths: Vec<String>,
@@ -405,7 +407,7 @@ struct NativeExternals {
 /// (`ext_native`), for an export to ship: the `Library` shared objects, the
 /// archives linked into one, the `Include` sources compiled into one.
 pub fn native_external_library_files(model: &SimModel) -> std::result::Result<Vec<String>, String> {
-    let mut native = NativeExternals::default();
+    let mut native = NativeExternals { shippable_only: true, ..Default::default() };
     for sig in &model.ext_native {
         if native.resolve(&sig.name, model).is_none() {
             return Err(unresolved_external_detail(&sig.name, model, &native.errors));
@@ -490,7 +492,10 @@ impl NativeExternals {
     }
 
     fn symbol(&self, name: &str) -> Option<usize> {
-        model::external_symbol_or_wrapper(&self.handles, name)
+        match self.shippable_only {
+            true => model::external_symbol_or_wrapper_shippable(&self.handles, name),
+            false => model::external_symbol_or_wrapper(&self.handles, name),
+        }
     }
 
     /// The model's own `usertab`: no `external "C"`, so never among `ext_imports`.

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -37,6 +37,11 @@ rtest special directives added to help creating testcases:
   at another toolchain. The wasm values are used when the target under test is
   wasm-jit (`OPENMODELICA_TEST_SIMCODETARGET` or `--simCodeTarget=` in
   `RTEST_OMCFLAGS`).
+
+  The same six are also exported as `OMC_NATIVE_CC`, `OMC_NATIVE_CFLAGS`, … with
+  the host values whatever the target under test is, for a test whose `Library`
+  exists for the platform alone — an `external "C"` the wasm side can only wrap
+  and has to reach through the host.
 * teardown_command: rm -f ...  
   Will execute the provided command after running omc.
 * suite: metamodelica, 63bit  

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/.gitignore
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/.gitignore
@@ -5,3 +5,5 @@
 *.json
 *.libs
 *.makefile
+# hand-written external "C" sources a setup_command builds, not generated ones
+!*-f.c

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/Makefile
@@ -23,6 +23,7 @@ fmi3_terminals_alias_nb.mos \
 fmi3_terminals_alias.mos \
 fmi3_terminals.mos \
 fmi3_types.mos \
+fmi3_wasm_native_record.mos \
 fmi3_wasm_output_record.mos
 
 # Dependency files that are not .mo .mos or Makefile
@@ -30,6 +31,7 @@ fmi3_wasm_output_record.mos
 DEPENDENCIES = \
 *.mo \
 *.mos \
+*.c \
 Makefile \
 
 CLEAN = `ls | grep -w -v -f deps.tmp`

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_wasm_native_record-f.c
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_wasm_native_record-f.c
@@ -1,0 +1,22 @@
+#include <ModelicaUtilities.h>
+
+/* The shape ExternalMedia's library has: the record filled through a pointer to
+   C's `<record>_external`, and the message handlers passed in rather than called
+   directly, so a wrapper is the only thing an `Include` can offer. */
+typedef struct { double T; double p; int phase; } om_state_external;
+
+void om_state_err(double p, double h, int hint, om_state_external* s,
+                  const char* medium, void (*err)(const char*))
+{
+  if (p <= 0.0) {
+    err("om_state_err: pressure must be positive");
+    return;
+  }
+  s->T = h / 4200.0;
+  s->p = p;
+  s->phase = h > 250000.0 ? 2 : 1;
+  if (medium == 0 || medium[0] == '\0') {
+    err("om_state_err: no medium name");
+  }
+  (void) hint;
+}

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_wasm_native_record.mo
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_wasm_native_record.mo
@@ -1,0 +1,33 @@
+model ExtNativeRecord
+  record State
+    Real T;
+    Real p;
+    Integer phase;
+  end State;
+
+  function setState
+    input Real p;
+    input Real h;
+    input Integer hint;
+    output State state;
+    input String medium = "water";
+    external "C" om_state_wrap(p, h, hint, state, medium)
+    annotation (
+      Library = "fmi3_wasm_native_record-f.o",
+      Include = "
+#include \"ModelicaUtilities.h\"
+typedef struct { double T; double p; int phase; } om_state_external;
+void om_state_err(double p, double h, int hint, om_state_external* s,
+                  const char* medium, void (*err)(const char*));
+
+/* Only a wrapper: `om_state_err` is in the platform library alone, and takes a
+   message handler this side has to pass in. */
+void om_state_wrap(double p, double h, int hint, void* s, const char* medium)
+{
+  om_state_err(p, h, hint, (om_state_external*) s, medium, ModelicaError);
+}
+");
+  end setState;
+
+  State st = setState(1e5, 1e5 * time + 2e5, 3);
+end ExtNativeRecord;

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_wasm_native_record.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_wasm_native_record.mos
@@ -1,0 +1,63 @@
+// name: fmi3_wasm_native_record.mos
+// keywords: FMI 3.0 export wasm external record native
+// status: correct
+// suite: wasm
+// setup_command: $OMC_NATIVE_CC $OMC_NATIVE_CFLAGS -I"$OPENMODELICAHOME/include/omc/c" $OMC_NATIVE_EXTLIB_FLAGS -o fmi3_wasm_native_record-f$OMC_NATIVE_EXTLIB_EXT fmi3_wasm_native_record-f.c $OMC_NATIVE_EXTLIB_LIBS
+// teardown_command: rm -rf ExtNativeRecord.fmu ExtNativeRecord_res.mat plain_res.mat art_cs.mat d_cs* om-wasm-include-* fmi3_wasm_native_record-f.o ExtNativeRecord*.log plain*
+// depends: fmi3_wasm_native_record-f.c
+//
+// An `external "C"` whose implementation is a platform library the wasm side has
+// no build of - the `setup_command` builds it with the host toolchain alone. The
+// `Include` sources can only wrap it, so they compile for wasm with the real entry
+// point left undefined. The functions are served from the host instead, over a
+// table that has to carry the `_Out_` record among the arguments.
+//
+// The plain simulation runs first on purpose: it dlopens the natively built
+// `Include` library into this omc, and the export must still ship that file rather
+// than count the symbol as already resolved.
+
+setCommandLineOptions("--simCodeTarget=wasm-jit"); getErrorString();
+loadFile("fmi3_wasm_native_record.mo"); getErrorString();
+
+simulate(ExtNativeRecord, stopTime=1.0, numberOfIntervals=10, fileNamePrefix="plain"); getErrorString();
+
+setCommandLineOptions("--fmuDirectory=true"); getErrorString();
+buildModelFMU(ExtNativeRecord, fileNamePrefix="ExtNativeRecord", fmuType="me_cs", version="3.0", platforms={"wasm"}); getErrorString();
+
+// The Co-Simulation face runs inside the component, reaching the host for the
+// external and copying the record back out of it.
+simulate(ExtNativeRecord, stopTime=1.0, numberOfIntervals=10, simflags="-s fmi3:cs -r=art_cs.mat", resimulateExecutable="ExtNativeRecord.fmu"); getErrorString();
+
+diffSimulationResults("art_cs.mat", "plain_res.mat", "d_cs", 1e-9, 1e-9);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "plain_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 10, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'plain', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// true
+// ""
+// "ExtNativeRecord.fmu"
+// "Notification: Building FMU for platform 'wasm' (1/1).
+// Notification: Finished FMU for platform 'wasm' (1/1).
+// "
+// record SimulationResult
+//     resultFile = "art_cs.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 10, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ExtNativeRecord', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s fmi3:cs -r=art_cs.mat'",
+//     messages = "LOG_STDOUT        | info    | wasm artifact loaded (model kernel 0.0 MB linked against the cached adapter)
+// LOG_STDOUT        | info    | CoSimulation instantiated
+// LOG_STDOUT        | info    | CoSimulation run: 500 communication steps, 0 events, 0 early returns, 501 samples
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// (true, {})
+// endResult

--- a/testsuite/rtest
+++ b/testsuite/rtest
@@ -153,27 +153,34 @@ sub wasm_builtins
 #
 # wasm-jit needs a PIC dylink module rather than a host object file: omc has no
 # linker, so the Library annotation must name the finished, loadable artifact.
+# The host toolchain stays reachable as $OMC_NATIVE_CC/... whatever the target
+# under test is: a `Library` may exist for the platform alone, which is the case
+# an external served from the host is about.
 sub setup_command_toolchain
 {
   my $wasm = sim_code_target() =~ /^wasm/;
   my $sysroot = $ENV{'OMC_WASI_SYSROOT'} || "$OPENMODELICAHOME/lib/wasm32-wasi/omc";
-  my %tc = $wasm ? (
-    OMC_CC           => "clang --target=wasm32-wasip1 --sysroot=$sysroot",
-    OMC_CFLAGS       => "-fPIC",
-    # --allow-undefined: ModelicaUtilities and libc are bound when omc loads it.
-    OMC_EXTLIB_FLAGS => "-shared -nodefaultlibs -Wl,--export-all -Wl,--allow-undefined",
-    OMC_EXTLIB_LIBS  => wasm_builtins($sysroot),
-    OMC_EXTLIB_EXT   => ".wasm",
-    # A dylink module is already linked.
-    OMC_AR           => "true",
-  ) : (
-    OMC_CC           => "gcc",
-    OMC_CFLAGS       => "-fPIC",
-    OMC_EXTLIB_FLAGS => "-c",
-    OMC_EXTLIB_LIBS  => "",
-    OMC_EXTLIB_EXT   => ".o",
-    OMC_AR           => "ar",
+  my %native = (
+    CC           => "gcc",
+    CFLAGS       => "-fPIC",
+    EXTLIB_FLAGS => "-c",
+    EXTLIB_LIBS  => "",
+    EXTLIB_EXT   => ".o",
+    AR           => "ar",
   );
+  my %wasm_tc = (
+    CC           => "clang --target=wasm32-wasip1 --sysroot=$sysroot",
+    CFLAGS       => "-fPIC",
+    # --allow-undefined: ModelicaUtilities and libc are bound when omc loads it.
+    EXTLIB_FLAGS => "-shared -nodefaultlibs -Wl,--export-all -Wl,--allow-undefined",
+    EXTLIB_LIBS  => wasm_builtins($sysroot),
+    EXTLIB_EXT   => ".wasm",
+    # A dylink module is already linked.
+    AR           => "true",
+  );
+  my %tc = map { ("OMC_NATIVE_$_" => $native{$_}) } keys %native;
+  my $target = $wasm ? \%wasm_tc : \%native;
+  $tc{"OMC_$_"} = $target->{$_} for keys %$target;
   for my $k (keys %tc) {
     $ENV{$k} = $tc{$k} unless defined $ENV{$k};
   }


### PR DESCRIPTION
ExternalMedia's `Include` sources cannot implement its externals, only wrap them: the real entry point is in the platform library and takes the ModelicaUtilities handlers as arguments, so a wrapper is all the sources can offer. They compile for wasm all the same - `--allow-undefined` asks for nothing else - so the wrapper looked like a wasm implementation, hid the functions from the host fallback that can serve them, and the FMU trapped on the undefined symbol at the first call.

A library is now kept only when the wasm world defines everything it needs, counting both the functions it calls (`env`) and the ones whose address it takes (`GOT.func`, which is how ModelicaUtilities reaches such a wrapper). ModelicaUtilities itself is unaffected: ModelicaExternalC carries it, and every artifact with an external links it.

Serving those functions from the host then ran into three bugs that path had never reached, having only ever carried scalars:

- `native_ext_stub` gave every 8-byte frame slot an alignment hint of 8, which wasm rejects for the 4-byte accesses among them ("alignment must not be larger than natural"). The slots stay 8-aligned; only the hint was wrong.
- The table carried no record type, so an `_Out_` record - the shape of `setState_ph` - could not be described. It crosses as a pointer to C's `<record>_external`, the bytes copied whole both ways, as an output array already did. `is_cell` moved into the marshalling crate so the two callers cannot disagree about which arguments are cells.
- An export resolved symbols through `external_symbol_in`, whose fallback searches the omc process image. A simulation earlier in the same session dlopens the natively built `Include` library `RTLD_GLOBAL`, so the export found the symbol, concluded nothing needed building and shipped an FMU without that library. Only files an export can ship count now.

The artifact's own log lines drop their timings while the testsuite runs, as they reach a `simulate()` record where a timing makes the baseline depend on the clock.

Co-Simulation of ExternalMedia.Test.TestMedium.TestState now matches the plain simulation, which serves the same externals natively.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
