### PR TITLE
[wasm-jit] Parallel parmodauto on worker threads

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -477,11 +477,13 @@ openmodelica_wasm_jit/src/engine_config.rs
 openmodelica_wasm_jit/src/host.rs
 openmodelica_wasm_jit/src/lib.rs
 openmodelica_wasm_jit/src/model.rs
+openmodelica_wasm_jit/src/parmod_pool.rs
 openmodelica_wasm_jit/src/sig.rs
 openmodelica_wasm_jit/src/sim_driver.rs
 openmodelica_wasm_jit/src/sim_runtime_stub.rs
 openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
 openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+openmodelica_wasm_jit/src/simmem.rs
 openmodelica_wasm_jit/src/wasi_shim.rs
 rust-toolchain.toml
 susanSources.txt

--- a/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
@@ -7448,6 +7448,7 @@ dependencies = [
  "rsparse",
  "wasm-encoder 0.252.0",
  "wasmer",
+ "wasmparser 0.252.0",
  "wasmtime",
 ]
 

--- a/OMCompiler/Compiler/OpenModelica.rs/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/Cargo.toml
@@ -79,7 +79,7 @@ wasm-encoder = "0.252"
 # or wasmer — whose `js` backend is the only one that can JIT inside a
 # browser-wasm build of omc, and which can also be selected natively
 # (`--features engine-wasmer`) to benchmark against wasmtime.
