### PR TITLE
Run the wasm-jit testsuite on every build

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -663,20 +663,6 @@ void assembleWeb() {
   sh "rm -f ${webZip} && (cd install_web/share/omc/web && zip -r -9 ${env.WORKSPACE}/${webZip} .)"
   archiveArtifacts artifacts: webZip, fingerprint: true
   stash name: 'web', includes: webZip
-
-  // Merge the Rust-partest partition shards into one sorted failure list,
-  // archived so regressions are easy to diff between runs. Here (not a dedicated
-  // agent) since the web deliverable is already assembled. Same guard as the
-  // testsuite-rust stages, so a missing shard is a hard error rather than the
-  // normal case of those stages not having run.
-  sh 'rm -f testsuite/partest-failed-*.txt partest-rust-failed.txt'
-  if (shouldWeRunRustTests()) {
-    for (p in [1,2]) {
-      unstash "partest-failed-${p}"
-    }
-    sh 'cat testsuite/partest-failed-*.txt | sort -u > partest-rust-failed.txt && wc -l partest-rust-failed.txt'
-    archiveArtifacts artifacts: 'partest-rust-failed.txt', allowEmptyArchive: true, fingerprint: true
-  }
 }
 
 void buildRustGUI() {
@@ -703,10 +689,11 @@ void buildRustGUI() {
   }
 }
 
