### PR TITLE
[wasm-jit] Port the parmodauto runtime

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -378,6 +378,7 @@ openmodelica_sim_meta/src/optimization/eval.rs
 openmodelica_sim_meta/src/optimization/ipopt.rs
 openmodelica_sim_meta/src/optimization/ipopt_out.rs
 openmodelica_sim_meta/src/optimization/mod.rs
+openmodelica_sim_meta/src/parmod.rs
 openmodelica_sim_meta/src/optimization/model.rs
 openmodelica_sim_meta/src/optimization/setup.rs
 openmodelica_sim_meta/src/qss.rs

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -5164,6 +5164,12 @@ fn build_sim_model(
     let lambda0_eqs = flatten_eqs(&sim_code.initialEquations_lambda0);
     let assert_eqs = flatten_eqs(&sim_code.algorithmAndEquationAsserts);
     let ode_eqs = with_local_known(flatten_eqs_ll(&sim_code.odeEquations));
+    let parmod = openmodelica_util::Flags::getConfigBool(openmodelica_util::Flags::PARMODAUTO.clone())?;
+    let ode_task_eqs = flatten_eqs_ll(&sim_code.odeEquations);
+    let parmod_info = match parmod && !ode_task_eqs.is_empty() {
+        true => Some(parmod_info(&ode_task_eqs)?),
+        false => None,
+    };
     let zc_eqs = flatten_eqs(&sim_code.equationsForZeroCrossings);
     let inline_eqs = flatten_eqs(&sim_code.inlineEquations);
     // Register every nonlinear system with the runtime solver `rt_solve_nls`
@@ -5374,7 +5380,7 @@ fn build_sim_model(
     let mut splits: Vec<SplitFn> = Vec::new();
     let param_units: Vec<EqUnit> =
         param_bindings.iter().map(|(cref, exp)| EqUnit::Binding(cref, exp)).collect();
-    splits.push(build_split_fn("functionParameters", &param_units, 1, eqfn_type, &stateset_diag, &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks)?);
+    splits.push(build_split_fn("functionParameters", &param_units, 1, eqfn_type, &stateset_diag, &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
     // Seed `relationsPre := relations` at the end of init (the in-wasm `simulate`
     // path skips the host `run_initialization`).
     let init_save: Vec<(u32, u32, u32)> = if layout.n_rel > 0 {
@@ -5382,9 +5388,15 @@ fn build_sim_model(
     } else {
         Vec::new()
     };
-    splits.push(build_split_fn("functionInitialEquations", &eq_units(&initial_eqs), 1, eqfn_type, &[], &init_save, &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks)?);
-    splits.push(build_split_fn("functionODE", &eq_units(&ode_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks)?);
-    splits.push(build_split_fn("functionAlgebraics", &eq_units(&algebraic_eqs), 1, eqfn_type, &[], &save_pre, &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks)?);
+    splits.push(build_split_fn("functionInitialEquations", &eq_units(&initial_eqs), 1, eqfn_type, &[], &init_save, &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
+    // `--parmodauto`: one chunk per ODE equation, each a schedulable task.
+    let ode_split = splits.len();
+    if parmod_info.is_some() {
+        splits.push(build_split_fn("functionODE", &eq_units(&ode_task_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, true)?);
+    } else {
+        splits.push(build_split_fn("functionODE", &eq_units(&ode_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
+    }
+    splits.push(build_split_fn("functionAlgebraics", &eq_units(&algebraic_eqs), 1, eqfn_type, &[], &save_pre, &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
     // eq_base + 4, before `simulate` so the in-wasm integrator can call it.
     let all_reals: Vec<&SimCodeVar::SimVar> = states
         .iter()
@@ -5602,6 +5614,7 @@ fn build_sim_model(
             mi.varInfo.numRelatedBoundaryConditions.max(0) as u32,
         )?,
         prof_info,
+        parmod_info.clone(),
     );
     let meta_bytes = openmodelica_sim_meta::encode(&meta);
     let meta_len = meta_bytes.len() as u32;
@@ -5765,7 +5778,7 @@ fn build_sim_model(
     // first step; a stub for models that do not use `homotopy()`.
     let init_lambda0_idx = {
         let idx = import_base + bodies.len() as u32;
-        splits.push(build_split_fn("functionInitialEquations_lambda0", &eq_units(&lambda0_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks)?);
+        splits.push(build_split_fn("functionInitialEquations_lambda0", &eq_units(&lambda0_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
         idx
     };
     // Min/max variable-attribute (and equation) assertion checks: C's
@@ -5774,14 +5787,14 @@ fn build_sim_model(
     let has_asserts = !assert_eqs.is_empty();
     let check_asserts_idx = {
         let idx = import_base + bodies.len() as u32;
-        splits.push(build_split_fn("functionCheckAsserts", &eq_units(&assert_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks)?);
+        splits.push(build_split_fn("functionCheckAsserts", &eq_units(&assert_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
         idx
     };
     // C's `function_ZeroCrossingsEquations`: what the crossings read, which is
     // neither `functionODE` nor all of `functionAlgebraics`.
     let zc_equations_idx = {
         let idx = import_base + bodies.len() as u32;
-        splits.push(build_split_fn("functionZeroCrossingsEquations", &eq_units(&zc_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks)?);
+        splits.push(build_split_fn("functionZeroCrossingsEquations", &eq_units(&zc_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
         idx
     };
     // C's `functionAlgebraics` + `storePreValues`. Only a `has_when` model needs its
@@ -5789,7 +5802,7 @@ fn build_sim_model(
     let outputs_idx = {
         let idx = import_base + bodies.len() as u32;
         if has_when {
-            splits.push(build_split_fn("functionOutputs", &eq_units(&output_eqs), 1, eqfn_type, &[], &save_pre, &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks)?);
+            splits.push(build_split_fn("functionOutputs", &eq_units(&output_eqs), 1, eqfn_type, &[], &save_pre, &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
         } else {
             use we::Instruction as I;
             let mut f = we::Function::new([]);
@@ -5856,7 +5869,7 @@ fn build_sim_model(
     // perturbation IDAS made to a sensitivity parameter.
     let update_bound_params_idx = {
         let idx = import_base + bodies.len() as u32;
-        splits.push(build_split_fn("functionUpdateBoundParameters", &eq_units(&param_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks)?);
+        splits.push(build_split_fn("functionUpdateBoundParameters", &eq_units(&param_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
         idx
     };
     // The optimizer's per-real-variable attributes (C reads them out of the
@@ -5931,14 +5944,14 @@ fn build_sim_model(
     // which form the model is in.
     let dae_residuals_idx = {
         let idx = import_base + bodies.len() as u32;
-        splits.push(build_split_fn("evaluateDAEResiduals", &dae_units(&dae_eqs), 2, dae_fn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks)?);
+        splits.push(build_split_fn("evaluateDAEResiduals", &dae_units(&dae_eqs), 2, dae_fn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
         idx
     };
     // C's `symbolicInlineSystem`. Emitted (empty without `--symSolver`) either way,
     // so every module's entry points sit at the same indices.
     let sym_inline_idx = {
         let idx = import_base + bodies.len() as u32;
-        splits.push(build_split_fn("symbolicInlineSystem", &eq_units(&inline_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks)?);
+        splits.push(build_split_fn("symbolicInlineSystem", &eq_units(&inline_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
         idx
     };
 
@@ -5950,8 +5963,26 @@ fn build_sim_model(
             let idx = import_base + bodies.len() as u32;
             let mut units = eq_units(&local_known_eqs);
             units.extend(eq_units(&all_eqs_for_dae));
-            splits.push(build_split_fn("functionDAE", &units, 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks)?);
+            splits.push(build_split_fn("functionDAE", &units, 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
             Some(idx)
+        }
+    };
+
+    // `parmodTask(sim_data, k)` `call_indirect`s task `k` out of the module's own table 1.
+    let parmod_fns = match parmod_info.is_some() {
+        false => None,
+        true => {
+            let lk_idx = import_base + bodies.len() as u32;
+            splits.push(build_split_fn("functionLocalKnownVars", &eq_units(&local_known_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
+            splits[ode_split].pre_calls.push(lk_idx);
+            let task_idx = import_base + bodies.len() as u32;
+            let mut f = we::Function::new([]);
+            f.instruction(&we::Instruction::LocalGet(0));
+            f.instruction(&we::Instruction::LocalGet(1));
+            f.instruction(&we::Instruction::CallIndirect { type_index: eqfn_type as u32, table_index: 1 });
+            f.instruction(&we::Instruction::End);
+            bodies.push(f);
+            Some((lk_idx, task_idx))
         }
     };
 
@@ -5962,6 +5993,10 @@ fn build_sim_model(
     for s in &splits {
         bodies[s.slot] = s.thunk(chunk_base);
     }
+    let parmod_tasks: Option<Vec<u32>> = parmod_fns.map(|_| {
+        let s = &splits[ode_split];
+        (0..s.count).map(|k| chunk_base + (s.first + k) as u32).collect()
+    });
 
     // --- Function section (type index per body, in body order). ---
     crate::CodegenWasmJitFunctions::set_ext_error_catch(None);
@@ -6033,6 +6068,10 @@ fn build_sim_model(
     functions.function(eqfn_type); // symbolicInlineSystem: (i32) -> ()
     if recon_dae_idx.is_some() {
         functions.function(eqfn_type); // functionDAE: (i32) -> ()
+    }
+    if parmod_fns.is_some() {
+        functions.function(eqfn_type); // functionLocalKnownVars: (i32) -> ()
+        functions.function(dae_fn_type); // parmodTask: (i32 SimData, i32 task) -> ()
     }
     for s in &splits {
         for _ in 0..s.count {
@@ -6107,7 +6146,7 @@ fn build_sim_model(
         functions.function(throw_fn_type);
         bodies.push(f);
     }
-    if nls_wiring.is_some() || !thunk_indices.is_empty() {
+    if nls_wiring.is_some() || !thunk_indices.is_empty() || parmod_fns.is_some() {
         imports.import("rt", "__indirect_function_table", we::EntityType::Table(we::TableType {
             element_type: we::RefType::FUNCREF,
             table64: false,
@@ -6178,6 +6217,10 @@ fn build_sim_model(
     exports.export("functionODE", we::ExportKind::Func, eqfn.ode);
     exports.export("functionAlgebraics", we::ExportKind::Func, eqfn.algebraics);
     exports.export("functionOutputs", we::ExportKind::Func, outputs_idx);
+    if let Some((lk_idx, task_idx)) = parmod_fns {
+        exports.export("functionLocalKnownVars", we::ExportKind::Func, lk_idx);
+        exports.export("parmodTask", we::ExportKind::Func, task_idx);
+    }
     exports.export("simulate", we::ExportKind::Func, simulate_idx);
     exports.export("om_meta_ptr", we::ExportKind::Func, om_meta_ptr_idx);
     exports.export("om_meta_len", we::ExportKind::Func, om_meta_len_idx);
@@ -6299,6 +6342,10 @@ fn build_sim_model(
     names.push((sync_eqs, "functionEquationsSynchronous".to_string()));
     names.push((dae_residuals_idx, "evaluateDAEResiduals".to_string()));
     names.push((sym_inline_idx, "symbolicInlineSystem".to_string()));
+    if let Some((lk_idx, task_idx)) = parmod_fns {
+        names.push((lk_idx, "functionLocalKnownVars".to_string()));
+        names.push((task_idx, "parmodTask".to_string()));
+    }
     for s in &splits {
         for k in 0..s.count {
             names.push((chunk_base + (s.first + k) as u32, format!("{}${k}", s.name)));
@@ -6316,6 +6363,17 @@ fn build_sim_model(
     module.section(&types);
     module.section(&imports);
     module.section(&functions);
+    if let Some(tasks) = &parmod_tasks {
+        let mut tables = we::TableSection::new();
+        tables.table(we::TableType {
+            element_type: we::RefType::FUNCREF,
+            table64: false,
+            minimum: tasks.len() as u64,
+            maximum: Some(tasks.len() as u64),
+            shared: false,
+        });
+        module.section(&tables);
+    }
     if let Some(ti) = error_tag_type {
         let mut tags = we::TagSection::new();
         tags.tag(we::TagType { kind: we::TagKind::Exception, func_type_idx: ti });
@@ -6341,13 +6399,21 @@ fn build_sim_model(
         module.section(&globals);
     }
     module.section(&exports);
+    let mut elements = we::ElementSection::new();
+    let mut have_elements = false;
     if let Some((start_idx, declared)) = &start_wiring {
         module.section(&we::StartSection { function_index: *start_idx });
         if !declared.is_empty() {
-            let mut elements = we::ElementSection::new();
             elements.declared(we::Elements::Functions(declared.as_slice().into()));
-            module.section(&elements);
+            have_elements = true;
         }
+    }
+    if let Some(tasks) = &parmod_tasks {
+        elements.active(Some(1), &we::ConstExpr::i32_const(0), we::Elements::Functions(tasks.as_slice().into()));
+        have_elements = true;
+    }
+    if have_elements {
+        module.section(&elements);
     }
     if !literals.is_empty() {
         module.section(&we::DataCountSection { count: 1 });
@@ -6961,6 +7027,7 @@ fn build_sim_meta(
     inputs: Vec<openmodelica_sim_meta::InputVar>,
     recon: Option<openmodelica_sim_meta::ReconInfo>,
     prof: Option<openmodelica_sim_meta::ProfInfo>,
+    parmod: Option<openmodelica_sim_meta::ParmodInfo>,
 ) -> openmodelica_sim_meta::SimMeta {
     openmodelica_sim_meta::SimMeta {
         layout: *layout,
@@ -6995,6 +7062,7 @@ fn build_sim_meta(
         inputs,
         recon,
         prof,
+        parmod,
     }
 }
 
@@ -7662,12 +7730,20 @@ struct SplitFn {
     /// `(SimData*)`, plus DAE mode's `stage`.
     n_params: u32,
     ty: u32,
+    /// Entry points called (with the same arguments) ahead of the chunks.
+    pre_calls: Vec<u32>,
 }
 
 impl SplitFn {
     fn thunk(&self, chunk_base: u32) -> we::Function {
         use we::Instruction as I;
         let mut f = we::Function::new([]);
+        for c in &self.pre_calls {
+            for p in 0..self.n_params {
+                f.instruction(&I::LocalGet(p));
+            }
+            f.instruction(&I::Call(*c));
+        }
         for k in 0..self.count {
             for p in 0..self.n_params {
                 f.instruction(&I::LocalGet(p));
@@ -7698,6 +7774,7 @@ fn build_split_fn(
     literals: &mut Literals,
     bodies: &mut Vec<we::Function>,
     chunks: &mut Vec<we::Function>,
+    per_unit: bool,
 ) -> Result<SplitFn> {
     let slot = bodies.len();
     bodies.push(empty_eqfn());
@@ -7719,7 +7796,7 @@ fn build_split_fn(
             }
             lower_unit(&mut ctx, &units[i], eq_index, &mut pending)?;
             i += 1;
-            if pending.is_empty() && ctx.instr_len() >= chunk_instrs() {
+            if per_unit || (pending.is_empty() && ctx.instr_len() >= chunk_instrs()) {
                 break;
             }
         }
@@ -7729,7 +7806,7 @@ fn build_split_fn(
         }
         chunks.push(finish_fn(ctx));
     }
-    Ok(SplitFn { name, slot, first, count: chunks.len() - first, n_params, ty })
+    Ok(SplitFn { name, slot, first, count: chunks.len() - first, n_params, ty, pre_calls: Vec::new() })
 }
 
 /// Lower `units` into one function, for entry points whose size is bounded by the
@@ -10310,6 +10387,122 @@ fn index_eq_recursive(e: &Arc<SimCode::SimEqSystem>, idx: &mut HashMap<i32, Arc<
 
 /// The `index` of a `SimEqSystem` (best-effort; systems without a top-level
 /// index report -1).
+/// The `--parmodauto` task graph C's `SerializeTaskSystemInfo` writes to
+/// `<model>_ode.json` and `om_pm_model.cpp` loads: one task per ODE equation with
+/// what it defines and uses, and an edge from every earlier task defining
+/// something a later one uses (`TaskSystem_v2::add_node`). Reads of a dense
+/// linear system's `A`/`b` count as uses too; C's loader only sees a torn system's
+/// inner equations.
+fn parmod_info(ode_eqs: &[Arc<SimCode::SimEqSystem>]) -> Result<openmodelica_sim_meta::ParmodInfo> {
+    use SimCode::SimEqSystem as E;
+    use openmodelica_frontend_base::{ComponentReference, Expression};
+    fn name(cref: &Arc<DAE::ComponentRef>) -> Result<String> {
+        Ok(ComponentReference::crefStr(cref.clone())?.to_string())
+    }
+    fn uses(exp: &Arc<DAE::Exp>) -> Result<Vec<String>> {
+        lst(&Expression::extractUniqueCrefsFromExpDerPreStart(exp.clone(), true)?).map(name).collect()
+    }
+    fn unsupported(index: i32, what: &str) -> &'static str {
+        Box::leak(format!("parmodauto: equation {index}: {what}").into_boxed_str())
+    }
+    // C's `load_simple_assign_check_local_define` / `load_simple_residual`.
+    fn inner(eq: &E, lhs: &mut HashSet<String>, rhs: &mut HashSet<String>) -> Result<()> {
+        let (define, exp) = match eq {
+            E::SES_SIMPLE_ASSIGN { cref, exp, .. }
+            | E::SES_SIMPLE_ASSIGN_CONSTRAINTS { cref, exp, .. }
+            | E::SES_FOR_LOOP { cref, exp, .. } => (Some(name(cref)?), exp),
+            E::SES_ARRAY_CALL_ASSIGN { lhs, exp, .. } => (Some(name(&Expression::expCref(lhs.clone())?)?), exp),
+            E::SES_RESIDUAL { exp, .. } => (None, exp),
+            other => return Err(unsupported(eq_index_of(other), "internal equation type not yet handled")),
+        };
+        match define {
+            Some(d) => {
+                lhs.insert(d);
+                for u in uses(exp)? {
+                    if !lhs.contains(&u) {
+                        rhs.insert(u);
+                    }
+                }
+            }
+            None => rhs.extend(uses(exp)?),
+        }
+        Ok(())
+    }
+    let sorted = |eqs: &Arc<List<Arc<E>>>| -> Vec<Arc<E>> {
+        let mut v: Vec<Arc<E>> = lst(eqs).cloned().collect();
+        v.sort_by_key(|e| eq_index_of(e));
+        v
+    };
+    let mut nodes: Vec<(i32, HashSet<String>, HashSet<String>)> = Vec::new();
+    for eq in ode_eqs {
+        let index = eq_index_of(eq);
+        let mut lhs = HashSet::new();
+        let mut rhs = HashSet::new();
+        match &**eq {
+            E::SES_RESIDUAL { exp, .. } => rhs.extend(uses(exp)?),
+            E::SES_SIMPLE_ASSIGN { cref, exp, .. }
+            | E::SES_SIMPLE_ASSIGN_CONSTRAINTS { cref, exp, .. }
+            | E::SES_FOR_LOOP { cref, exp, .. } => {
+                lhs.insert(name(cref)?);
+                rhs.extend(uses(exp)?);
+            }
+            E::SES_ARRAY_CALL_ASSIGN { lhs: l, exp, .. } => {
+                lhs.insert(name(&Expression::expCref(l.clone())?)?);
+                rhs.extend(uses(exp)?);
+            }
+            E::SES_ALGORITHM { statements, .. } | E::SES_INVERSE_ALGORITHM { statements, .. } => {
+                let (defs, used) = Expression::extractUniqueCrefsFromStatmentS(statements.clone())?;
+                lhs.extend(lst(&defs).map(name).collect::<Result<Vec<_>>>()?);
+                rhs.extend(lst(&used).map(name).collect::<Result<Vec<_>>>()?);
+            }
+            E::SES_LINEAR { lSystem, alternativeTearing: None, .. } => {
+                for v in lst(&lSystem.vars) {
+                    lhs.insert(name(&v.name)?);
+                }
+                for e in sorted(&lSystem.residual) {
+                    inner(&e, &mut lhs, &mut rhs)?;
+                }
+                for b in lst(&lSystem.beqs) {
+                    rhs.extend(uses(b)?.into_iter().filter(|u| !lhs.contains(u)));
+                }
+                for (_, _, cell) in lst(&lSystem.simJac) {
+                    if let E::SES_RESIDUAL { exp, .. } = &**cell {
+                        rhs.extend(uses(exp)?.into_iter().filter(|u| !lhs.contains(u)));
+                    }
+                }
+            }
+            E::SES_NONLINEAR { nlSystem, alternativeTearing: None, .. } => {
+                for c in lst(&nlSystem.crefs) {
+                    lhs.insert(name(c)?);
+                }
+                for e in sorted(&nlSystem.eqs) {
+                    inner(&e, &mut lhs, &mut rhs)?;
+                }
+            }
+            E::SES_LINEAR { .. } | E::SES_NONLINEAR { .. } => {
+                return Err(unsupported(index, "dynamic tearing is not supported"));
+            }
+            E::SES_WHEN { .. } => return Err(unsupported(index, "equation type not yet handled: when")),
+            E::SES_IFEQUATION { .. } => return Err(unsupported(index, "equation type not yet handled: if-equation")),
+            E::SES_MIXED { .. } => return Err(unsupported(index, "equation type not yet handled: container")),
+            E::SES_ALIAS { .. } => return Err(unsupported(index, "equation type not yet handled: alias")),
+            _ => return Err(unsupported(index, "equation type not yet handled")),
+        }
+        nodes.push((index, lhs, rhs));
+    }
+    let mut tasks = Vec::with_capacity(nodes.len());
+    for (j, (index, _, rhs)) in nodes.iter().enumerate() {
+        let parents: Vec<u32> = nodes[..j]
+            .iter()
+            .enumerate()
+            .filter(|(_, (_, lhs, _))| rhs.iter().any(|u| lhs.contains(u)))
+            .map(|(i, _)| i as u32)
+            .collect();
+        tasks.push(openmodelica_sim_meta::ParmodTask { eq_index: *index, parents });
+    }
+    Ok(openmodelica_sim_meta::ParmodInfo { tasks })
+}
+
 fn eq_index_of(eq: &SimCode::SimEqSystem) -> i32 {
     use SimCode::SimEqSystem as E;
     match eq {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -375,6 +375,10 @@ pub extern "C" fn rt_sim_start(meta_ptr: u32, meta_len: u32, fn_base: u32, prese
     openmodelica_sim_meta::profiling::start(&mut InWasmEngine { fn_base, present_mask }, &model);
     driver::set_cancel_hook(cancel_hook);
     driver::set_init_done_hook(init_done_hook);
+    openmodelica_sim_meta::files::set_writer(|path, bytes| {
+        crate::files::write_file(path, &alloc::string::String::from_utf8_lossy(bytes));
+        true
+    });
     driver::set_no_throw_hook(|v| unsafe { rt_host_set_no_throw(v as i32) });
 
     let mut engine = InWasmEngine { fn_base, present_mask };
@@ -467,6 +471,7 @@ fn finish(s: &mut Session) {
     }
     s.params = driver::finalize_run(&mut s.engine, &s.model, s.sim_data).unwrap_or_default();
     use openmodelica_sim_meta::rtclock;
+    openmodelica_sim_meta::parmod::finish();
     rtclock::accumulate(rtclock::TOTAL);
     openmodelica_sim_meta::profiling::end_of_run(&mut s.engine);
     s.prof = openmodelica_sim_meta::profiling::snapshot();

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -337,6 +337,8 @@ pub const MODEL_FNS: &[&str] = &[
     "reconJacF",
     "reconJacH",
     "symbolicInlineSystem",
+    "functionLocalKnownVars",
+    "parmodTask",
 ];
 
 /// The clock a model entry point runs under, where `CodegenC.tpl` ticks one inside
@@ -394,11 +396,24 @@ pub trait SimEngine {
     /// [`SimEngine::call1_raw`] under the clock C's generated entry point ticks
     /// around its own body ([`model_fn_clock`]); every driver goes through here.
     fn call1(&mut self, name: &str, arg: u32) -> Result<()> {
-        let Some(ix) = model_fn_clock(name) else { return self.call1_raw(name, arg) };
+        let parmod = name == "functionODE" && crate::parmod::active();
+        let Some(ix) = model_fn_clock(name) else {
+            return if parmod { self.call_parmod_ode(arg) } else { self.call1_raw(name, arg) };
+        };
         rtclock::tick(ix);
-        let out = self.call1_raw(name, arg);
+        let out = if parmod { self.call_parmod_ode(arg) } else { self.call1_raw(name, arg) };
         rtclock::accumulate(ix);
         out
+    }
+    /// C's `functionODE` under `--parmodauto`: the scheduler decides between the
+    /// sequential entry point and the per-task `parmodTask(sim_data, task)`.
+    fn call_parmod_ode(&mut self, sim_data: u32) -> Result<()> {
+        use crate::parmod::Op;
+        crate::parmod::evaluate_ode(&mut |op| match op {
+            Op::All => self.call1_raw("functionODE", sim_data),
+            Op::LocalKnown => self.call1_if_present_raw("functionLocalKnownVars", sim_data),
+            Op::Task(k) => self.call2_raw("parmodTask", sim_data, k),
+        })
     }
     fn call1_if_present(&mut self, name: &str, arg: u32) -> Result<()> {
         let Some(ix) = model_fn_clock(name) else { return self.call1_if_present_raw(name, arg) };
@@ -4091,6 +4106,7 @@ fn solver_setup(e: &mut dyn SimEngine, model: &SimModel, sim_data: u32) -> Resul
     );
     omclog::close(omclog::NLS);
     set_zc_tolerance(e, sim_data, layout, model.tolerance.min(model.step_size()))?;
+    crate::parmod::init(model);
     for k in 0..layout.n_sens {
         write_f64(e, sim_data + layout.sens_off + k * 8, 0.0)?;
     }
@@ -4304,7 +4320,7 @@ pub fn drive(
         // reached `euler` for want of states -- where the loop saves nothing anyway,
         // there being no integration -- keeps the host driver. `+profiling` also
         // needs the row-emitting loop (`fmtEmitStep`), so it stays off this path.
-        if !use_events && method == "euler" && layout.n_states > 0 && !host_driven && !csv_input_given() && model.prof.is_none() {
+        if !use_events && method == "euler" && layout.n_states > 0 && !host_driven && !csv_input_given() && model.prof.is_none() && model.parmod.is_none() {
             // Fast in-wasm Euler (one host->wasm call; not resumable/cancellable).
             label = "euler-wasm";
             solver_setup(e, model, sim_data)?;
@@ -4412,6 +4428,7 @@ pub fn drive(
         log_line(crate::omclog::STDOUT, crate::omclog::INFO, &recon_log);
     }
     recon_res?;
+    crate::parmod::finish();
     rtclock::accumulate(rtclock::TOTAL);
     crate::profiling::end_of_run(e);
     (stats.timers, stats.tcalls) = rtclock::snapshot();

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/files.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/files.rs
@@ -7,6 +7,7 @@
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 static WRITE: AtomicUsize = AtomicUsize::new(0);
+static READ: AtomicUsize = AtomicUsize::new(0);
 
 /// Install the writer every side file goes through. Unset, a `std` build writes
 /// with `std::fs` and the in-wasm runtime drops the file.
@@ -26,4 +27,24 @@ pub fn write(path: &str, bytes: &[u8]) -> bool {
     return std::fs::write(path, bytes).is_ok();
     #[cfg(not(feature = "std"))]
     false
+}
+
+/// Install the reader a run's input side file (`-parmodImportClustering`) goes
+/// through. Unset, a `std` build reads with `std::fs` and the in-wasm runtime has
+/// no file.
+pub fn set_reader(f: fn(&str) -> Option<alloc::vec::Vec<u8>>) {
+    READ.store(f as usize, Ordering::Relaxed);
+}
+
+/// C's `fopen(path, "rb")` + read to end; `None` when the file could not be read.
+pub fn read(path: &str) -> Option<alloc::vec::Vec<u8>> {
+    let p = READ.load(Ordering::Relaxed);
+    if p != 0 {
+        let f: fn(&str) -> Option<alloc::vec::Vec<u8>> = unsafe { core::mem::transmute(p) };
+        return f(path);
+    }
+    #[cfg(feature = "std")]
+    return std::fs::read(path).ok();
+    #[cfg(not(feature = "std"))]
+    None
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -43,6 +43,7 @@ pub mod profiling;
 /// The writer every file a run leaves beside its result goes through.
 pub mod files;
 pub mod optimization;
+pub mod parmod;
 pub(crate) mod qss;
 pub mod rtclock;
 pub mod sync;
@@ -992,6 +993,20 @@ pub struct FmiVr {
     pub der_off: u32,
 }
 
+/// The `--parmodauto` ODE task graph C reads from `<model>_ode.json`: one task per
+/// ODE equation, with the tasks it reads a variable from.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ParmodInfo {
+    pub tasks: Vec<ParmodTask>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ParmodTask {
+    pub eq_index: i32,
+    /// Task ids (positions in [`ParmodInfo::tasks`]) this one depends on.
+    pub parents: Vec<u32>,
+}
+
 /// Everything the driver and the `.mat` writer need about one model: its layout,
 /// the run scalars, the ordered result variables, and the solver metadata.
 #[derive(Clone, PartialEq, Debug, Default)]
@@ -1060,6 +1075,8 @@ pub struct SimMeta {
     pub clocks: Vec<BaseClockMeta>,
     /// What `-l` needs; `None` for a target that emits no linearization support.
     pub lin: Option<LinInfo>,
+    /// The `--parmodauto` ODE task graph; `None` for a model translated without it.
+    pub parmod: Option<ParmodInfo>,
     /// What `method="optimization"` needs; `None` for a model without an
     /// optimization problem.
     pub opt: Option<OptInfo>,
@@ -1792,6 +1809,17 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
             put_u32s(&mut o, &p.blocks);
         }
     }
+    match &m.parmod {
+        None => o.push(0),
+        Some(p) => {
+            o.push(1);
+            put_u32(&mut o, p.tasks.len() as u32);
+            for t in &p.tasks {
+                put_u32(&mut o, t.eq_index as u32);
+                put_u32s(&mut o, &t.parents);
+            }
+        }
+    }
     o
 }
 
@@ -2294,10 +2322,21 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
             Some(ProfInfo { level, functions, vars, equations, blocks: r.u32s()? })
         }
     };
+    let parmod = match r.u8()? {
+        0 => None,
+        _ => {
+            let mut tasks = Vec::new();
+            for _ in 0..r.u32()? {
+                tasks.push(ParmodTask { eq_index: r.u32()? as i32, parents: r.u32s()? });
+            }
+            Some(ParmodInfo { tasks })
+        }
+    };
     Ok(SimMeta {
         layout, start_time, stop_time, n_intervals, method, cs_method, tolerance, output_format, prefix,
         model_name, vars, jac_a, state_sets, fmi_vrs, zc_desc, rel_desc, params, attr_log,
         removed_init_desc, nls_warnings, sample_index, soti, sens_params, nls_vars, n_lin_systems, dae, clocks, lin, opt, inputs, recon, prof,
+        parmod,
     })
 }
 
@@ -2464,6 +2503,9 @@ mod tests {
                 model_file: "MyModel.mo".to_string(),
                 model_dir: "/tmp".to_string(),
                 version: "v1.25.0".to_string(),
+            }),
+            parmod: Some(ParmodInfo {
+                tasks: vec![ParmodTask { eq_index: 3, parents: vec![] }, ParmodTask { eq_index: 5, parents: vec![0] }],
             }),
             prof: Some(ProfInfo {
                 level: 5,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/parmod.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/parmod.rs
@@ -1,0 +1,1314 @@
+//! C's `ParModelica/auto` runtime (`--parmodauto`): the ODE task graph, its
+//! clustering passes, the two schedulers and the JSON export/import, ported from
+//! `SimulationRuntime/ParModelica/auto/pm_*.hpp`. The graph, costs, clusters and
+//! files are the C ones; the clusters are evaluated in dependency order on the
+//! runtime's single thread, where C hands them to a TBB thread pool.
+
+use alloc::collections::BTreeSet;
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
+use core::cell::UnsafeCell;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use openmodelica_solvers::log_line;
+
+use crate::driver::{Result, leak_error, now_ms_host};
+use crate::omclog;
+use crate::{ParmodInfo, SimMeta};
+
+/// `PM_Model_create`'s cap on the default thread count.
+const DEFAULT_THREAD_CAP: usize = 6;
+
+static HW_THREADS: AtomicUsize = AtomicUsize::new(0);
+
+/// The machine's hardware concurrency, the default `-parmodNumThreads` is capped
+/// from; unknown (0) counts as plenty.
+pub fn set_hw_threads(n: usize) {
+    HW_THREADS.store(n, Ordering::Relaxed);
+}
+
+fn stdout(s: &str) {
+    log_line(omclog::STDOUT, omclog::INFO, s);
+}
+
+/// `std::cout << double`: `%g` at the stream's default six digits.
+fn g(v: f64) -> String {
+    omclog::g(v, 0, 6)
+}
+
+struct Config {
+    scheduler: String,
+    clustering: String,
+    clusters_per_level: i32,
+    export_taskgraph: Option<String>,
+    import_clustering: Option<String>,
+    dump_stages: Option<String>,
+    num_threads: usize,
+}
+
+impl Config {
+    fn from_flags() -> Config {
+        crate::simflags::with_flags(|f| {
+            let hw = HW_THREADS.load(Ordering::Relaxed);
+            let default_threads = if hw == 0 { DEFAULT_THREAD_CAP } else { hw.min(DEFAULT_THREAD_CAP) };
+            Config {
+                scheduler: f.parmod_scheduler.clone().unwrap_or_else(|| "flow".to_string()),
+                clustering: f.parmod_clustering.clone().unwrap_or_else(|| "default".to_string()),
+                clusters_per_level: f.parmod_clusters_per_level.unwrap_or(0),
+                export_taskgraph: f.parmod_export_taskgraph.clone(),
+                import_clustering: f.parmod_import_clustering.clone(),
+                dump_stages: f.parmod_dump_stages.clone(),
+                num_threads: match f.parmod_num_threads {
+                    Some(n) if n > 0 => n as usize,
+                    _ => default_threads,
+                },
+            }
+        })
+    }
+}
+
+// ───────────────────────────── task system ─────────────────────────────
+
+#[derive(Clone)]
+struct Task {
+    task_id: u32,
+    index: i32,
+    cost: f64,
+}
+
+#[derive(Clone)]
+struct Cluster {
+    tasks: Vec<Task>,
+    cost: f64,
+    level: i64,
+    lane: i32,
+}
+
+impl Cluster {
+    fn add_task(&mut self, t: Task) {
+        self.cost += t.cost;
+        self.tasks.push(t);
+    }
+    fn index_list(&self) -> String {
+        let mut s = String::from("$");
+        for t in &self.tasks {
+            s.push_str(&format!(",{}", t.index));
+        }
+        s
+    }
+}
+
+const ROOT: usize = 0;
+
+/// `TaskSystem_v2`: clusters as vertices of a DAG whose root is the parentless
+/// tasks' common predecessor. Vertex ids are stable (a removed vertex leaves a
+/// hole), so a vertex walk is C's insertion-ordered `listS` walk.
+#[derive(Clone)]
+struct TaskSystem {
+    name: String,
+    max_num_threads: usize,
+    nodes: Vec<Option<Cluster>>,
+    parents: Vec<BTreeSet<usize>>,
+    children: Vec<BTreeSet<usize>>,
+    /// `clusters_by_level`, level 0 holding only the root.
+    levels: Vec<Vec<usize>>,
+    level_cost: Vec<f64>,
+    levels_valid: bool,
+}
+
+impl TaskSystem {
+    fn new(name: &str, max_num_threads: usize, info: &ParmodInfo) -> TaskSystem {
+        let root = Cluster { tasks: vec![Task { task_id: u32::MAX, index: -1, cost: 0.0 }], cost: 0.0, level: 0, lane: -1 };
+        let mut s = TaskSystem {
+            name: name.to_string(),
+            max_num_threads,
+            nodes: vec![Some(root)],
+            parents: vec![BTreeSet::new()],
+            children: vec![BTreeSet::new()],
+            levels: Vec::new(),
+            level_cost: Vec::new(),
+            levels_valid: false,
+        };
+        for (k, t) in info.tasks.iter().enumerate() {
+            let v = s.nodes.len();
+            s.nodes.push(Some(Cluster {
+                tasks: vec![Task { task_id: k as u32, index: t.eq_index, cost: 0.0 }],
+                cost: 0.0,
+                level: 0,
+                lane: -1,
+            }));
+            s.parents.push(BTreeSet::new());
+            s.children.push(BTreeSet::new());
+            if t.parents.is_empty() {
+                s.add_edge(ROOT, v);
+            }
+            for p in &t.parents {
+                s.add_edge(*p as usize + 1, v);
+            }
+        }
+        s
+    }
+
+    fn cluster(&self, v: usize) -> &Cluster {
+        self.nodes[v].as_ref().expect("live cluster")
+    }
+    fn cluster_mut(&mut self, v: usize) -> &mut Cluster {
+        self.nodes[v].as_mut().expect("live cluster")
+    }
+    fn vertices(&self) -> impl Iterator<Item = usize> + '_ {
+        (1..self.nodes.len()).filter(|&v| self.nodes[v].is_some())
+    }
+    fn add_edge(&mut self, a: usize, b: usize) {
+        self.children[a].insert(b);
+        self.parents[b].insert(a);
+    }
+    fn out_degree(&self, v: usize) -> usize {
+        self.children[v].len()
+    }
+    fn in_degree(&self, v: usize) -> usize {
+        self.parents[v].len()
+    }
+
+    /// `concat_clusters` / `concat_same_level_clusters` / `concat_with_parent`:
+    /// `src`'s tasks and edges move to `dest`, then `src` goes.
+    fn concat(&mut self, dest: usize, src: usize) {
+        if dest == src {
+            return;
+        }
+        let tasks = core::mem::take(&mut self.cluster_mut(src).tasks);
+        for t in tasks {
+            self.cluster_mut(dest).add_task(t);
+        }
+        for c in core::mem::take(&mut self.children[src]) {
+            self.parents[c].remove(&src);
+            if c != dest {
+                self.add_edge(dest, c);
+            }
+        }
+        for p in core::mem::take(&mut self.parents[src]) {
+            self.children[p].remove(&src);
+            if p != dest {
+                self.add_edge(p, dest);
+            }
+        }
+        self.nodes[src] = None;
+        self.levels_valid = false;
+    }
+
+    /// `update_node_levels`: longest path from the root, then the per-level lists.
+    fn update_node_levels(&mut self) {
+        let mut critical = 0i64;
+        for v in self.topological_order() {
+            let lvl = self.parents[v].iter().map(|&p| self.cluster(p).level).max().map_or(0, |m| m + 1);
+            self.cluster_mut(v).level = lvl;
+            critical = critical.max(lvl);
+        }
+        self.levels = vec![Vec::new(); critical as usize + 1];
+        self.level_cost = vec![0.0; critical as usize + 1];
+        self.levels[0].push(ROOT);
+        let vs: Vec<usize> = self.vertices().collect();
+        for v in vs {
+            let (level, cost) = (self.cluster(v).level as usize, self.cluster(v).cost);
+            self.levels[level].push(v);
+            self.level_cost[level] += cost;
+        }
+        self.levels_valid = true;
+    }
+
+    /// Kahn's order over the live vertices, lowest id first among the ready ones.
+    fn topological_order(&self) -> Vec<usize> {
+        let mut indeg: Vec<usize> = (0..self.nodes.len()).map(|v| self.parents[v].len()).collect();
+        let mut ready: BTreeSet<usize> =
+            (0..self.nodes.len()).filter(|&v| self.nodes[v].is_some() && indeg[v] == 0).collect();
+        let mut out = Vec::with_capacity(self.nodes.len());
+        while let Some(&v) = ready.iter().next() {
+            ready.remove(&v);
+            out.push(v);
+            for &c in &self.children[v] {
+                indeg[c] -= 1;
+                if indeg[c] == 0 {
+                    ready.insert(c);
+                }
+            }
+        }
+        out
+    }
+
+    fn ensure_levels(&mut self) {
+        if !self.levels_valid {
+            self.update_node_levels();
+        }
+    }
+
+    /// `cluster_cost_comparator_by_id`: by cost, then by out-degree.
+    fn cost_key(&self, v: usize) -> (f64, usize) {
+        (self.cluster(v).cost, self.out_degree(v))
+    }
+    fn less(&self, a: usize, b: usize) -> bool {
+        let (ca, da) = self.cost_key(a);
+        let (cb, db) = self.cost_key(b);
+        if ca == cb { da < db } else { ca < cb }
+    }
+    /// `std::sort(rbegin, rend, cccbi)`: decreasing cost.
+    fn sort_decreasing(&self, ids: &mut [usize]) {
+        ids.sort_by(|&a, &b| {
+            let (ca, da) = self.cost_key(a);
+            let (cb, db) = self.cost_key(b);
+            cb.partial_cmp(&ca).unwrap_or(core::cmp::Ordering::Equal).then(db.cmp(&da))
+        });
+    }
+    fn min_element(&self, ids: &[usize]) -> usize {
+        let mut best = ids[0];
+        for &v in &ids[1..] {
+            if self.less(v, best) {
+                best = v;
+            }
+        }
+        best
+    }
+
+    /// `TaskCluster::profile_execute`: time every task, the cluster's cost is their sum.
+    fn profile_execute(&mut self, v: usize, call: Call) -> Result<()> {
+        let n = self.cluster(v).tasks.len();
+        let mut total = 0.0;
+        for i in 0..n {
+            let id = self.cluster(v).tasks[i].task_id;
+            let t0 = now_ms_host();
+            call(Op::Task(id))?;
+            let elapsed = now_ms_host() - t0;
+            self.cluster_mut(v).tasks[i].cost = elapsed;
+            total += elapsed;
+        }
+        self.cluster_mut(v).cost = total;
+        Ok(())
+    }
+
+    /// One evaluation of every task. Task order is a valid schedule on its own
+    /// (every edge points forward), and with one thread nothing is gained from the
+    /// clustered order, so this is the sequential entry point in one call.
+    fn execute_all(&self, call: Call) -> Result<()> {
+        call(Op::All)
+    }
+
+    fn profile_all(&mut self, call: Call) -> Result<()> {
+        call(Op::LocalKnown)?;
+        let vs: Vec<usize> = self.vertices().collect();
+        for v in vs {
+            self.profile_execute(v, call)?;
+        }
+        Ok(())
+    }
+}
+
+// ───────────────────────────── clustering ─────────────────────────────
+
+const CLUSTER_MERGE_COMMON: &str = "cluster_merge_common";
+const CLUSTER_MERGE_LEVEL_FOR_BINS: &str = "cluster_merge_level_for_bins";
+const CLUSTER_FIXED_WIDTH_MIN_HEIGHT: &str = "cluster_fixed_width_min_height";
+
+/// `cluster_merge_common::concat_children_recursive`.
+fn merge_common_recursive(s: &mut TaskSystem, curr: usize) -> usize {
+    let target_cost = 20.0;
+    let mut child_ids: Vec<usize> = s.children[curr].iter().copied().filter(|&c| s.in_degree(c) == 1).collect();
+    s.sort_decreasing(&mut child_ids);
+    let mut i = 0;
+    while i < child_ids.len() {
+        let child = child_ids[i];
+        let mut gap = target_cost - s.cluster(child).cost;
+        if gap >= 0.005 {
+            let mut j = i + 1;
+            while j < child_ids.len() {
+                let other = child_ids[j];
+                if s.cluster(other).cost <= gap {
+                    gap -= s.cluster(other).cost;
+                    s.concat(child, other);
+                    child_ids.remove(j);
+                } else {
+                    j += 1;
+                }
+            }
+        }
+        i += 1;
+    }
+    let children: Vec<usize> = s.children[curr].iter().copied().collect();
+    for child in children {
+        if s.nodes[child].is_none() || !s.children[curr].contains(&child) {
+            continue;
+        }
+        let nr_of_parents = merge_common_recursive(s, child);
+        if nr_of_parents == 1 && s.cluster(curr).cost + s.cluster(child).cost < target_cost {
+            s.concat(curr, child);
+        }
+    }
+    s.in_degree(curr)
+}
+
+fn cluster_merge_common(s: &mut TaskSystem) {
+    let top: Vec<usize> = s.children[ROOT].iter().copied().collect();
+    for c in top {
+        if s.nodes[c].is_some() {
+            merge_common_recursive(s, c);
+        }
+    }
+    s.levels_valid = false;
+}
+
+fn cluster_merge_level_for_bins(s: &mut TaskSystem, cfg: &Config) {
+    let mut cluster_cap = 8usize;
+    if cfg.clusters_per_level > 0 {
+        cluster_cap = cfg.clusters_per_level as usize;
+    }
+    let nr_of_clusters = (s.max_num_threads * 2).min(cluster_cap).max(1);
+    s.ensure_levels();
+    for l in 1..s.levels.len() {
+        if s.levels[l].len() <= nr_of_clusters {
+            continue;
+        }
+        let mut level = core::mem::take(&mut s.levels[l]);
+        s.sort_decreasing(&mut level);
+        let (accepted, rest) = level.split_at(nr_of_clusters);
+        let accepted = accepted.to_vec();
+        for &v in rest {
+            let smallest = s.min_element(&accepted);
+            s.concat(smallest, v);
+        }
+        s.levels[l] = accepted;
+    }
+    s.levels_valid = false;
+}
+
+fn cluster_fixed_width_min_height(s: &mut TaskSystem) {
+    s.ensure_levels();
+    let vid: Vec<usize> = s.vertices().collect();
+    let n = vid.len();
+    if n == 0 {
+        s.levels_valid = false;
+        return;
+    }
+    let mut id_to_idx = vec![usize::MAX; s.nodes.len()];
+    for (i, &v) in vid.iter().enumerate() {
+        id_to_idx[v] = i;
+    }
+    let level: Vec<i64> = vid.iter().map(|&v| s.cluster(v).level).collect();
+    let cost: Vec<f64> = vid.iter().map(|&v| s.out_degree(v) as f64).collect();
+    let children: Vec<Vec<usize>> = vid
+        .iter()
+        .map(|&v| s.children[v].iter().filter_map(|&c| (id_to_idx[c] != usize::MAX).then_some(id_to_idx[c])).collect())
+        .collect();
+    let max_level = level.iter().copied().max().unwrap_or(0) as usize;
+    let mut nodes_by_level: Vec<Vec<usize>> = vec![Vec::new(); max_level + 1];
+    for i in 0..n {
+        nodes_by_level[level[i] as usize].push(i);
+    }
+    for i in 0..n {
+        for &c in &children[i] {
+            if level[c] <= level[i] {
+                stdout(&format!(
+                    "cluster_fixed_width_min_height: non-forward edge {} -> {} would create a cycle; skipping clustering.\n",
+                    level[i], level[c]
+                ));
+                s.levels_valid = false;
+                return;
+            }
+        }
+    }
+    let k = s.max_num_threads.max(1);
+    let by_cost_desc = |ids: &mut Vec<usize>| ids.sort_by(|&a, &b| cost[b].partial_cmp(&cost[a]).unwrap_or(core::cmp::Ordering::Equal));
+    let mut lane = vec![0usize; n];
+    for l in 1..=max_level {
+        let level_nodes = &mut nodes_by_level[l];
+        if level_nodes.is_empty() {
+            continue;
+        }
+        let width = level_nodes.len().min(k);
+        by_cost_desc(level_nodes);
+        let mut lane_load = vec![0.0; width];
+        for &nn in level_nodes.iter() {
+            let mut best = 0;
+            for l2 in 1..width {
+                if lane_load[l2] < lane_load[best] {
+                    best = l2;
+                }
+            }
+            lane[nn] = best;
+            lane_load[best] += cost[nn];
+        }
+    }
+    let lanes = k;
+    let cid_of = |i: usize, lane: &[usize]| level[i] as usize * lanes + lane[i];
+    let analyze = |lane: &[usize]| -> (f64, i64, i64) {
+        use alloc::collections::BTreeMap;
+        let mut ccost: BTreeMap<usize, f64> = BTreeMap::new();
+        for i in 0..n {
+            *ccost.entry(cid_of(i, lane)).or_insert(0.0) += cost[i];
+        }
+        let mut preds: BTreeMap<usize, BTreeSet<usize>> = BTreeMap::new();
+        for i in 0..n {
+            let ci = cid_of(i, lane);
+            for &c in &children[i] {
+                let cj = cid_of(c, lane);
+                if ci != cj {
+                    preds.entry(cj).or_default().insert(ci);
+                }
+            }
+        }
+        let mut dp: BTreeMap<usize, f64> = BTreeMap::new();
+        let mut par: BTreeMap<usize, Option<usize>> = BTreeMap::new();
+        let mut height = 0.0;
+        let mut end_c = None;
+        for (&c, &cc) in &ccost {
+            let mut best_pred = 0.0;
+            let mut best_pc = None;
+            if let Some(ps) = preds.get(&c) {
+                for &p in ps {
+                    let d = dp.get(&p).copied().unwrap_or(0.0);
+                    if d > best_pred {
+                        best_pred = d;
+                        best_pc = Some(p);
+                    }
+                }
+            }
+            dp.insert(c, best_pred + cc);
+            par.insert(c, best_pc);
+            if dp[&c] > height {
+                height = dp[&c];
+                end_c = Some(c);
+            }
+        }
+        let (mut hot_level, mut hot_lane, mut hot_cost) = (-1i64, -1i64, -1.0);
+        let mut c = end_c;
+        while let Some(cc) = c {
+            if ccost[&cc] > hot_cost {
+                hot_cost = ccost[&cc];
+                hot_level = (cc / lanes) as i64;
+                hot_lane = (cc % lanes) as i64;
+            }
+            c = par.get(&cc).copied().flatten();
+        }
+        (height, hot_level, hot_lane)
+    };
+    let max_evals = 20000;
+    let mut evals = 0;
+    while evals < max_evals {
+        let (height, hot_level, hot_lane) = analyze(&lane);
+        evals += 1;
+        if hot_level < 1 {
+            break;
+        }
+        let level_nodes = &nodes_by_level[hot_level as usize];
+        let width = level_nodes.len().min(k);
+        if width <= 1 {
+            break;
+        }
+        let mut lane_load = vec![0.0; width];
+        for &t in level_nodes {
+            lane_load[lane[t]] += cost[t];
+        }
+        let mut target: Option<usize> = None;
+        for l in 0..width {
+            if l as i64 != hot_lane && target.is_none_or(|t| lane_load[l] < lane_load[t]) {
+                target = Some(l);
+            }
+        }
+        let Some(target) = target else { break };
+        let mut hot_nodes: Vec<usize> = level_nodes.iter().copied().filter(|&t| lane[t] as i64 == hot_lane).collect();
+        by_cost_desc(&mut hot_nodes);
+        let mut improved = false;
+        for &nn in &hot_nodes {
+            if evals >= max_evals {
+                break;
+            }
+            let old = lane[nn];
+            lane[nn] = target;
+            let (new_height, _, _) = analyze(&lane);
+            evals += 1;
+            if new_height < height {
+                improved = true;
+                break;
+            }
+            lane[nn] = old;
+        }
+        if !improved {
+            break;
+        }
+    }
+    for l in 1..=max_level {
+        let level_nodes = nodes_by_level[l].clone();
+        let width = level_nodes.len().min(k);
+        for target_lane in 0..width {
+            let mut rep: Option<usize> = None;
+            for &nn in &level_nodes {
+                if lane[nn] != target_lane {
+                    continue;
+                }
+                match rep {
+                    None => rep = Some(vid[nn]),
+                    Some(r) => s.concat(r, vid[nn]),
+                }
+            }
+            if let Some(r) = rep {
+                s.cluster_mut(r).lane = target_lane as i32;
+            }
+        }
+    }
+    s.levels_valid = false;
+}
+
+// ───────────────────────────── JSON ─────────────────────────────
+
+enum Json {
+    Null,
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    Str(String),
+    Arr(Vec<Json>),
+    /// Keys kept sorted, as nlohmann's `std::map` object prints them.
+    Obj(Vec<(String, Json)>),
+}
+
+impl Json {
+    fn obj() -> Json {
+        Json::Obj(Vec::new())
+    }
+    fn set(&mut self, key: &str, v: Json) {
+        if let Json::Obj(m) = self {
+            match m.binary_search_by(|(k, _)| k.as_str().cmp(key)) {
+                Ok(i) => m[i].1 = v,
+                Err(i) => m.insert(i, (key.to_string(), v)),
+            }
+        }
+    }
+    fn get(&self, key: &str) -> Option<&Json> {
+        match self {
+            Json::Obj(m) => m.iter().find(|(k, _)| k == key).map(|(_, v)| v),
+            _ => None,
+        }
+    }
+    fn as_array(&self) -> Option<&[Json]> {
+        match self {
+            Json::Arr(a) => Some(a),
+            _ => None,
+        }
+    }
+    fn as_i64(&self) -> Option<i64> {
+        match self {
+            Json::Int(i) => Some(*i),
+            Json::Float(f) if libm::trunc(*f) == *f => Some(*f as i64),
+            _ => None,
+        }
+    }
+
+    /// `dump(2)`.
+    fn dump(&self) -> String {
+        let mut out = String::new();
+        self.write(&mut out, 0);
+        out
+    }
+    fn write(&self, out: &mut String, depth: usize) {
+        let pad = |out: &mut String, d: usize| {
+            for _ in 0..d * 2 {
+                out.push(' ');
+            }
+        };
+        match self {
+            Json::Null => out.push_str("null"),
+            Json::Bool(b) => out.push_str(if *b { "true" } else { "false" }),
+            Json::Int(i) => out.push_str(&i.to_string()),
+            Json::Float(f) => out.push_str(&format!("{f:?}")),
+            Json::Str(s) => {
+                out.push('"');
+                for c in s.chars() {
+                    match c {
+                        '"' => out.push_str("\\\""),
+                        '\\' => out.push_str("\\\\"),
+                        '\n' => out.push_str("\\n"),
+                        '\t' => out.push_str("\\t"),
+                        c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+                        c => out.push(c),
+                    }
+                }
+                out.push('"');
+            }
+            Json::Arr(a) => {
+                if a.is_empty() {
+                    out.push_str("[]");
+                    return;
+                }
+                out.push_str("[\n");
+                for (i, v) in a.iter().enumerate() {
+                    pad(out, depth + 1);
+                    v.write(out, depth + 1);
+                    out.push_str(if i + 1 < a.len() { ",\n" } else { "\n" });
+                }
+                pad(out, depth);
+                out.push(']');
+            }
+            Json::Obj(m) => {
+                if m.is_empty() {
+                    out.push_str("{}");
+                    return;
+                }
+                out.push_str("{\n");
+                for (i, (k, v)) in m.iter().enumerate() {
+                    pad(out, depth + 1);
+                    Json::Str(k.clone()).write(out, depth + 1);
+                    out.push_str(": ");
+                    v.write(out, depth + 1);
+                    out.push_str(if i + 1 < m.len() { ",\n" } else { "\n" });
+                }
+                pad(out, depth);
+                out.push('}');
+            }
+        }
+    }
+
+    fn parse(text: &str) -> core::result::Result<Json, String> {
+        let b = text.as_bytes();
+        let mut p = 0;
+        let v = parse_value(b, &mut p)?;
+        skip_ws(b, &mut p);
+        if p != b.len() {
+            return Err(format!("trailing characters at offset {p}"));
+        }
+        Ok(v)
+    }
+}
+
+fn skip_ws(b: &[u8], p: &mut usize) {
+    while *p < b.len() && matches!(b[*p], b' ' | b'\t' | b'\n' | b'\r') {
+        *p += 1;
+    }
+}
+
+fn parse_value(b: &[u8], p: &mut usize) -> core::result::Result<Json, String> {
+    skip_ws(b, p);
+    let Some(&c) = b.get(*p) else { return Err("unexpected end of input".to_string()) };
+    match c {
+        b'{' => {
+            *p += 1;
+            let mut m = Json::obj();
+            skip_ws(b, p);
+            if b.get(*p) == Some(&b'}') {
+                *p += 1;
+                return Ok(m);
+            }
+            loop {
+                skip_ws(b, p);
+                let Json::Str(k) = parse_value(b, p)? else { return Err(format!("object key expected at offset {p}")) };
+                skip_ws(b, p);
+                if b.get(*p) != Some(&b':') {
+                    return Err(format!("':' expected at offset {p}"));
+                }
+                *p += 1;
+                let v = parse_value(b, p)?;
+                m.set(&k, v);
+                skip_ws(b, p);
+                match b.get(*p) {
+                    Some(b',') => *p += 1,
+                    Some(b'}') => {
+                        *p += 1;
+                        return Ok(m);
+                    }
+                    _ => return Err(format!("',' or '}}' expected at offset {p}")),
+                }
+            }
+        }
+        b'[' => {
+            *p += 1;
+            let mut a = Vec::new();
+            skip_ws(b, p);
+            if b.get(*p) == Some(&b']') {
+                *p += 1;
+                return Ok(Json::Arr(a));
+            }
+            loop {
+                a.push(parse_value(b, p)?);
+                skip_ws(b, p);
+                match b.get(*p) {
+                    Some(b',') => *p += 1,
+                    Some(b']') => {
+                        *p += 1;
+                        return Ok(Json::Arr(a));
+                    }
+                    _ => return Err(format!("',' or ']' expected at offset {p}")),
+                }
+            }
+        }
+        b'"' => {
+            *p += 1;
+            let mut s = String::new();
+            loop {
+                let Some(&c) = b.get(*p) else { return Err("unterminated string".to_string()) };
+                *p += 1;
+                match c {
+                    b'"' => break,
+                    b'\\' => {
+                        let Some(&e) = b.get(*p) else { return Err("unterminated string".to_string()) };
+                        *p += 1;
+                        match e {
+                            b'"' => s.push('"'),
+                            b'\\' => s.push('\\'),
+                            b'/' => s.push('/'),
+                            b'n' => s.push('\n'),
+                            b't' => s.push('\t'),
+                            b'r' => s.push('\r'),
+                            b'b' => s.push('\u{8}'),
+                            b'f' => s.push('\u{c}'),
+                            b'u' => {
+                                let hex = b.get(*p..*p + 4).ok_or("bad \\u escape")?;
+                                let code = u32::from_str_radix(core::str::from_utf8(hex).map_err(|_| "bad \\u escape")?, 16)
+                                    .map_err(|_| "bad \\u escape")?;
+                                *p += 4;
+                                s.push(char::from_u32(code).unwrap_or('\u{fffd}'));
+                            }
+                            _ => return Err(format!("bad escape at offset {p}")),
+                        }
+                    }
+                    _ => {
+                        let start = *p - 1;
+                        let mut end = *p;
+                        while end < b.len() && b[end] != b'"' && b[end] != b'\\' {
+                            end += 1;
+                        }
+                        s.push_str(core::str::from_utf8(&b[start..end]).map_err(|_| "invalid utf-8 in string")?);
+                        *p = end;
+                    }
+                }
+            }
+            Ok(Json::Str(s))
+        }
+        b't' if b[*p..].starts_with(b"true") => {
+            *p += 4;
+            Ok(Json::Bool(true))
+        }
+        b'f' if b[*p..].starts_with(b"false") => {
+            *p += 5;
+            Ok(Json::Bool(false))
+        }
+        b'n' if b[*p..].starts_with(b"null") => {
+            *p += 4;
+            Ok(Json::Null)
+        }
+        b'-' | b'0'..=b'9' => {
+            let start = *p;
+            *p += 1;
+            while *p < b.len() && matches!(b[*p], b'0'..=b'9' | b'.' | b'e' | b'E' | b'+' | b'-') {
+                *p += 1;
+            }
+            let s = core::str::from_utf8(&b[start..*p]).map_err(|_| "bad number")?;
+            if let Ok(i) = s.parse::<i64>() {
+                return Ok(Json::Int(i));
+            }
+            s.parse::<f64>().map(Json::Float).map_err(|_| format!("bad number '{s}'"))
+        }
+        _ => Err(format!("unexpected character '{}' at offset {p}", c as char)),
+    }
+}
+
+/// `collect_task_graph_json`: the fine-grained graph, one task per vertex.
+fn collect_task_graph_json(s: &mut TaskSystem, out: &mut Json) {
+    s.ensure_levels();
+    out.set("name", Json::Str(s.name.clone()));
+    out.set("num_threads", Json::Int(s.max_num_threads as i64));
+    let mut tasks = Vec::new();
+    let mut deps = Vec::new();
+    for v in s.vertices() {
+        let c = s.cluster(v);
+        let eq = c.tasks[0].index as i64;
+        let mut t = Json::obj();
+        t.set("eq", Json::Int(eq));
+        t.set("level", Json::Int(c.level));
+        t.set("cost", Json::Float(c.cost));
+        t.set("out_degree", Json::Int(s.out_degree(v) as i64));
+        tasks.push(t);
+        for &ch in &s.children[v] {
+            deps.push(Json::Arr(vec![Json::Int(eq), Json::Int(s.cluster(ch).tasks[0].index as i64)]));
+        }
+    }
+    out.set("tasks", Json::Arr(tasks));
+    out.set("dependencies", Json::Arr(deps));
+}
+
+fn collect_clusters_json(s: &TaskSystem, out: &mut Json) {
+    let mut clusters = Vec::new();
+    for v in s.vertices() {
+        let c = s.cluster(v);
+        let mut cl = Json::obj();
+        cl.set("eqs", Json::Arr(c.tasks.iter().map(|t| Json::Int(t.index as i64)).collect()));
+        cl.set("lane", Json::Int(c.lane as i64));
+        clusters.push(cl);
+    }
+    out.set("clusters", Json::Arr(clusters));
+}
+
+fn write_json_file(path: &str, j: &Json, what: &str) -> Result<()> {
+    let mut text = j.dump();
+    text.push('\n');
+    if !crate::files::write(path, text.as_bytes()) {
+        return Err(leak_error(format!("Fatal : Could not open '{path}' for writing the parmodauto {what}.")));
+    }
+    stdout(&format!("Exported parmodauto {what} to {path}\n"));
+    Ok(())
+}
+
+fn stage_snapshot_path(prefix: &str, stage: usize, stage_name: &str) -> String {
+    let base = prefix.strip_suffix(".json").unwrap_or(prefix);
+    format!("{base}.{stage:02}.{stage_name}.json")
+}
+
+/// `ClusteringStageDumper`: `<prefix>.NN.<stage>.json` per clustering pass.
+struct StageDumper {
+    prefix: Option<String>,
+    base_graph: Json,
+    stage: usize,
+}
+
+impl StageDumper {
+    fn new(s: &mut TaskSystem, prefix: Option<&str>) -> StageDumper {
+        let prefix = prefix.filter(|p| !p.is_empty()).map(|p| p.to_string());
+        let mut base_graph = Json::obj();
+        if prefix.is_some() {
+            collect_task_graph_json(s, &mut base_graph);
+        }
+        StageDumper { prefix, base_graph, stage: 0 }
+    }
+    fn snapshot(&mut self, s: &TaskSystem, stage_name: &str) -> Result<()> {
+        let Some(prefix) = &self.prefix else { return Ok(()) };
+        let mut snap = self.base_graph.clone_json();
+        snap.set("stage", Json::Int(self.stage as i64));
+        snap.set("stage_name", Json::Str(stage_name.to_string()));
+        collect_clusters_json(s, &mut snap);
+        write_json_file(&stage_snapshot_path(prefix, self.stage, stage_name), &snap, &format!("stage '{stage_name}'"))?;
+        self.stage += 1;
+        Ok(())
+    }
+}
+
+impl Json {
+    fn clone_json(&self) -> Json {
+        match self {
+            Json::Null => Json::Null,
+            Json::Bool(b) => Json::Bool(*b),
+            Json::Int(i) => Json::Int(*i),
+            Json::Float(f) => Json::Float(*f),
+            Json::Str(s) => Json::Str(s.clone()),
+            Json::Arr(a) => Json::Arr(a.iter().map(Json::clone_json).collect()),
+            Json::Obj(m) => Json::Obj(m.iter().map(|(k, v)| (k.clone(), v.clone_json())).collect()),
+        }
+    }
+}
+
+/// `import_clustering_json`: apply an external clustering, rejecting an unknown or
+/// repeated equation and a cluster graph with a cycle.
+fn import_clustering_json(s: &mut TaskSystem, path: &str) -> Result<()> {
+    let fatal = |m: String| leak_error(format!("Fatal : {m}"));
+    let Some(bytes) = crate::files::read(path) else {
+        return Err(fatal(format!("Could not open clustering json '{path}'.")));
+    };
+    let text = String::from_utf8_lossy(&bytes);
+    let j = Json::parse(&text).map_err(|e| fatal(format!("Could not parse clustering json '{path}': {e}")))?;
+    let Some(clusters) = j.get("clusters").and_then(Json::as_array) else {
+        return Err(fatal(format!("Clustering json '{path}' has no 'clusters' array.")));
+    };
+    s.ensure_levels();
+    let mut eq_to_vid: Vec<(i64, usize)> = s.vertices().map(|v| (s.cluster(v).tasks[0].index as i64, v)).collect();
+    eq_to_vid.sort();
+    let vid_of = |eq: i64| eq_to_vid.binary_search_by_key(&eq, |(e, _)| *e).ok().map(|i| eq_to_vid[i].1);
+    let mut eq_to_cluster: Vec<Option<usize>> = vec![None; s.nodes.len()];
+    let mut cluster_eqs: Vec<Vec<usize>> = Vec::new();
+    for c in clusters {
+        let mut eqs = Vec::new();
+        for e in c.get("eqs").and_then(Json::as_array).unwrap_or(&[]) {
+            let eq = e.as_i64().unwrap_or(i64::MIN);
+            let Some(v) = vid_of(eq) else {
+                return Err(fatal(format!("Imported clustering references unknown equation {eq}.")));
+            };
+            if eq_to_cluster[v].is_some() {
+                return Err(fatal(format!("Imported clustering assigns equation {eq} to more than one cluster.")));
+            }
+            eq_to_cluster[v] = Some(cluster_eqs.len());
+            eqs.push(v);
+        }
+        if !eqs.is_empty() {
+            cluster_eqs.push(eqs);
+        }
+    }
+    for &(_, v) in &eq_to_vid {
+        if eq_to_cluster[v].is_none() {
+            eq_to_cluster[v] = Some(cluster_eqs.len());
+            cluster_eqs.push(vec![v]);
+        }
+    }
+    let num_clusters = cluster_eqs.len();
+    let mut succ: Vec<BTreeSet<usize>> = vec![BTreeSet::new(); num_clusters];
+    for v in s.vertices() {
+        let ca = eq_to_cluster[v].unwrap();
+        for &ch in &s.children[v] {
+            let cb = eq_to_cluster[ch].unwrap();
+            if ca != cb {
+                succ[ca].insert(cb);
+            }
+        }
+    }
+    let mut indeg = vec![0usize; num_clusters];
+    for a in 0..num_clusters {
+        for &b in &succ[a] {
+            indeg[b] += 1;
+        }
+    }
+    let mut ready: Vec<usize> = (0..num_clusters).filter(|&a| indeg[a] == 0).collect();
+    let mut visited = 0;
+    while let Some(a) = ready.pop() {
+        visited += 1;
+        for &b in &succ[a] {
+            indeg[b] -= 1;
+            if indeg[b] == 0 {
+                ready.push(b);
+            }
+        }
+    }
+    if visited != num_clusters {
+        return Err(fatal("Imported clustering forms a cycle in the cluster graph; aborting.".to_string()));
+    }
+    for eqs in &cluster_eqs {
+        if eqs.len() <= 1 {
+            continue;
+        }
+        let mut rep = eqs[0];
+        for &v in &eqs[1..] {
+            if s.cluster(v).level < s.cluster(rep).level {
+                rep = v;
+            }
+        }
+        for &v in eqs {
+            if v != rep {
+                s.concat(rep, v);
+            }
+        }
+    }
+    s.levels_valid = false;
+    stdout(&format!("Imported parmodauto clustering ({num_clusters} clusters) from {path}\n"));
+    Ok(())
+}
+
+// ───────────────────────────── schedulers ─────────────────────────────
+
+/// What the scheduler asks the model for: the whole sequential `functionODE`,
+/// `functionLocalKnownVars` alone, or one task via `parmodTask`.
+pub enum Op {
+    All,
+    LocalKnown,
+    Task(u32),
+}
+
+type Call<'a> = &'a mut dyn FnMut(Op) -> Result<()>;
+
+/// `StepLevels`: level-synchronous; re-profiles and re-clusters when the
+/// evaluation time drifts by more than half.
+struct LevelScheduler {
+    org: TaskSystem,
+    sys: TaskSystem,
+    schedule_available: bool,
+    total_evaluations: u32,
+    parallel_evaluations: u32,
+    sequential_evaluations: u32,
+    par_avg_at_last_sch: f64,
+    par_current_avg: f64,
+    total_parallel_cost: f64,
+    has_run_parallel: bool,
+    execution_time: f64,
+    clustering_time: f64,
+}
+
+impl LevelScheduler {
+    fn new(sys: TaskSystem) -> LevelScheduler {
+        LevelScheduler {
+            org: sys.clone(),
+            sys,
+            schedule_available: false,
+            total_evaluations: 0,
+            parallel_evaluations: 0,
+            sequential_evaluations: 0,
+            par_avg_at_last_sch: 0.0,
+            par_current_avg: 0.0,
+            total_parallel_cost: 0.0,
+            has_run_parallel: false,
+            execution_time: 0.0,
+            clustering_time: 0.0,
+        }
+    }
+
+    fn reschedule_needed(&self) -> bool {
+        if !self.schedule_available {
+            return true;
+        }
+        let change = libm::fabs(self.par_avg_at_last_sch - self.par_current_avg) / self.par_avg_at_last_sch;
+        change > 0.5
+    }
+
+    fn execute(&mut self, cfg: &Config, call: Call) -> Result<()> {
+        if self.reschedule_needed() {
+            self.sys = self.org.clone();
+            self.schedule_available = false;
+            self.profile_execute(call)?;
+            self.schedule(cfg)?;
+            self.par_avg_at_last_sch = self.par_current_avg;
+            return Ok(());
+        }
+        let t0 = now_ms_host();
+        self.sys.execute_all(call)?;
+        let step_cost = now_ms_host() - t0;
+        self.execution_time += step_cost;
+        self.total_evaluations += 1;
+        self.parallel_evaluations += 1;
+        self.total_parallel_cost += step_cost;
+        self.par_current_avg = self.total_parallel_cost / self.parallel_evaluations as f64;
+        if !self.has_run_parallel {
+            self.par_avg_at_last_sch = self.par_current_avg;
+            self.has_run_parallel = true;
+        }
+        Ok(())
+    }
+
+    fn profile_execute(&mut self, call: Call) -> Result<()> {
+        let t0 = now_ms_host();
+        self.sys.profile_all(call)?;
+        self.total_evaluations += 1;
+        self.sequential_evaluations += 1;
+        let step_cost = now_ms_host() - t0;
+        self.execution_time += step_cost;
+        stdout(&format!(
+            "S : {} : {} : {} : {}\n",
+            self.total_evaluations,
+            g(step_cost),
+            g(self.par_current_avg),
+            g(self.par_avg_at_last_sch)
+        ));
+        Ok(())
+    }
+
+    fn schedule(&mut self, cfg: &Config) -> Result<()> {
+        let t0 = now_ms_host();
+        self.sys.ensure_levels();
+        let mut stages = StageDumper::new(&mut self.sys, cfg.dump_stages.as_deref());
+        stages.snapshot(&self.sys, "initial")?;
+        cluster_merge_common(&mut self.sys);
+        stages.snapshot(&self.sys, CLUSTER_MERGE_COMMON)?;
+        cluster_merge_level_for_bins(&mut self.sys, cfg);
+        stages.snapshot(&self.sys, CLUSTER_MERGE_LEVEL_FOR_BINS)?;
+        self.schedule_available = true;
+        self.sys.levels_valid = false;
+        self.sys.update_node_levels();
+        // `estimate_speedup` leaves every level sorted by decreasing cost.
+        for l in 1..self.sys.levels.len() {
+            let mut level = core::mem::take(&mut self.sys.levels[l]);
+            self.sys.sort_decreasing(&mut level);
+            self.sys.levels[l] = level;
+        }
+        self.clustering_time += now_ms_host() - t0;
+        Ok(())
+    }
+}
+
+/// `ClusterDynamicScheduler`: clusters as a dependency graph, scheduled once.
+struct FlowScheduler {
+    sys: TaskSystem,
+    flow_graph_created: bool,
+    total_evaluations: u32,
+    parallel_evaluations: u32,
+    sequential_evaluations: u32,
+    execution_time: f64,
+    clustering_time: f64,
+}
+
+impl FlowScheduler {
+    fn new(sys: TaskSystem) -> FlowScheduler {
+        FlowScheduler {
+            sys,
+            flow_graph_created: false,
+            total_evaluations: 0,
+            parallel_evaluations: 0,
+            sequential_evaluations: 0,
+            execution_time: 0.0,
+            clustering_time: 0.0,
+        }
+    }
+
+    fn execute(&mut self, cfg: &Config, call: Call) -> Result<()> {
+        if !self.flow_graph_created {
+            self.schedule(cfg, call)?;
+        }
+        let t0 = now_ms_host();
+        self.sys.execute_all(call)?;
+        self.execution_time += now_ms_host() - t0;
+        self.total_evaluations += 1;
+        self.parallel_evaluations += 1;
+        Ok(())
+    }
+
+    fn schedule(&mut self, cfg: &Config, call: Call) -> Result<()> {
+        let t0 = now_ms_host();
+        for _ in 0..2 {
+            self.sys.execute_all(call)?;
+        }
+        self.sys.profile_all(call)?;
+        self.sequential_evaluations += 1;
+        self.total_evaluations += 1;
+        self.sys.ensure_levels();
+        let mut graph_dump = Json::obj();
+        if cfg.export_taskgraph.is_some() {
+            collect_task_graph_json(&mut self.sys, &mut graph_dump);
+        }
+        let mut stages = StageDumper::new(&mut self.sys, cfg.dump_stages.as_deref());
+        stages.snapshot(&self.sys, "initial")?;
+        if let Some(path) = &cfg.import_clustering {
+            import_clustering_json(&mut self.sys, path)?;
+            stages.snapshot(&self.sys, "imported")?;
+        } else if cfg.clustering == CLUSTER_FIXED_WIDTH_MIN_HEIGHT || cfg.clustering == "fixed_width_min_height" {
+            cluster_fixed_width_min_height(&mut self.sys);
+            stages.snapshot(&self.sys, CLUSTER_FIXED_WIDTH_MIN_HEIGHT)?;
+        } else if cfg.clustering == "none" {
+        } else {
+            cluster_merge_common(&mut self.sys);
+            stages.snapshot(&self.sys, CLUSTER_MERGE_COMMON)?;
+            cluster_merge_level_for_bins(&mut self.sys, cfg);
+            stages.snapshot(&self.sys, CLUSTER_MERGE_LEVEL_FOR_BINS)?;
+        }
+        self.sys.levels_valid = false;
+        self.sys.update_node_levels();
+        if let Some(path) = &cfg.export_taskgraph {
+            collect_clusters_json(&self.sys, &mut graph_dump);
+            write_json_file(path, &graph_dump, "task graph")?;
+        }
+        self.flow_graph_created = true;
+        self.clustering_time += now_ms_host() - t0;
+        Ok(())
+    }
+}
+
+enum Scheduler {
+    Level(LevelScheduler),
+    Flow(FlowScheduler),
+}
+
+struct State {
+    cfg: Config,
+    sched: Scheduler,
+    load_time: f64,
+}
+
+struct Store(UnsafeCell<Option<State>>);
+unsafe impl Sync for Store {}
+static STATE: Store = Store(UnsafeCell::new(None));
+
+// The driver is single-threaded per run (as is the in-wasm session).
+fn state() -> &'static mut Option<State> {
+    unsafe { &mut *STATE.0.get() }
+}
+
+/// `PM_Model_create` + `PM_Model_load_ODE_system`, for a model translated with
+/// `--parmodauto`; a plain model leaves `functionODE` alone.
+pub fn init(model: &SimMeta) {
+    *state() = None;
+    let Some(info) = &model.parmod else { return };
+    let cfg = Config::from_flags();
+    let t0 = now_ms_host();
+    let sys = TaskSystem::new(&model.prefix, cfg.num_threads, info);
+    stdout(&format!("Number of tasks      = {}\n", info.tasks.len()));
+    let load_time = now_ms_host() - t0;
+    let sched = match cfg.scheduler.as_str() {
+        "level" => Scheduler::Level(LevelScheduler::new(sys)),
+        _ => Scheduler::Flow(FlowScheduler::new(sys)),
+    };
+    *state() = Some(State { cfg, sched, load_time });
+}
+
+pub fn active() -> bool {
+    state().is_some()
+}
+
+/// `PM_evaluate_ODE_system`.
+pub fn evaluate_ode(call: Call) -> Result<()> {
+    let Some(st) = state().as_mut() else { return Err("parmodauto: no task system loaded") };
+    match &mut st.sched {
+        Scheduler::Level(s) => s.execute(&st.cfg, call),
+        Scheduler::Flow(s) => s.execute(&st.cfg, call),
+    }
+}
+
+/// `dump_times`, printed once after the run.
+pub fn finish() {
+    let Some(st) = state().take() else { return };
+    let (total, seq, par, exec, clust) = match &st.sched {
+        Scheduler::Level(s) => (s.total_evaluations, s.sequential_evaluations, s.parallel_evaluations, s.execution_time, s.clustering_time),
+        Scheduler::Flow(s) => (s.total_evaluations, s.sequential_evaluations, s.parallel_evaluations, s.execution_time, s.clustering_time),
+    };
+    let avg = if par > 0 { exec / par as f64 } else { 0.0 };
+    let mut out = String::new();
+    out.push_str(&format!(" : Using {} scheduler\n", st.cfg.scheduler));
+    out.push_str(&format!(" : Nr.of threads {}\n", st.cfg.num_threads));
+    out.push_str(&format!(" : Nr.of ODE evaluations: {total}\n"));
+    out.push_str(&format!(" : Nr.of profiling ODE Evaluations: {seq}\n"));
+    out.push_str(&format!(" : Total ODE evaluation time : {}\n", g(exec)));
+    out.push_str(&format!(" : Avg. ODE evaluation time : {}\n", g(avg)));
+    out.push_str(&format!(" : Total ODE loading time: {}\n", g(st.load_time)));
+    out.push_str(&format!(" : Total ODE Clustering time: {}\n", g(clust)));
+    stdout(&out);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ParmodTask;
+
+    fn chain_info() -> ParmodInfo {
+        // 1 -> 2 -> 3, 4 alone
+        ParmodInfo {
+            tasks: vec![
+                ParmodTask { eq_index: 1, parents: vec![] },
+                ParmodTask { eq_index: 2, parents: vec![0] },
+                ParmodTask { eq_index: 3, parents: vec![1] },
+                ParmodTask { eq_index: 4, parents: vec![] },
+            ],
+        }
+    }
+
+    #[test]
+    fn levels_follow_the_longest_path() {
+        let mut s = TaskSystem::new("m", 2, &chain_info());
+        s.update_node_levels();
+        let lv: Vec<i64> = s.vertices().map(|v| s.cluster(v).level).collect();
+        assert_eq!(lv, vec![1, 2, 3, 1]);
+        assert_eq!(s.levels[1], vec![1, 4]);
+    }
+
+    #[test]
+    fn merge_common_collapses_the_chain() {
+        let mut s = TaskSystem::new("m", 2, &chain_info());
+        s.update_node_levels();
+        cluster_merge_common(&mut s);
+        let live: Vec<usize> = s.vertices().collect();
+        assert_eq!(live, vec![1, 4]);
+        assert_eq!(s.cluster(1).index_list(), "$,1,2,3");
+        assert_eq!(s.topological_order(), vec![0, 1, 4]);
+    }
+
+    #[test]
+    fn json_round_trips() {
+        let text = "{\"clusters\": [{\"eqs\": [1, 2], \"lane\": -1}], \"name\": \"m\\n\", \"x\": 1.5}";
+        let j = Json::parse(text).unwrap();
+        assert_eq!(j.get("clusters").unwrap().as_array().unwrap()[0].get("eqs").unwrap().as_array().unwrap()[1].as_i64(), Some(2));
+        let dumped = j.dump();
+        assert!(dumped.starts_with("{\n  \"clusters\": [\n    {\n      \"eqs\": [\n        1,\n        2\n      ],\n      \"lane\": -1\n    }\n  ],\n  \"name\": \"m\\n\",\n  \"x\": 1.5\n}"));
+        assert_eq!(Json::parse(&dumped).unwrap().dump(), dumped);
+    }
+
+    #[test]
+    fn stage_paths() {
+        assert_eq!(stage_snapshot_path("stages", 0, "initial"), "stages.00.initial.json");
+        assert_eq!(stage_snapshot_path("a/b.json", 12, "x"), "a/b.12.x.json");
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/simflags.rs
@@ -345,6 +345,19 @@ pub struct SimFlags {
     pub linearize_datarec: bool,
     /// `-deltaXLinearize`: C's `numericalDifferentiationDeltaXlinearize`.
     pub delta_x_linearize: Option<f64>,
+    /// `-parmodNumThreads`: C's `PM_Model_create` thread count (0 = the default).
+    pub parmod_num_threads: Option<i32>,
+    /// `-parmodScheduler`: `flow` (default) or `level`.
+    pub parmod_scheduler: Option<String>,
+    /// `-parmodClustering`: `default`, `fixed_width_min_height` or `none`.
+    pub parmod_clustering: Option<String>,
+    /// `-parmodClustersPerLevel`: the default clustering's per-level cluster cap.
+    pub parmod_clusters_per_level: Option<i32>,
+    /// `-parmodExportTaskGraph=<file>`, `-parmodImportClustering=<file>`,
+    /// `-parmodDumpStages=<prefix>`.
+    pub parmod_export_taskgraph: Option<String>,
+    pub parmod_import_clustering: Option<String>,
+    pub parmod_dump_stages: Option<String>,
     /// The `-gb*` flags, `(name, value)`; a value-less one is stored as `""`.
     /// gbode reads these by name the way C reads `omc_flagValue`, so the whole
     /// family does not have to be mirrored as struct fields.
@@ -912,6 +925,13 @@ pub fn parse<S: AsRef<str>>(argv: &[S]) -> Result<SimFlags, String> {
             "l" => f.linearize = Some(real(name, &value(name)?)?),
             "l_datarec" => f.linearize_datarec = true,
             "deltaXLinearize" => f.delta_x_linearize = Some(real(name, &value(name)?)?),
+            "parmodNumThreads" => f.parmod_num_threads = Some(int(name, &value(name)?)?),
+            "parmodScheduler" => f.parmod_scheduler = Some(value(name)?),
+            "parmodClustering" => f.parmod_clustering = Some(value(name)?),
+            "parmodClustersPerLevel" => f.parmod_clusters_per_level = Some(int(name, &value(name)?)?),
+            "parmodExportTaskGraph" => f.parmod_export_taskgraph = Some(value(name)?),
+            "parmodImportClustering" => f.parmod_import_clustering = Some(value(name)?),
+            "parmodDumpStages" => f.parmod_dump_stages = Some(value(name)?),
             // The `-gb*` family is stored by name; gbode validates the values when
             // it is built, so an unused one is still rejected (C ignores it).
             _ if name.starts_with("gb") && C_FLAGS.iter().any(|(n, _)| *n == name) => {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_driver.rs
@@ -65,6 +65,10 @@ fn write_side_file(path: &str, bytes: &[u8]) -> bool {
     openmodelica_wasi::fs::write(path, bytes).is_ok()
 }
 
+fn read_side_file(path: &str) -> Option<Vec<u8>> {
+    openmodelica_wasi::fs::read(path).ok()
+}
+
 /// C's `time(NULL)`, for the `+profiling` report's `<date>`. The same clock the
 /// store stamps files with — `std::time::SystemTime::now()` panics in the web
 /// build.
@@ -81,6 +85,10 @@ fn openmodelica_home() -> Option<String> {
 pub fn init_host_hooks() {
     set_cancel_hook(metamodelica::cancel::check_cancel);
     openmodelica_sim_meta::files::set_writer(write_side_file);
+    openmodelica_sim_meta::files::set_reader(read_side_file);
+    openmodelica_sim_meta::parmod::set_hw_threads(
+        std::thread::available_parallelism().map(|n| n.get()).unwrap_or(0),
+    );
     openmodelica_sim_meta::profiling::set_wall_clock(wall_clock_secs);
     openmodelica_sim_meta::profiling::set_home(openmodelica_home);
     openmodelica_sim_meta::driver::set_uri_resolver(uri_to_filename);


### PR DESCRIPTION
`--parmodauto` under `--simCodeTarget=wasm-jit` had no task-graph runtime: `-parmodScheduler`/`-parmodClustering` were accepted silently, and `-parmodExportTaskGraph`, `-parmodImportClustering` and `-parmodDumpStages` did nothing or were rejected as not implemented.

Port `SimulationRuntime/ParModelica/auto` to `openmodelica_sim_meta` (`parmod.rs`): the task system, `cluster_merge_common`, `cluster_merge_level_for_bins`, `cluster_fixed_width_min_height`, the flow and level schedulers with their profiling and rescheduling, the JSON export/import and the per-optimization stage dumps, plus C's stdout lines (`Number of tasks`, `S : ...`, `dump_times`).

The codegen lowers each ODE equation into its own chunk, collects them in a module-local table reached through `parmodTask(sim_data, k)`, and exports `functionLocalKnownVars`. The dependency graph (the defines/uses rules of `SerializeTaskSystemInfo` and `om_pm_model.cpp`) is computed at translate time and embedded in `SimMeta` instead of a `<model>_ode.json` side file, so the artifact stays self-contained. Reads of a dense linear system's `A`/`b` count as dependencies too; C's loader only sees a torn system's inner equations.

The runtime has one thread, so once a schedule exists the clusters are evaluated through the sequential `functionODE` (task order is always a valid schedule); the per-task path is used for profiling only. Overhead over a plain wasm-jit run is about 5% on CauerLowPassSC.

Fixes
simulation/modelica/parmodauto/Modelica.Electrical.Analog.Examples.CauerLowPassSC.mos under wasm-jit.

Assisted-by: Claude Fable 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