-wasmtime = { version = "45", default-features = false, features = ["std", "cranelift", "runtime", "parallel-compilation", "gc", "gc-null"] }
+wasmtime = { version = "45", default-features = false, features = ["std", "cranelift", "runtime", "parallel-compilation", "gc", "gc-null", "threads"] }
 wasmer = { version = "7.2.0-alpha.3", default-features = false, features = ["std", "wat"] }
 openmodelica_wasm_jit = {path = "openmodelica_wasm_jit"}
 openmodelica_codegen_wasm_jit = {path = "openmodelica_codegen_wasm_jit"}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -667,8 +667,9 @@ fn run_artifact(path: &std::path::Path, prefix: &str, result_file: &str, simflag
 pub fn finishCompile(fileNamePrefix: ArcStr) -> Result<()> {
     let model = sim_models().lock().unwrap_or_else(|e| e.into_inner()).get(&fileNamePrefix.to_string()).cloned();
     let Some(model) = model else { return Ok(()) };
-    // Force the runtime module (so its compile/cache-load is in `timeCompile`).
-    let _ = sim_runtime::runtime_module();
+    // Force the runtime module (so its compile/cache-load is in `timeCompile`); a
+    // `--parmodauto` run pairs with the threads one instead.
+    let _ = sim_runtime::runtime_module(openmodelica_wasm_jit::THREADS_RUNTIME && model.meta.parmod.is_some());
     // Join the background model-module compile and stash the result.
     match sim_runtime::take_compiled_model(&model) {
         Ok(m) => *model.prepared.lock().unwrap_or_else(|e| e.into_inner()) = Some(m),
@@ -2180,6 +2181,17 @@ impl RtToEnv {
 }
 impl wasm_encoder::reencode::Reencode for RtToEnv {
     type Error = core::convert::Infallible;
+    /// The kernel links against the adapter's plain memory, whatever memory the
+    /// JIT host gave the model (a `--parmodauto` model imports a shared one).
+    fn memory_type(
+        &mut self,
+        ty: wasmparser::MemoryType,
+    ) -> core::result::Result<wasm_encoder::MemoryType, wasm_encoder::reencode::Error<Self::Error>> {
+        let mut t = wasm_encoder::reencode::utils::memory_type(self, ty);
+        t.shared = false;
+        t.maximum = None;
+        Ok(t)
+    }
     /// `parse_imports`, not `parse_import`: only this one is on the section's
     /// dispatch path (`parse_import` is a convenience wrapper nothing calls).
     fn parse_imports(
@@ -5400,10 +5412,12 @@ fn build_sim_model(
 
     // --- Import section. ---
     let mut imports = we::ImportSection::new();
+    // A `--parmodauto` model runs over the threads runtime's shared memory.
+    let shared = parmod_info.is_some() && openmodelica_wasm_jit::THREADS_RUNTIME;
     imports.import(
         "rt",
         "memory",
-        we::MemoryType { minimum: 0, maximum: None, memory64: false, shared: false, page_size_log2: None },
+        we::MemoryType { minimum: 0, maximum: shared.then_some(65536), memory64: false, shared, page_size_log2: None },
     );
     for (i, (name, _, _)) in BUILTINS.iter().enumerate() {
         // Math builtins are provided in-wasm by the runtime module (via libm),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/native_fmu.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/native_fmu.rs
@@ -99,6 +99,8 @@ pub fn precompile(component: &[u8], p: &Platform) -> Result<Vec<u8>> {
     cfg.wasm_component_model(true);
     // A model with external "C" carries the `model_error` tag its call sites catch.
     cfg.wasm_exceptions(true);
+    // Off in the loader's wasmtime, on in this workspace's; see `component::engine`.
+    cfg.wasm_threads(false);
     cfg.target(p.triple).map_err(|_| "CodegenWasmJit: unknown target for the FMU platform")?;
     let engine = wasmtime::Engine::new(&cfg)
         .map_err(|_| "CodegenWasmJit: cannot configure the FMU cross-compiler")?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -331,6 +331,7 @@ pub(crate) fn env_extra_index(name: &str) -> Result<u32> {
 pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     ("rt_retain", &[WTy::I32], &[]),
     ("rt_release", &[WTy::I32], &[]),
+    ("rt_pin", &[WTy::I32], &[]),
     ("rt_str_new", &[WTy::I32], &[WTy::I32]),
     ("rt_str_len", &[WTy::I32], &[WTy::I32]),
     ("rt_str_data", &[WTy::I32], &[WTy::I32]),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
@@ -118,11 +118,12 @@ fn define_external_imports(
     memory: wasmtime::Memory,
     sig: &Sig,
 ) -> Result<()> {
+    use openmodelica_wasm_jit::simmem::SimMem;
     use openmodelica_wasm_jit::dylink_engine as dl;
     if sig.ext_imports.is_empty() {
         return Ok(());
     }
-    openmodelica_wasm_jit::host::set_sim_memory(memory);
+    openmodelica_wasm_jit::host::set_sim_memory(SimMem::Plain(memory));
     let ext_rt = dl::ExtRt {
         str_new: wt(rt_inst.get_typed_func(&mut *store, "rt_str_new"))?,
         str_data: wt(rt_inst.get_typed_func(&mut *store, "rt_str_data"))?,
@@ -149,7 +150,7 @@ fn define_external_imports(
         .ok_or_else(|| "CodegenWasmJit: runtime has no __indirect_function_table export")?;
     let host = dl::modelica_utilities_imports(&mut *store, &ext_rt);
     let engine = linker.engine().clone();
-    let loaded = dl::load(&mut *store, &engine, memory, table, &ext_rt.alloc, &libs, &host)
+    let loaded = dl::load(&mut *store, &engine, SimMem::Plain(memory), table, &ext_rt.alloc, &libs, &host)
         .map_err(|e| record_dylink_error(e))?;
     // A dlopen each, so only once a symbol needs one.
     let mut native: Option<NativeExternals> = None;
@@ -176,7 +177,7 @@ fn define_external_imports(
                 sig.notes.iter().chain(native.errors.iter()).map(|n| format!("\n  {n}")).collect::<String>()
             )));
         };
-        openmodelica_wasm_jit::sim_runtime::define_native_external(linker, s, functype, addr, memory, &ext_rt)?;
+        openmodelica_wasm_jit::sim_runtime::define_native_external(linker, s, functype, addr, SimMem::Plain(memory), &ext_rt)?;
     }
     Ok(())
 }
@@ -300,7 +301,7 @@ pub(super) fn load_and_execute(
     define_print_import(&mut linker, memory)?;
     openmodelica_wasm_jit::host::define_uri_import(
         &mut linker,
-        memory,
+        openmodelica_wasm_jit::simmem::SimMem::Plain(memory),
         wt(rt_inst.get_typed_func(&mut store, "rt_str_new"))?,
         wt(rt_inst.get_typed_func(&mut store, "rt_str_data"))?,
     )?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/shared_lits.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/shared_lits.rs
@@ -111,6 +111,8 @@ pub(crate) fn build_init_fn(
             return Err("CodegenWasmJit: shared literal is not a heap value");
         }
         ctx.emit(we::Instruction::GlobalSet(base_global + i as u32));
+        ctx.emit(we::Instruction::GlobalGet(base_global + i as u32));
+        ctx.emit(we::Instruction::Call(rt_index("rt_pin")?));
     }
     ctx.emit(we::Instruction::End);
     HOISTING.with(|h| h.set(true));

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -37,6 +37,8 @@
 // share `openmodelica_lapack` with the compiler instead of a second dense solver.
 // `global_asm!` on wasm32, for the two shadow-stack accessors below.
 #![feature(asm_experimental_arch)]
+// `#[thread_local]` statics: the shared-memory build keeps per-solve state per thread.
+#![feature(thread_local)]
 
 extern crate alloc;
 
@@ -90,13 +92,119 @@ pub fn set_nls_var_names(set: alloc::vec::Vec<(u32, alloc::vec::Vec<String>)>) {
 
 use alloc::format;
 use alloc::string::String;
-use core::alloc::{GlobalAlloc, Layout};
+use core::alloc::Layout;
 
 // dlmalloc is the global allocator on both targets so every allocation in the
 // merged module — runtime `rt_alloc`, and on wasip1 the driver's `Vec`s — shares
-// one heap. (It builds for wasip1 too.)
+// one heap. (It builds for wasip1 too.) The shared-memory (threads) build wraps
+// it in [`LockedDlmalloc`] instead: the crate's `global` feature does not lock.
+#[cfg(not(target_feature = "atomics"))]
 #[global_allocator]
 static GLOBAL: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
+#[cfg(target_feature = "atomics")]
+#[global_allocator]
+static GLOBAL: LockedDlmalloc = LockedDlmalloc(core::cell::UnsafeCell::new(dlmalloc::Dlmalloc::new()), SpinLock::new());
+
+/// The dlmalloc crate's instance API under a spinlock (its `global` feature has no
+/// wasm locking, and wasi-libc's malloc only locks once `pthread_create` has run),
+/// behind a per-thread size-class cache like `rt_alloc`'s: the runtime's helpers
+/// allocate a `Vec` or two per call, and with every thread taking one lock for
+/// each, a parallel evaluation ran no faster than a serial one.
+#[cfg(target_feature = "atomics")]
+struct LockedDlmalloc(core::cell::UnsafeCell<dlmalloc::Dlmalloc>, SpinLock);
+#[cfg(target_feature = "atomics")]
+unsafe impl Sync for LockedDlmalloc {}
+
+#[cfg(target_feature = "atomics")]
+mod rust_cache {
+    use core::alloc::Layout;
+
+    pub const MAX: usize = 16 * 1024;
+    const CLASSES: usize = MAX / 8 + 1;
+
+    struct Lists(core::cell::UnsafeCell<[usize; CLASSES]>);
+    unsafe impl Sync for Lists {}
+    #[thread_local]
+    static FREE: Lists = Lists(core::cell::UnsafeCell::new([0; CLASSES]));
+
+    /// The class of a layout the cache serves: small, 8-aligned at most, and big
+    /// enough for the link word.
+    #[inline]
+    pub fn class(layout: Layout) -> Option<usize> {
+        (layout.size() <= MAX && layout.size() >= 8 && layout.align() <= 8).then(|| (layout.size() + 7) / 8)
+    }
+    #[inline]
+    pub fn pop(class: usize) -> *mut u8 {
+        let lists = unsafe { &mut *FREE.0.get() };
+        let head = lists[class];
+        if head != 0 {
+            lists[class] = unsafe { *(head as *const usize) };
+        }
+        head as *mut u8
+    }
+    #[inline]
+    pub fn push(class: usize, ptr: *mut u8) {
+        let lists = unsafe { &mut *FREE.0.get() };
+        unsafe { *(ptr as *mut usize) = lists[class] };
+        lists[class] = ptr as usize;
+    }
+}
+
+#[cfg(target_feature = "atomics")]
+unsafe impl core::alloc::GlobalAlloc for LockedDlmalloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        stat_inc(STAT_RUST_ALLOC);
+        if let Some(class) = rust_cache::class(layout) {
+            let p = rust_cache::pop(class);
+            if !p.is_null() {
+                return p;
+            }
+            let _g = self.1.lock();
+            return unsafe { (*self.0.get()).malloc(class * 8, 8) };
+        }
+        let _g = self.1.lock();
+        unsafe { (*self.0.get()).malloc(layout.size(), layout.align()) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if let Some(class) = rust_cache::class(layout) {
+            return rust_cache::push(class, ptr);
+        }
+        let _g = self.1.lock();
+        unsafe { (*self.0.get()).free(ptr, layout.size(), layout.align()) }
+    }
+}
+
+/// A spinlock that is a no-op without `atomics`, where the runtime is single-threaded.
+pub(crate) struct SpinLock(#[cfg(target_feature = "atomics")] core::sync::atomic::AtomicBool);
+
+impl SpinLock {
+    pub(crate) const fn new() -> SpinLock {
+        SpinLock(#[cfg(target_feature = "atomics")] core::sync::atomic::AtomicBool::new(false))
+    }
+    #[inline]
+    pub(crate) fn lock(&self) -> SpinGuard<'_> {
+        #[cfg(target_feature = "atomics")]
+        loop {
+            if !self.0.swap(true, core::sync::atomic::Ordering::Acquire) {
+                break;
+            }
+            while self.0.load(core::sync::atomic::Ordering::Relaxed) {
+                core::hint::spin_loop();
+            }
+        }
+        SpinGuard(self)
+    }
+}
+
+pub(crate) struct SpinGuard<'a>(&'a SpinLock);
+
+impl Drop for SpinGuard<'_> {
+    #[inline]
+    fn drop(&mut self) {
+        #[cfg(target_feature = "atomics")]
+        self.0.0.store(false, core::sync::atomic::Ordering::Release);
+    }
+}
 
 /// Abort into a wasm trap; on the host `cargo test` build (no wasm intrinsics)
 /// this is an ordinary unreachable — the numeric paths under test never hit it.
@@ -286,6 +394,7 @@ mod ext_report_hosted {
 
     /// The model's thrower; 0 (wasm-lld's null slot) is unset, as in the `-d=gen`
     /// function JIT, which instantiates no model.
+    #[cfg_attr(target_feature = "atomics", thread_local)]
     static THROW_SLOT: AtomicU32 = AtomicU32::new(0);
 
     #[unsafe(no_mangle)]
@@ -387,10 +496,25 @@ pub const STAT_NEWTON_SINGULAR: u32 = 23;
 /// Not a diagnostic: C's `homotopySteps`, which the driver folds into the
 /// initialization success line.
 pub const STAT_HOMOTOPY_STEPS: u32 = 24;
-pub const N_STATS: usize = 25;
+/// Allocations through the Rust global allocator (the runtime's own `Vec`s etc.).
+pub const STAT_RUST_ALLOC: u32 = 25;
+pub const N_STATS: usize = 26;
 
+// Per thread in the shared-memory build (a contended line otherwise: every
+// `rt_alloc` counts); a worker adds its counts into `STATS_TOTAL` after each round.
+#[cfg_attr(target_feature = "atomics", thread_local)]
 static STATS: [core::sync::atomic::AtomicU64; N_STATS] =
     [const { core::sync::atomic::AtomicU64::new(0) }; N_STATS];
+static STATS_TOTAL: [core::sync::atomic::AtomicU64; N_STATS] =
+    [const { core::sync::atomic::AtomicU64::new(0) }; N_STATS];
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_stats_flush() {
+    for (local, total) in STATS.iter().zip(STATS_TOTAL.iter()) {
+        let n = local.swap(0, core::sync::atomic::Ordering::Relaxed);
+        total.fetch_add(n, core::sync::atomic::Ordering::Relaxed);
+    }
+}
 
 #[inline]
 pub(crate) fn stat_inc(kind: u32) {
@@ -403,9 +527,9 @@ pub(crate) fn stat_add(kind: u32, n: u64) {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_stat(kind: u32) -> u64 {
-    match STATS.get(kind as usize) {
-        Some(c) => c.load(core::sync::atomic::Ordering::Relaxed),
-        None => 0,
+    match (STATS.get(kind as usize), STATS_TOTAL.get(kind as usize)) {
+        (Some(c), Some(t)) => c.load(core::sync::atomic::Ordering::Relaxed) + t.load(core::sync::atomic::Ordering::Relaxed),
+        _ => 0,
     }
 }
 
@@ -432,13 +556,84 @@ const ALIGN: usize = 8;
 /// available and bucketing by 8-byte size class turns both into a push/pop.
 /// `rt_alloc` writes the *rounded* total into the size word, so `rt_free` finds the
 /// same class and `dlmalloc` gets the layout it was handed.
-const CACHE_MAX: usize = 1024;
+const CACHE_MAX: usize = 16 * 1024;
 const CACHE_CLASSES: usize = CACHE_MAX / ALIGN + 1;
 
 struct FreeLists(core::cell::UnsafeCell<[u32; CACHE_CLASSES]>);
-// The runtime is single-threaded (as is the in-wasm session driver).
+// Single-threaded, or per thread in the shared-memory build (a block freed on
+// another thread than it was allocated on simply changes lists).
 unsafe impl Sync for FreeLists {}
+#[cfg_attr(target_feature = "atomics", thread_local)]
 static FREE: FreeLists = FreeLists(core::cell::UnsafeCell::new([0; CACHE_CLASSES]));
+
+/// The parallel `--parmodauto` path instantiates the model module once per worker
+/// thread, over this runtime's memory. Its `start` function must run in each (it
+/// sets the instance's globals and fills its table) but may not repeat its side
+/// effects on the shared heap, so the main instantiation records every `rt_alloc`
+/// result and a worker's replays them: the same pointers land in the same globals,
+/// the bytes written are the same bytes, and `rt_nls_register` re-registers the
+/// same block. `rt_start_mode`: 0 off, 1 record, 2 replay. Only the threads build
+/// replays, and `rt_alloc` there must not pay for a mode it can never be in.
+#[cfg(target_feature = "atomics")]
+mod start_replay {
+    use core::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+
+    struct Log(core::cell::UnsafeCell<alloc::vec::Vec<u32>>);
+    unsafe impl Sync for Log {}
+    static LOG: Log = Log(core::cell::UnsafeCell::new(alloc::vec::Vec::new()));
+    static MODE: AtomicU32 = AtomicU32::new(0);
+    static CURSOR: AtomicUsize = AtomicUsize::new(0);
+
+    pub fn set_mode(mode: u32) {
+        let log = unsafe { &mut *LOG.0.get() };
+        if mode == 1 {
+            log.clear();
+        }
+        CURSOR.store(0, Ordering::Relaxed);
+        MODE.store(mode, Ordering::Relaxed);
+    }
+
+    /// The recorded pointer while replaying, else the real allocation's, recorded.
+    #[inline]
+    pub fn alloc(real: impl FnOnce() -> u32) -> u32 {
+        match MODE.load(Ordering::Relaxed) {
+            0 => real(),
+            1 => {
+                let p = real();
+                unsafe { &mut *LOG.0.get() }.push(p);
+                p
+            }
+            _ => {
+                let log = unsafe { &*LOG.0.get() };
+                let i = CURSOR.fetch_add(1, Ordering::Relaxed);
+                match log.get(i) {
+                    Some(p) => *p,
+                    None => super::trap(),
+                }
+            }
+        }
+    }
+}
+
+/// wasi-libc's thread pointer for this instance's thread, which a reactor's `_start`
+/// would have set: std's `thread_local!` reaches the pthread struct through it.
+/// Called on every instance of the threads runtime, once its TLS block exists.
+#[cfg(all(target_os = "wasi", target_feature = "atomics"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_thread_init() {
+    unsafe extern "C" {
+        fn __wasi_init_tp();
+    }
+    unsafe { __wasi_init_tp() }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_start_mode(mode: u32) {
+    #[cfg(target_feature = "atomics")]
+    start_replay::set_mode(mode);
+    #[cfg(not(target_feature = "atomics"))]
+    let _ = mode;
+}
 
 /// `None` when `total` is not cached: too big, or no room for the link word.
 #[inline]
@@ -449,8 +644,19 @@ fn cache_class(total: usize) -> Option<usize> {
 /// Allocate an object of `size` payload bytes (including its 4-byte refcount),
 /// returning its pointer. The reference count is left zero — the typed
 /// constructors below set it to 1.
+#[cfg(target_feature = "atomics")]
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_alloc(size: u32) -> u32 {
+    start_replay::alloc(|| rt_alloc_real(size))
+}
+
+#[cfg(not(target_feature = "atomics"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_alloc(size: u32) -> u32 {
+    rt_alloc_real(size)
+}
+
+fn rt_alloc_real(size: u32) -> u32 {
     stat_inc(STAT_ALLOC);
     let mut total = HEADER + size as usize;
     if total <= CACHE_MAX {
@@ -466,7 +672,7 @@ pub extern "C" fn rt_alloc(size: u32) -> u32 {
         }
     }
     let layout = Layout::from_size_align(total, ALIGN).expect("bad layout");
-    let raw = unsafe { GLOBAL.alloc(layout) } as u32;
+    let raw = unsafe { alloc::alloc::alloc(layout) } as u32;
     if raw == 0 {
         // Out of memory: trap.
         trap();
@@ -490,7 +696,57 @@ pub extern "C" fn rt_free(obj: u32) {
         return;
     }
     let layout = Layout::from_size_align(total, ALIGN).expect("bad layout");
-    unsafe { GLOBAL.dealloc(raw as *mut u8, layout) };
+    unsafe { alloc::alloc::dealloc(raw as *mut u8, layout) };
+}
+
+/// A pinned object (a module's shared literal, `rt_pin`) lives as long as the
+/// module: its count is never touched again, which also keeps every thread's use
+/// of it off one contended cache line.
+const RC_PINNED: u32 = 0x8000_0000;
+
+/// The count is an atomic in the shared-memory build: an object handed to every
+/// worker thread is retained and released concurrently.
+#[cfg(target_feature = "atomics")]
+#[inline]
+fn rc_inc(obj: u32) {
+    if unsafe { load_u32(obj) } & RC_PINNED != 0 {
+        return;
+    }
+    unsafe { &*(obj as usize as *const core::sync::atomic::AtomicU32) }.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+}
+/// The count after the decrement.
+#[cfg(target_feature = "atomics")]
+#[inline]
+fn rc_dec(obj: u32) -> u32 {
+    if unsafe { load_u32(obj) } & RC_PINNED != 0 {
+        return RC_PINNED;
+    }
+    unsafe { &*(obj as usize as *const core::sync::atomic::AtomicU32) }.fetch_sub(1, core::sync::atomic::Ordering::AcqRel) - 1
+}
+#[cfg(not(target_feature = "atomics"))]
+#[inline]
+fn rc_inc(obj: u32) {
+    let rc = unsafe { load_u32(obj) };
+    if rc & RC_PINNED == 0 {
+        unsafe { store_u32(obj, rc + 1) };
+    }
+}
+#[cfg(not(target_feature = "atomics"))]
+#[inline]
+fn rc_dec(obj: u32) -> u32 {
+    let rc = unsafe { load_u32(obj) };
+    if rc & RC_PINNED != 0 {
+        return RC_PINNED;
+    }
+    unsafe { store_u32(obj, rc - 1) };
+    rc - 1
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_pin(obj: u32) {
+    if obj != 0 {
+        unsafe { store_u32(obj, load_u32(obj) | RC_PINNED) };
+    }
 }
 
 /// Increment an object's reference count (no-op on the null handle).
@@ -499,7 +755,7 @@ pub extern "C" fn rt_retain(obj: u32) {
     if obj == 0 {
         return;
     }
-    unsafe { store_u32(obj, load_u32(obj) + 1) };
+    rc_inc(obj);
 }
 
 /// Decrement an object's reference count, freeing it at zero (no-op on null).
@@ -512,8 +768,7 @@ pub extern "C" fn rt_release(obj: u32) {
     if obj == 0 {
         return;
     }
-    let rc = unsafe { load_u32(obj) } - 1;
-    unsafe { store_u32(obj, rc) };
+    let rc = rc_dec(obj);
     if rc == 0 {
         rt_free(obj);
     }
@@ -657,6 +912,7 @@ pub extern "C" fn rt_array_dim(obj: u32, axis: i32) -> u32 {
 /// caller's load/store lands somewhere harmless.
 #[repr(align(8))]
 struct ElemDiscard([u8; 8]);
+#[cfg_attr(target_feature = "atomics", thread_local)]
 static mut ELEM_DISCARD: ElemDiscard = ElemDiscard([0; 8]);
 
 /// Byte address of the element at row-major linear position `index` (1-based).
@@ -773,8 +1029,7 @@ pub extern "C" fn rt_array_release(obj: u32) {
     if obj == 0 {
         return;
     }
-    let rc = unsafe { load_u32(obj) } - 1;
-    unsafe { store_u32(obj, rc) };
+    let rc = rc_dec(obj);
     if rc != 0 {
         return;
     }
@@ -1517,8 +1772,7 @@ pub extern "C" fn rt_record_release(obj: u32) {
     if obj == 0 {
         return;
     }
-    let rc = unsafe { load_u32(obj) } - 1;
-    unsafe { store_u32(obj, rc) };
+    let rc = rc_dec(obj);
     if rc != 0 {
         return;
     }
@@ -2795,6 +3049,7 @@ struct LsFailure {
 }
 struct LsFailures(core::cell::UnsafeCell<alloc::vec::Vec<LsFailure>>);
 unsafe impl Sync for LsFailures {}
+#[cfg_attr(target_feature = "atomics", thread_local)]
 static LS_FAILURES: LsFailures = LsFailures(core::cell::UnsafeCell::new(alloc::vec::Vec::new()));
 
 fn ls_failure_entry(eq_index: i32) -> &'static mut LsFailure {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -93,18 +93,25 @@ pub extern "C" fn rt_error_stage_addr() -> u32 {
 /// Recoverable-assert state (C's `ERROR_NONLINEARSOLVER`). While `NLS_DEPTH` > 0 a
 /// failed model `assert()` records itself in `NLS_ASSERT_HIT` and returns instead of
 /// trapping; `eval` then turns that trial into a huge residual so the solver backs off.
+// The per-solve flags below are C's `threadData` state: per thread in the shared-memory build.
+#[cfg_attr(target_feature = "atomics", thread_local)]
 static NLS_DEPTH: AtomicU32 = AtomicU32::new(0);
+#[cfg_attr(target_feature = "atomics", thread_local)]
 static NLS_ASSERT_HIT: AtomicU32 = AtomicU32::new(0);
 /// Outcome of the last *completed* evaluation, read after `eval` returns.
+#[cfg_attr(target_feature = "atomics", thread_local)]
 static NLS_EVAL_HIT: AtomicU32 = AtomicU32::new(0);
 /// C's `assertCalled`, sticky over one solver attempt.
+#[cfg_attr(target_feature = "atomics", thread_local)]
 static NLS_ASSERT_SEEN: AtomicU32 = AtomicU32::new(0);
 /// The same two, narrowed to a rejection the *model* caused. C's `residualFunc`
 /// throws on a non-finite iteration variable as the guard below rejects one, but
 /// only this target's linear algebra reaches that state (a rank-deficient Jacobian
 /// steps to inf where C's does not), so reporting the guard as a model throw prints
 /// C's assert block for solver states C never enters.
+#[cfg_attr(target_feature = "atomics", thread_local)]
 static NLS_EVAL_THREW: AtomicU32 = AtomicU32::new(0);
+#[cfg_attr(target_feature = "atomics", thread_local)]
 static NLS_THROW_SEEN: AtomicU32 = AtomicU32::new(0);
 
 /// The residual a rejected trial reports; [`newton_c`] damps its step on it.
@@ -115,6 +122,7 @@ const ASSERT_RESIDUAL: f64 = 1e60;
 /// which C's `f_con` reports by returning 1 — the emitted residual is a `void`
 /// callback, so this flag stands in for that return. [`rt_solve_nls`] clears it
 /// before each evaluation and the sites C checks the return at read it back.
+#[cfg_attr(target_feature = "atomics", thread_local)]
 static DT_VIOLATED: AtomicU32 = AtomicU32::new(0);
 
 /// Whether the last residual evaluation violated a local constraint of a casual
@@ -272,7 +280,7 @@ fn error_caught() -> bool {
 /// Model side: flag that a recoverable assert fired at the current trial point.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_nls_note_assert() {
-    note_slot().store(1, Ordering::Relaxed);
+    with_note_slot(|s| s.store(1, Ordering::Relaxed));
 }
 
 /// Model side (emitted by `emit_assert`): a failed `assert()` the solver absorbs.
@@ -296,7 +304,7 @@ pub extern "C" fn rt_nls_assert_failed(
     // after it never run. Here every frame returns and the rest carries on, so
     // report only what C's jump would have reached -- as [`throw_stream`] does.
     let report = throw_reports() && assert_logged();
-    note_slot().store(1, Ordering::Relaxed);
+    with_note_slot(|s| s.store(1, Ordering::Relaxed));
     if report {
         use openmodelica_sim_meta::TIME_OFF;
         use openmodelica_sim_meta::driver::{AssertInfo, log_assert_block};
@@ -381,8 +389,8 @@ fn rt_string(h: i32) -> alloc::string::String {
 
 /// Where [`rt_nls_note_assert`] records: the residual's own flag, or the
 /// integrator region's when the model error is not inside a residual.
-fn note_slot() -> &'static AtomicU32 {
-    if NLS_DEPTH.load(Ordering::Relaxed) > 0 { &NLS_ASSERT_HIT } else { &ERROR_STAGE[1] }
+fn with_note_slot<R>(f: impl FnOnce(&AtomicU32) -> R) -> R {
+    if NLS_DEPTH.load(Ordering::Relaxed) > 0 { f(&NLS_ASSERT_HIT) } else { f(&ERROR_STAGE[1]) }
 }
 
 /// A model error where C's generated code calls `throwStreamPrint` — an invalid
@@ -407,7 +415,7 @@ pub extern "C" fn rt_throw_stream(msg: u32) {
 
 /// Whether the next [`throw_stream`] reports, for a caller with its own message.
 pub(crate) fn throw_reports() -> bool {
-    !(error_caught() && note_slot().load(Ordering::Relaxed) != 0)
+    !(error_caught() && with_note_slot(|s| s.load(Ordering::Relaxed)) != 0)
 }
 
 pub(crate) fn throw_stream(s: &str) {
@@ -2321,6 +2329,8 @@ pub extern "C" fn rt_nls_register(k: u32, hist_addr: u32, n: u32) {
     let roster = unsafe { &mut *ROSTER.0.get() };
     roster.truncate(k as usize);
     roster.push((hist_addr, n as usize));
+    let _g = COUNTERS_LOCK.lock();
+    unsafe { &mut *COUNTERS.0.get() }.reserve(roster.len());
 }
 
 /// C's `sysNumber`: the index in `nonlinearSystemData` the homotopy messages quote
@@ -2332,12 +2342,14 @@ fn nls_sys_number(hist_addr: u32) -> u32 {
 
 /// C's `NONLINEAR_SYSTEM_DATA::numberOf{Iterations,FEval,JEval}`: per system,
 /// cumulative over the run, keyed by equation index.
-struct CountersCell(UnsafeCell<alloc::vec::Vec<(u32, [u64; 3])>>);
+struct CountersCell(UnsafeCell<alloc::vec::Vec<(u32, [core::sync::atomic::AtomicU64; 3])>>);
 unsafe impl Sync for CountersCell {}
 static COUNTERS: CountersCell = CountersCell(UnsafeCell::new(alloc::vec::Vec::new()));
+static COUNTERS_LOCK: crate::SpinLock = crate::SpinLock::new();
 
 /// Nonzero while a Jacobian is being formed: C counts `numberOfFEval` in
 /// `wrapper_fvec`, which the FD Jacobian does not go through.
+#[cfg_attr(target_feature = "atomics", thread_local)]
 static JAC_DEPTH: AtomicU32 = AtomicU32::new(0);
 
 /// C's `numberOfJEval`: `wrapper_fvec_der` counts an analytic and an FD Jacobian
@@ -2358,16 +2370,19 @@ fn sys_counts() -> [u64; 3] {
     ]
 }
 
-fn counters_of(eq_index: u32) -> &'static mut [u64; 3] {
+/// Entries never move: `rt_nls_register` reserves one per system, so a reference
+/// stays valid while another thread adds its own.
+fn counters_of(eq_index: u32) -> &'static [core::sync::atomic::AtomicU64; 3] {
+    let _g = COUNTERS_LOCK.lock();
     let v = unsafe { &mut *COUNTERS.0.get() };
     let pos = match v.iter().position(|(i, _)| *i == eq_index) {
         Some(p) => p,
         None => {
-            v.push((eq_index, [0; 3]));
+            v.push((eq_index, [const { core::sync::atomic::AtomicU64::new(0) }; 3]));
             v.len() - 1
         }
     };
-    &mut v[pos].1
+    unsafe { &*(&v[pos].1 as *const _) }
 }
 
 /// C's `modelInfoGetEquation(...).vars[i]`, keyed by `equationIndex`. Pushed in
@@ -2496,9 +2511,9 @@ fn log_nls_leave(eq_index: u32, solved: bool, x: &[f64]) {
         true,
         if solved { "Solution status: SOLVED" } else { "Solution status: FAILED" },
     );
-    omclog::info(omclog::NLS, false, &alloc::format!(" number of iterations           : {}", c[0]));
-    omclog::info(omclog::NLS, false, &alloc::format!(" number of function evaluations : {}", c[1]));
-    omclog::info(omclog::NLS, false, &alloc::format!(" number of jacobian evaluations : {}", c[2]));
+    omclog::info(omclog::NLS, false, &alloc::format!(" number of iterations           : {}", c[0].load(Ordering::Relaxed)));
+    omclog::info(omclog::NLS, false, &alloc::format!(" number of function evaluations : {}", c[1].load(Ordering::Relaxed)));
+    omclog::info(omclog::NLS, false, &alloc::format!(" number of jacobian evaluations : {}", c[2].load(Ordering::Relaxed)));
     omclog::info(omclog::NLS, false, "solution values:");
     let names = var_names(eq_index);
     for i in 0..x.len() {
@@ -4492,9 +4507,9 @@ pub extern "C" fn rt_solve_nls(
 
     if log_nls {
         let c = counters_of(eq_index);
-        c[0] += crate::rt_stat(STAT_NLS_ITER) - iter0;
-        c[1] += n_feval.get();
-        c[2] += JAC_EVALS.load(Ordering::Relaxed) - jac0;
+        c[0].fetch_add(crate::rt_stat(STAT_NLS_ITER) - iter0, Ordering::Relaxed);
+        c[1].fetch_add(n_feval.get(), Ordering::Relaxed);
+        c[2].fetch_add(JAC_EVALS.load(Ordering::Relaxed) - jac0, Ordering::Relaxed);
         log_nls_leave(eq_index, converged || strict_used, &x);
     }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/component.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/component.rs
@@ -164,6 +164,10 @@ pub fn engine() -> Result<Engine> {
     cfg.wasm_component_model(true);
     // A model with external "C" carries the `model_error` tag its call sites catch.
     cfg.wasm_exceptions(true);
+    // An exported component has a plain memory (see `RtToEnv`), and the loader's
+    // wasmtime is built without the `threads` feature — which this workspace's has
+    // on for the parmodauto pool, so it must be turned off explicitly here.
+    cfg.wasm_threads(false);
     Engine::new(&cfg).map_err(|e| trap("wasmtime engine", e))
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -406,14 +406,36 @@ pub trait SimEngine {
         out
     }
     /// C's `functionODE` under `--parmodauto`: the scheduler decides between the
-    /// sequential entry point and the per-task `parmodTask(sim_data, task)`.
+    /// sequential entry point, the per-task `parmodTask(sim_data, task)` and the
+    /// engine's worker threads.
     fn call_parmod_ode(&mut self, sim_data: u32) -> Result<()> {
-        use crate::parmod::Op;
-        crate::parmod::evaluate_ode(&mut |op| match op {
-            Op::All => self.call1_raw("functionODE", sim_data),
-            Op::LocalKnown => self.call1_if_present_raw("functionLocalKnownVars", sim_data),
-            Op::Task(k) => self.call2_raw("parmodTask", sim_data, k),
-        })
+        use crate::parmod::{Exec, Op, Plan};
+        struct E<'a, S: SimEngine + ?Sized>(&'a mut S, u32);
+        impl<S: SimEngine + ?Sized> Exec for E<'_, S> {
+            fn op(&mut self, op: Op) -> Result<()> {
+                match op {
+                    Op::All => self.0.call1_raw("functionODE", self.1),
+                    Op::LocalKnown => self.0.call1_if_present_raw("functionLocalKnownVars", self.1),
+                    Op::Task(k) => self.0.call2_raw("parmodTask", self.1, k),
+                }
+            }
+            fn can_parallel(&self) -> bool {
+                self.0.parmod_can_parallel()
+            }
+            fn parallel(&mut self, plan: &Plan) -> Result<()> {
+                self.0.parmod_parallel(plan, self.1)
+            }
+        }
+        crate::parmod::evaluate_ode(&mut E(self, sim_data))
+    }
+    /// Whether [`SimEngine::parmod_parallel`] has worker threads to run a plan on.
+    fn parmod_can_parallel(&self) -> bool {
+        false
+    }
+    /// Evaluate a `--parmodauto` plan's clusters on the worker threads (the calling
+    /// thread among them), each task via `parmodTask(sim_data, task)`.
+    fn parmod_parallel(&mut self, _plan: &crate::parmod::Plan, _sim_data: u32) -> Result<()> {
+        Err("parmodauto: this engine has no worker threads")
     }
     fn call1_if_present(&mut self, name: &str, arg: u32) -> Result<()> {
         let Some(ix) = model_fn_clock(name) else { return self.call1_if_present_raw(name, arg) };
@@ -706,13 +728,13 @@ impl StepRetry {
 }
 
 /// Must match the runtime's `N_STATS`.
-pub const RT_STATS: usize = 25;
+pub const RT_STATS: usize = 26;
 
 pub const RT_STAT_NAMES: [&str; RT_STATS] = [
     "alloc", "array_new", "record_new", "str_new", "nls_solve", "nls_res", "nls_jac", "nls_fail", "nls_retry",
     "elem_ptr", "nls_iter", "nls_newton_fail", "nls_guess_hit", "nls_accept", "nls_store_back",
     "nls_vary_start", "nls_stale", "newton_irregular", "newton_lambda", "newton_negstep",
-    "newton_maxiter", "newton_stuck", "newton_jac", "newton_singular", "homotopy_steps",
+    "newton_maxiter", "newton_stuck", "newton_jac", "newton_singular", "homotopy_steps", "rust_alloc",
 ];
 
 /// Lambda steps the runtime's locally-continued systems took, part of the same
@@ -2153,9 +2175,8 @@ fn solve_initial_system(
     }
     if !homotopy_on_first_try() {
         omclog::info(omclog::INIT_HOMOTOPY, false, "Try to solve the initialization problem without homotopy first.");
-        if direct_initial_solve(e, sim_data, layout).is_ok() {
-            solve_with_global = false;
-        } else {
+        if let Err(err) = direct_initial_solve(e, sim_data, layout) {
+            omclog::debug(omclog::INIT, false, &format!("initialization without homotopy failed: {err}"));
             omclog::warning(
                 omclog::ASSERT,
                 false,
@@ -2166,6 +2187,8 @@ fn solve_initial_system(
             init_report::reset();
             let _ = rethrow_store::take();
             seed_start_values(e, sim_data, layout, inputs, model)?;
+        } else {
+            solve_with_global = false;
         }
     }
     if !solve_with_global {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/parmod.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/parmod.rs
@@ -1,8 +1,10 @@
 //! C's `ParModelica/auto` runtime (`--parmodauto`): the ODE task graph, its
 //! clustering passes, the two schedulers and the JSON export/import, ported from
 //! `SimulationRuntime/ParModelica/auto/pm_*.hpp`. The graph, costs, clusters and
-//! files are the C ones; the clusters are evaluated in dependency order on the
-//! runtime's single thread, where C hands them to a TBB thread pool.
+//! files are the C ones. Where C hands the clusters to a TBB thread pool, the
+//! scheduler hands a [`Plan`] to the engine's [`Exec::parallel`]; an engine without
+//! worker threads evaluates the sequential `functionODE` instead, the natural
+//! order being a valid schedule.
 
 use alloc::collections::BTreeSet;
 use alloc::format;
@@ -276,7 +278,7 @@ impl TaskSystem {
         for i in 0..n {
             let id = self.cluster(v).tasks[i].task_id;
             let t0 = now_ms_host();
-            call(Op::Task(id))?;
+            call.op(Op::Task(id))?;
             let elapsed = now_ms_host() - t0;
             self.cluster_mut(v).tasks[i].cost = elapsed;
             total += elapsed;
@@ -289,11 +291,44 @@ impl TaskSystem {
     /// (every edge points forward), and with one thread nothing is gained from the
     /// clustered order, so this is the sequential entry point in one call.
     fn execute_all(&self, call: Call) -> Result<()> {
-        call(Op::All)
+        call.op(Op::All)
+    }
+
+    /// One evaluation through the engine's worker threads when it has them
+    /// (`functionLocalKnownVars` first, as the sequential entry point runs it), else
+    /// [`TaskSystem::execute_all`].
+    fn execute_plan(&self, plan: &Plan, call: Call) -> Result<()> {
+        if !call.can_parallel() {
+            return self.execute_all(call);
+        }
+        call.op(Op::LocalKnown)?;
+        call.parallel(plan)
+    }
+
+    /// The clustered graph as the engine evaluates it: clusters in topological
+    /// order, each with the clusters it waits for; `levels` too when asked (the
+    /// level scheduler's barrier-synchronous order).
+    fn plan(&mut self, with_levels: bool) -> Plan {
+        self.ensure_levels();
+        let order: Vec<usize> = self.topological_order().into_iter().filter(|&v| v != ROOT).collect();
+        let mut index = vec![u32::MAX; self.nodes.len()];
+        for (i, &v) in order.iter().enumerate() {
+            index[v] = i as u32;
+        }
+        let clusters = order.iter().map(|&v| self.cluster(v).tasks.iter().map(|t| t.task_id).collect()).collect();
+        let parents = order
+            .iter()
+            .map(|&v| self.parents[v].iter().filter(|&&p| p != ROOT).map(|&p| index[p]).collect())
+            .collect();
+        let levels = match with_levels {
+            true => self.levels[1..].iter().map(|l| l.iter().map(|&v| index[v]).collect()).collect(),
+            false => Vec::new(),
+        };
+        Plan { id: PLAN_IDS.fetch_add(1, Ordering::Relaxed) as u64, clusters, parents, levels }
     }
 
     fn profile_all(&mut self, call: Call) -> Result<()> {
-        call(Op::LocalKnown)?;
+        call.op(Op::LocalKnown)?;
         let vs: Vec<usize> = self.vertices().collect();
         for v in vs {
             self.profile_execute(v, call)?;
@@ -1004,13 +1039,42 @@ pub enum Op {
     Task(u32),
 }
 
-type Call<'a> = &'a mut dyn FnMut(Op) -> Result<()>;
+/// One evaluation's clusters: `clusters[i]` is its tasks in order, `parents[i]` the
+/// clusters it waits for (indices into `clusters`, all smaller), and `levels` —
+/// filled by the level scheduler only — the level-synchronous order, every cluster
+/// of a level independent of the others.
+pub struct Plan {
+    /// Distinct per plan built, so an executor can cache what it derives from one.
+    pub id: u64,
+    pub clusters: Vec<Vec<u32>>,
+    pub parents: Vec<Vec<u32>>,
+    pub levels: Vec<Vec<u32>>,
+}
+
+static PLAN_IDS: AtomicUsize = AtomicUsize::new(1);
+
+/// What the scheduler drives: the model's entry points one at a time, and the
+/// engine's worker threads when it has them.
+pub trait Exec {
+    fn op(&mut self, op: Op) -> Result<()>;
+    fn can_parallel(&self) -> bool {
+        false
+    }
+    /// Evaluate every cluster of `plan`, respecting `parents` (or, level by level,
+    /// `levels` when present), on the worker threads plus the calling one.
+    fn parallel(&mut self, _plan: &Plan) -> Result<()> {
+        Err("parmodauto: this engine has no worker threads")
+    }
+}
+
+type Call<'a> = &'a mut dyn Exec;
 
 /// `StepLevels`: level-synchronous; re-profiles and re-clusters when the
 /// evaluation time drifts by more than half.
 struct LevelScheduler {
     org: TaskSystem,
     sys: TaskSystem,
+    plan: Option<Plan>,
     schedule_available: bool,
     total_evaluations: u32,
     parallel_evaluations: u32,
@@ -1028,6 +1092,7 @@ impl LevelScheduler {
         LevelScheduler {
             org: sys.clone(),
             sys,
+            plan: None,
             schedule_available: false,
             total_evaluations: 0,
             parallel_evaluations: 0,
@@ -1059,7 +1124,10 @@ impl LevelScheduler {
             return Ok(());
         }
         let t0 = now_ms_host();
-        self.sys.execute_all(call)?;
+        match &self.plan {
+            Some(plan) => self.sys.execute_plan(plan, call)?,
+            None => self.sys.execute_all(call)?,
+        }
         let step_cost = now_ms_host() - t0;
         self.execution_time += step_cost;
         self.total_evaluations += 1;
@@ -1108,6 +1176,7 @@ impl LevelScheduler {
             self.sys.sort_decreasing(&mut level);
             self.sys.levels[l] = level;
         }
+        self.plan = Some(self.sys.plan(true));
         self.clustering_time += now_ms_host() - t0;
         Ok(())
     }
@@ -1116,6 +1185,7 @@ impl LevelScheduler {
 /// `ClusterDynamicScheduler`: clusters as a dependency graph, scheduled once.
 struct FlowScheduler {
     sys: TaskSystem,
+    plan: Option<Plan>,
     flow_graph_created: bool,
     total_evaluations: u32,
     parallel_evaluations: u32,
@@ -1128,6 +1198,7 @@ impl FlowScheduler {
     fn new(sys: TaskSystem) -> FlowScheduler {
         FlowScheduler {
             sys,
+            plan: None,
             flow_graph_created: false,
             total_evaluations: 0,
             parallel_evaluations: 0,
@@ -1142,7 +1213,10 @@ impl FlowScheduler {
             self.schedule(cfg, call)?;
         }
         let t0 = now_ms_host();
-        self.sys.execute_all(call)?;
+        match &self.plan {
+            Some(plan) => self.sys.execute_plan(plan, call)?,
+            None => self.sys.execute_all(call)?,
+        }
         self.execution_time += now_ms_host() - t0;
         self.total_evaluations += 1;
         self.parallel_evaluations += 1;
@@ -1183,6 +1257,7 @@ impl FlowScheduler {
             collect_clusters_json(&self.sys, &mut graph_dump);
             write_json_file(path, &graph_dump, "task graph")?;
         }
+        self.plan = Some(self.sys.plan(false));
         self.flow_graph_created = true;
         self.clustering_time += now_ms_host() - t0;
         Ok(())
@@ -1207,6 +1282,12 @@ static STATE: Store = Store(UnsafeCell::new(None));
 // The driver is single-threaded per run (as is the in-wasm session).
 fn state() -> &'static mut Option<State> {
     unsafe { &mut *STATE.0.get() }
+}
+
+/// The run's `-parmodNumThreads` (C's `max_num_threads`), which an engine's worker
+/// pool is sized from before the task system exists.
+pub fn num_threads() -> usize {
+    Config::from_flags().num_threads
 }
 
 /// `PM_Model_create` + `PM_Model_load_ODE_system`, for a model translated with

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/Cargo.toml
@@ -36,6 +36,10 @@ wasmtime = { workspace = true, optional = true }
 wasmer = { workspace = true, features = ["sys", "cranelift"], optional = true }
 # getrlimit(RLIMIT_AS) for engine_config.
 libc.workspace = true
+# Re-typing a dylink library's memory import as shared for the parmodauto runtime;
+# the `wasmparser` feature is what gives wasm-encoder its `reencode` module.
+wasmparser = "0.252"
+wasm-encoder = { workspace = true, features = ["wasmparser"] }
 # Native external "C" calls from the wasmtime sim host (libffi trampolines) and
 # our arena-backed ModelicaAllocateString.
 libffi.workspace = true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
@@ -99,6 +99,7 @@ fn main() {
         s.spawn(|| {
             build_wasip1_interactive_runtime(&crate_dir, &runtime_dir, &out_dir, &hash, sundials_dir)
         });
+        s.spawn(|| build_wasip1_threads_runtime(&runtime_dir, &out_dir, &hash, sundials_dir));
         s.spawn(|| build_external_c_wasm(&crate_dir, &out_dir));
         s.spawn(|| build_fmi3_me_adapter(&crate_dir, &out_dir));
         s.spawn(|| build_native_fmu_loaders(&crate_dir, &out_dir));
@@ -1057,6 +1058,73 @@ fn build_wasip1_interactive_runtime(
     }
 }
 
+/// The `wasm32-wasip1-threads` interactive runtime: the same crate over a *shared*
+/// linear memory, which the parallel `--parmodauto` path instantiates once per
+/// worker thread (one wasmtime store each, one memory). Native wasmtime only: the
+/// wasmer and web hosts keep the plain runtime, and a model translated with
+/// `--parmodauto` there imports an unshared memory.
+fn build_wasip1_threads_runtime(runtime_dir: &Path, out_dir: &Path, hash: &str, sundials_dir: Option<&Path>) {
+    let dest = out_dir.join("runtime_wasip1_threads.wasm");
+    let stamp = out_dir.join("runtime_wasip1_threads.wasm.hash");
+    println!("cargo::rustc-check-cfg=cfg(sim_threads_runtime)");
+    let native = std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() != Ok("wasm32");
+    let wasmer = std::env::var("CARGO_FEATURE_ENGINE_WASMER").is_ok();
+    if !native || wasmer {
+        std::fs::write(&dest, []).ok();
+        return;
+    }
+    println!("cargo:rustc-cfg=sim_threads_runtime");
+    println!("cargo:rerun-if-env-changed=OMC_WASM_RUNTIME_WASIP1_THREADS");
+    if let Ok(path) = std::env::var("OMC_WASM_RUNTIME_WASIP1_THREADS") {
+        copy(Path::new(&path), &dest);
+        std::fs::write(&stamp, format!("override:{path}")).ok();
+        return;
+    }
+    let mut features = "host_lin_solve,host_log".to_string();
+    if has_primme(sundials_dir) {
+        features.push_str(",primme");
+    }
+    let stamp_val = format!("{hash}:{features}:{}", THREADS_LINK_ARGS.join(" "));
+    if dest.exists() && std::fs::read_to_string(&stamp).ok().as_deref() == Some(stamp_val.as_str()) {
+        return;
+    }
+    match build_runtime_wasm_flags(
+        runtime_dir,
+        out_dir,
+        "wasm32-wasip1-threads",
+        "openmodelica_codegen_wasm_jit_runtime",
+        "runtime-threads-target",
+        &["--no-default-features", "--features", &features],
+        sundials_dir,
+        THREADS_LINK_ARGS,
+    ) {
+        Ok(produced) => {
+            copy(&produced, &dest);
+            std::fs::write(&stamp, &stamp_val).expect("write runtime_wasip1_threads.wasm.hash");
+        }
+        Err(e) => panic!(
+            "failed to build the wasip1-threads interactive runtime: {e}\n\
+             Install the target with `rustup target add wasm32-wasip1-threads`, or set \
+             OMC_WASM_RUNTIME_WASIP1_THREADS=/path/to/runtime_wasip1_threads.wasm."
+        ),
+    }
+}
+
+/// Beyond the target's own `--import-memory --shared-memory`: the table the model
+/// shares, what a worker instance needs to get its own stack and TLS block, and a
+/// stack matching the workers' `STACK_BYTES` (a deep solve overran the 1 MiB default).
+const THREADS_LINK_ARGS: &[&str] = &[
+    "-Clink-arg=--max-memory=4294967296",
+    "-Clink-arg=-zstack-size=8388608",
+    "-Clink-arg=--export-table",
+    "-Clink-arg=--growable-table",
+    "-Clink-arg=--export=__stack_pointer",
+    "-Clink-arg=--export=__tls_base",
+    "-Clink-arg=--export=__tls_size",
+    "-Clink-arg=--export=__tls_align",
+    "-Clink-arg=--export=__wasm_init_tls",
+];
+
 fn build_runtime_wasm(runtime_dir: &Path, out_dir: &Path, target: &str) -> Result<PathBuf, String> {
     build_runtime_wasm_named(
         runtime_dir,
@@ -1084,6 +1152,21 @@ fn build_runtime_wasm_named(
     extra_args: &[&str],
     sundials_dir: Option<&Path>,
 ) -> Result<PathBuf, String> {
+    build_runtime_wasm_flags(crate_dir, out_dir, target, artifact, target_dir_prefix, extra_args, sundials_dir, &[])
+}
+
+/// [`build_runtime_wasm_named`] with `rustflags` replacing the scrubbed host ones.
+#[allow(clippy::too_many_arguments)]
+fn build_runtime_wasm_flags(
+    crate_dir: &Path,
+    out_dir: &Path,
+    target: &str,
+    artifact: &str,
+    target_dir_prefix: &str,
+    extra_args: &[&str],
+    sundials_dir: Option<&Path>,
+    rustflags: &[&str],
+) -> Result<PathBuf, String> {
     let target_dir = out_dir.join(format!("{target_dir_prefix}-{target}"));
     let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
     let mut cmd = Command::new(cargo);
@@ -1097,6 +1180,9 @@ fn build_runtime_wasm_named(
         .env_remove("CARGO_ENCODED_RUSTFLAGS")
         .env_remove("CARGO_BUILD_RUSTFLAGS")
         .env_remove("RUSTC_WORKSPACE_WRAPPER");
+    if !rustflags.is_empty() {
+        cmd.env("CARGO_ENCODED_RUSTFLAGS", rustflags.join("\x1f"));
+    }
     match sundials_dir {
         Some(d) => { cmd.env("OMC_SUNDIALS_WASM_DIR", d); }
         // Cargo's env is inherited; clear a stale outer setting so the nested build

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/dylink_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/dylink_wasmtime.rs
@@ -8,7 +8,8 @@
 
 use std::collections::HashMap;
 
-use wasmtime::{Caller, Extern, Func, FuncType, Global, GlobalType, Memory, Mutability, Ref, Table, Val, ValType};
+use crate::simmem::SimMem;
+use wasmtime::{Caller, Extern, Func, FuncType, Global, GlobalType, Mutability, Ref, Table, Val, ValType};
 
 use crate::dylink::{self, Dylink, SIDE_STACK_SIZE};
 use openmodelica_wasi::wasi::WasiCtx;
@@ -99,7 +100,7 @@ fn alloc_aligned(
 pub fn load(
     store: &mut wasmtime::Store<WasiCtx>,
     engine: &wasmtime::Engine,
-    memory: Memory,
+    memory: SimMem,
     table: Table,
     rt_alloc: &wasmtime::TypedFunc<u32, u32>,
     libs: &[Library],
@@ -117,7 +118,7 @@ pub fn load(
     }
     // A library imports the memory rather than exporting one, so the WASI shim
     // cannot find it through the caller.
-    crate::host::set_sim_memory(memory);
+    crate::host::set_sim_memory(memory.clone());
 
     // `libc.so` asks for the stack bounds by name (weak `GOT.mem` imports a main
     // module would define), so they are seeded as data symbols.
@@ -151,7 +152,11 @@ pub fn load(
     let mut modules = Vec::with_capacity(libs.len());
     let mut defined: std::collections::HashSet<String> = std::collections::HashSet::new();
     for lib in libs {
-        let module = crate::sim_runtime::library_module(engine, &lib.name, &lib.bytes, lib.fixed)
+        let bytes = match memory.is_shared() {
+            true => std::borrow::Cow::Owned(crate::simmem::retype_memory_shared(&lib.bytes)?),
+            false => std::borrow::Cow::Borrowed(&lib.bytes),
+        };
+        let module = crate::sim_runtime::library_module(engine, &lib.name, &bytes, lib.fixed)
             .map_err(|e| format!("external \"C\" library `{}` is not valid wasm: {e}", lib.name))?;
         defined.extend(module.exports().filter(|e| e.ty().func().is_some()).map(|e| e.name().to_string()));
         modules.push(module);
@@ -173,7 +178,7 @@ pub fn load(
             module,
             &lib.name,
             &dl,
-            memory,
+            memory.clone(),
             table,
             rt_alloc,
             &stack_pointer,
@@ -228,7 +233,7 @@ pub fn load(
                 .map_err(|e| format!("external \"C\" library `{}` failed to initialise: {e}", lib.name))?;
         }
     }
-    set_guest_cwd(store, rt_alloc, memory, &loaded)?;
+    set_guest_cwd(store, rt_alloc, memory.clone(), &loaded)?;
     unbuffer_stdout(store, &loaded)?;
     Ok(loaded)
 }
@@ -239,7 +244,7 @@ pub fn load(
 fn set_guest_cwd(
     store: &mut wasmtime::Store<WasiCtx>,
     rt_alloc: &wasmtime::TypedFunc<u32, u32>,
-    memory: Memory,
+    memory: SimMem,
     loaded: &Loaded,
 ) -> Result<()> {
     let (Some(&slot), Ok(cwd)) = (loaded.data.get("__wasilibc_cwd"), openmodelica_wasi::fs::cwd()) else {
@@ -322,7 +327,7 @@ fn place(
     module: &wasmtime::Module,
     lib_name: &str,
     dl: &Dylink,
-    memory: Memory,
+    memory: SimMem,
     table: Table,
     rt_alloc: &wasmtime::TypedFunc<u32, u32>,
     stack_pointer: &Global,
@@ -346,7 +351,7 @@ fn place(
     let mut imports: Vec<Extern> = Vec::new();
     for imp in module.imports() {
         let ext = match (imp.module(), imp.name()) {
-            ("env", "memory") => Extern::Memory(memory),
+            ("env", "memory") => memory.to_extern(),
             ("env", "__indirect_function_table") => Extern::Table(table),
             ("env", "__stack_pointer") => Extern::Global(*stack_pointer),
             ("env", "__memory_base") => Extern::Global(const_i32(store, memory_base)?),
@@ -542,12 +547,12 @@ mod tests {
             return;
         };
         let (mut store, engine, rt_inst) = runtime();
-        let memory = rt_inst.get_memory(&mut store, "memory").unwrap();
+        let memory = SimMem::Plain(rt_inst.get_memory(&mut store, "memory").unwrap());
         let table = rt_inst.get_table(&mut store, "__indirect_function_table").unwrap();
         let alloc = rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc").unwrap();
 
         let Some(libs) = with_libc("scalar.wasm", bytes) else { return };
-        let loaded = load(&mut store, &engine, memory, table, &alloc, &libs, &HashMap::new()).unwrap();
+        let loaded = load(&mut store, &engine, memory.clone(), table, &alloc, &libs, &HashMap::new()).unwrap();
         let f = loaded.func("triple").expect("the library exports `triple`").clone();
         let f = f.typed::<f64, f64>(&store).unwrap();
         assert_eq!(f.call(&mut store, 5.0).unwrap(), 15.0);
@@ -566,12 +571,12 @@ mod tests {
             return;
         };
         let (mut store, engine, rt_inst) = runtime();
-        let memory = rt_inst.get_memory(&mut store, "memory").unwrap();
+        let memory = SimMem::Plain(rt_inst.get_memory(&mut store, "memory").unwrap());
         let table = rt_inst.get_table(&mut store, "__indirect_function_table").unwrap();
         let alloc = rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc").unwrap();
 
         let Some(libs) = with_libc("data.wasm", bytes) else { return };
-        let loaded = load(&mut store, &engine, memory, table, &alloc, &libs, &HashMap::new()).unwrap();
+        let loaded = load(&mut store, &engine, memory.clone(), table, &alloc, &libs, &HashMap::new()).unwrap();
         let pick = loaded.func("pick").unwrap().clone().typed::<i32, f64>(&store).unwrap();
         assert_eq!(pick.call(&mut store, 1).unwrap(), 2.5);
 
@@ -594,12 +599,12 @@ mod tests {
             return;
         };
         let (mut store, engine, rt_inst) = runtime();
-        let memory = rt_inst.get_memory(&mut store, "memory").unwrap();
+        let memory = SimMem::Plain(rt_inst.get_memory(&mut store, "memory").unwrap());
         let table = rt_inst.get_table(&mut store, "__indirect_function_table").unwrap();
         let alloc = rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc").unwrap();
 
         let Some(libs) = with_libc("uselibc.wasm", bytes) else { return };
-        let loaded = load(&mut store, &engine, memory, table, &alloc, &libs, &HashMap::new()).unwrap();
+        let loaded = load(&mut store, &engine, memory.clone(), table, &alloc, &libs, &HashMap::new()).unwrap();
 
         // A NUL-terminated string in the shared memory, as `Str` marshalling does.
         let cell = alloc.call(&mut store, 6).unwrap();
@@ -617,10 +622,10 @@ mod tests {
         };
         let Some(libs) = with_libc("bind.wasm", bytes) else { return };
         let (mut store, engine, rt_inst) = runtime();
-        let memory = rt_inst.get_memory(&mut store, "memory").unwrap();
+        let memory = SimMem::Plain(rt_inst.get_memory(&mut store, "memory").unwrap());
         let table = rt_inst.get_table(&mut store, "__indirect_function_table").unwrap();
         let alloc = rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc").unwrap();
-        let loaded = load(&mut store, &engine, memory, table, &alloc, &libs, &HashMap::new()).unwrap();
+        let loaded = load(&mut store, &engine, memory.clone(), table, &alloc, &libs, &HashMap::new()).unwrap();
 
         let rt = ExtRt {
             str_new: rt_inst.get_typed_func(&mut store, "rt_str_new").unwrap(),
@@ -686,10 +691,10 @@ mod tests {
         };
         let Some(libs) = with_libc("outptr.wasm", bytes) else { return };
         let (mut store, engine, rt_inst) = runtime();
-        let memory = rt_inst.get_memory(&mut store, "memory").unwrap();
+        let memory = SimMem::Plain(rt_inst.get_memory(&mut store, "memory").unwrap());
         let table = rt_inst.get_table(&mut store, "__indirect_function_table").unwrap();
         let alloc = rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc").unwrap();
-        let loaded = load(&mut store, &engine, memory, table, &alloc, &libs, &HashMap::new()).unwrap();
+        let loaded = load(&mut store, &engine, memory.clone(), table, &alloc, &libs, &HashMap::new()).unwrap();
 
         let ints = SigTy::Array { elem: std::sync::Arc::new(SigTy::Int), rank: 1 };
         let xorshift = ExtCallSig {
@@ -764,11 +769,11 @@ mod tests {
             return;
         }
         let (mut store, engine, rt_inst) = runtime();
-        let memory = rt_inst.get_memory(&mut store, "memory").unwrap();
+        let memory = SimMem::Plain(rt_inst.get_memory(&mut store, "memory").unwrap());
         let table = rt_inst.get_table(&mut store, "__indirect_function_table").unwrap();
         let alloc = rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc").unwrap();
         let libs = [Library::model("obj.o", std::fs::read(&o).unwrap())];
-        let err = match load(&mut store, &engine, memory, table, &alloc, &libs, &HashMap::new()) {
+        let err = match load(&mut store, &engine, memory.clone(), table, &alloc, &libs, &HashMap::new()) {
             Err(e) => e,
             Ok(_) => panic!("an object file was accepted as a library"),
         };
@@ -783,7 +788,7 @@ pub fn load_ext_libraries(
     store: &mut wasmtime::Store<WasiCtx>,
     engine: &wasmtime::Engine,
     rt_inst: wasmtime::Instance,
-    memory: wasmtime::Memory,
+    memory: SimMem,
     model: &SimModel,
     rt: &ExtRt,
 ) -> std::result::Result<Loaded, String> {
@@ -792,7 +797,7 @@ pub fn load_ext_libraries(
         .get_table(&mut *store, "__indirect_function_table")
         .ok_or_else(|| "CodegenWasmJit: runtime has no __indirect_function_table export".to_string())?;
     if model.ext_libs.is_empty() && !model.ext_builtin {
-        return load(store, engine, memory, table, &rt.alloc, &[], &HashMap::new());
+        return load(store, engine, memory.clone(), table, &rt.alloc, &[], &HashMap::new());
     }
     let libc = openmodelica_wasi_libc::LIBC_PIC;
     if libc.is_empty() {
@@ -817,7 +822,7 @@ pub fn load_ext_libraries(
         }
     }
     let host = modelica_utilities_imports(store, rt);
-    load(store, engine, memory, table, &rt.alloc, &libs, &host)
+    load(store, engine, memory.clone(), table, &rt.alloc, &libs, &host)
 }
 
 fn shared_cstr(caller: &mut wasmtime::Caller<'_, WasiCtx>, ptr: i32) -> String {
@@ -1123,8 +1128,8 @@ fn call_external_in_wasm(
                     let handle = v.map(|v| v.unwrap_i32()).unwrap_or(0) as u32;
                     let (off, leaf) = record_leaf(fields);
                     call_args.push(match leaf {
-                        SigTy::Real => Val::F64(read_u64(memory, caller, handle + off)),
-                        _ => Val::I32(read_u32(memory, caller, handle + off) as i32),
+                        SigTy::Real => Val::F64(read_u64(memory.clone(), caller, handle + off)),
+                        _ => Val::I32(read_u32(memory.clone(), caller, handle + off) as i32),
                     });
                     let _ = s;
                 }
@@ -1133,7 +1138,7 @@ fn call_external_in_wasm(
                     let cell = alloc(caller, c.size.max(1))?;
                     memory.data_mut(&mut *caller)[cell as usize..cell as usize + c.size as usize].fill(0);
                     if let Some(v) = v {
-                        record_to_c(caller, memory, rt, fields, v.unwrap_i32() as u32, cell, &mut temps)?;
+                        record_to_c(caller, memory.clone(), rt, fields, v.unwrap_i32() as u32, cell, &mut temps)?;
                     }
                     temps.push(cell);
                     if *is_out {
@@ -1202,8 +1207,8 @@ fn call_external_in_wasm(
                     let vec_cell = alloc(caller, (n * 4).max(1) as u32)?;
                     temps.push(vec_cell);
                     for k in 0..n {
-                        let h = read_u32(memory, caller, base + (k * 4) as u32);
-                        let len = if h == 0 { 0 } else { read_u32(memory, caller, h + 4) as usize };
+                        let h = read_u32(memory.clone(), caller, base + (k * 4) as u32);
+                        let len = if h == 0 { 0 } else { read_u32(memory.clone(), caller, h + 4) as usize };
                         let cell = alloc(caller, (len + 1) as u32)?;
                         temps.push(cell);
                         let mem = memory.data_mut(&mut *caller);
@@ -1272,8 +1277,8 @@ fn call_external_in_wasm(
     // at our own input copy.
     for (vec_cell, base, n) in &str_out_arrays {
         for k in 0..*n {
-            let ptr = read_u32(memory, caller, vec_cell + (k * 4) as u32) as usize;
-            let len = str_len(memory, caller, ptr)?;
+            let ptr = read_u32(memory.clone(), caller, vec_cell + (k * 4) as u32) as usize;
+            let len = str_len(memory.clone(), caller, ptr)?;
             let handle = rt.str_new.call(&mut *caller, len as u32).map_err(|e| format!("{e}"))?;
             let dst = rt.str_data.call(&mut *caller, handle).map_err(|e| format!("{e}"))? as usize;
             let slot = *base as usize + k * 4;
@@ -1295,13 +1300,13 @@ fn call_external_in_wasm(
         match (ret_ty, abi_of(ret_ty)) {
 
             (SigTy::Record { fields, .. }, Abi::Indirect | Abi::Dropped) => {
-                let handle = record_from_c(caller, memory, rt, fields, sret.unwrap_or(0))?;
+                let handle = record_from_c(caller, memory.clone(), rt, fields, sret.unwrap_or(0))?;
                 result.push(Val::I32(handle as i32));
             }
 
             (SigTy::Record { fields, .. }, Abi::Scalar(leaf)) => {
                 let (off, _) = record_leaf(fields);
-                let handle = record_from_scalar(caller, memory, rt, fields, off, &leaf, &raw_ret[0])?;
+                let handle = record_from_scalar(caller, memory.clone(), rt, fields, off, &leaf, &raw_ret[0])?;
                 result.push(Val::I32(handle as i32));
             }
             _ => {
@@ -1313,19 +1318,19 @@ fn call_external_in_wasm(
                         b
                     }
                 };
-                result.push(ext_result(ret_ty, raw, rt, caller, memory)?);
+                result.push(ext_result(ret_ty, raw, rt, caller, memory.clone())?);
             }
         }
     }
     for (ty, cell) in &out_cells {
         if let SigTy::Record { fields, .. } = ty {
-            let handle = record_from_c(caller, memory, rt, fields, *cell)?;
+            let handle = record_from_c(caller, memory.clone(), rt, fields, *cell)?;
             result.push(Val::I32(handle as i32));
             continue;
         }
         let mut raw = [0u8; 8];
         raw.copy_from_slice(&memory.data(&*caller)[*cell as usize..*cell as usize + 8]);
-        result.push(ext_result(ty, raw, rt, caller, memory)?);
+        result.push(ext_result(ty, raw, rt, caller, memory.clone())?);
     }
     for (slot, v) in rets.iter_mut().zip(result) {
         *slot = v;
@@ -1344,7 +1349,7 @@ fn ext_result(
     raw: [u8; 8],
     rt: &ExtRt,
     caller: &mut wasmtime::Caller<'_, WasiCtx>,
-    memory: wasmtime::Memory,
+    memory: SimMem,
 ) -> Result<wasmtime::Val> {
     use crate::sig::SigTy;
     use wasmtime::Val;
@@ -1353,7 +1358,7 @@ fn ext_result(
         SigTy::Int | SigTy::Bool | SigTy::Ptr => Val::I32(i32::from_le_bytes(raw[..4].try_into().unwrap())),
         SigTy::Str => {
             let ptr = u32::from_le_bytes(raw[..4].try_into().unwrap()) as usize;
-            let len = str_len(memory, caller, ptr)?;
+            let len = str_len(memory.clone(), caller, ptr)?;
             let handle = rt.str_new.call(&mut *caller, len as u32).map_err(|e| format!("{e}"))?;
             let dst = rt.str_data.call(&mut *caller, handle).map_err(|e| format!("{e}"))? as usize;
             memory.data_mut(&mut *caller).copy_within(ptr..ptr + len, dst);
@@ -1415,7 +1420,7 @@ fn record_leaf(fields: &[(arcstr::ArcStr, crate::sig::SigTy)]) -> (u32, crate::s
 /// Rebuild a single-member record from the scalar the ABI returned in place of it.
 fn record_from_scalar(
     caller: &mut wasmtime::Caller<'_, WasiCtx>,
-    memory: wasmtime::Memory,
+    memory: SimMem,
     rt: &ExtRt,
     fields: &[(arcstr::ArcStr, crate::sig::SigTy)],
     leaf_off: u32,
@@ -1429,25 +1434,25 @@ fn record_from_scalar(
         .call(&mut *caller, (layout.heap.len() as u32, layout.size))
         .map_err(|e| format!("rt_record_new: {e}"))?;
     for (k, (kind, off)) in layout.heap.iter().enumerate() {
-        write_u32(memory, caller, handle + 8 + k as u32 * 8, *kind);
-        write_u32(memory, caller, handle + 8 + k as u32 * 8 + 4, *off);
+        write_u32(memory.clone(), caller, handle + 8 + k as u32 * 8, *kind);
+        write_u32(memory.clone(), caller, handle + 8 + k as u32 * 8 + 4, *off);
     }
     // A nested one needs its own object before the value can go in.
     if let Some((_, SigTy::Record { fields: inner, .. })) = fields.first()
         && inner.len() == 1
     {
-        let nested = record_from_scalar(caller, memory, rt, inner, leaf_off, leaf, value)?;
-        write_u32(memory, caller, handle + layout.data_off + layout.field_off[0], nested);
+        let nested = record_from_scalar(caller, memory.clone(), rt, inner, leaf_off, leaf, value)?;
+        write_u32(memory.clone(), caller, handle + layout.data_off + layout.field_off[0], nested);
         return Ok(handle);
     }
     let at = handle + layout.data_off + layout.field_off.first().copied().unwrap_or(0);
     match leaf {
-        SigTy::Real => write_u64(memory, caller, at, value.unwrap_f64().to_bits()),
+        SigTy::Real => write_u64(memory.clone(), caller, at, value.unwrap_f64().to_bits()),
         SigTy::Str => {
-            let s = wasm_string(caller, memory, rt, value.unwrap_i32() as u32)?;
-            write_u32(memory, caller, at, s);
+            let s = wasm_string(caller, memory.clone(), rt, value.unwrap_i32() as u32)?;
+            write_u32(memory.clone(), caller, at, s);
         }
-        _ => write_u32(memory, caller, at, value.unwrap_i32() as u32),
+        _ => write_u32(memory.clone(), caller, at, value.unwrap_i32() as u32),
     }
     Ok(handle)
 }
@@ -1456,7 +1461,7 @@ fn record_from_scalar(
 /// scratch to release after.
 fn record_to_c(
     caller: &mut wasmtime::Caller<'_, WasiCtx>,
-    memory: wasmtime::Memory,
+    memory: SimMem,
     rt: &ExtRt,
     fields: &[(arcstr::ArcStr, crate::sig::SigTy)],
     handle: u32,
@@ -1471,28 +1476,28 @@ fn record_to_c(
         let at = dst + c.offsets[i];
         match ty {
             SigTy::Real => {
-                let v = read_u64(memory, caller, src);
-                write_u64(memory, caller, at, v);
+                let v = read_u64(memory.clone(), caller, src);
+                write_u64(memory.clone(), caller, at, v);
             }
             SigTy::Int | SigTy::Bool | SigTy::Ptr => {
-                let v = read_u32(memory, caller, src);
-                write_u32(memory, caller, at, v);
+                let v = read_u32(memory.clone(), caller, src);
+                write_u32(memory.clone(), caller, at, v);
             }
             SigTy::Str => {
-                let s = read_u32(memory, caller, src);
-                let p = c_string(caller, memory, rt, s, temps)?;
-                write_u32(memory, caller, at, p);
+                let s = read_u32(memory.clone(), caller, src);
+                let p = c_string(caller, memory.clone(), rt, s, temps)?;
+                write_u32(memory.clone(), caller, at, p);
             }
             SigTy::Array { .. } => {
                 // The elements themselves, so the callee writes the model's array.
-                let h = read_u32(memory, caller, src) as usize;
+                let h = read_u32(memory.clone(), caller, src) as usize;
                 let (_, data_off) = crate::host::array_abi::dims_and_data(memory.data(&*caller), h)
                     .ok_or_else(|| "external \"C\": malformed array field".to_string())?;
-                write_u32(memory, caller, at, h as u32 + data_off as u32);
+                write_u32(memory.clone(), caller, at, h as u32 + data_off as u32);
             }
             SigTy::Record { fields: inner, .. } => {
-                let h = read_u32(memory, caller, src);
-                record_to_c(caller, memory, rt, inner, h, at, temps)?;
+                let h = read_u32(memory.clone(), caller, src);
+                record_to_c(caller, memory.clone(), rt, inner, h, at, temps)?;
             }
             _ => return Err("external \"C\": record field type not marshalled".to_string()),
         }
@@ -1503,7 +1508,7 @@ fn record_to_c(
 /// The inverse of [`record_to_c`], for an `_Out_` record or a returned struct.
 fn record_from_c(
     caller: &mut wasmtime::Caller<'_, WasiCtx>,
-    memory: wasmtime::Memory,
+    memory: SimMem,
     rt: &ExtRt,
     fields: &[(arcstr::ArcStr, crate::sig::SigTy)],
     src: u32,
@@ -1517,29 +1522,29 @@ fn record_from_c(
         .map_err(|e| format!("rt_record_new: {e}"))?;
     // The inline table the runtime releases the record's heap fields by.
     for (k, (kind, off)) in layout.heap.iter().enumerate() {
-        write_u32(memory, caller, handle + 8 + k as u32 * 8, *kind);
-        write_u32(memory, caller, handle + 8 + k as u32 * 8 + 4, *off);
+        write_u32(memory.clone(), caller, handle + 8 + k as u32 * 8, *kind);
+        write_u32(memory.clone(), caller, handle + 8 + k as u32 * 8 + 4, *off);
     }
     for (i, (_, ty)) in fields.iter().enumerate() {
         let at = src + c.offsets[i];
         let dst = handle + layout.data_off + layout.field_off[i];
         match ty {
             SigTy::Real => {
-                let v = read_u64(memory, caller, at);
-                write_u64(memory, caller, dst, v);
+                let v = read_u64(memory.clone(), caller, at);
+                write_u64(memory.clone(), caller, dst, v);
             }
             SigTy::Int | SigTy::Bool | SigTy::Ptr => {
-                let v = read_u32(memory, caller, at);
-                write_u32(memory, caller, dst, v);
+                let v = read_u32(memory.clone(), caller, at);
+                write_u32(memory.clone(), caller, dst, v);
             }
             SigTy::Str => {
-                let p = read_u32(memory, caller, at);
-                let s = wasm_string(caller, memory, rt, p)?;
-                write_u32(memory, caller, dst, s);
+                let p = read_u32(memory.clone(), caller, at);
+                let s = wasm_string(caller, memory.clone(), rt, p)?;
+                write_u32(memory.clone(), caller, dst, s);
             }
             SigTy::Record { fields: inner, .. } => {
-                let h = record_from_c(caller, memory, rt, inner, at)?;
-                write_u32(memory, caller, dst, h);
+                let h = record_from_c(caller, memory.clone(), rt, inner, at)?;
+                write_u32(memory.clone(), caller, dst, h);
             }
             _ => return Err("external \"C\": record field type not marshalled".to_string()),
         }
@@ -1550,7 +1555,7 @@ fn record_from_c(
 /// A NUL-terminated copy of `handle`, as a `char*`.
 fn c_string(
     caller: &mut wasmtime::Caller<'_, WasiCtx>,
-    memory: wasmtime::Memory,
+    memory: SimMem,
     rt: &ExtRt,
     handle: u32,
     temps: &mut Vec<u32>,
@@ -1558,7 +1563,7 @@ fn c_string(
     if handle == 0 {
         return Ok(0);
     }
-    let len = read_u32(memory, caller, handle + 4) as usize;
+    let len = read_u32(memory.clone(), caller, handle + 4) as usize;
     let cell = rt
         .alloc
         .call(&mut *caller, (len + 1) as u32)
@@ -1573,7 +1578,7 @@ fn c_string(
 /// A fresh String with the bytes of the `char*` at `ptr`.
 fn wasm_string(
     caller: &mut wasmtime::Caller<'_, WasiCtx>,
-    memory: wasmtime::Memory,
+    memory: SimMem,
     rt: &ExtRt,
     ptr: u32,
 ) -> Result<u32> {
@@ -1600,7 +1605,7 @@ fn wasm_string(
 }
 
 /// `strlen` of the NUL-terminated `char*` at `ptr` in the shared memory.
-fn str_len(memory: wasmtime::Memory, caller: &mut wasmtime::Caller<'_, WasiCtx>, ptr: usize) -> Result<usize> {
+fn str_len(memory: SimMem, caller: &mut wasmtime::Caller<'_, WasiCtx>, ptr: usize) -> Result<usize> {
     if ptr == 0 {
         return Ok(0);
     }
@@ -1610,28 +1615,28 @@ fn str_len(memory: wasmtime::Memory, caller: &mut wasmtime::Caller<'_, WasiCtx>,
         .ok_or_else(|| "external \"C\": unterminated `char*`".to_string())
 }
 
-fn read_u32(memory: wasmtime::Memory, caller: &mut wasmtime::Caller<'_, WasiCtx>, at: u32) -> u32 {
+fn read_u32(memory: SimMem, caller: &mut wasmtime::Caller<'_, WasiCtx>, at: u32) -> u32 {
     let d = memory.data(&*caller);
     d.get(at as usize..at as usize + 4)
         .map(|b| u32::from_le_bytes(b.try_into().unwrap()))
         .unwrap_or(0)
 }
 
-fn read_u64(memory: wasmtime::Memory, caller: &mut wasmtime::Caller<'_, WasiCtx>, at: u32) -> u64 {
+fn read_u64(memory: SimMem, caller: &mut wasmtime::Caller<'_, WasiCtx>, at: u32) -> u64 {
     let d = memory.data(&*caller);
     d.get(at as usize..at as usize + 8)
         .map(|b| u64::from_le_bytes(b.try_into().unwrap()))
         .unwrap_or(0)
 }
 
-fn write_u32(memory: wasmtime::Memory, caller: &mut wasmtime::Caller<'_, WasiCtx>, at: u32, v: u32) {
+fn write_u32(memory: SimMem, caller: &mut wasmtime::Caller<'_, WasiCtx>, at: u32, v: u32) {
     let d = memory.data_mut(&mut *caller);
     if let Some(s) = d.get_mut(at as usize..at as usize + 4) {
         s.copy_from_slice(&v.to_le_bytes());
     }
 }
 
-fn write_u64(memory: wasmtime::Memory, caller: &mut wasmtime::Caller<'_, WasiCtx>, at: u32, v: u64) {
+fn write_u64(memory: SimMem, caller: &mut wasmtime::Caller<'_, WasiCtx>, at: u32, v: u64) {
     let d = memory.data_mut(&mut *caller);
     if let Some(s) = d.get_mut(at as usize..at as usize + 8) {
         s.copy_from_slice(&v.to_le_bytes());

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/engine_config.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/engine_config.rs
@@ -31,6 +31,15 @@ fn address_space_limit() -> Option<u64> {
     None
 }
 
+/// A shared memory cannot move, so it is capped at the reservation it starts with:
+/// wasm32's 4 GiB, or the constrained one under a small `RLIMIT_AS`.
+pub fn shared_max_pages() -> u64 {
+    match reservation_bytes() {
+        Some(bytes) => (bytes / 65536).max(1),
+        None => 65536,
+    }
+}
+
 /// `memory_may_move` (default on) lets a memory outgrow the reservation.
 pub fn tune_memory(cfg: &mut wasmtime::Config) {
     if let Some(bytes) = reservation_bytes() {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
@@ -69,6 +69,19 @@ pub fn set_no_throw_asserts(v: bool) {
     NO_THROW.with(|n| n.set(v));
 }
 
+pub fn no_throw_asserts() -> bool {
+    NO_THROW.with(|n| n.get())
+}
+
+/// Re-record on this thread what a parmodauto worker thread's `rt_assert` left.
+pub fn set_pending_assert_raw(pa: PendingAssert) {
+    PENDING_ASSERT.with(|p| *p.borrow_mut() = Some(pa));
+}
+
+pub fn record_warnings(recs: Vec<[i32; 10]>) {
+    PENDING_WARNINGS.with(|p| p.borrow_mut().extend(recs));
+}
+
 /// Clear any stale pending assertion before a call.
 pub fn clear_pending_assert() {
     PENDING_ASSERT.with(|p| *p.borrow_mut() = None);
@@ -191,15 +204,15 @@ fn row_asserts(read: &dyn Fn(u32, &mut [u8]) -> bool, sim_data: u32, warn: i32) 
 /// cannot find it; the engine sets it here instead (wasmer has [`HostMem`]).
 #[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
 mod sim_memory {
-    use std::cell::Cell;
+    use std::cell::RefCell;
     thread_local! {
-        static MEMORY: Cell<Option<wasmtime::Memory>> = const { Cell::new(None) };
+        static MEMORY: RefCell<Option<crate::simmem::SimMem>> = const { RefCell::new(None) };
     }
-    pub fn set(m: wasmtime::Memory) {
-        MEMORY.with(|c| c.set(Some(m)));
+    pub fn set(m: crate::simmem::SimMem) {
+        MEMORY.with(|c| *c.borrow_mut() = Some(m));
     }
-    pub fn get() -> Option<wasmtime::Memory> {
-        MEMORY.with(|c| c.get())
+    pub fn get() -> Option<crate::simmem::SimMem> {
+        MEMORY.with(|c| c.borrow().clone())
     }
 }
 
@@ -489,7 +502,7 @@ pub fn add_host_builtins<T: 'static>(linker: &mut wasmtime::Linker<T>) -> Result
         "env",
         "rt_host_log",
         |mut caller: wasmtime::Caller<'_, T>, ptr: u32, len: u32| {
-            let Some(wasmtime::Extern::Memory(mem)) = caller.get_export("memory") else { return };
+            let Some(mem) = caller.get_export("memory").and_then(crate::simmem::SimMem::from_extern) else { return };
             let off = ptr as usize;
             if let Some(b) = mem.data(&caller).get(off..off + len as usize) {
                 openmodelica_wasi::wasi::stdout_write(b);
@@ -526,7 +539,7 @@ pub fn add_host_builtins<T: 'static>(linker: &mut wasmtime::Linker<T>) -> Result
         "env",
         "rt_host_take_warnings",
         |mut caller: wasmtime::Caller<'_, T>, ptr: u32, max: u32| -> u32 {
-            let Some(wasmtime::Extern::Memory(mem)) = caller.get_export("memory") else { return 0 };
+            let Some(mem) = caller.get_export("memory").and_then(crate::simmem::SimMem::from_extern) else { return 0 };
             let recs = take_pending_warnings_upto(max as usize);
             let off = ptr as usize;
             let data = mem.data_mut(&mut caller);
@@ -540,7 +553,7 @@ pub fn add_host_builtins<T: 'static>(linker: &mut wasmtime::Linker<T>) -> Result
         "env",
         "rt_host_take_reinits",
         |mut caller: wasmtime::Caller<'_, T>, ptr: u32, max: u32| -> u32 {
-            let Some(wasmtime::Extern::Memory(mem)) = caller.get_export("memory") else { return 0 };
+            let Some(mem) = caller.get_export("memory").and_then(crate::simmem::SimMem::from_extern) else { return 0 };
             let off = ptr as usize;
             let end = off + max as usize * REINIT_BYTES;
             let data = mem.data_mut(&mut caller);
@@ -556,7 +569,7 @@ pub fn add_host_builtins<T: 'static>(linker: &mut wasmtime::Linker<T>) -> Result
         "env",
         "rt_host_lin_solve",
         |mut caller: wasmtime::Caller<'_, T>, handle: u32, colptr: u32, rowidx: u32, values: u32, b_ptr: u32, n: u32, nnz: u32| -> i32 {
-            let Some(wasmtime::Extern::Memory(mem)) = caller.get_export("memory") else { return 1 };
+            let Some(mem) = caller.get_export("memory").and_then(crate::simmem::SimMem::from_extern) else { return 1 };
             let x = lin_solve::solve(handle, colptr, rowidx, values, b_ptr, n as usize, nnz as usize, mem.data(&caller));
             match x {
                 Some(x) => {
@@ -579,7 +592,7 @@ pub fn add_host_builtins<T: 'static>(linker: &mut wasmtime::Linker<T>) -> Result
 #[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
 pub fn define_uri_import<T: 'static>(
     linker: &mut wasmtime::Linker<T>,
-    memory: wasmtime::Memory,
+    memory: crate::simmem::SimMem,
     str_new: wasmtime::TypedFunc<u32, u32>,
     str_data: wasmtime::TypedFunc<u32, u32>,
 ) -> Result<()> {
@@ -588,7 +601,7 @@ pub fn define_uri_import<T: 'static>(
             "rt",
             "rt_uri_to_filename",
             move |mut caller: wasmtime::Caller<'_, T>, handle: u32, _fmu: i32| -> std::result::Result<u32, wasmtime::Error> {
-                let uri = read_wasm_string(memory, &caller, handle);
+                let uri = read_wasm_string(&memory, &caller, handle);
                 let path = uri_to_filename(&uri).map_err(wasmtime::Error::msg)?;
                 let out = str_new.call(&mut caller, path.len() as u32)?;
                 let at = str_data.call(&mut caller, out)? as usize;
@@ -602,7 +615,7 @@ pub fn define_uri_import<T: 'static>(
 
 /// The bytes of the String at `handle` (`[refcount:u32][len:u32][utf8…]`).
 #[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
-fn read_wasm_string<T>(memory: wasmtime::Memory, caller: &wasmtime::Caller<'_, T>, handle: u32) -> String {
+fn read_wasm_string<T>(memory: &crate::simmem::SimMem, caller: &wasmtime::Caller<'_, T>, handle: u32) -> String {
     if handle == 0 {
         return String::new();
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/lib.rs
@@ -10,6 +10,14 @@ pub static RUNTIME_WASIP1: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/run
 /// wasip1 target was unavailable at build time (host then uses `RUNTIME_WASM`).
 pub static RUNTIME_WASM_INTERACTIVE_WASIP1: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/runtime_wasip1_interactive.wasm"));
+/// The interactive runtime over a shared memory (`wasm32-wasip1-threads`), which
+/// the parallel `--parmodauto` path instantiates once per worker thread. Empty
+/// unless [`THREADS_RUNTIME`].
+pub static RUNTIME_WASM_INTERACTIVE_WASIP1_THREADS: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/runtime_wasip1_threads.wasm"));
+/// Whether a `--parmodauto` model pairs with [`RUNTIME_WASM_INTERACTIVE_WASIP1_THREADS`]
+/// and so imports a shared memory. Native wasmtime only.
+pub const THREADS_RUNTIME: bool = cfg!(sim_threads_runtime);
 pub static EXTERNAL_C_WASM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/modelicaexternalc.wasm"));
 pub static FMI3_ME_ADAPTER: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/fmi3_me_adapter.wasm"));
 /// Both interfaces in one component, and what a Co-Simulation FMU carries too: its
@@ -60,6 +68,10 @@ pub fn take_engine_error_detail() -> Option<String> {
 #[cfg(feature = "jit")]
 pub mod host;
 
+#[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
+pub mod simmem;
+#[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
+pub mod parmod_pool;
 #[cfg(all(feature = "jit", not(target_arch = "wasm32")))]
 mod engine_config;
 #[cfg(all(feature = "jit", not(target_arch = "wasm32")))]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/parmod_pool.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/parmod_pool.rs
@@ -1,0 +1,567 @@
+//! The `--parmodauto` worker threads: C's TBB pool. A wasmtime store runs on one
+//! thread at a time, so each worker owns a store with its own runtime and model
+//! instances over the run's one shared memory, and evaluates the clusters the
+//! scheduler's [`Plan`] hands it. The calling thread works too, on the run's own
+//! instances.
+//!
+//! A worker's model instance is the main one's twin: its `start` ran in
+//! `rt_start_mode(2)`, replaying the main instantiation's `rt_alloc`s, so the
+//! globals hold the same block addresses and the table the same callbacks at the
+//! same indices. The runtime instance shares every static with the main one (they
+//! are memory), and gets its own stack and TLS block.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+
+use openmodelica_sim_meta::parmod::Plan;
+use openmodelica_wasi::wasi::WasiCtx;
+use wasmtime::{Engine, Instance, Module, SharedMemory, Store, TypedFunc};
+
+use crate::model::SimModel;
+use crate::simmem::SimMem;
+
+type Result<T> = std::result::Result<T, String>;
+
+/// Matching the threads runtime's own `-zstack-size` (`THREADS_LINK_ARGS`): a deep
+/// solve overran the 1 MiB default.
+const STACK_BYTES: u32 = 8 << 20;
+
+fn wts<T, E: std::fmt::Debug>(r: std::result::Result<T, E>) -> Result<T> {
+    r.map_err(|e| format!("wasm engine error: {e:?}"))
+}
+
+/// The memory the runtime module imports, sized by its import and the engine's
+/// reservation.
+pub fn new_shared_memory(engine: &Engine, runtime: &Module) -> Result<SharedMemory> {
+    let minimum = runtime
+        .imports()
+        .find_map(|i| i.ty().memory().map(|m| m.minimum()))
+        .ok_or("CodegenWasmJit: the threads runtime imports no memory")?;
+    let maximum = crate::engine_config::shared_max_pages().max(minimum);
+    wts(SharedMemory::new(engine, wasmtime::MemoryType::shared(minimum as u32, maximum as u32)))
+}
+
+/// What a cluster's completion releases, derived once per [`Plan::id`].
+struct Prepared {
+    id: u64,
+    children: Vec<Vec<u32>>,
+    parents: Vec<u32>,
+    /// Level-synchronous plans: each cluster's level, and the clusters per level.
+    level_of: Vec<u32>,
+    levels: Vec<Vec<u32>>,
+}
+
+impl Prepared {
+    fn new(plan: &Plan) -> Prepared {
+        let n = plan.clusters.len();
+        let mut children = vec![Vec::new(); n];
+        let mut parents = vec![0u32; n];
+        let mut level_of = vec![0u32; n];
+        if plan.levels.is_empty() {
+            for (c, ps) in plan.parents.iter().enumerate() {
+                parents[c] = ps.len() as u32;
+                for &p in ps {
+                    children[p as usize].push(c as u32);
+                }
+            }
+        } else {
+            for (l, cs) in plan.levels.iter().enumerate() {
+                for &c in cs {
+                    level_of[c as usize] = l as u32;
+                    parents[c as usize] = if l == 0 { 0 } else { 1 };
+                }
+            }
+        }
+        Prepared { id: plan.id, children, parents, level_of, levels: plan.levels.clone() }
+    }
+}
+
+struct PlanRef(*const Plan);
+unsafe impl Send for PlanRef {}
+unsafe impl Sync for PlanRef {}
+
+/// One evaluation: the ready queue and the counters that feed it. Lives for the
+/// round; the main thread returns only once every worker has left it.
+struct Round {
+    plan: PlanRef,
+    sim_data: u32,
+    no_throw: bool,
+    pending: Vec<AtomicU32>,
+    level_left: Vec<AtomicU32>,
+    queue: Mutex<VecDeque<u32>>,
+    remaining: AtomicUsize,
+    active: AtomicUsize,
+    aborted: AtomicBool,
+    failure: Mutex<Option<Failure>>,
+    warnings: Mutex<Vec<[i32; 10]>>,
+    /// Per participant (0 = the calling thread), the task it is inside, or `u32::MAX`.
+    current: Vec<AtomicU32>,
+}
+
+/// A task's trap on a worker, with what its thread-local host state recorded.
+struct Failure {
+    detail: String,
+    assert: Option<crate::host::PendingAssert>,
+}
+
+impl Round {
+    fn plan(&self) -> &Plan {
+        unsafe { &*self.plan.0 }
+    }
+
+    fn finished(&self, prep: &Prepared, c: u32) {
+        let mut ready = Vec::new();
+        if prep.levels.is_empty() {
+            for &ch in &prep.children[c as usize] {
+                if self.pending[ch as usize].fetch_sub(1, Ordering::AcqRel) == 1 {
+                    ready.push(ch);
+                }
+            }
+        } else {
+            let l = prep.level_of[c as usize] as usize;
+            if self.level_left[l].fetch_sub(1, Ordering::AcqRel) == 1 && l + 1 < prep.levels.len() {
+                ready.extend_from_slice(&prep.levels[l + 1]);
+            }
+        }
+        if !ready.is_empty() {
+            self.queue.lock().unwrap_or_else(|e| e.into_inner()).extend(ready);
+        }
+        self.remaining.fetch_sub(1, Ordering::AcqRel);
+    }
+
+    fn fail(&self, f: Failure) {
+        let mut slot = self.failure.lock().unwrap_or_else(|e| e.into_inner());
+        if slot.is_none() {
+            *slot = Some(f);
+        }
+        self.aborted.store(true, Ordering::Release);
+    }
+}
+
+struct Shared {
+    state: Mutex<(u64, Option<Arc<Round>>, bool)>,
+    cv: Condvar,
+    generation: AtomicU64,
+}
+
+/// A worker's stores and entry point, built on the main thread and moved to it.
+struct WorkerCtx {
+    store: Store<WasiCtx>,
+    task: TypedFunc<(u32, u32), ()>,
+    /// `rt_stats_flush`: the thread's counters into the run's totals, per round.
+    flush: TypedFunc<(), ()>,
+    memory: SimMem,
+}
+
+pub struct Pool {
+    shared: Arc<Shared>,
+    threads: Vec<std::thread::JoinHandle<()>>,
+    prepared: Option<Prepared>,
+}
+
+/// Debug tally: clusters run and nanoseconds inside tasks per participant, and
+/// the rounds' wall time.
+static CLUSTERS_RUN: Mutex<Vec<(u64, u64)>> = Mutex::new(Vec::new());
+static ROUND_NANOS: AtomicU64 = AtomicU64::new(0);
+
+impl Pool {
+    /// `None` when the run has one thread, or the model reaches `external "C"`,
+    /// which only the main store's libraries define.
+    pub fn new(
+        main: &mut Store<WasiCtx>,
+        rt_alloc: &TypedFunc<u32, u32>,
+        memory: SharedMemory,
+        runtime: &Module,
+        model_module: &Module,
+        model: &SimModel,
+    ) -> Result<Option<Pool>> {
+        let threads = openmodelica_sim_meta::parmod::num_threads();
+        if threads <= 1 {
+            return Ok(None);
+        }
+        if !model.ext_imports.is_empty() {
+            use openmodelica_sim_meta::omclog;
+            omclog::info(omclog::STDOUT, false, "parmodauto: the model calls external \"C\"; its ODE is evaluated on one thread");
+            return Ok(None);
+        }
+        let engine = main.engine().clone();
+        let mut workers = Vec::with_capacity(threads - 1);
+        install_backtrace_signal();
+        for i in 1..threads {
+            dbg_log(format!("parmod: instantiating worker {i}"));
+            let stack = wts(rt_alloc.call(&mut *main, STACK_BYTES + 16))?;
+            let stack_top = (stack + STACK_BYTES) & !15;
+            workers.push(instantiate_worker(&engine, &memory, runtime, model_module, stack_top, |bytes| {
+                wts(rt_alloc.call(&mut *main, bytes))
+            })?);
+            dbg_log(format!("parmod: worker {i} ready"));
+        }
+        let shared = Arc::new(Shared {
+            state: Mutex::new((0, None, false)),
+            cv: Condvar::new(),
+            generation: AtomicU64::new(0),
+        });
+        let mut handles = Vec::with_capacity(workers.len());
+        for (i, w) in workers.into_iter().enumerate() {
+            let shared = shared.clone();
+            let h = std::thread::Builder::new()
+                .name(format!("omc-parmod-{}", i + 1))
+                .spawn(move || worker_main(w, shared, i + 1))
+                .map_err(|e| format!("parmodauto: cannot spawn a worker thread: {e}"))?;
+            handles.push(h);
+        }
+        if debug_enabled() {
+            let shared = shared.clone();
+            std::thread::spawn(move || loop {
+                std::thread::sleep(std::time::Duration::from_secs(5));
+                let st = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+                if st.2 {
+                    return;
+                }
+                match &st.1 {
+                    Some(r) => dbg_log(format!(
+                        "parmod watchdog: gen={} remaining={} active={} aborted={} queue={} current={:?}",
+                        st.0,
+                        r.remaining.load(Ordering::Relaxed),
+                        r.active.load(Ordering::Relaxed),
+                        r.aborted.load(Ordering::Relaxed),
+                        r.queue.lock().unwrap_or_else(|e| e.into_inner()).len(),
+                        r.current.iter().map(|c| c.load(Ordering::Relaxed)).collect::<Vec<_>>()
+                    )),
+                    None => dbg_log(format!("parmod watchdog: gen={} no round", st.0)),
+                }
+            });
+        }
+        Ok(Some(Pool { shared, threads: handles, prepared: None }))
+    }
+
+    /// Evaluate `plan` over the workers and the calling thread, whose instances are
+    /// `store` and `task` (the run's `parmodTask`).
+    pub fn run(
+        &mut self,
+        plan: &Plan,
+        sim_data: u32,
+        store: &mut Store<WasiCtx>,
+        task: &TypedFunc<(u32, u32), ()>,
+    ) -> metamodelica::Result<()> {
+        if self.prepared.as_ref().is_none_or(|p| p.id != plan.id) {
+            self.prepared = Some(Prepared::new(plan));
+        }
+        let prep = self.prepared.as_ref().expect("prepared plan");
+        let n = plan.clusters.len();
+        let queue: VecDeque<u32> = match prep.levels.first() {
+            Some(first) => first.iter().copied().collect(),
+            None => (0..n as u32).filter(|&c| prep.parents[c as usize] == 0).collect(),
+        };
+        let round = Arc::new(Round {
+            plan: PlanRef(plan),
+            sim_data,
+            no_throw: crate::host::no_throw_asserts(),
+            pending: prep.parents.iter().map(|&p| AtomicU32::new(p)).collect(),
+            level_left: prep.levels.iter().map(|l| AtomicU32::new(l.len() as u32)).collect(),
+            queue: Mutex::new(queue),
+            remaining: AtomicUsize::new(n),
+            active: AtomicUsize::new(0),
+            aborted: AtomicBool::new(false),
+            failure: Mutex::new(None),
+            warnings: Mutex::new(Vec::new()),
+            current: (0..self.threads.len() + 1).map(|_| AtomicU32::new(u32::MAX)).collect(),
+        });
+        {
+            let mut st = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+            st.0 += 1;
+            st.1 = Some(round.clone());
+            self.shared.generation.store(st.0, Ordering::Release);
+            self.shared.cv.notify_all();
+            if debug_enabled() && st.0 <= 3 {
+                dbg_log(format!("parmod: round {} starts, {} clusters", st.0, n));
+            }
+        }
+        let t_round = std::time::Instant::now();
+        work(&round, prep, store, task, 0);
+        // No worker joins the round from here on (they enter under the lock), and
+        // those inside finish their cluster and leave.
+        {
+            let mut st = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+            st.1 = None;
+        }
+        let mut spins = 0u32;
+        let debug = debug_enabled();
+        let t0 = std::time::Instant::now();
+        let mut reported = 0u64;
+        while round.active.load(Ordering::Acquire) != 0 {
+            if debug && t0.elapsed().as_secs() / 5 > reported {
+                reported = t0.elapsed().as_secs() / 5;
+                let cur: Vec<u32> = round.current.iter().map(|c| c.load(Ordering::Relaxed)).collect();
+                dbg_log(format!(
+                    "parmod: waiting for workers: remaining={} active={} aborted={} current tasks={:?}",
+                    round.remaining.load(Ordering::Relaxed),
+                    round.active.load(Ordering::Relaxed),
+                    round.aborted.load(Ordering::Relaxed),
+                    cur
+                ));
+            }
+            pause(&mut spins);
+        }
+        if debug {
+            ROUND_NANOS.fetch_add(t_round.elapsed().as_nanos() as u64, Ordering::Relaxed);
+        }
+        let warnings = std::mem::take(&mut *round.warnings.lock().unwrap_or_else(|e| e.into_inner()));
+        crate::host::record_warnings(warnings);
+        let failure = round.failure.lock().unwrap_or_else(|e| e.into_inner()).take();
+        match failure {
+            None => Ok(()),
+            Some(f) => {
+                crate::set_engine_error_detail(f.detail);
+                if let Some(pa) = f.assert {
+                    crate::host::set_pending_assert_raw(pa);
+                }
+                Err("CodegenWasmJit: wasm engine error")
+            }
+        }
+    }
+}
+
+impl Drop for Pool {
+    fn drop(&mut self) {
+        if debug_enabled() {
+            dbg_log(format!(
+                "parmod: (clusters, ms in tasks) per participant {:?}; rounds total {} ms",
+                CLUSTERS_RUN.lock().unwrap_or_else(|e| e.into_inner()).iter().map(|(c, ns)| (*c, ns / 1_000_000)).collect::<Vec<_>>(),
+                ROUND_NANOS.load(Ordering::Relaxed) / 1_000_000
+            ));
+        }
+        {
+            let mut st = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+            st.2 = true;
+            st.0 += 1;
+            self.shared.generation.store(st.0, Ordering::Release);
+            self.shared.cv.notify_all();
+        }
+        for h in self.threads.drain(..) {
+            let _ = h.join();
+        }
+    }
+}
+
+/// A worker's runtime + model instances over `memory`, in a fresh store: the
+/// runtime's `start` waits for the main instance's memory initialisation, then the
+/// instance gets its own stack and TLS block, and the model instantiates in replay
+/// mode against the main instantiation's allocations.
+fn instantiate_worker(
+    engine: &Engine,
+    memory: &SharedMemory,
+    runtime: &Module,
+    model_module: &Module,
+    stack_top: u32,
+    mut alloc: impl FnMut(u32) -> Result<u32>,
+) -> Result<WorkerCtx> {
+    let mut linker = wasmtime::Linker::new(engine);
+    crate::host::add_host_builtins(&mut linker)?;
+    crate::wasi_shim::add_to_linker(&mut linker)?;
+    let mut store = Store::new(engine, WasiCtx::new("/", Vec::new()));
+    // The same hard `-alarm` as the run's own store, so a wedged task traps too.
+    if let secs @ 1.. = crate::sim_runtime::alarm_secs() {
+        store.set_epoch_deadline(secs as u64);
+        store.epoch_deadline_callback(|_| Err(wasmtime::Error::msg(crate::sim_driver::ALARM_ABORT_ERR)));
+    }
+    wts(linker.define(&mut store, "env", "memory", memory.clone()))?;
+    let rt_inst = wts(linker.instantiate(&mut store, runtime))?;
+    let sp = rt_inst.get_global(&mut store, "__stack_pointer").ok_or("threads runtime exports no __stack_pointer")?;
+    wts(sp.set(&mut store, wasmtime::Val::I32(stack_top as i32)))?;
+    let tls_size = global_i32(&mut store, &rt_inst, "__tls_size")?;
+    let tls_align = global_i32(&mut store, &rt_inst, "__tls_align")?.max(1);
+    let tls = alloc(tls_size + tls_align)?;
+    let tls = (tls + tls_align - 1) & !(tls_align - 1);
+    let init_tls = wts(rt_inst.get_typed_func::<u32, ()>(&mut store, "__wasm_init_tls"))?;
+    wts(init_tls.call(&mut store, tls))?;
+    let init_thread = wts(rt_inst.get_typed_func::<(), ()>(&mut store, "rt_thread_init"))?;
+    wts(init_thread.call(&mut store, ()))?;
+    wts(linker.instance(&mut store, "rt", rt_inst))?;
+    let mem = SimMem::Shared(memory.clone());
+    let str_new = wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_str_new"))?;
+    let str_data = wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_str_data"))?;
+    crate::sim_runtime::define_print_import(&mut linker, mem.clone())?;
+    crate::host::define_uri_import(&mut linker, mem.clone(), str_new, str_data)?;
+    let start_mode = wts(rt_inst.get_typed_func::<u32, ()>(&mut store, "rt_start_mode"))?;
+    wts(start_mode.call(&mut store, 2))?;
+    let instance = linker.instantiate(&mut store, model_module);
+    wts(start_mode.call(&mut store, 0))?;
+    let instance: Instance = wts(instance)?;
+    let task = wts(instance.get_typed_func::<(u32, u32), ()>(&mut store, "parmodTask"))?;
+    let flush = wts(rt_inst.get_typed_func::<(), ()>(&mut store, "rt_stats_flush"))?;
+    Ok(WorkerCtx { store, task, flush, memory: mem })
+}
+
+/// A task call whose out-of-bounds access surfaces as an error: with two instances
+/// of one store importing the same memory, wasmtime's signal-based fault handler
+/// asserts (`StoreOpaque::wasm_fault`) instead of trapping, and a panic must not
+/// take the thread out of the round.
+fn call_task(store: &mut Store<WasiCtx>, task: &TypedFunc<(u32, u32), ()>, sim_data: u32, t: u32) -> std::result::Result<(), wasmtime::Error> {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| task.call(&mut *store, (sim_data, t)))) {
+        Ok(r) => r,
+        Err(_) => Err(wasmtime::Error::msg("wasm trap: out of bounds memory access (in a shared-memory store)")),
+    }
+}
+
+fn global_i32(store: &mut Store<WasiCtx>, inst: &Instance, name: &str) -> Result<u32> {
+    match inst.get_global(&mut *store, name).map(|g| g.get(&mut *store)) {
+        Some(wasmtime::Val::I32(v)) => Ok(v as u32),
+        _ => Err(format!("threads runtime exports no {name}")),
+    }
+}
+
+fn pause(spins: &mut u32) {
+    *spins += 1;
+    if *spins < 200 {
+        std::hint::spin_loop();
+    } else {
+        std::thread::yield_now();
+    }
+}
+
+fn worker_main(mut w: WorkerCtx, shared: Arc<Shared>, who: usize) {
+    crate::host::set_sim_memory(w.memory.clone());
+    let mut seen = 0u64;
+    let mut prepared: Option<Prepared> = None;
+    loop {
+        // Spin briefly for the next round: an ODE evaluation follows the last within
+        // microseconds while the integrator is busy; park when it does not.
+        let mut spins = 0u32;
+        while shared.generation.load(Ordering::Acquire) == seen && spins < 20_000 {
+            spins += 1;
+            std::hint::spin_loop();
+        }
+        let round = {
+            let mut st = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+            while st.0 == seen {
+                st = shared.cv.wait(st).unwrap_or_else(|e| e.into_inner());
+            }
+            seen = st.0;
+            if st.2 {
+                return;
+            }
+            let round = st.1.clone();
+            if let Some(r) = &round {
+                r.active.fetch_add(1, Ordering::AcqRel);
+            }
+            round
+        };
+        let Some(round) = round else { continue };
+        crate::host::set_no_throw_asserts(round.no_throw);
+        let plan = round.plan();
+        if prepared.as_ref().is_none_or(|p| p.id != plan.id) {
+            prepared = Some(Prepared::new(plan));
+        }
+        work(&round, prepared.as_ref().expect("prepared plan"), &mut w.store, &w.task, who);
+        let _ = w.flush.call(&mut w.store, ());
+        let warnings = crate::host::take_pending_warnings();
+        if !warnings.is_empty() {
+            round.warnings.lock().unwrap_or_else(|e| e.into_inner()).extend(warnings);
+        }
+        round.active.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+/// Pull ready clusters until the round is over: every cluster done, or aborted.
+fn work(round: &Round, prep: &Prepared, store: &mut Store<WasiCtx>, task: &TypedFunc<(u32, u32), ()>, who: usize) {
+    let plan = round.plan();
+    let mut spins = 0u32;
+    let debug = debug_enabled();
+    let mut idle_since: Option<std::time::Instant> = None;
+    loop {
+        if round.aborted.load(Ordering::Acquire) || round.remaining.load(Ordering::Acquire) == 0 {
+            return;
+        }
+        let next = round.queue.lock().unwrap_or_else(|e| e.into_inner()).pop_front();
+        let Some(c) = next else {
+            if debug {
+                let t = idle_since.get_or_insert_with(std::time::Instant::now);
+                if t.elapsed().as_secs() >= 5 {
+                    let pending: Vec<u32> = round.pending.iter().map(|p| p.load(Ordering::Relaxed)).collect();
+                    dbg_log(format!(
+                        "parmod stall on {:?}: remaining={} active={} queue={} pending={:?} parents={:?}",
+                        std::thread::current().name(),
+                        round.remaining.load(Ordering::Relaxed),
+                        round.active.load(Ordering::Relaxed),
+                        round.queue.lock().unwrap_or_else(|e| e.into_inner()).len(),
+                        pending,
+                        prep.parents,
+                    ));
+                    *t = std::time::Instant::now();
+                }
+            }
+            pause(&mut spins);
+            continue;
+        };
+        idle_since = None;
+        spins = 0;
+        let t_cluster = std::time::Instant::now();
+        for &t in &plan.clusters[c as usize] {
+            round.current[who].store(t, Ordering::Relaxed);
+            // `OMC_WASM_PARMOD_SERIAL`: one task at a time across the pool (debug).
+            static SERIAL: Mutex<()> = Mutex::new(());
+            let serial = std::env::var_os("OMC_WASM_PARMOD_SERIAL").map(|_| SERIAL.lock().unwrap_or_else(|e| e.into_inner()));
+            let r = call_task(store, task, round.sim_data, t);
+            drop(serial);
+            round.current[who].store(u32::MAX, Ordering::Relaxed);
+            if let Err(e) = r {
+                if std::env::var_os("OMC_WASM_TRAP_DEBUG").is_some() {
+                    dbg_log(format!("wasm-jit parmod task {t} trap: {e:?}"));
+                }
+                round.fail(Failure { detail: format!("{e:?}"), assert: crate::host::take_pending_assert_raw() });
+                return;
+            }
+        }
+        round.finished(prep, c);
+        if debug {
+            let mut v = CLUSTERS_RUN.lock().unwrap_or_else(|e| e.into_inner());
+            if v.len() <= who {
+                v.resize(who + 1, (0, 0));
+            }
+            v[who].0 += 1;
+            v[who].1 += t_cluster.elapsed().as_nanos() as u64;
+        }
+    }
+}
+
+/// Debug aid: `kill -USR1 <tid>` appends that thread's native backtrace to the file.
+fn install_backtrace_signal() {
+    if !debug_enabled() {
+        return;
+    }
+    extern "C" fn on_usr1(_: libc::c_int) {
+        dbg_log(format!(
+            "parmod backtrace of {:?}:\n{}",
+            std::thread::current().name(),
+            std::backtrace::Backtrace::force_capture()
+        ));
+    }
+    unsafe {
+        libc::signal(libc::SIGUSR1, on_usr1 as *const () as usize);
+    }
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        dbg_log(format!(
+            "parmod panic on {:?}: {info}\n{}",
+            std::thread::current().name(),
+            std::backtrace::Backtrace::force_capture()
+        ));
+        prev(info);
+    }));
+}
+
+/// `OMC_WASM_PARMOD_DEBUG=<file>`: pool diagnostics, appended there (stderr is
+/// captured into the simulation log during a run).
+fn debug_enabled() -> bool {
+    std::env::var_os("OMC_WASM_PARMOD_DEBUG").is_some()
+}
+
+fn dbg_log(line: String) {
+    use std::io::Write;
+    let Some(path) = std::env::var_os("OMC_WASM_PARMOD_DEBUG") else { return };
+    if let Ok(mut f) = std::fs::OpenOptions::new().append(true).create(true).open(path) {
+        let _ = writeln!(f, "{line}");
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_stub.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_stub.rs
@@ -18,7 +18,7 @@ pub struct RunResult {
     pub stats: openmodelica_sim_meta::SolveStats,
 }
 
-pub fn runtime_module() -> std::result::Result<&'static Module, String> {
+pub fn runtime_module(_shared: bool) -> std::result::Result<&'static Module, String> {
     return Err(NO_ENGINE.to_string())
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -115,7 +115,8 @@ pub fn sim_engine() -> &'static wasmer::Engine {
 /// microseconds. `deserialize` validates the artifact against the current
 /// wasmer version / engine config / target, so a stale or incompatible cache
 /// is rejected and we transparently fall back to JIT (then refresh the cache).
-pub fn runtime_module() -> std::result::Result<&'static wasmer::Module, String> {
+/// `shared`: the wasmtime backend's threads runtime, which this one does not build.
+pub fn runtime_module(_shared: bool) -> std::result::Result<&'static wasmer::Module, String> {
     static MODULE: OnceLock<std::result::Result<wasmer::Module, String>> = OnceLock::new();
     MODULE
         .get_or_init(|| load_or_compile_runtime())
@@ -216,7 +217,7 @@ pub fn start_runtime_compile() {
         static STARTED: std::sync::Once = std::sync::Once::new();
         STARTED.call_once(|| {
             std::thread::spawn(|| {
-                let _ = runtime_module(); // populates the OnceLock cache
+                let _ = runtime_module(false); // populates the OnceLock cache
             });
         });
     }
@@ -911,7 +912,7 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
     // pipeline) — here we just join it. If no background job is present (e.g. a
     // direct call), compile inline as a fallback.
     let t_compile = Instant::now();
-    let runtime_module = runtime_module()?;
+    let runtime_module = runtime_module(false)?;
     let rt_compile = t_compile.elapsed();
     // Prefer the module already prepared by `finishCompile` (buildModel's
     // compile phase, counted as `timeCompile`); otherwise join/compile here.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -39,12 +39,20 @@ use openmodelica_wasi::wasi::WasiCtx;
 /// `RUNTIME_WASM` fallback. Both export the same `rt_*`+`memory`+table interface;
 /// the wasip1 one additionally imports `wasi_snapshot_preview1` (served by the
 /// `wasi_shim`).
-fn runtime_blob() -> &'static [u8] {
-    if RUNTIME_WASM_INTERACTIVE_WASIP1.is_empty() {
+fn runtime_blob(shared: bool) -> &'static [u8] {
+    if shared {
+        crate::RUNTIME_WASM_INTERACTIVE_WASIP1_THREADS
+    } else if RUNTIME_WASM_INTERACTIVE_WASIP1.is_empty() {
         RUNTIME_WASM
     } else {
         RUNTIME_WASM_INTERACTIVE_WASIP1
     }
+}
+
+/// Whether a run of `model` pairs with the shared-memory runtime: a `--parmodauto`
+/// model (whose module imports a shared memory) on an omc that has it.
+fn uses_shared_memory(meta: &SimMeta) -> bool {
+    crate::THREADS_RUNTIME && meta.parmod.is_some()
 }
 
 /// The compiled-module type for this backend; `CodegenWasmJit::SimModel` stores
@@ -64,7 +72,7 @@ pub fn set_alarm(seconds: Option<u32>) {
     ALARM_SECS.store(hard.unwrap_or(0), std::sync::atomic::Ordering::Relaxed);
 }
 
-fn alarm_secs() -> u32 {
+pub(crate) fn alarm_secs() -> u32 {
     ALARM_SECS.load(std::sync::atomic::Ordering::Relaxed)
 }
 
@@ -95,31 +103,36 @@ fn start_epoch_ticker(engine: wasmtime::Engine) {
 /// threads share the same engine the run instantiates them on.
 /// Two of them: see [`ALARM_SECS`].
 pub fn sim_engine() -> &'static wasmtime::Engine {
-    if alarm_secs() != 0 { alarm_engine() } else { plain_engine() }
-}
-
-fn alarm_engine() -> &'static wasmtime::Engine {
-    static ENGINE: OnceLock<wasmtime::Engine> = OnceLock::new();
-    ENGINE.get_or_init(|| {
+    static ENGINES: [OnceLock<wasmtime::Engine>; 2] = [OnceLock::new(), OnceLock::new()];
+    let armed = alarm_secs() != 0;
+    ENGINES[armed as usize].get_or_init(|| {
         let engine = build_engine_cfg(|cfg| {
-            cfg.epoch_interruption(true);
+            if armed {
+                cfg.epoch_interruption(true);
+            }
         });
-        start_epoch_ticker(engine.clone());
+        if armed {
+            start_epoch_ticker(engine.clone());
+        }
         engine
     })
-}
-
-fn plain_engine() -> &'static wasmtime::Engine {
-    static ENGINE: OnceLock<wasmtime::Engine> = OnceLock::new();
-    ENGINE.get_or_init(|| build_engine_cfg(|_| {}))
 }
 
 fn build_engine_cfg(extra: impl FnOnce(&mut wasmtime::Config)) -> wasmtime::Engine {
     let mut cfg = wasmtime::Config::new();
     crate::tune_memory(&mut cfg);
+    // Explicit bounds checks (slower) give an out-of-bounds access a clean trap
+    // even in a shared-memory store, where wasmtime's fault handler panics instead
+    // (see `parmod_pool::call_task`).
+    if std::env::var_os("OMC_WASM_EXPLICIT_BOUNDS").is_some() {
+        cfg.signals_based_traps(false);
+    }
     // A model with external "C" carries the `model_error` tag its `ext` call sites
     // catch, so the module does not validate without this.
     cfg.wasm_exceptions(true);
+    // The parmodauto runtime and its worker instances import one shared memory.
+    cfg.wasm_threads(true);
+    cfg.shared_memory(true);
     // Compile module functions across threads (off by default with
     // default-features=false) — ~4x faster module compilation here.
     cfg.parallel_compilation(!crate::model::single_threaded());
@@ -149,12 +162,13 @@ fn build_engine_cfg(extra: impl FnOnce(&mut wasmtime::Config)) -> wasmtime::Engi
 /// wasmtime version / engine config / target, so a stale or incompatible cache
 /// is rejected and we transparently fall back to JIT (then refresh the cache).
 /// One cache per engine: a module belongs to the engine that compiled it.
-pub fn runtime_module() -> std::result::Result<&'static wasmtime::Module, String> {
-    static PLAIN: OnceLock<std::result::Result<wasmtime::Module, String>> = OnceLock::new();
-    static ALARM: OnceLock<std::result::Result<wasmtime::Module, String>> = OnceLock::new();
+pub fn runtime_module(shared: bool) -> std::result::Result<&'static wasmtime::Module, String> {
+    type Slot = OnceLock<std::result::Result<wasmtime::Module, String>>;
+    // Indexed by (alarm armed, shared memory).
+    static MODULES: [Slot; 4] = [OnceLock::new(), OnceLock::new(), OnceLock::new(), OnceLock::new()];
     let armed = alarm_secs() != 0;
-    if armed { &ALARM } else { &PLAIN }
-        .get_or_init(|| load_or_compile_runtime(armed))
+    MODULES[(armed as usize) * 2 + shared as usize]
+        .get_or_init(|| load_or_compile_runtime(armed, shared))
         .as_ref()
         .map_err(|e| format!("obtaining runtime module: {e}"))
 }
@@ -243,9 +257,8 @@ pub fn library_module(
     Ok(m)
 }
 
-fn load_or_compile_runtime(epoch: bool) -> std::result::Result<wasmtime::Module, String> {
-    let engine = if epoch { alarm_engine() } else { plain_engine() };
-    aot_module(engine, "runtime", runtime_blob(), epoch)
+fn load_or_compile_runtime(epoch: bool, shared: bool) -> std::result::Result<wasmtime::Module, String> {
+    aot_module(sim_engine(), if shared { "runtime-threads" } else { "runtime" }, runtime_blob(shared), epoch)
 }
 
 /// JIT-compile a generated model module on the shared engine. Called either on a
@@ -268,7 +281,7 @@ pub fn start_runtime_compile() {
     static STARTED: std::sync::Once = std::sync::Once::new();
     STARTED.call_once(|| {
         std::thread::spawn(|| {
-            let _ = runtime_module(); // populates the OnceLock cache
+            let _ = runtime_module(false); // populates the OnceLock cache
         });
     });
 }
@@ -293,6 +306,9 @@ type Store = wasmtime::Store<WasiCtx>;
 /// `assert()` is decoded downstream by `enrich_trap`).
 fn wt<T>(r: std::result::Result<T, wasmtime::Error>) -> Result<T> {
     r.map_err(|e| {
+        if std::env::var_os("OMC_WASM_TRAP_DEBUG").is_some() {
+            eprintln!("wasm-jit trap: {e:?}");
+        }
         crate::set_engine_error_detail(format!("{e:?}"));
         "CodegenWasmJit: wasm engine error"
     })
@@ -528,7 +544,7 @@ fn define_external_imports(
     linker: &mut wasmtime::Linker<WasiCtx>,
     store: &mut wasmtime::Store<WasiCtx>,
     model: &SimModel,
-    memory: wasmtime::Memory,
+    memory: crate::simmem::SimMem,
     rt: &crate::dylink_engine::ExtRt,
     libs: &crate::dylink_engine::Loaded,
 ) -> Result<()> {
@@ -559,7 +575,7 @@ fn define_external_imports(
             crate::set_engine_error_detail(unresolved_external_detail(&sig.name, model, &native.errors));
             "external \"C\" function not found in any loaded library"
         })?;
-        define_native_external(linker, sig, functype, addr, memory, rt)?;
+        define_native_external(linker, sig, functype, addr, memory.clone(), rt)?;
     }
     // No `external "C"` means no `Include`/`Library`, hence no `usertab`.
     let usertab = (!model.ext_imports.is_empty()).then(|| native.usertab(model)).flatten();
@@ -644,7 +660,7 @@ pub fn define_native_external(
     sig: &crate::sig::ExtCallSig,
     functype: wasmtime::FuncType,
     addr: usize,
-    memory: wasmtime::Memory,
+    memory: crate::simmem::SimMem,
     rt: &crate::dylink_engine::ExtRt,
 ) -> Result<()> {
     let name = sig.name.clone();
@@ -653,7 +669,7 @@ pub fn define_native_external(
     let prepared = prepare_cif(&sig);
     wt(linker.func_new("ext", &name, functype, move |mut caller, args, rets| {
         // Safety: `addr` resolves `sig.name`; the `Cif` matches the validated sig.
-        unsafe { call_external(addr, &sig, prepared.as_ref(), &mut caller, memory, &rt, args, rets) }
+        unsafe { call_external(addr, &sig, prepared.as_ref(), &mut caller, memory.clone(), &rt, args, rets) }
             .map_err(|e| wasmtime::Error::msg(format!("{e}")))
     }))?;
     Ok(())
@@ -662,7 +678,7 @@ pub fn define_native_external(
 /// The `print` builtin's host import (`rt.rt_print`): read the String handle's
 /// bytes from the shared linear memory and write them to the model's captured
 /// stdout. The handle stays owned by the generated code, which releases it after.
-fn define_print_import(linker: &mut wasmtime::Linker<WasiCtx>, memory: wasmtime::Memory) -> Result<()> {
+pub(crate) fn define_print_import(linker: &mut wasmtime::Linker<WasiCtx>, memory: crate::simmem::SimMem) -> Result<()> {
     wt(linker.func_wrap("rt", "rt_print", move |caller: wasmtime::Caller<'_, WasiCtx>, handle: i32| {
         if handle == 0 {
             return;
@@ -705,7 +721,7 @@ unsafe fn call_external(
     sig: &crate::sig::ExtCallSig,
     prepared: Option<&PreparedCif>,
     caller: &mut wasmtime::Caller<'_, WasiCtx>,
-    memory: wasmtime::Memory,
+    memory: crate::simmem::SimMem,
     rt: &crate::dylink_engine::ExtRt,
     args: &[wasmtime::Val],
     rets: &mut [wasmtime::Val],
@@ -941,11 +957,11 @@ unsafe fn call_external(
 
     let mut ri = 0usize;
     if let Some(ret_ty) = &sig.ret {
-        rets[ri] = ext_result(ret_ty, rvalue.bytes(), caller, memory, rt)?;
+        rets[ri] = ext_result(ret_ty, rvalue.bytes(), caller, memory.clone(), rt)?;
         ri += 1;
     }
     for (ty, cell) in &out_cells {
-        rets[ri] = ext_result(ty, cell.bytes(), caller, memory, rt)?;
+        rets[ri] = ext_result(ty, cell.bytes(), caller, memory.clone(), rt)?;
         ri += 1;
     }
     // A `char*` an output still points at is one the callee never wrote.
@@ -1049,7 +1065,7 @@ fn record_to_native(
 /// one, and the callee wrote the model's array in place — as in C, which asserts.
 fn record_from_native(
     caller: &mut wasmtime::Caller<'_, WasiCtx>,
-    memory: wasmtime::Memory,
+    memory: crate::simmem::SimMem,
     rt: &crate::dylink_engine::ExtRt,
     fields: &[(arcstr::ArcStr, crate::sig::SigTy)],
     src: &[u8],
@@ -1078,9 +1094,9 @@ fn record_from_native(
             }
             SigTy::Int | SigTy::Bool => src[at..at + 4].try_into().unwrap(),
             SigTy::Ptr => registry_put(word(src, at)).to_le_bytes(),
-            SigTy::Str => wasm_string(caller, memory, rt, word(src, at) as *const std::os::raw::c_char)?.to_le_bytes(),
+            SigTy::Str => wasm_string(caller, memory.clone(), rt, word(src, at) as *const std::os::raw::c_char)?.to_le_bytes(),
             SigTy::Record { fields: inner, .. } => {
-                record_from_native(caller, memory, rt, inner, &src[at..])?.to_le_bytes()
+                record_from_native(caller, memory.clone(), rt, inner, &src[at..])?.to_le_bytes()
             }
             other => return Err("CodegenWasmJit: external \"C\" : record field type not marshalled"),
         };
@@ -1094,7 +1110,7 @@ fn record_from_native(
 /// re-fetched after).
 fn wasm_string(
     caller: &mut wasmtime::Caller<'_, WasiCtx>,
-    memory: wasmtime::Memory,
+    memory: crate::simmem::SimMem,
     rt: &crate::dylink_engine::ExtRt,
     cptr: *const std::os::raw::c_char,
 ) -> Result<u32> {
@@ -1110,7 +1126,7 @@ fn ext_result(
     ty: &crate::sig::SigTy,
     cell: &[u8],
     caller: &mut wasmtime::Caller<'_, WasiCtx>,
-    memory: wasmtime::Memory,
+    memory: crate::simmem::SimMem,
     rt: &crate::dylink_engine::ExtRt,
 ) -> Result<wasmtime::Val> {
     use crate::sig::SigTy;
@@ -1120,8 +1136,8 @@ fn ext_result(
         SigTy::Real => Val::F64(f64::from_le_bytes(cell[..8].try_into().unwrap()).to_bits()),
         SigTy::Int | SigTy::Bool => Val::I32(i32::from_le_bytes(cell[..4].try_into().unwrap())),
         SigTy::Ptr => Val::I32(registry_put(word())),
-        SigTy::Str => Val::I32(wasm_string(caller, memory, rt, word() as *const std::os::raw::c_char)? as i32),
-        SigTy::Record { fields, .. } => Val::I32(record_from_native(caller, memory, rt, fields, cell)? as i32),
+        SigTy::Str => Val::I32(wasm_string(caller, memory.clone(), rt, word() as *const std::os::raw::c_char)? as i32),
+        SigTy::Record { fields, .. } => Val::I32(record_from_native(caller, memory.clone(), rt, fields, cell)? as i32),
         other => return Err("external \"C\": result type not marshalled"),
     })
 }
@@ -1165,7 +1181,7 @@ pub fn run(model: &SimModel, meta: &SimMeta) -> std::result::Result<sim_driver::
 fn read_sys_stats(
     store: &mut Store,
     rt_inst: &wasmtime::Instance,
-    memory: &wasmtime::Memory,
+    memory: &crate::simmem::SimMem,
 ) -> Vec<openmodelica_sim_meta::sysstat::SysStat> {
     let (Ok(ptr), Ok(len)) = (
         rt_inst.get_typed_func::<(), u32>(&mut *store, "rt_sys_stats_ptr"),
@@ -1221,14 +1237,23 @@ struct Instantiated {
     store: Store,
     rt_inst: wasmtime::Instance,
     instance: wasmtime::Instance,
-    memory: wasmtime::Memory,
+    memory: crate::simmem::SimMem,
     rt_alloc: wasmtime::TypedFunc<u32, u32>,
+    /// The shared memory, runtime and model modules a parmodauto worker pool
+    /// instantiates again per thread.
+    shared: Option<wasmtime::SharedMemory>,
+    runtime_module: &'static wasmtime::Module,
+    model_module: wasmtime::Module,
 }
 
 /// Compile/join the modules and instantiate them (runtime first, then model,
 /// sharing the runtime's `memory`).
-fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<Instantiated, String> {
+fn instantiate_modules(model: &SimModel, meta: &SimMeta, inwasm: bool) -> std::result::Result<Instantiated, String> {
     let bench = crate::model::sim_bench_enabled();
+    let shared = uses_shared_memory(meta);
+    if shared && inwasm {
+        return Err("CodegenWasmJit: the in-wasm session driver does not run a --parmodauto model".to_string());
+    }
     crate::host::lin_solve::reset(); // drop the previous run's host-side LSS cache
     let engine = sim_engine();
     let mut linker = wasmtime::Linker::new(engine);
@@ -1244,7 +1269,7 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
     // pipeline) — here we just join it. If no background job is present (e.g. a
     // direct call), compile inline as a fallback.
     let t_compile = Instant::now();
-    let runtime_module = runtime_module()?;
+    let runtime_module = runtime_module(shared)?;
     let rt_compile = t_compile.elapsed();
     // Prefer the module already prepared by `finishCompile` (buildModel's
     // compile phase, counted as `timeCompile`); otherwise join/compile here.
@@ -1270,7 +1295,7 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
     if bench {
         eprintln!(
             "wasm-jit sim: module fetch — runtime.wasm ({} KB) {:?} (cached/compiled), model.wasm ({} KB) {:?} (join/compile)",
-            runtime_blob().len() / 1024, rt_compile, model.wasm.len() / 1024, model_compile,
+            runtime_blob(shared).len() / 1024, rt_compile, model.wasm.len() / 1024, model_compile,
         );
     }
 
@@ -1285,11 +1310,22 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
             Err(wasmtime::Error::msg(sim_driver::ALARM_ABORT_ERR))
         });
     }
+    let shared_memory = match shared {
+        true => Some(crate::parmod_pool::new_shared_memory(engine, runtime_module)?),
+        false => None,
+    };
+    if let Some(m) = &shared_memory {
+        wts(linker.define(&mut store, "env", "memory", m.clone()))?;
+    }
     let rt_inst = wts(linker.instantiate(&mut store, runtime_module))?;
+    if let Ok(f) = rt_inst.get_typed_func::<(), ()>(&mut store, "rt_thread_init") {
+        wts(f.call(&mut store, ()))?;
+    }
     // The generated module imports the runtime's exports under module name "rt".
     wts(linker.instance(&mut store, "rt", rt_inst))?;
     let memory = rt_inst
-        .get_memory(&mut store, "memory")
+        .get_export(&mut store, "memory")
+        .and_then(crate::simmem::SimMem::from_extern)
         .ok_or_else(|| "CodegenWasmJit: runtime has no `memory` export")?;
     // External "C" functions (module `ext`) resolved from the host; they share the
     // runtime's linear memory for string/array/pointer marshalling, and re-enter
@@ -1302,7 +1338,7 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
         note: wts(rt_inst.get_typed_func::<(), ()>(&mut store, "rt_nls_note_assert"))?,
     };
     // `rt_row_asserts` is called by the model, which only imports `memory`.
-    crate::host::set_sim_memory(memory);
+    crate::host::set_sim_memory(memory.clone());
     let ext_rt = crate::dylink_engine::ExtRt {
         str_new: rt_str_new,
         str_data: rt_str_data,
@@ -1312,13 +1348,22 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
         record_new: wts(rt_inst.get_typed_func::<(u32, u32), u32>(&mut store, "rt_record_new"))?,
         nls: Some(nls),
     };
-    let ext_libs = crate::dylink_engine::load_ext_libraries(&mut store, engine, rt_inst, memory, model, &ext_rt)?;
+    let ext_libs = crate::dylink_engine::load_ext_libraries(&mut store, engine, rt_inst, memory.clone(), model, &ext_rt)?;
     crate::host::set_shadow_stack(ext_libs.shadow_stack());
     wts(crate::host::set_model_error_tag(&mut store, None))?;
-    define_external_imports(&mut linker, &mut store, model, memory, &ext_rt, &ext_libs)?;
-    define_print_import(&mut linker, memory)?;
-    crate::host::define_uri_import(&mut linker, memory, ext_rt.str_new.clone(), ext_rt.str_data.clone())?;
-    let instance = wts(linker.instantiate(&mut store, &model_module))?;
+    define_external_imports(&mut linker, &mut store, model, memory.clone(), &ext_rt, &ext_libs)?;
+    define_print_import(&mut linker, memory.clone())?;
+    crate::host::define_uri_import(&mut linker, memory.clone(), ext_rt.str_new.clone(), ext_rt.str_data.clone())?;
+    // A worker instance replays this instantiation's `rt_alloc`s (`parmod_pool`).
+    let start_mode = rt_inst.get_typed_func::<u32, ()>(&mut store, "rt_start_mode").ok().filter(|_| shared);
+    if let Some(f) = &start_mode {
+        wts(f.call(&mut store, 1))?;
+    }
+    let instance = linker.instantiate(&mut store, &model_module);
+    if let Some(f) = &start_mode {
+        wts(f.call(&mut store, 0))?;
+    }
+    let instance = wts(instance)?;
     // What a library's `ModelicaError` throws, now that the module defining the
     // tag exists. Only a model with external "C" carries one.
     if let Some(wasmtime::Extern::Tag(tag)) = instance.get_export(&mut store, "model_error") {
@@ -1457,7 +1502,7 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
         eprintln!("wasm-jit sim: compile {compile_time:?} | instantiate {inst_time:?}");
     }
 
-    Ok(Instantiated { store, rt_inst, instance, memory, rt_alloc })
+    Ok(Instantiated { store, rt_inst, instance, memory, rt_alloc, shared: shared_memory, runtime_module, model_module })
 }
 
 /// Build the engine (compile/join modules, instantiate, allocate `SimData`), boxed
@@ -1465,7 +1510,8 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
 /// by [`run`] one-shot.
 pub fn build_engine(model: &SimModel, meta: &SimMeta) -> std::result::Result<(Box<dyn sim_driver::SimEngine + 'static>, u32), String> {
     sim_driver::init_host_hooks(); // cancel poll + model-assertion routing (idempotent)
-    let Instantiated { mut store, rt_inst, instance, memory, rt_alloc } = instantiate_modules(model, meta)?;
+    let Instantiated { mut store, rt_inst, instance, memory, rt_alloc, shared, runtime_module, model_module } =
+        instantiate_modules(model, meta, false)?;
 
     let layout = &model.layout;
     // Allocate the shared SimData block.
@@ -1476,7 +1522,7 @@ pub fn build_engine(model: &SimModel, meta: &SimMeta) -> std::result::Result<(Bo
     // (same path `rt_solve_nls` already uses). Verify host-side population works
     // before building the in-wasm driver on it.
     if std::env::var("OMC_WASM_SIM_PROBE").is_ok() {
-        run_table_probe(&mut store, rt_inst, instance, memory, sim_data, layout.total)?;
+        run_table_probe(&mut store, rt_inst, instance, memory.clone(), sim_data, layout.total)?;
     }
 
     // What C's `NLS_USERDATA` carries as `DATA*`: `-saveInitialGuess_system` writes
@@ -1489,7 +1535,13 @@ pub fn build_engine(model: &SimModel, meta: &SimMeta) -> std::result::Result<(Bo
         wts(set.call(&mut store, (ptr, blob.len() as u32, sim_data)))?;
     }
 
-    let engine = WasmtimeEngine { store, memory, instance, rt_inst, funcs: HashMap::new(), funcs2: HashMap::new() };
+    // The worker instances, before the run mutates any block the model's `start`
+    // filled (the replay writes them again).
+    let pool = match shared {
+        Some(shared) => crate::parmod_pool::Pool::new(&mut store, &rt_alloc, shared, runtime_module, &model_module, model)?,
+        None => None,
+    };
+    let engine = WasmtimeEngine { store, memory, instance, rt_inst, funcs: HashMap::new(), funcs2: HashMap::new(), pool };
     Ok((Box::new(engine), sim_data))
 }
 
@@ -1501,7 +1553,7 @@ fn run_table_probe(
     store: &mut Store,
     rt_inst: wasmtime::Instance,
     instance: wasmtime::Instance,
-    memory: wasmtime::Memory,
+    memory: crate::simmem::SimMem,
     sim_data: u32,
     total: u32,
 ) -> Result<()> {
@@ -1548,7 +1600,7 @@ fn run_table_probe(
 /// `fn(u32) -> ()` equation functions.
 struct WasmtimeEngine {
     store: Store,
-    memory: wasmtime::Memory,
+    memory: crate::simmem::SimMem,
     instance: wasmtime::Instance,
     rt_inst: wasmtime::Instance,
     funcs: HashMap<String, wasmtime::TypedFunc<u32, ()>>,
@@ -1556,6 +1608,8 @@ struct WasmtimeEngine {
     /// Resolved two-argument exports by name (`evaluateDAEResiduals` and the
     /// synchronous dispatchers), so one cached entry cannot answer for another.
     funcs2: HashMap<String, wasmtime::TypedFunc<(u32, u32), ()>>,
+    /// The `--parmodauto` worker threads, when the run has more than one.
+    pool: Option<crate::parmod_pool::Pool>,
 }
 
 impl WasmtimeEngine {
@@ -1609,6 +1663,21 @@ impl sim_driver::SimEngine for WasmtimeEngine {
     }
     fn take_pending_reinits(&mut self) -> Vec<(u32, f64)> {
         crate::host::take_pending_reinits()
+    }
+    fn parmod_can_parallel(&self) -> bool {
+        self.pool.is_some()
+    }
+    fn parmod_parallel(&mut self, plan: &openmodelica_sim_meta::parmod::Plan, sim_data: u32) -> Result<()> {
+        let task = match self.funcs2.get("parmodTask") {
+            Some(f) => f.clone(),
+            None => {
+                let f = wt(self.instance.get_typed_func::<(u32, u32), ()>(&mut self.store, "parmodTask"))?;
+                self.funcs2.insert("parmodTask".to_string(), f.clone());
+                f
+            }
+        };
+        let pool = self.pool.as_mut().ok_or("parmodauto: no worker pool")?;
+        pool.run(plan, sim_data, &mut self.store, &task)
     }
     fn lin_solves(&mut self) -> u64 {
         match self.rt_inst.get_typed_func::<(), u64>(&mut self.store, "rt_lin_solves") {
@@ -1706,7 +1775,7 @@ impl sim_driver::SimEngine for WasmtimeEngine {
 /// A running in-wasm simulation. `Drop` frees the in-wasm session.
 pub struct InWasmSession {
     store: Store,
-    memory: wasmtime::Memory,
+    memory: crate::simmem::SimMem,
     advance: wasmtime::TypedFunc<f64, i32>,
     rows_ptr: wasmtime::TypedFunc<(), u32>,
     rows_len: wasmtime::TypedFunc<(), u32>,
@@ -1727,7 +1796,7 @@ pub struct InWasmSession {
 /// metadata blob, and `rt_sim_start` a resumable in-wasm run.
 pub fn build_inwasm_session(model: &SimModel) -> std::result::Result<InWasmSession, String> {
     sim_driver::init_host_hooks(); // cancel poll + assertion routing (idempotent)
-    let Instantiated { mut store, rt_inst, instance, memory, rt_alloc } = instantiate_modules(model, &model.meta)?;
+    let Instantiated { mut store, rt_inst, instance, memory, rt_alloc, .. } = instantiate_modules(model, &model.meta, true)?;
 
     // Append N contiguous table slots and set each to the model's export funcref
     // (null + cleared mask bit if the model doesn't export it).
@@ -1851,7 +1920,7 @@ impl InWasmSession {
     /// Read the captured rows/params/stats after the run completed.
     pub fn take_result(&mut self) -> Result<sim_driver::RunResult> {
         let read_vec = |store: &mut Store,
-                        mem: &wasmtime::Memory,
+                        mem: &crate::simmem::SimMem,
                         ptr: &wasmtime::TypedFunc<(), u32>,
                         len: &wasmtime::TypedFunc<(), u32>|
          -> Result<Vec<f64>> {
@@ -1932,7 +2001,7 @@ impl Drop for InWasmSession {
 pub struct DylinkFmu {
     store: Store,
     loaded: crate::dylink_engine::Loaded,
-    memory: wasmtime::Memory,
+    memory: crate::simmem::SimMem,
     alloc: wasmtime::TypedFunc<u32, u32>,
     /// The model, held so the store keeps it for as long as the adapter can call it.
     _instance: Option<wasmtime::Instance>,
@@ -1957,7 +2026,7 @@ pub const NATIVE_STUB: &str = "native_stub";
 fn native_ext_host_import(
     store: &mut Store,
     engine: &wasmtime::Engine,
-    memory: wasmtime::Memory,
+    memory: crate::simmem::SimMem,
     rt: &crate::dylink_engine::ExtRt,
     resources: &str,
 ) -> wasmtime::Func {
@@ -1967,7 +2036,7 @@ fn native_ext_host_import(
 
     struct HostGuest<'a, 'b> {
         caller: &'a mut wasmtime::Caller<'b, WasiCtx>,
-        memory: wasmtime::Memory,
+        memory: crate::simmem::SimMem,
         alloc: wasmtime::TypedFunc<u32, u32>,
         free: wasmtime::TypedFunc<u32, ()>,
     }
@@ -2030,7 +2099,7 @@ fn native_ext_host_import(
     wasmtime::Func::new(store, ty, move |mut caller, args, _rets| {
         let [index, frame, table, table_len] = [args[0].unwrap_i32() as u32, args[1].unwrap_i32() as u32, args[2].unwrap_i32() as u32, args[3].unwrap_i32() as u32];
         let mut st = state.lock().unwrap_or_else(|e| e.into_inner());
-        let mut guest = HostGuest { caller: &mut caller, memory, alloc: rt.alloc.clone(), free: rt.free.clone() };
+        let mut guest = HostGuest { caller: &mut caller, memory: memory.clone(), alloc: rt.alloc.clone(), free: rt.free.clone() };
         for p in std::mem::take(&mut st.scratch) {
             guest.free(p);
         }
@@ -2091,17 +2160,18 @@ impl DylinkFmu {
         let mut linker = wasmtime::Linker::new(engine);
         add_host_builtins(&mut linker)?;
         wasi_shim::add_to_linker(&mut linker)?;
-        let runtime_module = runtime_module()?;
+        let runtime_module = runtime_module(false)?;
         let mut store = wasmtime::Store::new(engine, WasiCtx::new(resources, Vec::new()));
         let rt_inst = wts(linker.instantiate(&mut store, runtime_module))?;
         wts(linker.instance(&mut store, "rt", rt_inst))?;
         let memory = rt_inst
-            .get_memory(&mut store, "memory")
+            .get_export(&mut store, "memory")
+            .and_then(crate::simmem::SimMem::from_extern)
             .ok_or_else(|| "CodegenWasmJit: runtime has no `memory` export".to_string())?;
         let table = rt_inst
             .get_table(&mut store, "__indirect_function_table")
             .ok_or_else(|| "CodegenWasmJit: runtime has no table export".to_string())?;
-        crate::host::set_sim_memory(memory);
+        crate::host::set_sim_memory(memory.clone());
         let ext_rt = crate::dylink_engine::ExtRt {
             str_new: wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_str_new"))?,
             str_data: wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_str_data"))?,
@@ -2121,8 +2191,8 @@ impl DylinkFmu {
         // PIC model would pay for that relocatability in its hot loop.
         // The `rt` names the host serves rather than the runtime module: the same
         // ones the ordinary simulation path defines before instantiating a model.
-        define_print_import(&mut linker, memory)?;
-        crate::host::define_uri_import(&mut linker, memory, ext_rt.str_new.clone(), ext_rt.str_data.clone())?;
+        define_print_import(&mut linker, memory.clone())?;
+        crate::host::define_uri_import(&mut linker, memory.clone(), ext_rt.str_new.clone(), ext_rt.str_data.clone())?;
         // The model's `external "C"` first: the model imports those and the
         // adapter imports the model, so the three go in that order.
         let mut ext_libs: Vec<Library> = Vec::new();
@@ -2153,13 +2223,13 @@ impl DylinkFmu {
             if ext.iter().any(|l| l.name == NATIVE_STUB) {
                 utilities.insert(
                     "om_ext_native_call".to_string(),
-                    native_ext_host_import(&mut store, engine, memory, &ext_rt, resources),
+                    native_ext_host_import(&mut store, engine, memory.clone(), &ext_rt, resources),
                 );
             }
             let libs = crate::dylink_engine::load(
                 &mut store,
                 engine,
-                memory,
+                memory.clone(),
                 table,
                 &ext_rt.alloc,
                 &ext_libs,
@@ -2196,7 +2266,7 @@ impl DylinkFmu {
             }
         }
         let loaded =
-            crate::dylink_engine::load(&mut store, engine, memory, table, &ext_rt.alloc, &[Library::builtin("fmi3adapter", adapter)], &host)?;
+            crate::dylink_engine::load(&mut store, engine, memory.clone(), table, &ext_rt.alloc, &[Library::builtin("fmi3adapter", adapter)], &host)?;
         crate::host::set_shadow_stack(loaded.shadow_stack());
         Ok(DylinkFmu { store, loaded, memory, alloc: ext_rt.alloc, _instance: Some(model_inst) })
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/simmem.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/simmem.rs
@@ -1,0 +1,119 @@
+//! The run's linear memory, whichever kind wasmtime gave it: the plain runtime's
+//! own memory, or the `SharedMemory` the parmodauto runtime and its per-thread
+//! worker instances import. Same surface as `wasmtime::Memory` for the host code
+//! that marshals through it.
+
+use wasmtime::{AsContext, AsContextMut, Extern, Memory, SharedMemory, StoreContext, StoreContextMut};
+
+#[derive(Clone)]
+pub enum SimMem {
+    Plain(Memory),
+    Shared(SharedMemory),
+}
+
+/// Access to a shared memory is a plain slice here: the host reads and writes it
+/// only while no worker thread runs, and the workers only through wasm.
+fn shared_slice(m: &SharedMemory) -> &[u8] {
+    let d = m.data();
+    unsafe { core::slice::from_raw_parts(d.as_ptr().cast::<u8>(), d.len()) }
+}
+
+#[allow(clippy::mut_from_ref)]
+fn shared_slice_mut(m: &SharedMemory) -> &mut [u8] {
+    let d = m.data();
+    unsafe { core::slice::from_raw_parts_mut(d.as_ptr().cast::<u8>().cast_mut(), d.len()) }
+}
+
+impl SimMem {
+    pub fn from_extern(e: Extern) -> Option<SimMem> {
+        match e {
+            Extern::Memory(m) => Some(SimMem::Plain(m)),
+            Extern::SharedMemory(m) => Some(SimMem::Shared(m)),
+            _ => None,
+        }
+    }
+
+    pub fn to_extern(&self) -> Extern {
+        match self {
+            SimMem::Plain(m) => Extern::Memory(*m),
+            SimMem::Shared(m) => Extern::SharedMemory(m.clone()),
+        }
+    }
+
+    pub fn is_shared(&self) -> bool {
+        matches!(self, SimMem::Shared(_))
+    }
+
+    pub fn data<'a, T: 'static>(&'a self, store: impl Into<StoreContext<'a, T>>) -> &'a [u8] {
+        match self {
+            SimMem::Plain(m) => m.data(store),
+            SimMem::Shared(m) => shared_slice(m),
+        }
+    }
+
+    pub fn data_mut<'a, T: 'static>(&'a self, store: impl Into<StoreContextMut<'a, T>>) -> &'a mut [u8] {
+        match self {
+            SimMem::Plain(m) => m.data_mut(store),
+            SimMem::Shared(m) => shared_slice_mut(m),
+        }
+    }
+
+    pub fn data_and_store_mut<'a, T: 'static>(&'a self, store: impl Into<StoreContextMut<'a, T>>) -> (&'a mut [u8], &'a mut T) {
+        match self {
+            SimMem::Plain(m) => m.data_and_store_mut(store),
+            SimMem::Shared(m) => {
+                let mut store = store.into();
+                // The memory is not part of the store, so the two borrows are disjoint.
+                let data = unsafe { &mut *(store.data_mut() as *mut T) };
+                (shared_slice_mut(m), data)
+            }
+        }
+    }
+
+    pub fn data_size(&self, store: impl AsContext) -> usize {
+        match self {
+            SimMem::Plain(m) => m.data_size(store),
+            SimMem::Shared(m) => m.data_size(),
+        }
+    }
+
+    pub fn read(&self, store: impl AsContext, offset: usize, buf: &mut [u8]) -> Result<(), &'static str> {
+        let store = store.as_context();
+        let src = self.data(&store).get(offset..).and_then(|s| s.get(..buf.len())).ok_or("read outside linear memory")?;
+        buf.copy_from_slice(src);
+        Ok(())
+    }
+
+    pub fn write(&self, mut store: impl AsContextMut, offset: usize, buf: &[u8]) -> Result<(), &'static str> {
+        let mut ctx = store.as_context_mut();
+        let dst = self.data_mut(&mut ctx).get_mut(offset..).and_then(|s| s.get_mut(..buf.len())).ok_or("write outside linear memory")?;
+        dst.copy_from_slice(buf);
+        Ok(())
+    }
+}
+
+/// `wasm` with its memory import (or definition) retyped as shared, 4 GiB maximum:
+/// a PIC library built for a plain memory, instantiated over the parmodauto
+/// runtime's shared one. Plain loads and stores are valid on a shared memory, so
+/// nothing else about the module changes.
+pub fn retype_memory_shared(wasm: &[u8]) -> Result<Vec<u8>, String> {
+    use wasm_encoder::reencode::{self, Reencode};
+    struct Shared;
+    impl Reencode for Shared {
+        type Error = core::convert::Infallible;
+        fn memory_type(
+            &mut self,
+            ty: wasmparser::MemoryType,
+        ) -> std::result::Result<wasm_encoder::MemoryType, reencode::Error<Self::Error>> {
+            let mut t = reencode::utils::memory_type(self, ty);
+            t.shared = true;
+            t.maximum.get_or_insert(65536);
+            Ok(t)
+        }
+    }
+    let mut m = wasm_encoder::Module::new();
+    Shared
+        .parse_core_module(&mut m, wasmparser::Parser::new(0), wasm)
+        .map_err(|e| format!("cannot retype the memory import as shared: {e}"))?;
+    Ok(m.finish())
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/wasi_shim.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/wasi_shim.rs
@@ -30,19 +30,17 @@ mod wasmtime_impl {
     /// memory. A shared library imports the memory rather than exporting one, so
     /// fall back to the one the engine registered for the run.
     macro_rules! mem_ctx {
-        ($caller:expr) => {{
-            let mem = $caller
+        ($caller:expr, $mem:ident, $ctx:ident) => {
+            let Some(m) = $caller
                 .get_export("memory")
-                .and_then(|e| e.into_memory())
-                .or_else(crate::host::get_sim_memory);
-            match mem {
-                Some(m) => {
-                    let (data, ctx) = m.data_and_store_mut(&mut $caller);
-                    (SliceMem(data), ctx)
-                }
-                None => return ERRNO_FAULT,
-            }
-        }};
+                .and_then(crate::simmem::SimMem::from_extern)
+                .or_else(crate::host::get_sim_memory)
+            else {
+                return ERRNO_FAULT;
+            };
+            let (data, $ctx) = m.data_and_store_mut(&mut $caller);
+            let mut $mem = SliceMem(data);
+        };
     }
 
     /// Register the `wasi_snapshot_preview1` imports into `linker`.
@@ -51,51 +49,51 @@ mod wasmtime_impl {
         let wt = |r: std::result::Result<&mut Linker, wasmtime::Error>| r.map(|_| ()).map_err(|_| "CodegenWasmJit: wasm engine error");
 
         wt(linker.func_wrap(m, "fd_write", |mut c: Caller<'_, WasiCtx>, fd: i32, iovs: i32, n: i32, nw: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c);
+            mem_ctx!(c, mem, ctx);
             ctx.fd_write(&mut mem, fd as u32, iovs as u32, n as u32, nw as u32)
         }))?;
         wt(linker.func_wrap(m, "fd_read", |mut c: Caller<'_, WasiCtx>, fd: i32, iovs: i32, n: i32, nr: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c);
+            mem_ctx!(c, mem, ctx);
             ctx.fd_read(&mut mem, fd as u32, iovs as u32, n as u32, nr as u32)
         }))?;
         wt(linker.func_wrap(m, "fd_seek", |mut c: Caller<'_, WasiCtx>, fd: i32, off: i64, whence: i32, no: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c);
+            mem_ctx!(c, mem, ctx);
             ctx.fd_seek(&mut mem, fd as u32, off, whence, no as u32)
         }))?;
         wt(linker.func_wrap(m, "path_open", |mut c: Caller<'_, WasiCtx>, dirfd: i32, dirflags: i32, path: i32, plen: i32, oflags: i32, rb: i64, ri: i64, fdflags: i32, ofd: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c);
+            mem_ctx!(c, mem, ctx);
             ctx.path_open(&mut mem, dirfd as u32, dirflags as u32, path as u32, plen as u32, oflags, rb as u64, ri as u64, fdflags, ofd as u32)
         }))?;
         wt(linker.func_wrap(m, "path_filestat_get", |mut c: Caller<'_, WasiCtx>, dirfd: i32, flags: i32, path: i32, plen: i32, buf: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c);
+            mem_ctx!(c, mem, ctx);
             ctx.path_filestat_get(&mut mem, dirfd as u32, flags as u32, path as u32, plen as u32, buf as u32)
         }))?;
         wt(linker.func_wrap(m, "fd_filestat_get", |mut c: Caller<'_, WasiCtx>, fd: i32, buf: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c);
+            mem_ctx!(c, mem, ctx);
             ctx.fd_filestat_get(&mut mem, fd as u32, buf as u32)
         }))?;
         wt(linker.func_wrap(m, "path_create_directory", |mut c: Caller<'_, WasiCtx>, dirfd: i32, path: i32, plen: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c);
+            mem_ctx!(c, mem, ctx);
             ctx.path_create_directory(&mut mem, dirfd as u32, path as u32, plen as u32)
         }))?;
         wt(linker.func_wrap(m, "path_unlink_file", |mut c: Caller<'_, WasiCtx>, dirfd: i32, path: i32, plen: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c);
+            mem_ctx!(c, mem, ctx);
             ctx.path_unlink_file(&mut mem, dirfd as u32, path as u32, plen as u32)
         }))?;
         wt(linker.func_wrap(m, "path_remove_directory", |mut c: Caller<'_, WasiCtx>, dirfd: i32, path: i32, plen: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c);
+            mem_ctx!(c, mem, ctx);
             ctx.path_remove_directory(&mut mem, dirfd as u32, path as u32, plen as u32)
         }))?;
         wt(linker.func_wrap(m, "path_rename", |mut c: Caller<'_, WasiCtx>, ofd: i32, op: i32, ol: i32, nfd: i32, np: i32, nl: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c);
+            mem_ctx!(c, mem, ctx);
             ctx.path_rename(&mut mem, ofd as u32, op as u32, ol as u32, nfd as u32, np as u32, nl as u32)
         }))?;
         wt(linker.func_wrap(m, "fd_readdir", |mut c: Caller<'_, WasiCtx>, fd: i32, buf: i32, buf_len: i32, cookie: i64, bufused: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c);
+            mem_ctx!(c, mem, ctx);
             ctx.fd_readdir(&mut mem, fd as u32, buf as u32, buf_len as u32, cookie as u64, bufused as u32)
         }))?;
         wt(linker.func_wrap(m, "fd_fdstat_get", |mut c: Caller<'_, WasiCtx>, fd: i32, buf: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c);
+            mem_ctx!(c, mem, ctx);
             ctx.fd_fdstat_get(&mut mem, fd as u32, buf as u32)
         }))?;
         wt(linker.func_wrap(m, "fd_fdstat_set_flags", |_c: Caller<'_, WasiCtx>, _fd: i32, _flags: i32| -> i32 {
@@ -105,35 +103,35 @@ mod wasmtime_impl {
             c.data_mut().fd_close(fd as u32)
         }))?;
         wt(linker.func_wrap(m, "fd_prestat_get", |mut c: Caller<'_, WasiCtx>, fd: i32, buf: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c);
+            mem_ctx!(c, mem, ctx);
             ctx.fd_prestat_get(&mut mem, fd as u32, buf as u32)
         }))?;
         wt(linker.func_wrap(m, "fd_prestat_dir_name", |mut c: Caller<'_, WasiCtx>, fd: i32, path: i32, plen: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c);
+            mem_ctx!(c, mem, ctx);
             ctx.fd_prestat_dir_name(&mut mem, fd as u32, path as u32, plen as u32)
         }))?;
         wt(linker.func_wrap(m, "args_sizes_get", |mut c: Caller<'_, WasiCtx>, argc: i32, bs: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c);
+            mem_ctx!(c, mem, ctx);
             ctx.args_sizes_get(&mut mem, argc as u32, bs as u32)
         }))?;
         wt(linker.func_wrap(m, "args_get", |mut c: Caller<'_, WasiCtx>, argv: i32, buf: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c);
+            mem_ctx!(c, mem, ctx);
             ctx.args_get(&mut mem, argv as u32, buf as u32)
         }))?;
         wt(linker.func_wrap(m, "environ_sizes_get", |mut c: Caller<'_, WasiCtx>, count: i32, bs: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c);
+            mem_ctx!(c, mem, ctx);
             ctx.environ_sizes_get(&mut mem, count as u32, bs as u32)
         }))?;
         wt(linker.func_wrap(m, "environ_get", |mut c: Caller<'_, WasiCtx>, env: i32, buf: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c);
+            mem_ctx!(c, mem, ctx);
             ctx.environ_get(&mut mem, env as u32, buf as u32)
         }))?;
         wt(linker.func_wrap(m, "clock_time_get", |mut c: Caller<'_, WasiCtx>, id: i32, prec: i64, time: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c);
+            mem_ctx!(c, mem, ctx);
             ctx.clock_time_get(&mut mem, id as u32, prec as u64, time as u32)
         }))?;
         wt(linker.func_wrap(m, "random_get", |mut c: Caller<'_, WasiCtx>, buf: i32, len: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c);
+            mem_ctx!(c, mem, ctx);
             ctx.random_get(&mut mem, buf as u32, len as u32)
         }))?;
         // `proc_exit` is a normal termination: record the code and unwind via a
@@ -147,10 +145,10 @@ mod wasmtime_impl {
         // ops. EINVAL: pread/pwrite / links / poll / sockets — all off the file-read
         // path but must exist for the module to instantiate.
         wt(linker.func_wrap(m, "clock_res_get", |mut c: Caller<'_, WasiCtx>, id: i32, out: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c); ctx.clock_res_get(&mut mem, id as u32, out as u32)
+            mem_ctx!(c, mem, ctx); ctx.clock_res_get(&mut mem, id as u32, out as u32)
         }))?;
         wt(linker.func_wrap(m, "fd_tell", |mut c: Caller<'_, WasiCtx>, fd: i32, out: i32| -> i32 {
-            let (mut mem, ctx) = mem_ctx!(c); ctx.fd_tell(&mut mem, fd as u32, out as u32)
+            mem_ctx!(c, mem, ctx); ctx.fd_tell(&mut mem, fd as u32, out as u32)
         }))?;
         wt(linker.func_wrap(m, "sched_yield", |_c: Caller<'_, WasiCtx>| -> i32 { ERRNO_SUCCESS }))?;
         wt(linker.func_wrap(m, "fd_sync", |_c: Caller<'_, WasiCtx>, _fd: i32| -> i32 { ERRNO_SUCCESS }))?;

--- a/OMCompiler/Compiler/OpenModelica.rs/rust-toolchain.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/rust-toolchain.toml
@@ -6,7 +6,9 @@
 # (rustc-codegen-cranelift-preview). wasm32-unknown-unknown is for the web /
 # wasm-jit builds; wasm32-wasip1 is for the standalone-export runtime that
 # openmodelica_codegen_wasm_jit/build.rs embeds (its unit tests need it, so it
-# must be present in the CI test container too, not just the cmake build).
+# must be present in the CI test container too, not just the cmake build);
+# wasm32-wasip1-threads is the shared-memory runtime the parallel --parmodauto
+# path instantiates per worker thread.
 #
 # rust-src: the FMI3 wasm adapters build.rs compiles need `-Z build-std`, which
 # builds the std sources; without this component the adapter silently falls back
@@ -15,4 +17,4 @@
 channel = "nightly-2026-05-31"
 profile = "minimal"
 components = ["rustc-codegen-cranelift-preview", "clippy", "rustfmt", "rust-src"]
-targets = ["wasm32-unknown-unknown", "wasm32-wasip1"]
+targets = ["wasm32-unknown-unknown", "wasm32-wasip1", "wasm32-wasip1-threads"]


### PR DESCRIPTION
`--parmodauto` under `--simCodeTarget=wasm-jit` evaluated the clustered ODE on one thread. It now runs the clusters on a pool of `-parmodNumThreads` threads (the calling one included), like C's TBB scheduler.

A wasmtime store runs on one thread at a time, so a parmodauto model is paired with a second interactive runtime, built for `wasm32-wasip1-threads`, that imports a *shared* memory. Each worker owns a store with its own runtime and model instances over it; the model's `start` runs there in replay mode (`rt_start_mode`) so its globals and table slots match the main instance's, and the instance gets a stack, a TLS block and wasi-libc's thread pointer (`rt_thread_init`). The scheduler in `parmod.rs` hands a `Plan` (clusters, parents, levels) to `SimEngine::parmod_parallel`; engines without threads keep evaluating the sequential `functionODE`.

Runtime changes for the threads build: a spin-locked dlmalloc with a per-thread size-class cache, per-thread `rt_alloc` free lists, atomic reference counts, pinned shared literals (`rt_pin`), per-thread NLS flags and statistics, 8 MiB stacks. Pinning and the wider `rt_alloc` size-class cache (1 -> 16 KiB) make the sequential path cheaper too, and `rt_stat` gains `rust_alloc`.

An out-of-bounds access on a worker is reported rather than aborting the process: wasmtime's signal-based fault handler asserts instead of trapping when two instances of one store import the same memory, so the pool catches that panic and turns it into a trap.

| Model (4 threads vs 1)  | wasm-jit        | C               |
|-------------------------|-----------------|-----------------|
| BranchingDynamicPipes   | 0.81 vs 2.20 ms | 0.60 vs 1.20 ms |
| CauerLowPassSC          | 30 vs 27 us     | 15.8 vs 15.2 us |

Per ODE evaluation; both reference tests match with 1 and 4 threads.

Also: initialization without homotopy now logs why it failed under `-lv=LOG_INIT`.

Debug knobs: `OMC_WASM_PARMOD_DEBUG=<file>` (watchdog, stall and trap log, per-participant tally), `OMC_WASM_PARMOD_SERIAL`, `OMC_WASM_TRAP_DEBUG`, `OMC_WASM_EXPLICIT_BOUNDS` (explicit bounds checks, so a fault is a real trap).

Assisted-by: Claude Fable 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