-// One partest shard against the Rust-built omc (unstashed). Builds the test
-// libraries with that omc (cmake's libs-for-testing == omc index.mos); the repo's
-// index.json is copied into place first so omc uses it instead of downloading.
-void partestRust(partition) {
+// One partest shard against the Rust-built omc (unstashed) for one simCodeTarget.
+// Builds the test libraries with that omc (cmake's libs-for-testing == omc
+// index.mos); the repo's index.json is copied into place first so omc uses it
+// instead of downloading. An empty simCodeTarget leaves the compiler default.
+void partestRust(String simCodeTarget, partition, partitionmodulo) {
   standardSetup()
   unstash 'omc-cmake-rust'
   // OMSimulator + libomcruntime aren't produced by the Rust omc build; pull the
@@ -725,51 +712,44 @@ void partestRust(partition) {
     ( cd libraries && "\$PWD/../build/bin/omc" index.mos )
     build/bin/omc-diff -v1.4
   """
-  String simCodeTargetArg = params.RUST_PARTEST_SIMCODETARGET ? " -simCodeTarget=${params.RUST_PARTEST_SIMCODETARGET}" : ''
+  boolean isWasmTarget = ['wasm-jit', 'wasm'].contains(simCodeTarget)
+  String simCodeTargetArg = simCodeTarget ? " -simCodeTarget=${simCodeTarget}" : ''
+  // Properties of the Rust omc itself, so excluded for every target.
   // cpp/hpcom: the Rust omc is built without the C++ runtime. metamodelica:
   // MetaModelica code generation only works against the C runtime.
-  // cSources/fmuCSources check generated C files or FMU sources - wasm-jit does not use C
   // 63bit/antlr: the port's Integer is i32 and its parser is winnow, not ANTLR
   // stackoverflow: Rust aborts on stack overflow, MMC unwinds out of the SEGV handler
   // wasm: off everywhere else - these tests select the wasm-jit/wasm target
   // themselves, which only this build has.
-  String suitesArg = ' -suites=-cpp,-hpcom,-metamodelica,-63bit,-antlr,-cSources,-fmuCSources,-stackoverflow,+wasm'
+  String suites = '-cpp,-hpcom,-metamodelica,-63bit,-antlr,-stackoverflow,+wasm'
+  // cSources/fmuCSources inspect generated C, which a wasm target does not write.
+  if (isWasmTarget) {
+    suites += ',-cSources,-fmuCSources'
+  }
   // wasmtime reserves ~4 GiB of address space per wasm memory, and shrinking that
   // reservation to fit an RLIMIT_AS costs the bounds-check-free fast path.
-  String asLimit = params.RUST_PARTEST_SIMCODETARGET == 'wasm-jit'
-                   ? '# wasm-jit: address space is not limited, only the cgroup is'
+  String asLimit = isWasmTarget
+                   ? '# wasm: address space is not limited, only the cgroup is'
                    : 'ulimit -v 6291456 # Max 6GB per process'
   try {
     sh """#!/bin/bash
-      set -o pipefail
       ulimit -t 1500
       ${asLimit}
       .CI/scripts/cgroup-memory.sh check
-      rm -f testsuite/partest-failed-${partition}.txt
       cd testsuite/partest
       set -x
-      ./runtests.pl -j${numPhysicalCPU()} -partition=${partition}/2 -nocolour -with-xml${suitesArg}${simCodeTargetArg} 2>&1 | tee runtests-${partition}.log
-      CODE=\${PIPESTATUS[0]}
+      ./runtests.pl -j${numPhysicalCPU()} -partition=${partition}/${partitionmodulo} -nocolour -with-xml -suites=${suites}${simCodeTargetArg}
+      CODE=\$?
       set +x
       ../../.CI/scripts/cgroup-memory.sh report
       # 0/7 == the run completed (7 means some tests failed); only fail the step on
       # anything else, so junit below still publishes the per-test results.
       test \$CODE = 0 -o \$CODE = 7 || exit 1
-      # This partition's failures, from the 'Failed tests:' block (the only
-      # tab-indented lines). Parsing stdout rather than failed.<branch> avoids the
-      # die on branch names with '/'. Stashed and merged in assemble-web.
-      grep -E '^[[:space:]]+[^[:space:]].*[.]mo[fs]?\$' runtests-${partition}.log | sed -E 's/^[[:space:]]+//' | sort -u > ../partest-failed-${partition}.txt || true
-      wc -l ../partest-failed-${partition}.txt
     """
-    stash name: "partest-failed-${partition}", includes: "testsuite/partest-failed-${partition}.txt"
   } finally {
     // Per-partition result.xml; disjoint shards merge into one per-test view in
     // Jenkins. In finally so a hard shard failure still publishes what ran.
-    if (params.RUST_PARTEST_JUNIT) {
-      junit testResults: 'testsuite/partest/result.xml', allowEmptyResults: true, skipPublishingChecks: true
-    }
-    sh "cp testsuite/partest/result.xml partest-rust-partest-junit-${partition}.xml || true"
-    archiveArtifacts artifacts: "partest-rust-partest-junit-${partition}.xml", allowEmptyArchive: true, fingerprint: true
+    junit testResults: 'testsuite/partest/result.xml', allowEmptyResults: true, skipPublishingChecks: true
   }
 }
 
@@ -1026,6 +1006,7 @@ private def shouldWeEnableMacOSCMakeBuild() {
   return params.ENABLE_MACOS_CMAKE_BUILD
 }
 
+// The extra Rust-omc partest on RUST_PARTEST_SIMCODETARGET; wasm-jit always runs.
 private def shouldWeRunRustTests() {
   if (isPR()) {
     if (pullRequest.labels.contains("CI/Enable Rust Tests")) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,9 +27,8 @@ pipeline {
     booleanParam(name: 'BUILD_ENTERPRISE_LINUX', defaultValue: false, description: 'Build with Enterprise Linux')
     booleanParam(name: 'BUILD_FEDORA', defaultValue: false, description: 'Build with Fedora 44')
     booleanParam(name: 'ENABLE_MACOS_CMAKE_BUILD', defaultValue: false, description: 'Enable building omc with CMake on MacOS')
-    booleanParam(name: 'ENABLE_RUST_PARTEST', defaultValue: false, description: 'Enable running partest on the Rust target')
-    string(name: 'RUST_PARTEST_SIMCODETARGET', defaultValue: 'wasm-jit', description: 'Override simCodeTarget for the Rust partest, e.g. wasm-jit (empty = compiler default)')
-    booleanParam(name: 'RUST_PARTEST_JUNIT', defaultValue: false, description: 'Register the Rust partest result.xml as JUnit results (per-test view; makes the build unstable on failures)')
+    booleanParam(name: 'ENABLE_RUST_PARTEST', defaultValue: false, description: 'Enable the extra partest run on the Rust omc with RUST_PARTEST_SIMCODETARGET (the wasm-jit partest always runs)')
+    string(name: 'RUST_PARTEST_SIMCODETARGET', defaultValue: 'C+Rust', description: 'simCodeTarget for the ENABLE_RUST_PARTEST run (empty = compiler default)')
   }
   // stages are ordered according to execution time; highest time first
   // nodes are selected based on a priority (in Jenkins config)
@@ -315,7 +314,8 @@ pipeline {
     stage('tests + extras') {
       parallel {
         // partest against the Rust-built omc; dedicated runtest cache. See
-        // common.partestRust().
+        // common.partestRust(). Opt-in, on RUST_PARTEST_SIMCODETARGET; the
+        // wasm-jit run is stages 23/24.
         stage('01 testsuite-rust 1/2') {
           agent {
             label 'linux'
@@ -332,7 +332,7 @@ pipeline {
             script {
               common.insideTestImage('docker.openmodelica.org/build-deps:ubuntu-26.04-rust',
                                      common.testCacheMounts('runtest-rust-cache')) {
-                common.partestRust(1)
+                common.partestRust(params.RUST_PARTEST_SIMCODETARGET, 1, 2)
               }
             }
           }
@@ -353,7 +353,7 @@ pipeline {
             script {
               common.insideTestImage('docker.openmodelica.org/build-deps:ubuntu-26.04-rust',
                                      common.testCacheMounts('runtest-rust-cache')) {
-                common.partestRust(2)
+                common.partestRust(params.RUST_PARTEST_SIMCODETARGET, 2, 2)
               }
             }
           }
@@ -841,6 +841,58 @@ pipeline {
           post {
             always {
               junit testResults: 'build_cmake/junit.xml', skipPublishingChecks: true
+            }
+          }
+        }
+
+        // The wasm-jit partest, same setup as stages 01/02. Last in the block
+        // (against the ordering rule above): the fastest of the testsuite runs,
+        // so it loses the least by starting after the others.
+        stage('23 testsuite-wasm-jit 1/2') {
+          agent {
+            label 'linux'
+          }
+          environment {
+            RUNTESTDB = "/cache/runtest/"
+            LIBRARIES = "/cache/omlibrary"
+          }
+          when {
+            beforeAgent true
+            expression { shouldWeRunTests }
+          }
+          options {
+            retry(count: 2, conditions: [nonresumable()])
+          }
+          steps {
+            script {
+              common.insideTestImage('docker.openmodelica.org/build-deps:ubuntu-26.04-rust',
+                                     common.testCacheMounts('runtest-rust-cache')) {
+                common.partestRust('wasm-jit', 1, 2)
+              }
+            }
+          }
+        }
+        stage('24 testsuite-wasm-jit 2/2') {
+          agent {
+            label 'linux'
+          }
+          environment {
+            RUNTESTDB = "/cache/runtest/"
+            LIBRARIES = "/cache/omlibrary"
+          }
+          when {
+            beforeAgent true
+            expression { shouldWeRunTests }
+          }
+          options {
+            retry(count: 2, conditions: [nonresumable()])
+          }
+          steps {
+            script {
+              common.insideTestImage('docker.openmodelica.org/build-deps:ubuntu-26.04-rust',
+                                     common.testCacheMounts('runtest-rust-cache')) {
+                common.partestRust('wasm-jit', 2, 2)
+              }
             }
           }
         }


### PR DESCRIPTION
The Rust omc partest was one opt-in pair of stages whose simCodeTarget came from a parameter, defaulting to wasm-jit. Since the whole testsuite now runs under wasm-jit, make it a normal always-on lane and leave the opt-in pair for the `C+Rust` simCodeTarget that is still to come.

`partestRust` takes the target and the partition modulo as arguments instead of reading `params`, so the two lanes differ only in what they are called with:

| suite                   | wasm-jit | other targets |
| ----------------------- | -------- | ------------- |
| cSources, fmuCSources   | off      | on            |
| cpp, hpcom, metamodelica, 63bit, antlr, stackoverflow | off | off |

The last row is what the Rust omc itself cannot do, so it does not depend on the target. `ulimit -v` is likewise skipped for a wasm target rather than for a parameter value.

JUnit is now always registered, which drops the machinery that existed only because the lane was missing from the test report: the `Failed tests:` grep, the per-partition `partest-failed-N` stash, the merge of those into `partest-rust-failed.txt` in assemble-web, and the archived copy of result.xml. `RUST_PARTEST_JUNIT` goes with them.

The wasm-jit stages sit last in the parallel block rather than first: they are the fastest testsuite run now, so they lose the least by starting after the others.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
