### PR TITLE
Fix `TreeSearchFilters` search syntax on Qt6

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/ElementTreeWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ElementTreeWidget.cpp
@@ -643,13 +643,11 @@ void ElementWidget::filterElements()
 {
   QString searchText = mpTreeSearchFilters->getFilterTextBox()->text();
   Qt::CaseSensitivity caseSensitivity = mpTreeSearchFilters->getCaseSensitiveCheckBox()->isChecked() ? Qt::CaseSensitive: Qt::CaseInsensitive;
+  TreeSearchFilters::FilterSyntax syntax = mpTreeSearchFilters->getFilterSyntax();
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  // TODO: handle PatternSyntax: https://doc.qt.io/qt-6/qregularexpression.html
-  mpElementTreeProxyModel->setFilterRegularExpression(QRegularExpression::fromWildcard(searchText, caseSensitivity, QRegularExpression::UnanchoredWildcardConversion));
+  mpElementTreeProxyModel->setFilterRegularExpression(TreeSearchFilters::getFilterRegularExpression(searchText, caseSensitivity, syntax));
 #else
-  QRegExp::PatternSyntax syntax = QRegExp::PatternSyntax(mpTreeSearchFilters->getSyntaxComboBox()->itemData(mpTreeSearchFilters->getSyntaxComboBox()->currentIndex()).toInt());
-  QRegExp regExp(searchText, caseSensitivity, syntax);
-  mpElementTreeProxyModel->setFilterRegExp(regExp);
+  mpElementTreeProxyModel->setFilterRegExp(TreeSearchFilters::getFilterRegExp(searchText, caseSensitivity, syntax));
 #endif
 }
 

--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
@@ -5279,12 +5279,10 @@ void LibraryWidget::searchClasses()
 {
   QString searchText = mpTreeSearchFilters->getFilterTextBox()->text();
   Qt::CaseSensitivity caseSensitivity = mpTreeSearchFilters->getCaseSensitiveCheckBox()->isChecked() ? Qt::CaseSensitive: Qt::CaseInsensitive;
+  TreeSearchFilters::FilterSyntax syntax = mpTreeSearchFilters->getFilterSyntax();
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  // TODO: handle PatternSyntax: https://doc.qt.io/qt-6/qregularexpression.html
-  mpLibraryTreeProxyModel->setFilterRegularExpression(QRegularExpression::fromWildcard(searchText, caseSensitivity, QRegularExpression::UnanchoredWildcardConversion));
+  mpLibraryTreeProxyModel->setFilterRegularExpression(TreeSearchFilters::getFilterRegularExpression(searchText, caseSensitivity, syntax));
 #else
-  QRegExp::PatternSyntax syntax = QRegExp::PatternSyntax(mpTreeSearchFilters->getSyntaxComboBox()->itemData(mpTreeSearchFilters->getSyntaxComboBox()->currentIndex()).toInt());
-  QRegExp regExp(searchText, caseSensitivity, syntax);
-  mpLibraryTreeProxyModel->setFilterRegExp(regExp);
+  mpLibraryTreeProxyModel->setFilterRegExp(TreeSearchFilters::getFilterRegExp(searchText, caseSensitivity, syntax));
 #endif
 }

--- a/OMEdit/OMEditLIB/Modeling/ModelicaClassDialog.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelicaClassDialog.cpp
@@ -162,15 +162,14 @@ void LibraryBrowseDialog::searchClasses()
   mpLibraryTreeView->selectionModel()->clearSelection();
   QString searchText = mpTreeSearchFilters->getFilterTextBox()->text();
   Qt::CaseSensitivity caseSensitivity = mpTreeSearchFilters->getCaseSensitiveCheckBox()->isChecked() ? Qt::CaseSensitive: Qt::CaseInsensitive;
+  TreeSearchFilters::FilterSyntax syntax = mpTreeSearchFilters->getFilterSyntax();
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  // TODO: handle PatternSyntax: https://doc.qt.io/qt-6/qregularexpression.html
-  QRegularExpression regExp(QRegularExpression::fromWildcard(searchText, caseSensitivity, QRegularExpression::UnanchoredWildcardConversion));
-  mpLibraryTreeProxyModel->setFilterRegularExpression(QRegularExpression::fromWildcard(searchText, caseSensitivity, QRegularExpression::UnanchoredWildcardConversion));
+  QRegularExpression regExp = TreeSearchFilters::getFilterRegularExpression(searchText, caseSensitivity, syntax);
+  mpLibraryTreeProxyModel->setFilterRegularExpression(regExp);
 #else
