### PR TITLE
wasm-jit: report inf/nan NLS iteration variables

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -2891,6 +2891,12 @@ fn newton_c(
             if dt_violated() {
                 return (false, false);
             }
+            if assert_hit() {
+                if let Some(t) = trace {
+                    crate::omclog::debug_double(crate::omclog::NLS_V, UPS, t.time);
+                }
+                return (false, false);
+            }
             let error_f2_sqrd = nsq(&fvec);
             if trace.is_some() {
                 crate::omclog::debug_double(crate::omclog::NLS_V, "Need to damp, error_f2 = ", libm::sqrt(error_f2_sqrd));
@@ -2926,6 +2932,12 @@ fn newton_c(
                 }
                 eval(&x1, &mut fvec);
                 if dt_violated() {
+                    return (false, false);
+                }
+                if assert_hit() {
+                    if let Some(t) = trace {
+                        crate::omclog::debug_double(crate::omclog::NLS_V, UPS, t.time);
+                    }
                     return (false, false);
                 }
                 if trace.is_some() {
@@ -3787,6 +3799,16 @@ pub extern "C" fn rt_solve_nls(
         // and its line search takes a nan step length, which no exit test catches.
         // Not a model throw — see [`NLS_EVAL_THREW`].
         if xs.iter().any(|v| !v.is_finite()) {
+            if let Some(i) = xs[..n.min(xs.len())].iter().position(|v| !v.is_finite()) {
+                crate::omclog::error(
+                    crate::omclog::NLS,
+                    false,
+                    &alloc::format!(
+                        "residualFunc{eq_index}: Iteration variable `{}` is inf or nan.",
+                        var_names(eq_index).get(i).map_or("", |s| s.as_str())
+                    ),
+                );
+            }
             note_eval_hit(true, false);
             for i in 0..n {
                 r[i] = ASSERT_RESIDUAL;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -348,11 +348,7 @@ pub extern "C" fn rt_sim_start(meta_ptr: u32, meta_len: u32, fn_base: u32, prese
     if openmodelica_sim_meta::omclog::active(openmodelica_sim_meta::omclog::NLS_NEWTON_DIAGNOSTICS) {
         crate::nls::set_diag(&model.nls_vars);
     }
-    crate::nls::set_var_names(if openmodelica_sim_meta::omclog::wants_nls_var_names(openmodelica_sim_meta::omclog::mask()) {
-        model.nls_vars.iter().map(|s| (s.eq_index, s.names.clone())).collect()
-    } else {
-        Vec::new()
-    });
+    crate::nls::set_var_names(model.nls_vars.iter().map(|s| (s.eq_index, s.names.clone())).collect());
 
     driver::set_clock(now_ms_hook);
     // This session runs its own start/advance/finish instead of `drive`, so the

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/omclog.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/omclog.rs
@@ -147,14 +147,6 @@ pub const FMU_STREAMS: Mask = (1 << STDOUT) | (1 << ASSERT);
 /// into the wasm runtime carries it too.
 pub const SHOW_ALL_WARNINGS: Mask = 1 << 63;
 
-/// Which streams name a nonlinear system's iteration variables, and so need the
-/// roster the model metadata carries (C reads it out of `modelDataXml` instead).
-pub fn wants_nls_var_names(m: Mask) -> bool {
-    [NLS, NLS_DERIVATIVE_TEST, NLS_SVD, NLS_SVD_V, INIT_HOMOTOPY, NLS_NEWTON_DIAGNOSTICS]
-        .iter()
-        .any(|s| mask_has(m, *s))
-}
-
 pub fn mask_has(m: Mask, s: Stream) -> bool {
     m & (1 << s) != 0
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -1062,9 +1062,7 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
     }
     // See the wasmtime counterpart.
     let diag_on = openmodelica_sim_meta::omclog::mask_has(log_mask, openmodelica_sim_meta::omclog::NLS_NEWTON_DIAGNOSTICS);
-    if openmodelica_sim_meta::omclog::wants_nls_var_names(log_mask)
-        && let Ok(set) = rt_inst.exports.get_typed_function::<(u32, u32, u32), ()>(&store, "rt_nls_set_names")
-    {
+    if let Ok(set) = rt_inst.exports.get_typed_function::<(u32, u32, u32), ()>(&store, "rt_nls_set_names") {
         let free = rt_inst.exports.get_typed_function::<u32, ()>(&store, "rt_free").ok();
         wts(set.call(&mut store, u32::MAX, 0, 0))?;
         for sys in &meta.nls_vars {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -1398,13 +1398,10 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
         let on = openmodelica_sim_meta::omclog::mask_has(log_mask, openmodelica_sim_meta::omclog::STATS_V);
         wts(set.call(&mut store, on as u32))?;
     }
-    // `-lv=LOG_NLS` names the iteration variables, which only the metadata has. The
-    // roster is per model, so it is cleared first and pushed only when the stream is
-    // on: an ordinary run carries no names.
+    // The iteration-variable names, which only the metadata has: the per-model
+    // roster is cleared, then pushed per system.
     let diag_on = openmodelica_sim_meta::omclog::mask_has(log_mask, openmodelica_sim_meta::omclog::NLS_NEWTON_DIAGNOSTICS);
-    if openmodelica_sim_meta::omclog::wants_nls_var_names(log_mask)
-        && let Ok(set) = rt_inst.get_typed_func::<(u32, u32, u32), ()>(&mut store, "rt_nls_set_names")
-    {
+    if let Ok(set) = rt_inst.get_typed_func::<(u32, u32, u32), ()>(&mut store, "rt_nls_set_names") {
         let free = rt_inst.get_typed_func::<u32, ()>(&mut store, "rt_free").ok();
         wts(set.call(&mut store, (u32::MAX, 0, 0)))?;
         for sys in &meta.nls_vars {

--- a/testsuite/partest/runtest.pl
+++ b/testsuite/partest/runtest.pl
@@ -316,7 +316,15 @@ if ( $osname eq 'MSWin32' ) {
 # Run the testscript and redirect output to a logfile.
 my $cmd = "$rtest $test > $test.test_log 2>&1";
 # print ("CMD: ", $cmd, "\n");
-system("$cmd");
+if (-e $test_suit_path_rel . "rtest") {
+  system("$cmd");
+} else {
+  open(my $out, ">", "$test.test_log");
+  print $out "No rtest at ${test_suit_path_rel}rtest (cwd " . cwd() . ").\n"
+           . "Give the test as ./path/to/$test relative to the testsuite root,\n"
+           . "and run runtest.pl from there (runtests.pl from partest/).\n";
+  close($out);
+}
 
 # Read the logfile and see if the test succeeded or failed.
 open(my $test_log, "<", "$test.test_log") or die "Couldn't open test log $test.log: $!\n";

--- a/testsuite/partest/runtests.pl
+++ b/testsuite/partest/runtests.pl
@@ -295,6 +295,7 @@ my $test_queue = Thread::Queue->new();
 my $tests_failed :shared = 0;
 my @failed_tests :shared;
 my $testscript = cwd() . "/runtest.pl";
+-f $testscript or die "runtests.pl must be started from the partest directory; no runtest.pl in " . cwd() . "\n";
 if ( $osname eq 'MSWin32' ) {
   $testscript = "perl " . $testscript;
 }
@@ -346,7 +347,17 @@ sub read_file {
   open(my $in, "<", $file) or die "Couldn't open $file: $!";
 
   while(<$in>) {
-    push @test_list, trim($_);
+    my $test = trim($_);
+    push @test_list, $test if length($test);
+  }
+}
+
+sub check_file_tests {
+  my $file = shift;
+
+  for my $test (@test_list) {
+    $test =~ m{^\./} or die "$file: '$test' should be given as ./path/to/test.mos, relative to the testsuite root\n";
+    -f $test or die "$file: '$test' not found from " . cwd() . "\n";
   }
 }
 
@@ -446,6 +457,7 @@ if (!defined($file)) {
 } else {
   read_file($file);
   chdir("..");
+  check_file_tests($file);
 }
 
 my $test_count = @test_list;


### PR DESCRIPTION
C's generated `residualFunc` guards its entry: a non-finite iteration variable prints an unconditional `LOG_NLS` error naming the first offender, poisons the residual and throws, and the per-trial catches in `newtonAlgorithm`'s damping treat that throw as a failed trial that ends the whole Newton attempt (`info = -1`).

The port's `eval` guard rejected such a trial silently and kept damping on the huge stand-in residual, so `dynamicTearing3.mos` missed the one message C prints when the cubic line search degenerates to `lambda = inf` on the strict tearing set:

- print C's `residualFunc<i>: Iteration variable ... is inf or nan.` at the guard,
- give up at the `lambda2`/cubic damping sites when the trial was rejected, as C's `if (assert)` blocks do,
- always ship the iteration-variable name roster to the runtime module (C always has it in `modelDataXml`); this drops the now unused `wants_nls_var_names` gate.

Fixes `simulation/modelica/tearing/dynamicTearing3.mos` on wasm-jit; the tearing, nonlinear_system and initialization suites pass under `--simCodeTarget=wasm-jit`.

Also make partest fail early with clear messages when invoked on the wrong form: `runtest.pl` finds rtest by counting the slashes in the test path, which only comes out right for tests named `./dir/test.mos` with the testsuite root as cwd — a `-file=` list without the `./` prefix made every test fail in milliseconds with `sh: ../../../rtest: not found` in each fail log. `runtests.pl` now dies at startup when not started from `partest/`, checks each `-file=` entry for the `./` prefix and existence (skipping empty lines), and `runtest.pl` writes the expected invocation into the test log when rtest is not at the computed path.

Assisted-by: Claude Fable 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
