### PR TITLE
wasm-jit: record delay history before the event

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -2672,6 +2672,31 @@ fn store_operators_at(
     store_operators(e, sim_data, layout)
 }
 
+/// C's `findRoot`/`findRoot_gb` tail: the pre-event operator history is recorded at
+/// the bracket's *left* end. Storing only at the root leaves both rows of the jump at
+/// the same time, and `delayImpl` then reads the post-event value a step early.
+fn store_operators_left(
+    e: &mut dyn SimEngine,
+    sim_data: u32,
+    layout: &SimLayout,
+    states_base: u32,
+    time: f64,
+    y: &[f64],
+) -> Result<()> {
+    // Nothing to record: the `relationsPre` this freezes is overwritten by the
+    // discrete update that follows.
+    if !layout.has_history_ops {
+        return Ok(());
+    }
+    write_time(e, sim_data, time)?;
+    if !y.is_empty() {
+        write_f64s(e, states_base, y)?;
+    }
+    eval_continuous(e, sim_data, layout)?;
+    store_operators(e, sim_data, layout)?;
+    update_relations_pre(e, sim_data, layout)
+}
+
 pub(crate) fn eval_continuous(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
     if layout.dae_mode() {
         return e.call2(MODEL_FN_DAE, sim_data, eval_stage::ALGEBRAIC);
@@ -3462,7 +3487,7 @@ fn zc_crossed_idx(a: &[f64], b: &[f64]) -> Vec<usize> {
 }
 
 /// C's `findRoot`/`bisection` (`events.c`) with only `time` varying. Returns the
-/// bracket's right end, C's event time.
+/// bracket's two ends: the point `findRoot` evaluates at, and C's event time.
 fn locate_zc_root(
     e: &mut dyn SimEngine,
     sim_data: u32,
@@ -3471,7 +3496,7 @@ fn locate_zc_root(
     mut b: f64,
     zc_left: &[f64],
     zc_right: &[f64],
-) -> Result<f64> {
+) -> Result<(f64, f64)> {
     let hunted = zc_crossed_idx(zc_left, zc_right);
     let ttol = MINIMAL_STEP_SIZE + MINIMAL_STEP_SIZE * libm::fabs(b - a);
     let mut iters = bisection_iterations(b - a, ttol);
@@ -3495,7 +3520,7 @@ fn locate_zc_root(
             cur.copy_from_slice(&backup);
         }
     }
-    Ok(b)
+    Ok((a, b))
 }
 
 /// Snapshot of the discrete state — boolean/integer algebraics and held relations
@@ -7280,6 +7305,29 @@ impl SolverCore {
         }
     }
 
+    /// C's `solverInfo->solverRootFinding`: the solver rooted for itself, so
+    /// `simulationUpdate` still evaluates at the root. For the two that bisect here,
+    /// `findRoot` has already pulled that evaluation back to the bracket's left end.
+    fn solver_root_finding(&self) -> bool {
+        !matches!(self.solver, Solver::Fixed(_) | Solver::Sym(_))
+    }
+
+    /// C's `time_left`/`states_left`, or `None` for a solver that roots without
+    /// bisecting.
+    fn event_left(&self) -> Option<(f64, Vec<f64>)> {
+        let (t, y) = match &self.solver {
+            Solver::Daskr(_) => return None,
+            #[cfg(sundials)]
+            Solver::Cvode(_) => return None,
+            #[cfg(sundials)]
+            Solver::Ida(_) => return None,
+            Solver::Gbode(g) => g.event_left(),
+            Solver::Fixed(f) => f.event_left(),
+            Solver::Sym(s) => s.event_left(),
+        };
+        Some((t, y.to_vec()))
+    }
+
     /// Every crossing whose indicator flipped at the located root — C's `eventLst`.
     fn roots_nonzero(&self) -> Vec<usize> {
         let pos = |r: &[i32]| r.iter().enumerate().filter(|(_, v)| **v != 0).map(|(i, _)| i).collect();
@@ -7485,6 +7533,15 @@ impl SolverCore {
                     let roots = self.roots_nonzero();
                     log_state_event(troot, &roots, model);
                     self.note_chatter(model, roots.first().copied().unwrap_or(0))?;
+                    if let Some((t_l, y_l)) = self.event_left() {
+                        store_operators_left(e, sim_data, layout, self.states_base, t_l, &y_l)?;
+                        // C restores `time_right`/`states_right`.
+                        write_time(e, sim_data, troot)?;
+                        self.write_states(e)?;
+                    }
+                    if self.solver_root_finding() {
+                        store_operators_at(e, sim_data, layout, troot)?;
+                    }
                     // pre-event row (before the discrete update), then event +
                     // post-event row.
                     if let Some(r) = rows.as_deref_mut()
@@ -7492,7 +7549,6 @@ impl SolverCore {
                     {
                         capture_pre(e, r, sim_data, layout, troot)?;
                     }
-                    store_operators_at(e, sim_data, layout, troot)?;
                     let _ = save_zero_crossings(e, sim_data, layout)?;
                     event_update(e, sim_data, layout, None, troot)?;
                     save_zero_crossings_after_event(e, sim_data, layout)?;
@@ -8079,15 +8135,15 @@ impl Driver for EventsDriver {
                             )?);
                         }
                     }
-                    if let Some(tr) = troot {
+                    if let Some((tleft, tr)) = troot {
                         supersede(e, &mut evaluated);
+                        store_operators_left(e, sim_data, layout, sim_data + REAL_OFF, tleft, &[])?;
                         // The bisection left `SimData` at its last trial point.
                         update_zero_crossings(e, sim_data, layout, tr, &mut scratch, false)?;
                         log_state_event(tr, &zc_crossed_idx(&zc0, &scratch), model);
                         if !no_event_emit() {
                             capture_pre(e, &mut self.rows, sim_data, layout, tr)?; // pre-event row
                         }
-                        store_operators_at(e, sim_data, layout, tr)?;
                         event_update(e, sim_data, layout, None, tr)?;
                         self.core.state_events += 1;
                         self.core.walk_steps += 1;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/events.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/events.rs
@@ -18,6 +18,7 @@ pub enum StepEnd {
 
 /// One step's event bracket: the states at both ends and the crossing values there.
 pub struct Bracket {
+    t_left: f64,
     y_left: Vec<f64>,
     y_right: Vec<f64>,
     zc: Vec<f64>,
@@ -29,6 +30,7 @@ pub struct Bracket {
 impl Bracket {
     pub fn new(n_states: usize, n_zc: usize) -> Self {
         Bracket {
+            t_left: 0.0,
             y_left: vec![0.0; n_states],
             y_right: vec![0.0; n_states],
             zc: vec![0.0; n_zc],
@@ -41,6 +43,7 @@ impl Bracket {
     /// The step's left end: the states it starts from and the crossing values
     /// there, which are the comparison base for [`Bracket::close`].
     pub fn open(&mut self, ode: &mut dyn Ode, t: f64, y: &[f64]) -> Result<()> {
+        self.t_left = t;
         self.y_left.copy_from_slice(y);
         if !self.zc.is_empty() {
             ode.eval_zc(t, &self.y_left, &mut self.zc)?;
@@ -75,6 +78,9 @@ impl Bracket {
             return Ok(None);
         }
         if no_root_finding() {
+            // No bracket: the pre-event history belongs at the root itself.
+            self.t_left = t_right;
+            self.y_left.copy_from_slice(&self.y_right);
             return Ok(Some(t_right));
         }
         Ok(Some(self.find_root(ode, t_left, t_right)?))
@@ -82,6 +88,11 @@ impl Bracket {
 
     pub fn right(&self) -> &[f64] {
         &self.y_right
+    }
+
+    /// The final bracket's left end, C's `time_left`/`states_left`.
+    pub fn left_end(&self) -> (f64, &[f64]) {
+        (self.t_left, &self.y_left)
     }
 
     pub fn root_index(&self) -> usize {
@@ -113,6 +124,7 @@ impl Bracket {
             } else {
                 self.y_left.copy_from_slice(&mid);
                 a = c;
+                self.t_left = c;
                 self.zc_pre.copy_from_slice(&self.zc);
                 self.zc.copy_from_slice(&self.zc_backup);
             }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/fixedstep.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/fixedstep.rs
@@ -69,6 +69,11 @@ impl FixedStep {
         self.br.root_index()
     }
 
+    /// C's `time_left`/`states_left` for the root just located.
+    pub fn event_left(&self) -> (f64, &[f64]) {
+        self.br.left_end()
+    }
+
     /// One step from `t` to `target`. `yp` is the derivative at `(t, y)`, which the
     /// caller already has (C reads it out of the previous step's `localData[1]`);
     /// on return it holds the derivative at the point reported.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/gbode/events.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/gbode/events.rs
@@ -58,7 +58,25 @@ impl Gbode {
                 self.zc.copy_from_slice(&self.zc_backup);
             }
         }
+        self.latch_event_left(a, false);
         Ok(b)
+    }
+
+    /// Record the converged bracket's lower end.
+    pub(super) fn latch_event_left(&mut self, a: f64, inner: bool) {
+        self.ev_left_time = a;
+        let mut y = core::mem::take(&mut self.ev_left_y);
+        if inner {
+            self.interpolate_gbf_all(a, &mut y);
+        } else {
+            self.interpolate_step(a, &mut y);
+        }
+        self.ev_left_y = y;
+    }
+
+    /// C's `time_left`/`states_left` for the root just located.
+    pub fn event_left(&self) -> (f64, &[f64]) {
+        (self.ev_left_time, &self.ev_left_y)
     }
 
     /// C's `checkForEvents`: evaluate the crossings at the right end of the
@@ -77,6 +95,8 @@ impl Gbode {
         let found = !self.event_ids.is_empty();
         let event_time = if found {
             if no_root_finding() {
+                // C skips `findRoot_gb`: the pre-event history stays at the root.
+                self.latch_event_left(self.time_right, false);
                 Some(self.time_right)
             } else {
                 let (l, r) = (self.time_left, self.time_right);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/gbode/mod.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/gbode/mod.rs
@@ -123,6 +123,9 @@ pub struct Gbode {
     zc_backup: Vec<f64>,
     /// The crossings that changed sign over the accepted step (C's `eventLst`).
     event_ids: Vec<usize>,
+    /// C's `findRoot_gb` `time_left`/`states_left`, which the driver evaluates at.
+    ev_left_time: f64,
+    ev_left_y: Vec<f64>,
 
     start_time: f64,
     stop_time: f64,
@@ -385,6 +388,8 @@ impl Gbode {
             zc_pre: vec![0.0; n_zc],
             zc_backup: vec![0.0; n_zc],
             event_ids: Vec::new(),
+            ev_left_time: 0.0,
+            ev_left_y: vec![0.0; n_states],
             start_time: 0.0,
             stop_time: f64::MAX,
             desired_step_size: 0.0,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/gbode/multirate.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/gbode/multirate.rs
@@ -2215,6 +2215,8 @@ impl Gbode {
         let found = !self.event_ids.is_empty();
         let event_time = if found {
             if crate::simflags::with_flags(|f| f.no_root_finding) {
+                // C skips `findRoot_gb`: the pre-event history stays at the root.
+                self.latch_event_left(t_right, true);
                 Some(t_right)
             } else {
                 let (l, r) = {
@@ -2254,6 +2256,7 @@ impl Gbode {
                 self.zc.copy_from_slice(&backup);
             }
         }
+        self.latch_event_left(a, true);
         Ok(b)
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/symsolver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/symsolver.rs
@@ -129,6 +129,11 @@ impl SymSolver {
         self.br.root_index()
     }
 
+    /// C's `time_left`/`states_left` for the root just located.
+    pub fn event_left(&self) -> (f64, &[f64]) {
+        self.br.left_end()
+    }
+
     /// One output step from `t` to `target`. `yp` holds the derivative at `(t, y)`
     /// going in (C's `localData[1]` derivative slots) and at the reported point
     /// coming out.


### PR DESCRIPTION
C's `findRoot` (`events.c`) does not stop at the bisection: it sets the state back to `time_left`/`states_left`, runs a full `updateContinuousSystem` there, freezes `relationsPre`, and only then restores the right end it returns as the event time. That evaluation is what calls `function_storeDelayed`/`function_storeSpatialDistribution`, so the pre-event sample lands one bisection step *older* than the event.

The port bisected but skipped the tail and stored at the root instead, leaving both rows of a jump at the same time. `delayImpl`'s `findTime` then selects the post-event row where C interpolates the pre-event one.

In `TestExpressionSolve`'s `nls10`, `sign(delay(y, 0.01))` flipped a step early at t=0.01, `der(x)` changed sign, and the run diverged: `val(m10.x, 1.0)` came out 0.5110 against C's 0.5191, past rtest's 5e-3.

`Bracket` now tracks `t_left` beside `y_left` and exposes `left_end()`; gbode latches the same for its own `findRoot_gb`, outer and multirate. `store_operators_left` runs the tail, and `locate_zc_root` hands back both ends for the walk that has no continuous states.

Which stores happen follows C's `solverRootFinding`:

| solver | pre-event store |
| --- | --- |
| euler, rungekutta, symSolver | bracket's left end only | | gbode | left end, then the root |
| dassl, ida, cvode | the root only |

euler's step-end store is popped by the left-end one, gbode roots inside its own step so `simulationUpdate` still evaluates at the root, and a solver that roots for itself never runs `findRoot`. `-noRootFinding` degenerates the left end to the root, as C does.

The delay ring buffer now matches C row for row under euler and gbode. 113 tests pass under wasm-jit: the delay and spatialDistribution tests, `simulation/modelica/events`, and `solver`, `solver/gbode` and `qss`.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