-  QRegExp::PatternSyntax syntax = QRegExp::PatternSyntax(mpTreeSearchFilters->getSyntaxComboBox()->itemData(mpTreeSearchFilters->getSyntaxComboBox()->currentIndex()).toInt());
-  QRegExp regExp(searchText, caseSensitivity, syntax);
+  QRegExp regExp = TreeSearchFilters::getFilterRegExp(searchText, caseSensitivity, syntax);
   mpLibraryTreeProxyModel->setFilterRegExp(regExp);
- #endif
+#endif
   // if we have really searched something
   if (!searchText.isEmpty()) {
     findAndSelectLibraryTreeItem(regExp);

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -3090,13 +3090,12 @@ void VariablesWidget::findVariables()
 {
   QString findText = mpTreeSearchFilters->getFilterTextBox()->text();
   Qt::CaseSensitivity caseSensitivity = mpTreeSearchFilters->getCaseSensitiveCheckBox()->isChecked() ? Qt::CaseSensitive: Qt::CaseInsensitive;
+  TreeSearchFilters::FilterSyntax syntax = mpTreeSearchFilters->getFilterSyntax();
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  // TODO: handle PatternSyntax
-  QRegularExpression regExp(QRegularExpression::fromWildcard(findText, caseSensitivity, QRegularExpression::UnanchoredWildcardConversion));
+  QRegularExpression regExp = TreeSearchFilters::getFilterRegularExpression(findText, caseSensitivity, syntax);
   mpVariableTreeProxyModel->setFilterRegularExpression(regExp);
 #else
-  QRegExp::PatternSyntax syntax = QRegExp::PatternSyntax(mpTreeSearchFilters->getSyntaxComboBox()->itemData(mpTreeSearchFilters->getSyntaxComboBox()->currentIndex()).toInt());
-  QRegExp regExp(findText, caseSensitivity, syntax);
+  QRegExp regExp = TreeSearchFilters::getFilterRegExp(findText, caseSensitivity, syntax);
   mpVariableTreeProxyModel->setFilterRegExp(regExp);
 #endif
   /* expand all so that the filtered items can be seen. */

--- a/OMEdit/OMEditLIB/Search/FindUsageWidget.cpp
+++ b/OMEdit/OMEditLIB/Search/FindUsageWidget.cpp
@@ -614,12 +614,10 @@ void FindUsageWidget::filterMatches()
 {
   QString searchText = mpTreeSearchFilters->getFilterTextBox()->text();
   Qt::CaseSensitivity caseSensitivity = mpTreeSearchFilters->getCaseSensitiveCheckBox()->isChecked() ? Qt::CaseSensitive: Qt::CaseInsensitive;
+  TreeSearchFilters::FilterSyntax syntax = mpTreeSearchFilters->getFilterSyntax();
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  // TODO: handle PatternSyntax: https://doc.qt.io/qt-6/qregularexpression.html
-  mpClassTreeProxyModel->setFilterRegularExpression(QRegularExpression::fromWildcard(searchText, caseSensitivity, QRegularExpression::UnanchoredWildcardConversion));
+  mpClassTreeProxyModel->setFilterRegularExpression(TreeSearchFilters::getFilterRegularExpression(searchText, caseSensitivity, syntax));
 #else
-  QRegExp::PatternSyntax syntax = QRegExp::PatternSyntax(mpTreeSearchFilters->getSyntaxComboBox()->itemData(mpTreeSearchFilters->getSyntaxComboBox()->currentIndex()).toInt());
-  QRegExp regExp(searchText, caseSensitivity, syntax);
-  mpClassTreeProxyModel->setFilterRegExp(regExp);
+  mpClassTreeProxyModel->setFilterRegExp(TreeSearchFilters::getFilterRegExp(searchText, caseSensitivity, syntax));
 #endif
 }

--- a/OMEdit/OMEditLIB/TransformationalDebugger/TransformationsWidget.cpp
+++ b/OMEdit/OMEditLIB/TransformationalDebugger/TransformationsWidget.cpp
@@ -1720,13 +1720,12 @@ void TransformationsWidget::findVariables()
 {
   QString findText = mpTreeSearchFilters->getFilterTextBox()->text();
   Qt::CaseSensitivity caseSensitivity = mpTreeSearchFilters->getCaseSensitiveCheckBox()->isChecked() ? Qt::CaseSensitive: Qt::CaseInsensitive;
+  TreeSearchFilters::FilterSyntax syntax = mpTreeSearchFilters->getFilterSyntax();
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  // TODO: handle PatternSyntax
-  QRegularExpression regExp(QRegularExpression::fromWildcard(findText, caseSensitivity, QRegularExpression::UnanchoredWildcardConversion));
+  QRegularExpression regExp = TreeSearchFilters::getFilterRegularExpression(findText, caseSensitivity, syntax);
   mpTVariableTreeProxyModel->setFilterRegularExpression(regExp);
 #else
-  QRegExp::PatternSyntax syntax = QRegExp::PatternSyntax(mpTreeSearchFilters->getSyntaxComboBox()->itemData(mpTreeSearchFilters->getSyntaxComboBox()->currentIndex()).toInt());
-  QRegExp regExp(findText, caseSensitivity, syntax);
+  QRegExp regExp = TreeSearchFilters::getFilterRegExp(findText, caseSensitivity, syntax);
   mpTVariableTreeProxyModel->setFilterRegExp(regExp);
 #endif
   /* expand all so that the filtered items can be seen. */

--- a/OMEdit/OMEditLIB/Util/Utilities.cpp
+++ b/OMEdit/OMEditLIB/Util/Utilities.cpp
@@ -52,6 +52,7 @@
 #include <QPainter>
 #include <QColorDialog>
 #include <QDir>
+#include <QRegularExpression>
 #include <QRegExp>
 
 extern "C" {
@@ -259,9 +260,9 @@ TreeSearchFilters::TreeSearchFilters(QWidget *pParent)
   syntaxDescriptions << tr("A rich Perl-like pattern matching syntax.")
                       << tr("A simple pattern matching syntax similar to that used by shells (command interpreters) for \"file globbing\".")
                       << tr("Fixed string matching.");
-  mpSyntaxComboBox->addItem(tr("Regular Expression"), QRegExp::RegExp);
-  mpSyntaxComboBox->addItem(tr("Wildcard"), QRegExp::Wildcard);
-  mpSyntaxComboBox->addItem(tr("Fixed String"), QRegExp::FixedString);
+  mpSyntaxComboBox->addItem(tr("Regular Expression"), TreeSearchFilters::Regexp);
+  mpSyntaxComboBox->addItem(tr("Wildcard"), TreeSearchFilters::Wildcard);
+  mpSyntaxComboBox->addItem(tr("Fixed String"), TreeSearchFilters::FixedString);
   Utilities::setToolTip(mpSyntaxComboBox, "Filters", syntaxDescriptions);
   // create the layout
   QGridLayout *pFiltersWidgetLayout = new QGridLayout;
@@ -293,6 +294,42 @@ void TreeSearchFilters::showHideFilters(bool On)
     mpFiltersWidget->hide();
   }
 }
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+/*!
+ * \brief TreeSearchFilters::getFilterRegExp
+ * Returns the QRegExp for the given filter text, case sensitivity and syntax.
+ * \param filterText
+ * \param caseSensitivity
+ * \param syntax
+ * \return
+ */
+QRegExp TreeSearchFilters::getFilterRegExp(const QString &filterText, Qt::CaseSensitivity caseSensitivity, TreeSearchFilters::FilterSyntax syntax)
+{
+  return QRegExp(filterText, caseSensitivity, QRegExp::PatternSyntax(syntax));
+}
+#else
+/*!
+ * \brief TreeSearchFilters::getFilterRegularExpression
+ * Returns the QRegularExpression for the given filter text, case sensitivity and syntax.
+ * \param filterText
+ * \param caseSensitivity
+ * \param syntax
+ * \return
+ */
+QRegularExpression TreeSearchFilters::getFilterRegularExpression(const QString &filterText, Qt::CaseSensitivity caseSensitivity, TreeSearchFilters::FilterSyntax syntax)
+{
+  const QRegularExpression::PatternOptions options = (caseSensitivity == Qt::CaseSensitive) ? QRegularExpression::NoPatternOption : QRegularExpression::CaseInsensitiveOption;
+  switch (syntax) {
+    case TreeSearchFilters::Wildcard:
+      return QRegularExpression::fromWildcard(filterText, caseSensitivity, QRegularExpression::UnanchoredWildcardConversion);
+    case TreeSearchFilters::FixedString:
+      return QRegularExpression(QRegularExpression::escape(filterText), options);
+    default:
+      return QRegularExpression(filterText, options);
+  }
+}
+#endif
 
 /*!
  * \class FileDataNotifier

--- a/OMEdit/OMEditLIB/Util/Utilities.cpp
+++ b/OMEdit/OMEditLIB/Util/Utilities.cpp
@@ -306,7 +306,13 @@ void TreeSearchFilters::showHideFilters(bool On)
  */
 QRegExp TreeSearchFilters::getFilterRegExp(const QString &filterText, Qt::CaseSensitivity caseSensitivity, TreeSearchFilters::FilterSyntax syntax)
 {
-  return QRegExp(filterText, caseSensitivity, QRegExp::PatternSyntax(syntax));
+  QRegExp regExp(filterText, caseSensitivity, QRegExp::PatternSyntax(syntax));
+  // An invalid pattern (e.g. typing 'mass[') is treated as a literal string so that
+  // it matches something instead of silently matching nothing.
+  if (!regExp.isValid()) {
+    regExp.setPattern(QRegExp::escape(filterText));
+  }
+  return regExp;
 }
 #else
 /*!
@@ -320,14 +326,24 @@ QRegExp TreeSearchFilters::getFilterRegExp(const QString &filterText, Qt::CaseSe
 QRegularExpression TreeSearchFilters::getFilterRegularExpression(const QString &filterText, Qt::CaseSensitivity caseSensitivity, TreeSearchFilters::FilterSyntax syntax)
 {
   const QRegularExpression::PatternOptions options = (caseSensitivity == Qt::CaseSensitive) ? QRegularExpression::NoPatternOption : QRegularExpression::CaseInsensitiveOption;
+  QRegularExpression regExp;
   switch (syntax) {
     case TreeSearchFilters::Wildcard:
-      return QRegularExpression::fromWildcard(filterText, caseSensitivity, QRegularExpression::UnanchoredWildcardConversion);
+      regExp = QRegularExpression::fromWildcard(filterText, caseSensitivity, QRegularExpression::UnanchoredWildcardConversion);
+      break;
     case TreeSearchFilters::FixedString:
-      return QRegularExpression(QRegularExpression::escape(filterText), options);
+      regExp = QRegularExpression(QRegularExpression::escape(filterText), options);
+      break;
     default:
-      return QRegularExpression(filterText, options);
+      regExp = QRegularExpression(filterText, options);
+      break;
   }
+  // An invalid pattern (e.g. typing 'mass[') is treated as a literal string so that
+  // QString::contains()/QSortFilterProxyModel do not warn about an invalid regex.
+  if (!regExp.isValid()) {
+    regExp = QRegularExpression(QRegularExpression::escape(filterText), options);
+  }
+  return regExp;
 }
 #endif
 

--- a/OMEdit/OMEditLIB/Util/Utilities.h
+++ b/OMEdit/OMEditLIB/Util/Utilities.h
@@ -147,10 +147,24 @@ protected:
 };
 
 class LineEdit;
+class QRegExp;
+class QRegularExpression;
 class TreeSearchFilters : public QWidget
 {
   Q_OBJECT
 public:
+  /*!
+   * \brief The FilterSyntax enum
+   * The filter syntax used for the filter search. The values must stay in sync
+   * with QRegExp::PatternSyntax (RegExp=0, Wildcard=1, FixedString=2) so that
+   * the stored combo box data remains compatible between Qt5 and Qt6.
+   */
+  enum FilterSyntax {
+    Regexp = 0,
+    Wildcard = 1,
+    FixedString = 2
+  };
+
   TreeSearchFilters(QWidget *pParent = 0);
   LineEdit* getFilterTextBox() {return mpFilterTextBox;}
   QTimer* getFilterTimer() {return mpFilterTimer;}
@@ -159,6 +173,12 @@ public:
   QToolButton* getCollapseAllButton() {return mpCollapseAllButton;}
   QComboBox* getSyntaxComboBox() {return mpSyntaxComboBox;}
   QCheckBox* getCaseSensitiveCheckBox() {return mpCaseSensitiveCheckBox;}
+  FilterSyntax getFilterSyntax() const {return FilterSyntax(mpSyntaxComboBox->itemData(mpSyntaxComboBox->currentIndex()).toInt());}
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+  static QRegExp getFilterRegExp(const QString &filterText, Qt::CaseSensitivity caseSensitivity, FilterSyntax syntax);
+#else
+  static QRegularExpression getFilterRegularExpression(const QString &filterText, Qt::CaseSensitivity caseSensitivity, FilterSyntax syntax);
+#endif
 private:
   LineEdit *mpFilterTextBox;
   QTimer *mpFilterTimer;


### PR DESCRIPTION
### Related Issues

#16346