### PR TITLE
Fuse the wasm artifact runtime; link FMU solvers

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -783,11 +783,6 @@ void ctestRust() {
     "OMC_SUNDIALS_WASM_DIR=${env.WORKSPACE}/build_cmake/rust-sundials-wasm",
     "OMC_WASI_P1_ADAPTER=${env.WORKSPACE}/build_cmake/downloads/wasi_snapshot_preview1.reactor.wasm",
     "OMC_EXTERNAL_C_SOURCES=${env.WORKSPACE}/OMCompiler/SimulationRuntime/ModelicaExternalC/C-Sources",
-    // Without these the SUNDIALS dylink is empty and the FMU link test skips it.
-    // The include dir is under rust-sundials-wasm because that is what is stashed.
-    "OMC_SUNDIALS_SOURCES=${env.WORKSPACE}/OMCompiler/3rdParty/sundials",
-    "OMC_SUITESPARSE_SOURCES=${env.WORKSPACE}/OMCompiler/3rdParty/SuiteSparse",
-    "OMC_SUNDIALS_WASM_INCLUDE=${env.WORKSPACE}/build_cmake/rust-sundials-wasm/include",
   ]
   try {
     withSccache(wasmEnv) {

--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -329,7 +329,12 @@ if(RUST_OMC_ENABLE_SUNDIALS)
 
   # SuiteSparse toolchain: base wasi toolchain + include dirs for KLU headers.
   # CMAKE_C_FLAGS_INIT is a STRING (not list) so no semicolon issues.
-  set(_sundials_cflags "-O2 -I${_suitesparse_sources}/AMD/Include -I${_suitesparse_sources}/COLAMD/Include -I${_suitesparse_sources}/BTF/Include -I${_suitesparse_sources}/SuiteSparse_config")
+  #
+  # `-fPIC`: one archive set serves both users. wasm-ld relaxes the GOT/`__memory_base`
+  # relocations away in a non-PIC link, so the wasip1 runtime that links these
+  # statically gets a byte-identical module -- while an FMU's `--experimental-pic
+  # --shared` SUNDIALS side module can only be linked from PIC objects at all.
+  set(_sundials_cflags "-O2 -fPIC -I${_suitesparse_sources}/AMD/Include -I${_suitesparse_sources}/COLAMD/Include -I${_suitesparse_sources}/BTF/Include -I${_suitesparse_sources}/SuiteSparse_config")
   # UMFPACK adds its own headers and `NBLAS`, its no-BLAS build, there being no
   # BLAS for wasm. Passed as CMAKE_C_FLAGS, not through the toolchain's
   # CMAKE_C_FLAGS_INIT, which an already-configured build directory ignores.
@@ -430,6 +435,7 @@ target_include_directories(lis PRIVATE
     BINARY_DIR ${_lis_ep_build}
     CMAKE_ARGS
       -DCMAKE_TOOLCHAIN_FILE=${_sundials_toolchain}
+      -DCMAKE_C_FLAGS=${_sundials_cflags}
       -DBUILD_SHARED_LIBS=OFF
     BUILD_COMMAND ${CMAKE_COMMAND} --build ${_lis_ep_build} --parallel
     INSTALL_COMMAND ""
@@ -476,6 +482,7 @@ target_include_directories(primme PRIVATE
     BINARY_DIR ${_primme_ep_build}
     CMAKE_ARGS
       -DCMAKE_TOOLCHAIN_FILE=${_sundials_toolchain}
+      -DCMAKE_C_FLAGS=${_sundials_cflags}
       -DBUILD_SHARED_LIBS=OFF
     BUILD_COMMAND ${CMAKE_COMMAND} --build ${_primme_ep_build} --parallel
     INSTALL_COMMAND ""
@@ -492,6 +499,7 @@ target_include_directories(primme PRIVATE
     BINARY_DIR ${_sundials_ep_build}
     CMAKE_ARGS
       -DCMAKE_TOOLCHAIN_FILE=${_sundials_toolchain}
+      -DCMAKE_C_FLAGS=${_sundials_cflags}
       # Keep in sync with 3rdParty/CMakeLists.txt.
       -DBUILD_STATIC_LIBS=ON
       -DBUILD_SHARED_LIBS=OFF
@@ -530,14 +538,23 @@ target_include_directories(primme PRIVATE
       sundials_nvecserial_static sundials_sunmatrixdense_static
       sundials_sunmatrixsparse_static sundials_sunlinsoldense_static
       sundials_sunlinsolklu_static
+      # The Krylov `-idaLS` solvers and the SUNNonlinearSolver implementations.
+      # SUNDIALS bundles a copy of each into every integrator archive, so the
+      # wasip1 runtime resolves them either way; an FMU links one side module per
+      # solver library, and a symbol with no archive of its own has no group to
+      # belong to.
+      sundials_sunlinsolspgmr_static sundials_sunlinsolspbcgs_static
+      sundials_sunlinsolsptfqmr_static
+      sundials_sunnonlinsolnewton_static sundials_sunnonlinsolfixedpoint_static
     INSTALL_COMMAND ""
     BUILD_ALWAYS ON
     EXCLUDE_FROM_ALL ON)
   add_dependencies(rust_sundials_wasm rust_suitesparse_wasm)
 
-  # RUST_SUNDIALS_WASM_DIR is the whole wasm SUNDIALS hand-off: lib/ for the wasip1
-  # runtime to link, include/ for the PIC dylink build to compile against. A CI
-  # stage with only this directory, not the ExternalProject tree, can do both.
+  # RUST_SUNDIALS_WASM_DIR is the whole wasm solver hand-off: the archives the
+  # wasip1 runtimes link statically and an FMU's PIC side module is linked from,
+  # plus the generated headers. A CI stage with only this directory, not the
+  # ExternalProject tree, can build every wasm artifact that needs them.
   add_custom_target(rust_sundials_collect
     COMMAND ${CMAKE_COMMAND} -E make_directory ${RUST_SUNDIALS_WASM_DIR}/lib
     COMMAND ${CMAKE_COMMAND} -E copy_directory
@@ -559,6 +576,11 @@ target_include_directories(primme PRIVATE
       ${_sundials_ep_build}/src/sunmatrix/sparse/libsundials_sunmatrixsparse.a
       ${_sundials_ep_build}/src/sunlinsol/dense/libsundials_sunlinsoldense.a
       ${_sundials_ep_build}/src/sunlinsol/klu/libsundials_sunlinsolklu.a
+      ${_sundials_ep_build}/src/sunlinsol/spgmr/libsundials_sunlinsolspgmr.a
+      ${_sundials_ep_build}/src/sunlinsol/spbcgs/libsundials_sunlinsolspbcgs.a
+      ${_sundials_ep_build}/src/sunlinsol/sptfqmr/libsundials_sunlinsolsptfqmr.a
+      ${_sundials_ep_build}/src/sunnonlinsol/newton/libsundials_sunnonlinsolnewton.a
+      ${_sundials_ep_build}/src/sunnonlinsol/fixedpoint/libsundials_sunnonlinsolfixedpoint.a
       ${_lis_ep_build}/liblis.a
       ${_primme_ep_build}/libprimme.a
       ${RUST_SUNDIALS_WASM_DIR}/lib/
@@ -714,14 +736,45 @@ endif()
 if(EXISTS ${_wasi_libc_src}/CMakeLists.txt)
   list(APPEND CARGO_ENV "OMC_WASI_LIBC_SRC=${_wasi_libc_src}")
 endif()
-if(RUST_OMC_ENABLE_SUNDIALS)
-  list(APPEND CARGO_ENV
-       "OMC_SUNDIALS_SOURCES=${CMAKE_CURRENT_SOURCE_DIR}/../3rdParty/sundials"
-       "OMC_SUITESPARSE_SOURCES=${CMAKE_CURRENT_SOURCE_DIR}/../3rdParty/SuiteSparse"
-       # The PIC dylink side module compiles the sources again, so it needs the
-       # generated `sundials_config.h` rust_sundials_collect puts here.
-       "OMC_SUNDIALS_WASM_INCLUDE=${RUST_SUNDIALS_WASM_DIR}/include")
+
+# ---------------------------------------------------------------------------
+# wasm-opt, found once and used by the web target, the wasm-jit runtime and --
+# through the cargo environment below -- openmodelica_wasm_jit's build script.
+# ---------------------------------------------------------------------------
+find_program(WASM_OPT_EXECUTABLE wasm-opt
+             HINTS $ENV{CARGO_HOME}/bin $ENV{HOME}/.cargo/bin)
+# wasm-opt -Oz on the 130+ MB debug/omc wasm takes many minutes and only shrinks
+# the shipped bundle — skip it for dev iteration. Clearing the executable var makes
+# every `if(WASM_OPT_EXECUTABLE)` site below fall through to the no-op branch.
+option(RUST_OMC_WASM_OPT "Run wasm-opt -Oz on the produced wasm (slow; OFF for faster dev builds)" ON)
+if(NOT RUST_OMC_WASM_OPT)
+  set(WASM_OPT_EXECUTABLE "")
+  message(STATUS "rust_omc: wasm-opt disabled (RUST_OMC_WASM_OPT=OFF)")
 endif()
+
+# wasm-opt feature flags, shared by every wasm-opt invocation below. rustc/LLVM
+# emit wasm32-unknown-unknown with these post-MVP features on, but the release
+# `strip` drops the target_features custom section binaryen would auto-detect
+# from — so it defaults to MVP and rejects the bulk-memory/sign-ext/etc. ops.
+# Enable exactly the set rustc reports (`rustc --print cfg --target
+# wasm32-unknown-unknown`), plus `simd`: faer's kernels are
+# `#[target_feature(enable = "simd128")]`, so every module linking them carries
+# v128 ops. Blindly enabling the rest could let wasm-opt emit instructions the
+# JIT/browser consumers don't support.
+set(WASM_OPT_FEATURES
+    --enable-bulk-memory --enable-multivalue --enable-mutable-globals
+    --enable-nontrapping-float-to-int --enable-reference-types --enable-sign-ext
+    --enable-simd)
+
+# The FMI3 adapters and the solver side modules are produced inside
+# openmodelica_wasm_jit's build script rather than by a CMake command, so it runs
+# wasm-opt itself. Every exported FMU links those modules and they are built once per
+# omc build and stamped, so this is paid here instead of per export. Empty when
+# binaryen is missing or RUST_OMC_WASM_OPT is OFF.
+string(JOIN " " _wasm_opt_features ${WASM_OPT_FEATURES})
+list(APPEND CARGO_ENV
+     "OMC_WASM_OPT=${WASM_OPT_EXECUTABLE}"
+     "OMC_WASM_OPT_FEATURES=${_wasm_opt_features}")
 
 # Always via ${CARGO_BUILD} so target/ is never the in-source default.
 set(CARGO_BUILD ${CARGO_ENV} ${CARGO_EXECUTABLE} build --target-dir ${RUST_TARGET_DIR})
@@ -778,18 +831,7 @@ add_test(NAME rust_cargo_test
 #     instead of rebuilding. Stage 2 (the web build) sets it to stage 1's
 #     artifact; it is forwarded as OMC_WASM_RUNTIME to the cargo build, which the
 #     build.rs honours (skipping the rebuild). Empty = build it normally.
-# wasm-opt is found here (optional) and reused by the web target below.
 # ---------------------------------------------------------------------------
-find_program(WASM_OPT_EXECUTABLE wasm-opt
-             HINTS $ENV{CARGO_HOME}/bin $ENV{HOME}/.cargo/bin)
-# wasm-opt -Oz on the 130+ MB debug/omc wasm takes many minutes and only shrinks
-# the shipped bundle — skip it for dev iteration. Clearing the executable var makes
-# every `if(WASM_OPT_EXECUTABLE)` site below fall through to the no-op branch.
-option(RUST_OMC_WASM_OPT "Run wasm-opt -Oz on the produced wasm (slow; OFF for faster dev builds)" ON)
-if(NOT RUST_OMC_WASM_OPT)
-  set(WASM_OPT_EXECUTABLE "")
-  message(STATUS "rust_omc: wasm-opt disabled (RUST_OMC_WASM_OPT=OFF)")
-endif()
 
 # Independent of RUST_OMC_WASM_OPT (which only gates omc.wasm -Oz): an -O0 OMEdit
 # link does not run in the browser, so keep it ON even for PR builds.
@@ -804,19 +846,6 @@ if(RUST_OMC_WEB_QT_STANDALONE)
 else()
   set(_qt_web_all ALL)
 endif()
-# wasm-opt feature flags, shared by every wasm-opt invocation below. rustc/LLVM
-# emit wasm32-unknown-unknown with these post-MVP features on, but the release
-# `strip` drops the target_features custom section binaryen would auto-detect
-# from — so it defaults to MVP and rejects the bulk-memory/sign-ext/etc. ops.
-# Enable exactly the set rustc reports (`rustc --print cfg --target
-# wasm32-unknown-unknown`), plus `simd`: faer's kernels are
-# `#[target_feature(enable = "simd128")]`, so every module linking them carries
-# v128 ops. Blindly enabling the rest could let wasm-opt emit instructions the
-# JIT/browser consumers don't support.
-set(WASM_OPT_FEATURES
-    --enable-bulk-memory --enable-multivalue --enable-mutable-globals
-    --enable-nontrapping-float-to-int --enable-reference-types --enable-sign-ext
-    --enable-simd)
 set(RUST_OMC_WASM_RUNTIME "" CACHE FILEPATH
     "Prebuilt wasm-jit runtime.wasm to embed (empty = build it). In CI stage 2, point at the rust_wasm_runtime artifact from stage 1.")
 set(RUST_OMC_WASM_RUNTIME_OUT ${RUST_OMC_TARGET_DIR}/runtime.wasm CACHE PATH
@@ -1136,6 +1165,28 @@ function(omc_rust_setup_codegen)
   # platform. Read at export time, not linked into omc.
   install(DIRECTORY ${RUST_FMU_LOADERS_DIR}/
           DESTINATION lib/omc/fmu-loaders COMPONENT omc)
+
+  # The wasm-jit runtime, the FMI adapter and the external "C" side libraries,
+  # compiled here rather than by whoever runs omc first: the per-user cache is
+  # filled lazily, so parallel omc processes each compile them before any writes
+  # one. `aot_module` reads this directory before `$HOME/.openmodelica/cache`.
+  # No OUTPUT to go stale on: the artifacts are keyed by a hash of the blobs, so
+  # one left behind by an earlier omc is never looked up again and the run it was
+  # meant to spare compiles instead. omc skips a blob whose artifact is current,
+  # so a build that changed none of them costs the process start.
+  set(RUST_WASMJIT_CACHE_DIR ${CMAKE_CURRENT_BINARY_DIR}/wasmjit-cache)
+  add_custom_target(rust_wasmjit_cache ALL
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${RUST_WASMJIT_CACHE_DIR}
+    COMMAND ${CMAKE_COMMAND} -E env
+            OMC_WASM_PRECOMPILE_CACHE=${RUST_WASMJIT_CACHE_DIR}
+            ${RUST_OMC_ARTIFACT_DIR}/openmodelica${RUST_OMC_EXE_SUFFIX}
+    DEPENDS rust_libopenmodelica
+    COMMENT "Precompiling the wasm-jit artifacts"
+    VERBATIM)
+  add_dependencies(rust_wasmjit_cache rust_omc)
+  install(DIRECTORY ${RUST_WASMJIT_CACHE_DIR}/
+          DESTINATION lib/omc/cache COMPONENT omc
+          FILES_MATCHING PATTERN "*.cwasm")
 
   # The PIC wasi-libc sysroot an external "C" library for wasm-jit is compiled
   # against. Under the wasm triple with an `omc` subdirectory so it cannot be

--- a/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
@@ -5192,6 +5192,7 @@ dependencies = [
  "openmodelica_scripting_qt",
  "openmodelica_util",
  "openmodelica_wasi",
+ "openmodelica_wasm_jit",
  "tikv-jemallocator",
  "wasm-bindgen",
  "web-sys",

--- a/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/Cargo.toml
@@ -35,6 +35,10 @@ libc.workspace = true
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 mimalloc = { version = "0.1", optional = true }
 tikv-jemallocator = { version = "0.6", optional = true }
+# The wasm-jit engine, for `OMC_WASM_PRECOMPILE_CACHE`: the build compiles the
+# model-independent blobs once so no run has to. The wasm build keeps no on-disk
+# artifact cache, hence native only.
+openmodelica_wasm_jit.workspace = true
 
 # wasm build: the JS bindings (src/wasm_api.rs). Pinned to match the
 # wasm-bindgen the wasmer `js` backend targets (see the workspace Cargo.lock);

--- a/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/lib.rs
@@ -112,6 +112,23 @@ fn set_revision() {
 pub extern "C" fn omc_cli_run(argc: c_int, argv: *const *const c_char) -> c_int {
     use std::io::Write;
     set_revision();
+    // `OMC_WASM_PRECOMPILE_CACHE=<dir>`: compile the fixed wasm blobs into <dir>
+    // and stop. For the build; not a user-facing flag.
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(dir) = std::env::var_os("OMC_WASM_PRECOMPILE_CACHE") {
+        return match openmodelica_wasm_jit::sim_runtime::precompile_fixed_blobs(
+            std::path::Path::new(&dir),
+        ) {
+            Ok(names) => {
+                println!("precompiled {} wasm artifacts into {}", names.len(), std::path::Path::new(&dir).display());
+                0
+            }
+            Err(e) => {
+                eprintln!("omc: precompiling the wasm cache failed: {e}");
+                1
+            }
+        };
+    }
     let args: Vec<ArcStr> = if argv.is_null() || argc <= 0 {
         Vec::new()
     } else {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -302,6 +302,7 @@ struct FmuKernel {
     model: Arc<SimModel>,
     /// Reaches the kernel's embedded metadata, so a different one cannot reuse it.
     cs_method: String,
+    fmi_solver_flags: String,
 }
 
 /// Kept by [`translateFmu`] so the export that follows links this kernel rather
@@ -535,7 +536,7 @@ pub fn translateModel(simCode: SimCode::SimCode) -> Result<()> {
     let prefix = simCode.fileNamePrefix.to_string();
     let _ = std::fs::remove_file(format!("{prefix}.wasm"));
     let errs_before = openmodelica_util::Error::getNumErrorMessages();
-    let outcome = build_sim_model(&simCode, false, ExtHost::SIM, "").and_then(|model| {
+    let outcome = build_sim_model(&simCode, false, ExtHost::SIM, "", "").and_then(|model| {
         write_output(&format!("{prefix}.wasm"), &model.wasm).map_err(|_| "CodegenWasmJit: write failed")?;
         sim_models().lock().unwrap_or_else(|e| e.into_inner()).insert(prefix.clone(), Arc::new(model));
         Ok(())
@@ -791,6 +792,9 @@ const SUNDIALS_DRIVER: bool =
 /// parse, where a rejection still has a message channel to report on.
 const CAPABILITIES: simflags::Capabilities = simflags::Capabilities {
     klu: openmodelica_wasm_jit::SUNDIALS,
+    kinsol: openmodelica_wasm_jit::SUNDIALS,
+    umfpack: openmodelica_wasm_jit::SUNDIALS,
+    lis: openmodelica_wasm_jit::SUNDIALS,
     ida: SUNDIALS_DRIVER,
     cvode: SUNDIALS_DRIVER,
     // Served by the driver's per-step deadline, so every engine has it.
@@ -809,13 +813,15 @@ pub fn solver_options() -> Vec<(&'static str, Vec<&'static str>)> {
     simflags::supported(CAPABILITIES)
 }
 
-/// What an exported wasm FMU can serve, which is not what this omc can: CVODE and IDA
-/// ride in as a side module the FMU linker adds only for a method that asks for them.
-/// `klu` is the *nonlinear* solver's, which the FMU's runtime has no build of; IDA's
-/// own `SUNLinSol_KLU` is in the side module regardless.
+/// What an exported wasm FMU *could* serve: every solver, each a PIC side module the
+/// FMU linker adds beside the model. What a given FMU carries is narrower —
+/// [`fmu_solver_libraries`] picks from the flags it was exported with.
 fn fmu_capabilities() -> simflags::Capabilities {
     simflags::Capabilities {
-        klu: false,
+        klu: sundials_available(),
+        kinsol: sundials_available(),
+        umfpack: sundials_available(),
+        lis: sundials_available(),
         ida: sundials_available(),
         cvode: sundials_available(),
         // The driver's per-step deadline comes along; a regex engine does not.
@@ -831,6 +837,49 @@ fn fmu_capabilities() -> simflags::Capabilities {
 /// Whether an FMU exported with `method` needs the SUNDIALS side module.
 fn fmu_needs_sundials(method: &str) -> bool {
     matches!(method, "cvode" | "ida")
+}
+
+/// The nonlinear/linear solver selection to hard-code into an FMU's metadata. An
+/// importer has no channel to pass simulation flags, so `--fmiFlags` is consumed here
+/// and the FMU applies these when it instantiates. `-s` is not among them: it is the
+/// Co-Simulation integrator, and [`SimMeta::cs_method`] already carries it.
+fn fmu_solver_flags(flags_json: &str) -> String {
+    ["nls", "nlsLS", "ls", "lss"]
+        .iter()
+        .filter_map(|f| fmi_flag(flags_json, f).map(|v| format!("-{f}={v}")))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Which solver libraries an FMU exported with these `--fmiFlags` can reach; the rest
+/// are linked as stubs. The flags are fixed at export, so this is the whole set the
+/// FMU will ever select from. `klu` comes along with any of the others: the shared
+/// SUNDIALS core they call into, and IDA's default linear solver.
+///
+/// `cs` gates only the integrator: Model Exchange never integrates, but its
+/// initialisation and residuals run the same nonlinear and linear solvers.
+fn fmu_solver_libraries(flags_json: &str, cs: bool) -> Vec<&'static str> {
+    let flag = |name: &str| fmi_flag(flags_json, name).unwrap_or_default();
+    let (nls, ls, lss) = (flag("nls"), flag("ls"), flag("lss"));
+    let named = |v: &str| ls == v || lss == v;
+    let mut wanted = Vec::new();
+    if cs && fmu_needs_sundials(&flag("s")) {
+        wanted.push("sundials_driver");
+    }
+    if matches!(nls.as_str(), "kinsol" | "experimental-kinsol") {
+        wanted.push("kinsol");
+    }
+    if named("umfpack") {
+        wanted.push("umfpack");
+    }
+    if named("lis") {
+        wanted.push("lis");
+    }
+    if !wanted.is_empty() || named("klu") || flag("nlsLS") == "klu" || (cs && flag("idaLS") == "klu")
+    {
+        wanted.push("klu");
+    }
+    wanted
 }
 
 /// The `method=` values `buildModelFMU` accepts for a `cs`/`me_cs` wasm FMU.
@@ -1657,7 +1706,7 @@ use openmodelica_wasm_jit::RUNTIME_WASIP1;
 /// `wasm-merge` is an external tool, absent in the omc wasm build.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn emit_standalone_module(sim_code: &SimCode::SimCode) -> Result<Vec<u8>> {
-    let model = build_sim_model(sim_code, false, ExtHost::Wasm, "")?;
+    let model = build_sim_model(sim_code, false, ExtHost::Wasm, "", "")?;
     merge_standalone(&model.wasm)
 }
 
@@ -1715,18 +1764,17 @@ fn merge_standalone(model_wasm: &[u8]) -> Result<Vec<u8>> {
 use openmodelica_wasm_jit::FMI3_ME_ADAPTER;
 /// The combined me_cs component (both interfaces, one binary, one modelIdentifier).
 use openmodelica_wasm_jit::FMI3_MECS_ADAPTER;
-/// The me_cs world with CVODE/IDA in the embedded driver; its SUNDIALS calls are
-/// resolved by [`SUNDIALS_DYLINK`].
-use openmodelica_wasm_jit::FMI3_MECS_SUNDIALS_ADAPTER;
 /// LAPACK for the `external "FORTRAN 77"` calls of `Modelica.Math.Matrices`, which
 /// a host-free FMU has no system library to resolve.
 use openmodelica_wasm_jit::LAPACK_DYLINK;
+/// The solvers the me_cs adapter's embedded driver calls, one side module each.
+use openmodelica_wasm_jit::{sundials_dylink_available as sundials_available, SOLVER_LIBRARIES};
 
 /// The external-"C" FMU artifacts, linked in only when the model uses `external
 /// "C"`. Any is empty when that omc was built without the toolchain.
 use openmodelica_wasi_libc::{
-    available as external_c_available, sundials_available, EXTERNAL_C_DYLINK, LIBC_PIC,
-    SUNDIALS_DYLINK, USERTAB_DYLINK, WASI_P1_ADAPTER,
+    available as external_c_available, EXTERNAL_C_DYLINK, LIBC_PIC, USERTAB_DYLINK,
+    WASI_P1_ADAPTER,
 };
 
 // ===========================================================================
@@ -2250,6 +2298,85 @@ fn add_dylink0_sized(module: &[u8], mem_size: u32, mem_align: u32) -> Vec<u8> {
     out
 }
 
+const NATIVE_EXT_ABSENT: &str = "om_ext_native_absent";
+
+/// The me_cs adapter always imports `om:ext/native@0.1.0`, but only an export whose
+/// `external "C"` a host must serve reaches it, and a component importing it is one
+/// no fmi-ls-wasm host will instantiate. Point it at [`native_ext_absent`] instead.
+fn drop_native_ext_import(adapter: &[u8]) -> Option<Vec<u8>> {
+    const MODULE: &str = "om:ext/native@0.1.0";
+    struct Redirect;
+    impl wasm_encoder::reencode::Reencode for Redirect {
+        type Error = core::convert::Infallible;
+        fn parse_imports(
+            &mut self,
+            imports: &mut we::ImportSection,
+            group: wasmparser::Imports<'_>,
+        ) -> core::result::Result<(), wasm_encoder::reencode::Error<Self::Error>> {
+            use wasmparser::Imports;
+            let single = |ty| wasmparser::Import { module: "env", name: NATIVE_EXT_ABSENT, ty };
+            match group {
+                Imports::Single(n, import) if import.module == MODULE => {
+                    let group = Imports::Single(n, single(import.ty));
+                    wasm_encoder::reencode::utils::parse_imports(self, imports, group)
+                }
+                Imports::Compact1 { module: MODULE, items } => {
+                    for item in items {
+                        let group = Imports::Single(0, single(item?.ty));
+                        wasm_encoder::reencode::utils::parse_imports(self, imports, group)?;
+                    }
+                    Ok(())
+                }
+                Imports::Compact2 { module: MODULE, ty, names } => {
+                    for _ in names {
+                        let group = Imports::Single(0, single(ty));
+                        wasm_encoder::reencode::utils::parse_imports(self, imports, group)?;
+                    }
+                    Ok(())
+                }
+                group => wasm_encoder::reencode::utils::parse_imports(self, imports, group),
+            }
+        }
+    }
+    if !wasm_imports_module(adapter, MODULE) {
+        return None;
+    }
+    use wasm_encoder::reencode::Reencode;
+    let mut m = we::Module::new();
+    Redirect.parse_core_module(&mut m, wasmparser::Parser::new(0), adapter).ok()?;
+    Some(m.finish())
+}
+
+/// Defines [`NATIVE_EXT_ABSENT`] as a trap: its only caller is the stub of a
+/// host-served `external "C"`, which such an export has none of.
+fn native_ext_absent() -> Vec<u8> {
+    let mut types = we::TypeSection::new();
+    types.ty().function([we::ValType::I32; 4], []);
+    let mut functions = we::FunctionSection::new();
+    functions.function(0);
+    let mut exports = we::ExportSection::new();
+    exports.export(NATIVE_EXT_ABSENT, we::ExportKind::Func, 0);
+    let mut code = we::CodeSection::new();
+    let mut f = we::Function::new(Vec::<(u32, we::ValType)>::new());
+    f.instruction(&we::Instruction::Unreachable);
+    f.instruction(&we::Instruction::End);
+    code.function(&f);
+    let mut m = we::Module::new();
+    m.section(&types).section(&functions).section(&exports).section(&code);
+    add_dylink0(&m.finish())
+}
+
+fn wasm_imports_module(wasm: &[u8], module: &str) -> bool {
+    use wasmparser::Imports;
+    wasmparser::Parser::new(0).parse_all(wasm).flatten().any(|payload| {
+        let wasmparser::Payload::ImportSection(reader) = payload else { return false };
+        reader.into_iter().flatten().any(|group| match group {
+            Imports::Single(_, imp) => imp.module == module,
+            Imports::Compact1 { module: m, .. } | Imports::Compact2 { module: m, .. } => m == module,
+        })
+    })
+}
+
 /// Turn an emitted model kernel module into a dylink side module.
 fn model_to_dylink(model_wasm: &[u8]) -> Result<Vec<u8>> {
     use wasm_encoder::reencode::Reencode;
@@ -2579,10 +2706,11 @@ fn native_externals(model: &SimModel, _kind: &str) -> Result<Option<NativeExtern
 fn link_fmu_component(
     model_wasm: &[u8],
     adapter: &[u8],
-    sundials: bool,
+    solvers: Option<&[&str]>,
     ext_libs: &[ExtLibrary],
     native_stub: Option<&[u8]>,
 ) -> Result<Vec<u8>> {
+    let sundials = solvers.is_some();
     if adapter.is_empty() {
         // The plain adapter is always built; the SUNDIALS one only where the
         // wasm SUNDIALS archives were, so name which is missing.
@@ -2597,21 +2725,32 @@ fn link_fmu_component(
     }
     let has_ext = first_external_import(model_wasm).is_some();
     let model = model_to_dylink(model_wasm)?;
+    let plain_adapter = native_stub.is_none().then(|| drop_native_ext_import(adapter)).flatten();
     let mut l = wit_component::Linker::default().validate(true);
-    l = l.library("adapter", adapter, false).map_err(link_err)?;
+    l = l.library("adapter", plain_adapter.as_deref().unwrap_or(adapter), false).map_err(link_err)?;
+    if plain_adapter.is_some() {
+        l = l.library("native_absent", &native_ext_absent(), false).map_err(link_err)?;
+    }
     l = l.library("model", &model, false).map_err(link_err)?;
-    if sundials {
-        // CVODE reaches the residual through a C function pointer, which works because
-        // every library here imports the one `env.__indirect_function_table`.
-        l = l.library("sundials", SUNDIALS_DYLINK, false).map_err(link_err)?;
+    // The adapter imports every solver whatever the flags say, so each is resolved
+    // either way; what changes is whether the real library or its stub answers. CVODE
+    // reaches the residual through a C function pointer, which works because every
+    // library here imports the one `env.__indirect_function_table`.
+    if let Some(wanted) = solvers {
+        for lib in SOLVER_LIBRARIES {
+            let bytes =
+                if wanted.contains(&lib.name) { lib.module } else { lib.stub };
+            l = l.library(lib.name, bytes, false).map_err(link_err)?;
+        }
     }
     if needs_lapack(model_wasm, ext_libs) {
         l = l.library("lapack", LAPACK_DYLINK, false).map_err(link_err)?;
     }
-    if has_ext || sundials {
+    let real_solvers = solvers.is_some_and(|w| !w.is_empty());
+    if has_ext || real_solvers {
         // modelicaexternalc before libc; the coexisting allocator (libc dlmalloc +
-        // runtime rt_alloc over one shared heap) is intentional. SUNDIALS needs libc
-        // too, so it brings the same libraries along.
+        // runtime rt_alloc over one shared heap) is intentional. A solver library
+        // needs libc too, so it brings the same libraries along; the stubs do not.
         if has_ext {
             // First, so a symbol they define wins over ModelicaExternalC's.
             let ext_bytes: Vec<Vec<u8>> =
@@ -2903,7 +3042,7 @@ pub fn emitMeFmu(
     terminals_dir: ArcStr,
     simulation_flags_json: ArcStr,
 ) -> Result<()> {
-    emit_fmu(sim_code, fmu_path, model_description, extra_files, terminals_dir, simulation_flags_json, (FMI3_ME_ADAPTER, &[]), "ME")
+    emit_fmu(sim_code, fmu_path, model_description, extra_files, terminals_dir, simulation_flags_json, FMI3_ME_ADAPTER, "ME")
 }
 
 /// Co-Simulation: the FMU integrates itself, so the adapter embeds the driver.
@@ -2921,7 +3060,7 @@ pub fn emitCsFmu(
     terminals_dir: ArcStr,
     simulation_flags_json: ArcStr,
 ) -> Result<()> {
-    emit_fmu(sim_code, fmu_path, model_description, extra_files, terminals_dir, simulation_flags_json, (FMI3_MECS_ADAPTER, FMI3_MECS_SUNDIALS_ADAPTER), "CS")
+    emit_fmu(sim_code, fmu_path, model_description, extra_files, terminals_dir, simulation_flags_json, FMI3_MECS_ADAPTER, "CS")
 }
 
 /// me_cs: one component exporting both interfaces (the wasm equivalent of a
@@ -2935,7 +3074,7 @@ pub fn emitMeCsFmu(
     terminals_dir: ArcStr,
     simulation_flags_json: ArcStr,
 ) -> Result<()> {
-    emit_fmu(sim_code, fmu_path, model_description, extra_files, terminals_dir, simulation_flags_json, (FMI3_MECS_ADAPTER, FMI3_MECS_SUNDIALS_ADAPTER), "me_cs")
+    emit_fmu(sim_code, fmu_path, model_description, extra_files, terminals_dir, simulation_flags_json, FMI3_MECS_ADAPTER, "me_cs")
 }
 
 /// Say that the FMU answers `fmi3GetDirectionalDerivative` when the model was
@@ -2974,6 +3113,8 @@ pub(crate) const NATIVE_TABLE: &str = "resources/native_externals.txt";
 /// What the host has to load beside the model kernel, decided here because this
 /// is where the model's `external "C"` libraries were resolved. A tiny JSON, read
 /// by `CodegenWasmJit::artifact`.
+/// `sundials` is the *fused* runtime's, which this form binds the model to: it links
+/// the archives statically, so it has every solver whatever the flags say.
 fn artifact_manifest(model: &SimModel, sundials: bool) -> String {
     let ext = first_external_import(&model.wasm).is_some();
     let mut out = String::from("{\n");
@@ -3026,6 +3167,7 @@ fn compile_for_host(
     component: &[u8],
     fmu_path: &str,
     linked: bool,
+    bare: bool,
 ) -> Option<std::sync::Arc<openmodelica_fmi_driver::component::WasmArtifact>> {
     // The unzipped form is not a component at all — the host links the model
     // kernel against the adapter it has already compiled — so there is nothing
@@ -3034,7 +3176,11 @@ fn compile_for_host(
         return None;
     }
     let host = native_fmu::host_platform()?;
-    if !requested_native_platforms().iter().any(|n| native_fmu::lookup(n).is_some_and(|p| p.fmi == host.fmi)) {
+    // An unzipped export is for this omc: compiling here means the runs that
+    // follow take the live component rather than each compiling it again.
+    if !bare
+        && !requested_native_platforms().iter().any(|n| native_fmu::lookup(n).is_some_and(|p| p.fmi == host.fmi))
+    {
         return None;
     }
     // The resources it reads through are written after this, so the caller points
@@ -3046,7 +3192,7 @@ fn compile_for_host(
 }
 
 #[cfg(not(all(feature = "artifact", not(target_arch = "wasm32"))))]
-fn compile_for_host(_component: &[u8], _fmu_path: &str, _linked: bool) -> Option<()> {
+fn compile_for_host(_component: &[u8], _fmu_path: &str, _linked: bool, _bare: bool) -> Option<()> {
     None
 }
 
@@ -3186,9 +3332,14 @@ fn fmu_cs_method(simulation_flags_json: &str, kind: &str) -> String {
 /// this `kind` can serve it. Shared linear memory across model + runtime +
 /// ModelicaExternalC, so `external "C"` calls pass real pointers rather than
 /// runtime handles — which is also why the simulation path cannot bind it.
-fn lower_fmu_kernel(sim_code: &SimCode::SimCode, kind: &str, cs_method: &str) -> Result<SimModel> {
+fn lower_fmu_kernel(
+    sim_code: &SimCode::SimCode,
+    kind: &str,
+    cs_method: &str,
+    fmi_solver_flags: &str,
+) -> Result<SimModel> {
     let model = crate::CodegenWasmJitFunctions::with_shared_externals(|| {
-        build_sim_model(sim_code, true, ExtHost::Wasm, cs_method)
+        build_sim_model(sim_code, true, ExtHost::Wasm, cs_method, fmi_solver_flags)
     })?;
     if let Some(func) = first_external_import(&model.wasm) {
         if !external_c_available() {
@@ -3221,14 +3372,23 @@ fn check_fmu_method(model: &SimModel, kind: &str) -> Result<()> {
 
 /// The kernel to build this FMU around: the one [`translateFmu`] left behind if it
 /// was lowered the way this export needs, and a fresh lowering otherwise.
-fn fmu_kernel(sim_code: &SimCode::SimCode, kind: &str, cs_method: &str) -> Result<Arc<SimModel>> {
+fn fmu_kernel(
+    sim_code: &SimCode::SimCode,
+    kind: &str,
+    cs_method: &str,
+    fmi_solver_flags: &str,
+) -> Result<Arc<SimModel>> {
     let prefix = sim_code.fileNamePrefix.to_string();
     let cached = fmu_kernels().lock().unwrap_or_else(|e| e.into_inner()).get(&prefix).cloned();
-    if let Some(k) = cached.filter(|k| k.cs_method == cs_method) {
+    // Both are baked into the kernel's metadata, so a re-export that changed either
+    // has to lower again rather than reuse what the last one left behind.
+    if let Some(k) = cached
+        .filter(|k| k.cs_method == cs_method && k.fmi_solver_flags == fmi_solver_flags)
+    {
         check_fmu_method(&k.model, kind)?;
         return Ok(k.model.clone());
     }
-    let model = Arc::new(lower_fmu_kernel(sim_code, kind, cs_method)?);
+    let model = Arc::new(lower_fmu_kernel(sim_code, kind, cs_method, fmi_solver_flags)?);
     keep_fmu_kernel(&prefix, &model);
     Ok(model)
 }
@@ -3236,7 +3396,11 @@ fn fmu_kernel(sim_code: &SimCode::SimCode, kind: &str, cs_method: &str) -> Resul
 fn keep_fmu_kernel(prefix: &str, model: &Arc<SimModel>) {
     fmu_kernels().lock().unwrap_or_else(|e| e.into_inner()).insert(
         prefix.to_string(),
-        Arc::new(FmuKernel { model: model.clone(), cs_method: model.meta.cs_method.clone() }),
+        Arc::new(FmuKernel {
+            model: model.clone(),
+            cs_method: model.meta.cs_method.clone(),
+            fmi_solver_flags: model.meta.fmi_solver_flags.clone(),
+        }),
     );
 }
 
@@ -3249,6 +3413,7 @@ pub fn translateFmu(sim_code: SimCode::SimCode, fmu_type: ArcStr, simulation_fla
     sim_runtime::start_runtime_compile();
     let kind = fmu_kind(&fmu_type);
     let cs_method = fmu_cs_method(&simulation_flags_json, kind);
+    let fmi_solver_flags = fmu_solver_flags(&simulation_flags_json);
     let prefix = sim_code.fileNamePrefix.to_string();
     let _ = openmodelica_wasi::fs::remove_file(&format!("{prefix}.wasm"));
     let errs_before = openmodelica_util::Error::getNumErrorMessages();
@@ -3256,7 +3421,7 @@ pub fn translateFmu(sim_code: SimCode::SimCode, fmu_type: ArcStr, simulation_fla
         // Lowered the way the simulation path binds it, since that is what runs it.
         // With no `external "C"` this is the FMU kernel too: shared externals
         // change the lowering only where there are `ext` imports.
-        let model = Arc::new(build_sim_model(&sim_code, true, ExtHost::SIM, &cs_method)?);
+        let model = Arc::new(build_sim_model(&sim_code, true, ExtHost::SIM, &cs_method, &fmi_solver_flags)?);
         check_fmu_method(&model, kind)?;
         write_output(&format!("{prefix}.wasm"), &model.wasm).map_err(|_| "CodegenWasmJit: write failed")?;
         sim_models().lock().unwrap_or_else(|e| e.into_inner()).insert(prefix.clone(), model.clone());
@@ -3286,7 +3451,7 @@ fn keep_translated_model(sim_code: &SimCode::SimCode, kernel: &Arc<SimModel>) ->
     let model = match kept {
         Some(m) => m,
         None if first_external_import(&kernel.wasm).is_none() => kernel.clone(),
-        None => Arc::new(build_sim_model(sim_code, true, ExtHost::SIM, &kernel.meta.cs_method)?),
+        None => Arc::new(build_sim_model(sim_code, true, ExtHost::SIM, &kernel.meta.cs_method, &kernel.meta.fmi_solver_flags)?),
     };
     if model.prepared.lock().unwrap_or_else(|e| e.into_inner()).is_none()
         && let Ok(compiled) = sim_runtime::take_compiled_model(&model)
@@ -3315,12 +3480,13 @@ fn emit_fmu(
     extra_files: Arc<List<(ArcStr, ArcStr)>>,
     terminals_dir: ArcStr,
     simulation_flags_json: ArcStr,
-    adapter: (&[u8], &[u8]),
+    adapter: &[u8],
     kind: &str,
 ) -> Result<()> {
     sync_engine_threading()?;
     sim_runtime::start_runtime_compile();
     let cs_method = fmu_cs_method(&simulation_flags_json, kind);
+    let fmi_solver_flags = fmu_solver_flags(&simulation_flags_json);
     // Emitting the model takes seconds; a host that compiles the native platforms
     // out of process can spend them loading its compiler.
     if !requested_native_platforms().is_empty() {
@@ -3328,7 +3494,7 @@ fn emit_fmu(
     }
     let errs_before = openmodelica_util::Error::getNumErrorMessages();
     let outcome = (|| -> Result<()> {
-        let model = fmu_kernel(&sim_code, kind, &cs_method)?;
+        let model = fmu_kernel(&sim_code, kind, &cs_method, &fmi_solver_flags)?;
         export_phase("FMU model kernel");
         let natives = native_externals(&model, kind)?;
         let bare = fmu_directory();
@@ -3337,7 +3503,10 @@ fn emit_fmu(
             export_phase("FMU translated model");
         }
         let cs = kind != "ME";
-        let sundials = cs && (fmu_needs_sundials(&model.meta.cs_method) || fmu_needs_sundials(&model.method));
+        // Both adapters import every solver, real or stubbed; only the integrator is
+        // Co-Simulation's alone.
+        let solvers =
+            sundials_available().then(|| fmu_solver_libraries(&simulation_flags_json, cs));
         // An unzipped export is for an OpenModelica importer: it holds the model
         // description and the model kernel and nothing else, and the host links
         // that kernel against an adapter it compiled once into
@@ -3355,8 +3524,8 @@ fn emit_fmu(
         } else {
             link_fmu_component(
                 &model.wasm,
-                if sundials { adapter.1 } else { adapter.0 },
-                sundials,
+                adapter,
+                solvers.as_deref(),
                 &model.ext_libs,
                 natives.as_ref().map(|n| &n.stub[..]),
             )?
@@ -3384,7 +3553,7 @@ fn emit_fmu(
         let version = fmi_version();
         // This machine's artifact, compiled once: the runs that follow in this
         // session get the live component and never read a `.cwasm` back.
-        let host = compile_for_host(&component, &fmu_path, linked);
+        let host = compile_for_host(&component, &fmu_path, linked, bare);
         add_native_platforms(&mut entries, &component, &model_id, &version, linked, natives.as_ref(), host.as_ref())?;
         export_phase("FMU precompile");
         if version == "2.0" {
@@ -3405,13 +3574,25 @@ fn emit_fmu(
             // Not a component: the model kernel as a dylink library, which the host
             // links against the adapter and libc it has already compiled.
             entries.push((format!("{DYLINK_DIR}/{model_id}.wasm"), component));
-            entries.push(("resources/artifact.json".to_string(), artifact_manifest(&model, sundials).into_bytes()));
+            entries.push(("resources/artifact.json".to_string(), artifact_manifest(&model, sundials_available()).into_bytes()));
             for (i, lib) in model.ext_libs.iter().enumerate() {
                 entries.push((format!("resources/ext/{i:02}.wasm"), lib.bytes.clone()));
             }
             if let Some(n) = &natives {
                 entries.push((format!("resources/ext/{NATIVE_STUB}.wasm"), n.stub.clone()));
             }
+        } else if natives.is_some() {
+            // Imports `om:ext/native`, so no fmi-ls-wasm host can instantiate it:
+            // out of `binaries/`, as an FMI 2.0 export is for the same reason.
+            let names: Vec<&str> = model.ext_native.iter().map(|s| s.name.as_str()).collect();
+            let _ = openmodelica_util::Error::addCompilerNotification(ArcStr::from(format!(
+                "`external \"C\"` {} is served from a platform library, so this FMU's wasm binary \
+                 imports `om:ext/native`, which fmi-ls-wasm does not define. It is at \
+                 `resources/{model_id}.wasm` rather than `binaries/wasm32-wasip2/`, and runs only \
+                 in an OpenModelica host or through one of the FMU's native platform binaries.",
+                names.join(", ")
+            ).as_str()));
+            entries.push((format!("resources/{model_id}.wasm"), component));
         } else {
             entries.push((format!("binaries/wasm32-wasip2/{model_id}.wasm"), component));
         }
@@ -4868,6 +5049,7 @@ fn build_sim_model(
     fmi_vrs: bool,
     ext_host: ExtHost,
     cs_method: &str,
+    fmi_solver_flags: &str,
 ) -> Result<SimModel> {
     crate::CodegenWasmJitFunctions::set_record_decls(&sim_code.recordDecls)?;
     let mi = &sim_code.modelInfo;
@@ -5667,7 +5849,8 @@ fn build_sim_model(
         }
     }
     let meta = build_sim_meta(
-        &layout, &result_vars, settings, cs_method, &model_name, &sim_code.fileNamePrefix, jac_a.clone(), &state_sets,
+        &layout, &result_vars, settings, cs_method, fmi_solver_flags, &model_name,
+        &sim_code.fileNamePrefix, jac_a.clone(), &state_sets,
         fmi_vrs, zc_descriptions(&zero_crossings), rel_descriptions(&sim_code.relations),
         param_vars(vars)?, attr_log_entries(sim_code)?,
         removed_init_residuals(sim_code).iter().map(|e| dump_exp(e)).collect(),
@@ -7072,6 +7255,7 @@ fn build_sim_meta(
     result_vars: &[ResultVar],
     settings: &SimCode::SimulationSettings,
     cs_method: &str,
+    fmi_solver_flags: &str,
     model_name: &str,
     prefix: &str,
     jac_a: Option<JacAInfo>,
@@ -7104,6 +7288,7 @@ fn build_sim_meta(
         n_intervals: settings.numberOfIntervals.max(0) as u32,
         method: settings.method.to_string(),
         cs_method: cs_method.to_string(),
+        fmi_solver_flags: fmi_solver_flags.to_string(),
         tolerance: settings.tolerance.into_inner(),
         output_format: settings.outputFormat.to_string(),
         prefix: prefix.to_string(),
@@ -11177,19 +11362,94 @@ mod link_tests {
     /// unresolved symbol here.
     #[test]
     fn fmu_component_links_without_a_host() {
-        for (label, adapter, sundials) in [
-            ("ME", FMI3_ME_ADAPTER, false),
-            ("me_cs", FMI3_MECS_ADAPTER, false),
-            ("me_cs+SUNDIALS", FMI3_MECS_SUNDIALS_ADAPTER, true),
-        ] {
-            if adapter.is_empty() || (sundials && !sundials_available()) {
-                continue; // omc built without the wasm32 toolchain or without sundials
+        // Both ends of the selection have to resolve, for both adapters: each imports
+        // every solver whatever its flags named.
+        let all: Vec<&str> = SOLVER_LIBRARIES.iter().map(|l| l.name).collect();
+        let mut cases: Vec<(&str, &[u8], Option<&[&str]>)> = Vec::new();
+        if sundials_available() {
+            for (label, adapter) in [("ME", FMI3_ME_ADAPTER), ("me_cs", FMI3_MECS_ADAPTER)] {
+                cases.push((label, adapter, Some(&all)));
+                cases.push((label, adapter, Some(&[])));
+            }
+        } else {
+            cases.push(("ME", FMI3_ME_ADAPTER, None));
+        }
+        for (label, adapter, solvers) in cases {
+            if adapter.is_empty() {
+                continue; // omc built without the wasm32 toolchain
             }
             assert!(
-                link_fmu_component(&build_stub_model(), adapter, sundials, &[], None).is_ok(),
-                "{label} adapter does not link into a component: {}",
+                link_fmu_component(&build_stub_model(), adapter, solvers, &[], None).is_ok(),
+                "{label} does not link into a component: {}",
                 openmodelica_util::Error::printMessagesStr(false)
             );
+        }
+    }
+
+    /// The mapping has to name `klu`, the shared core, whenever anything else is named.
+    /// Only the integrator is Co-Simulation's alone: a Model Exchange FMU runs the same
+    /// nonlinear and linear solvers during initialisation.
+    #[test]
+    fn solver_libraries_follow_the_fmi_flags() {
+        for (json, cs, want) in [
+            ("{}", true, vec![]),
+            (r#"{"s":"euler"}"#, true, vec![]),
+            (r#"{"s":"cvode"}"#, true, vec!["sundials_driver", "klu"]),
+            (r#"{"s":"ida"}"#, true, vec!["sundials_driver", "klu"]),
+            (r#"{"nls":"kinsol"}"#, true, vec!["kinsol", "klu"]),
+            (r#"{"lss":"lis"}"#, true, vec!["lis", "klu"]),
+            (r#"{"ls":"umfpack"}"#, true, vec!["umfpack", "klu"]),
+            (r#"{"nlsLS":"klu"}"#, true, vec!["klu"]),
+            (r#"{"ls":"lapack"}"#, true, vec![]),
+            // ME: the same solvers, never the integrator.
+            (r#"{"nls":"kinsol"}"#, false, vec!["kinsol", "klu"]),
+            (r#"{"lss":"lis"}"#, false, vec!["lis", "klu"]),
+            (r#"{"s":"cvode"}"#, false, vec![]),
+        ] {
+            assert_eq!(fmu_solver_libraries(json, cs), want, "{json} cs={cs}");
+        }
+        // Every name the mapping can produce must be a library that exists.
+        let known: Vec<&str> = SOLVER_LIBRARIES.iter().map(|l| l.name).collect();
+        let all = r#"{"s":"ida","nls":"kinsol","ls":"lis","lss":"umfpack"}"#;
+        for name in fmu_solver_libraries(all, true) {
+            assert!(known.contains(&name), "{name} is not a solver library");
+        }
+    }
+
+    /// What the FMU applies when it instantiates, since an importer cannot pass flags.
+    /// `-s` is not among them: it is the integrator, carried by `SimMeta::cs_method`.
+    #[test]
+    fn baked_solver_flags_come_from_the_fmi_flags() {
+        assert_eq!(fmu_solver_flags("{}"), "");
+        assert_eq!(fmu_solver_flags(r#"{"s":"cvode"}"#), "");
+        assert_eq!(fmu_solver_flags(r#"{"nls":"kinsol"}"#), "-nls=kinsol");
+        assert_eq!(
+            fmu_solver_flags(r#"{"s":"ida","nls":"kinsol","lss":"klu"}"#),
+            "-nls=kinsol -lss=klu"
+        );
+        // Whatever is baked has to parse, and be servable by the libraries the same
+        // flags select.
+        for json in [r#"{"nls":"kinsol"}"#, r#"{"ls":"lis"}"#, r#"{"lss":"umfpack"}"#,
+                     r#"{"nlsLS":"klu"}"#] {
+            let baked = fmu_solver_flags(json);
+            let argv: Vec<String> = core::iter::once("model".to_string())
+                .chain(baked.split_whitespace().map(str::to_string))
+                .collect();
+            let f = simflags::parse(&argv).expect(&baked);
+            let libs = fmu_solver_libraries(json, true);
+            let cap = simflags::Capabilities {
+                klu: libs.contains(&"klu"),
+                kinsol: libs.contains(&"kinsol"),
+                umfpack: libs.contains(&"umfpack"),
+                lis: libs.contains(&"lis"),
+                ida: false,
+                cvode: false,
+                alarm: true,
+                variable_filter: false,
+                optimization: false,
+                qss: true,
+            };
+            assert!(simflags::check(&f, cap).is_ok(), "{json}: {baked}");
         }
     }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/artifact.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/artifact.rs
@@ -304,8 +304,8 @@ fn load(path: &Path) -> std::result::Result<Loaded, String> {
             dir,
             form: Form::Dylink { model, ext, external_c: flag("externalC"), lapack: flag("lapack") },
             how: format!(
-                "model kernel {:.1} MB linked against the cached adapter{}",
-                size as f64 / 1.0e6,
+                "model kernel linked against the cached adapter{}{}",
+                mb(size as u64),
                 if unpacked { ", unpacked here" } else { "" }
             ),
             load_ms: ms(t),
@@ -330,9 +330,9 @@ fn load(path: &Path) -> std::result::Result<Loaded, String> {
             return Ok(Loaded {
                 form: Form::Component(Arc::new(artifact)),
                 how: format!(
-                    "{}.cwasm, {:.1} MB, mapped{}",
+                    "{}.cwasm{}, mapped{}",
                     platform().unwrap_or("?"),
-                    size as f64 / 1.0e6,
+                    mb(size),
                     if unpacked { ", unpacked here" } else { "" }
                 ),
                 load_ms: ms(t),
@@ -353,7 +353,7 @@ fn load(path: &Path) -> std::result::Result<Loaded, String> {
         .map_err(|e| format!("wasm artifact {}: {e}", path.display()))?;
     Ok(Loaded {
         form: Form::Component(Arc::new(artifact)),
-        how: format!("compiled from the component, {:.1} MB", component.len() as f64 / 1.0e6),
+        how: format!("compiled from the component{}", mb(component.len() as u64)),
         load_ms: ms(t),
         dir,
     })
@@ -432,6 +432,11 @@ pub fn run(
         Ok(f) => f,
         Err(e) => return (Err(e), log),
     };
+    // Neither the in-wasm runtime nor the FMI driver has a regex engine, so the
+    // pattern is compiled here: the runtime asks per name through
+    // `rt_host_name_matches`, the masters filter their columns. `Regex` is not
+    // `Clone`, hence one compile per consumer.
+    openmodelica_wasm_jit::host::set_output_filter(compile_output_filter(&flags, &mut log));
     let out = result_path(&flags, result_file);
     let res = match face {
         Face::Simulation => run_simulation(&loaded, &flags, &out, simflags, &mut log),
@@ -439,6 +444,25 @@ pub fn run(
         Face::CoSimulation => run_fmi(&loaded, &flags, &out, None, &mut log),
     };
     (res, log)
+}
+
+/// The run's `-variableFilter`, compiled. `None` keeps everything: an absent,
+/// empty or `.*` pattern, or C's "Defaulting to outputting all variables".
+fn compile_output_filter(
+    flags: &openmodelica_sim_meta::simflags::SimFlags,
+    log: &mut String,
+) -> Option<openmodelica_util::System::Regex> {
+    let pattern = flags.variable_filter.as_deref().filter(|p| !p.is_empty() && *p != ".*")?;
+    match openmodelica_util::System::Regex::new(&format!("^({pattern})$")) {
+        Ok(re) => Some(re),
+        Err(e) => {
+            log.push_str(&format!(
+                "LOG_STDOUT        | warning | Failed to compile regular expression: {pattern} \
+                 with error: {e}. Defaulting to outputting all variables.\n"
+            ));
+            None
+        }
+    }
 }
 
 /// The artifact's own simulation runtime.
@@ -468,7 +492,12 @@ fn run_simulation(
             }
         }
         Form::Dylink { .. } => {
-            loaded.with_dylink(|i| i.run_simulation(&args).map_err(|e| e.to_string()))?
+            // The model's `LOG_*`/asserts/`Streams.print` go to the artifact's
+            // WASI stdout; fold them into the run's log as the other forms do.
+            openmodelica_wasi::wasi::start_stdout_capture();
+            let r = loaded.with_dylink(|i| i.run_simulation(&args).map_err(|e| e.to_string()));
+            log.push_str(&openmodelica_wasi::wasi::take_stdout_capture());
+            r?
         }
     };
     let elapsed = ms(t);
@@ -580,6 +609,10 @@ fn run_fmi(
     // `-lv=LOG_STATS` asks the *runtime* for a block, not the FMU for a trace of
     // every event, so it alone leaves the FMI logger off.
     opts.logging_on = flags.has_log("LOG_EVENTS") || flags.has_log("LOG_NLS") || flags.has_log("LOG_DSS");
+    opts.alarm = flags.alarm;
+    // A run wedged inside one call into wasm never reaches the master's deadline;
+    // the epoch alarm interrupts that (`OMC_WASM_HARD_ALARM`).
+    openmodelica_wasm_jit::sim_runtime::set_alarm(flags.alarm);
     if let Some(s) = me_solver {
         opts.solver = s;
     }
@@ -602,6 +635,12 @@ fn run_fmi(
         });
     }
 
+    // The masters record here, so the columns the filter rejects are never sampled.
+    let re = compile_output_filter(flags, &mut String::new());
+    let keep = |name: &str| re.as_ref().is_none_or(|r| r.is_match(name));
+    if re.is_some() {
+        opts.keep = Some(&keep);
+    }
     let t = Instant::now();
     let (recorder, summary, elapsed) = match &loaded.form {
         Form::Component(a) => {
@@ -616,17 +655,21 @@ fn run_fmi(
                 took(ms(t))
             ));
             let t = Instant::now();
-            let (r, s) = drive(&mut inst, kind, md, &opts)?;
+            // Drained before the failure propagates: what the FMU printed on the
+            // way to it is the only account of why.
+            let driven = drive(&mut inst, kind, md, &opts);
             let elapsed = ms(t);
             log.push_str(&inst.output());
             for (_, category, message) in inst.take_log() {
                 log.push_str(&format!("LOG_STDOUT        | info    | {category}: {message}\n"));
             }
+            let (r, s) = driven?;
             (r, s, elapsed)
         }
         Form::Dylink { .. } => {
             let mut linked_ms = 0.0;
-            let (r, s, e) = loaded.with_dylink(|inst| {
+            openmodelica_wasi::wasi::start_stdout_capture();
+            let driven = loaded.with_dylink(|inst| {
                 match kind {
                     InterfaceKind::ModelExchange => inst.instantiate_me(&instance_name(md), opts.logging_on),
                     _ => inst.instantiate_cs(&instance_name(md), opts.logging_on, opts.event_mode),
@@ -636,7 +679,9 @@ fn run_fmi(
                 let t = Instant::now();
                 let (r, s) = drive(inst, kind, md, &opts)?;
                 Ok((r, s, ms(t)))
-            })?;
+            });
+            log.push_str(&openmodelica_wasi::wasi::take_stdout_capture());
+            let (r, s, e) = driven?;
             log.push_str(&format!(
                 "LOG_STDOUT        | info    | {} instantiated{}\n",
                 kind.as_str(),
@@ -695,6 +740,16 @@ fn took(ms: f64) -> String {
     match openmodelica_util::Testsuite::isRunning() {
         Ok(true) => String::new(),
         _ => format!(" in {ms:.1} ms"),
+    }
+}
+
+/// How big the artifact was, left out of a testsuite run for the same reason the
+/// timing is: it moves whenever the adapter or the model kernel is rebuilt, and a
+/// baseline that records it fails on changes that are not about this test.
+fn mb(bytes: u64) -> String {
+    match openmodelica_util::Testsuite::isRunning() {
+        Ok(true) => String::new(),
+        _ => format!(", {:.1} MB", bytes as f64 / 1.0e6),
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/dylink_fmi.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/dylink_fmi.rs
@@ -52,15 +52,24 @@ impl DylinkInstance {
         lapack: bool,
         resources: &str,
     ) -> Result<DylinkInstance> {
-        let fmu = DylinkFmu::load(
-            openmodelica_wasm_jit::FMI3_MECS_CAPI_ADAPTER,
-            model,
-            ext,
-            external_c,
-            lapack,
-            resources,
-        )
-        .map_err(|e| Error::Load(e))?;
+        // One non-PIC module for the runtime, the driver and the adapter, so the
+        // model and the driver share one runtime copy. `OMC_WASM_FUSED_ARTIFACT=0`
+        // falls back to the dylink adapter.
+        let fused = std::env::var("OMC_WASM_FUSED_ARTIFACT").as_deref() != Ok("0")
+            && !openmodelica_wasm_jit::FMI3_FUSED_WASIP1.is_empty();
+        let fmu = if fused {
+            DylinkFmu::load_fused(model, ext, external_c, lapack, resources).map_err(Error::Load)?
+        } else {
+            DylinkFmu::load(
+                openmodelica_wasm_jit::FMI3_MECS_CAPI_ADAPTER,
+                model,
+                ext,
+                external_c,
+                lapack,
+                resources,
+            )
+            .map_err(Error::Load)?
+        };
         Ok(DylinkInstance { fmu, scratch: (0, 0) })
     }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/Cargo.toml
@@ -33,6 +33,10 @@ standalone = ["dep:daskr", "dep:openmodelica_plt_writer", "inwasm_solve"]
 inwasm_solve = ["dep:rsparse"]
 # Delegate the sparse solve to the host (`env.rt_host_lin_solve`); native interactive only.
 host_lin_solve = []
+# `cfg(sundials)` without linking anything: the FMI3 adapter's PIC build leaves the
+# CVODE/IDA/KINSOL/KLU/UMFPACK/Lis calls undefined, as imports the FMU's SUNDIALS
+# side module resolves.
+sundials_extern = ["openmodelica_sim_meta/sundials_extern"]
 # PRIMME's partial SVD, which `-lv=LOG_NLS_SVD` with `-svdCount` runs. Its archive
 # rides with the SUNDIALS hand-off, and its BLAS/LAPACK calls bind to
 # openmodelica_lapack's Fortran ABI -- which is why the feature turns that on, and
@@ -54,6 +58,11 @@ libm = "0.2"
 # host boundary. The same crate omc itself calls, so a linear system gets
 # LAPACK's pivot order and `INFO` whichever side factors it.
 openmodelica_lapack = { path = "../openmodelica_lapack" }
+# The `.mat` serializer: the standalone driver's result file, and the state
+# `-saveInitialGuess_system` writes from inside the nonlinear solver — which is
+# `cfg(sundials)` code, so every target that can have SUNDIALS needs it. `no_std`,
+# so it costs the interactive runtimes nothing they do not call.
+openmodelica_mat_writer = { path = "../openmodelica_mat_writer" }
 
 # In-wasm session driver (`src/session.rs`) for the no_std JIT runtime
 # (wasm32-unknown-unknown): the shared driver + solver compiled in-wasm so the
@@ -68,10 +77,6 @@ daskr = { path = "../daskr", default-features = false, optional = true }
 # `.mat`. wasip1 has std, so these keep their default (`std`) features.
 [target.'cfg(target_os = "wasi")'.dependencies]
 openmodelica_sim_meta = { path = "../openmodelica_sim_meta", features = ["std"] }
-# The `.mat` serializer: the standalone driver's result file, and the state
-# `-saveInitialGuess_system` writes from inside the nonlinear solver. `no_std`,
-# so it costs the interactive runtimes nothing they do not call.
-openmodelica_mat_writer = { path = "../openmodelica_mat_writer" }
 openmodelica_plt_writer = { path = "../openmodelica_plt_writer", optional = true }
 daskr = { path = "../daskr", optional = true }
 # Sparse direct solver (CSparse port, AMD fill-reducing ordering) for torn linear

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/build.rs
@@ -39,11 +39,22 @@ const PRIMME: &str = "primme";
 
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(sundials)");
+    // `cfg(sundials)` plus: the solvers arrive as imports, one side module per
+    // library, so which of them an FMU actually got is only knowable at run time.
+    println!("cargo::rustc-check-cfg=cfg(sundials_dylink)");
     println!("cargo:rerun-if-env-changed=OMC_SUNDIALS_WASM_DIR");
 
     // wasip1 only: the no_std JIT runtime (wasm32-unknown-unknown) has no libc for
     // SUNDIALS to call, and the host `cargo test` build links nothing.
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("wasi") {
+        // Except the FMI3 adapter's PIC build, which has nothing to link: its calls
+        // stay undefined and become wasm imports the FMU's SUNDIALS side module
+        // resolves. The fused wasip1 adapter asks for the same feature and falls
+        // through to the archives below.
+        if std::env::var_os("CARGO_FEATURE_SUNDIALS_EXTERN").is_some() {
+            println!("cargo:rustc-cfg=sundials");
+            println!("cargo:rustc-cfg=sundials_dylink");
+        }
         return;
     }
     let Ok(dir) = std::env::var("OMC_SUNDIALS_WASM_DIR") else { return };

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -3061,12 +3061,21 @@ pub(crate) fn lin_sparse_cached(
     #[cfg(not(sundials))]
     let _ = backend;
 
-    // Native interactive runtime: the host solves natively (cheap crossings).
-    #[cfg(all(target_os = "wasi", feature = "host_lin_solve"))]
+    // Both linked: which one is the host's to say (`rt_set_host_lin_solve`), so
+    // one module serves a host with a native solver and one without.
+    #[cfg(all(target_os = "wasi", feature = "host_lin_solve", feature = "inwasm_solve"))]
+    {
+        if solvers::host_lin_solve() {
+            return unsafe { rt_host_lin_solve(handle, colptr, rowidx, values, b_ptr, n as u32, nnz as u32) };
+        }
+        return solve_lin_sparse_cached_inwasm(handle, colptr, rowidx, values, b_ptr, n, nnz);
+    }
+    // Host only: nothing to fall back to, so the flag does not apply.
+    #[cfg(all(target_os = "wasi", feature = "host_lin_solve", not(feature = "inwasm_solve")))]
     {
         return unsafe { rt_host_lin_solve(handle, colptr, rowidx, values, b_ptr, n as u32, nnz as u32) };
     }
-    // In-wasm rsparse cache: web interactive (boundary too costly) + standalone.
+    // In-wasm only: the web interactive and standalone runtimes.
     #[cfg(all(target_os = "wasi", feature = "inwasm_solve", not(feature = "host_lin_solve")))]
     {
         return solve_lin_sparse_cached_inwasm(handle, colptr, rowidx, values, b_ptr, n, nnz);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/solvers.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/solvers.rs
@@ -240,6 +240,19 @@ pub extern "C" fn rt_set_homotopy_tuning(
     }
 }
 
+/// Whether the host serves `env.rt_host_lin_solve`. Off unless it says so: a
+/// module instantiated by something without a native solver must not call out.
+static HOST_LIN_SOLVE: AtomicU32 = AtomicU32::new(0);
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_set_host_lin_solve(on: u32) {
+    HOST_LIN_SOLVE.store(on, Ordering::Relaxed);
+}
+
+pub(crate) fn host_lin_solve() -> bool {
+    HOST_LIN_SOLVE.load(Ordering::Relaxed) != 0
+}
+
 /// Set the four selectors for the next run. Host-driven builds call this through
 /// the export; the in-wasm session calls [`apply_flags`] instead.
 #[unsafe(no_mangle)]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/sundials.rs
@@ -13,9 +13,12 @@ pub extern "C" fn rt_sundials_available() -> i32 {
 /// What this build can serve, for `simflags::check`.
 pub fn capabilities() -> openmodelica_sim_meta::simflags::Capabilities {
     openmodelica_sim_meta::simflags::Capabilities {
-        klu: cfg!(sundials),
-        ida: openmodelica_sim_meta::IDA,
-        cvode: openmodelica_sim_meta::CVODE,
+        klu: groups::klu(),
+        kinsol: groups::kinsol(),
+        umfpack: groups::umfpack(),
+        lis: groups::lis(),
+        ida: openmodelica_sim_meta::IDA && groups::driver(),
+        cvode: openmodelica_sim_meta::CVODE && groups::driver(),
         // Served by the driver's per-step deadline; both runtimes install a clock.
         alarm: true,
         // No regex engine in wasm; the model's own filter is resolved at codegen.
@@ -26,6 +29,49 @@ pub fn capabilities() -> openmodelica_sim_meta::simflags::Capabilities {
         // Both runtimes drive a whole trajectory, which is all QSS can do.
         qss: true,
     }
+}
+
+/// Which solver libraries this build has. An FMU links one PIC side module per
+/// library, chosen at export, so the answer is a run-time one: the stub standing in
+/// for what was left out answers 0 where a real module answers 1. Every other build
+/// links the archives statically and has all of them or none.
+#[cfg(sundials_dylink)]
+mod groups {
+    unsafe extern "C" {
+        fn om_have_klu() -> i32;
+        fn om_have_kinsol() -> i32;
+        fn om_have_umfpack() -> i32;
+        fn om_have_lis() -> i32;
+        fn om_have_sundials_driver() -> i32;
+    }
+    macro_rules! ask {
+        ($name:ident, $sym:ident) => {
+            pub fn $name() -> bool {
+                unsafe { $sym() != 0 }
+            }
+        };
+    }
+    ask!(klu, om_have_klu);
+    ask!(kinsol, om_have_kinsol);
+    ask!(umfpack, om_have_umfpack);
+    ask!(lis, om_have_lis);
+    ask!(driver, om_have_sundials_driver);
+}
+
+#[cfg(not(sundials_dylink))]
+mod groups {
+    macro_rules! ask {
+        ($name:ident) => {
+            pub fn $name() -> bool {
+                cfg!(sundials)
+            }
+        };
+    }
+    ask!(klu);
+    ask!(kinsol);
+    ask!(umfpack);
+    ask!(lis);
+    ask!(driver);
 }
 
 /// Smoke test that the archives are linked and callable: `klu_defaults` reports

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/lib.rs
@@ -66,7 +66,8 @@ pub enum Preference {
 pub enum BinaryKind {
     /// A shared library implementing the FMI C API.
     Native,
-    /// `binaries/wasm32-wasip2/*.wasm`, an fmi-ls-wasm component.
+    /// `binaries/wasm32-wasip2/*.wasm`, an fmi-ls-wasm component; `resources/*.wasm`
+    /// where it imports the OpenModelica extension.
     Wasm,
 }
 
@@ -186,6 +187,17 @@ impl Fmu {
                 })
             })
             .collect();
+        // A component importing `om:ext/native` is kept out of `binaries/`, being no
+        // fmi-ls-wasm binary. It is still the FMU's wasm binary to us.
+        let extended = format!("resources/{id}.wasm");
+        if !out.iter().any(|b| b.kind == BinaryKind::Wasm) && self.names.iter().any(|n| *n == extended) {
+            out.push(Binary {
+                kind: BinaryKind::Wasm,
+                platform_dir: platform::WASM_DIR.to_string(),
+                path: extended,
+                is_host: false,
+            });
+        }
         out.sort_by_key(|b| (!b.is_host, b.kind == BinaryKind::Wasm));
         out
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/Cargo.lock
@@ -563,6 +563,7 @@ dependencies = [
  "openmodelica_lapack",
  "openmodelica_mat_writer",
  "openmodelica_sim_meta",
+ "rsparse",
 ]
 
 [[package]]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/Cargo.toml
@@ -56,7 +56,13 @@ cs = []
 # instead of composing it into a per-model component — and can then compile it
 # once and keep the `.cwasm`, as it already does for the simulation runtime.
 capi = []
-# CVODE/IDA for the embedded driver, as imports the SUNDIALS side module resolves. A
-# second `cs`/`me_cs` blob is built with it, so an FMU that does not ask for those
-# solvers links neither the calls nor the module.
-sundials = ["openmodelica_sim_meta/sundials_extern"]
+# Both sparse-solve paths, chosen at run time by `rt_set_host_lin_solve`: the
+# host's native solver when one is instantiating this (1.3-2.7x on the large
+# systems of ScalableTestSuite's advection models), the in-wasm one otherwise.
+host_lin_solve = ["openmodelica_codegen_wasm_jit_runtime/host_lin_solve",
+                  "openmodelica_codegen_wasm_jit_runtime/inwasm_solve"]
+# The SUNDIALS/SuiteSparse/Lis solvers for the embedded driver -- CVODE, IDA, KINSOL,
+# KLU, UMFPACK, Lis -- as imports the FMU's SUNDIALS side module resolves. On for the
+# `me_cs` blob, which is the only one that embeds a driver.
+sundials = ["openmodelica_sim_meta/sundials_extern",
+            "openmodelica_codegen_wasm_jit_runtime/sundials_extern"]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -32,7 +32,7 @@ use openmodelica_sim_meta::driver::{
 };
 #[cfg(feature = "cs")]
 use openmodelica_sim_meta::driver::{CsDefer, CsDriver, CsStep};
-use openmodelica_sim_meta::{decode, omclog, FmiVr, Layout, Neg, WTy, REAL_OFF, TIME_OFF};
+use openmodelica_sim_meta::{decode, omclog, simflags, FmiVr, Layout, Neg, WTy, REAL_OFF, TIME_OFF};
 
 // ── Model kernel imports ─────────────────────────────────────────────────────
 // `env` is the dylink convention: the Linker resolves these against the model
@@ -735,6 +735,34 @@ pub struct Instance {
 
 /// Allocate and zero the model's `SimData` and build the instance state. Shared by
 /// both worlds' instantiate.
+/// The nonlinear/linear solver selection the export hard-coded into the metadata.
+/// An importer has no channel to pass simulation flags, so this is the only one there
+/// is; the export linked exactly the libraries these reach, so a rejection here means
+/// the two disagree and the instance must not come up quietly using another solver.
+fn apply_baked_solver_flags(flags: &str) -> Option<()> {
+    if flags.is_empty() {
+        return Some(());
+    }
+    let argv: Vec<String> = core::iter::once("model".to_string())
+        .chain(flags.split_whitespace().map(str::to_string))
+        .collect();
+    let parsed = simflags::parse(&argv)
+        .and_then(|f| {
+            simflags::check(&f, openmodelica_codegen_wasm_jit_runtime::sim_capabilities())?;
+            Ok(f)
+        })
+        .map_err(|e| {
+            omclog::error(
+                omclog::ASSERT,
+                false,
+                &alloc::format!("this FMU was exported with `{flags}`: {e}"),
+            )
+        })
+        .ok()?;
+    openmodelica_codegen_wasm_jit_runtime::apply_sim_flags(&parsed);
+    Some(())
+}
+
 fn new_state() -> Option<MeState> {
     #[allow(unused_mut)]
     let mut meta = read_meta();
@@ -744,6 +772,7 @@ fn new_state() -> Option<MeState> {
     }
     // From the model's own DefaultExperiment, as in C's FMU.
     openmodelica_codegen_wasm_jit_runtime::rt_set_step_size(meta.step_size());
+    apply_baked_solver_flags(&meta.fmi_solver_flags)?;
     let sim_data = openmodelica_codegen_wasm_jit_runtime::rt_alloc(layout.total);
     // rt_alloc leaves the block uninitialised; zero it so unset slots read 0.
     unsafe {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/sim_run.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/sim_run.rs
@@ -103,19 +103,30 @@ mod clock {
 }
 
 pub(crate) fn run(args: Vec<String>) -> Result<RunResult, String> {
-    // `parse` takes an argv, program name first, as a simulation executable's.
-    let mut argv: Vec<String> = vec!["model".to_string()];
-    argv.extend(args);
-    let flags = simflags::parse(&argv)?;
-    simflags::check(&flags, openmodelica_codegen_wasm_jit_runtime::sim_capabilities())?;
-    openmodelica_codegen_wasm_jit_runtime::apply_sim_flags(&flags);
-    // Installs the `-lv` log mask too, so the notices below are already filtered.
-    simflags::set_flags(flags);
-
     let mut m = read_meta();
     if m.layout.total == 0 {
         return Err("wasm-jit: the artifact carries no model metadata".to_string());
     }
+    // `parse` takes an argv, program name first, as a simulation executable's. The
+    // solver selection the export hard-coded goes in ahead of the caller's, so a
+    // later `-nls`/`-ls`/`-lss` overrides it and one the caller omits is kept --
+    // `apply_sim_flags` sets the whole selection at once, defaults included, so
+    // parsing them together is what merges them.
+    let mut argv: Vec<String> = vec!["model".to_string()];
+    argv.extend(m.fmi_solver_flags.split_whitespace().map(str::to_string));
+    argv.extend(args);
+    let flags = simflags::parse(&argv)?;
+    // `-variableFilter` is served by the host's matcher, so this runtime takes it
+    // despite having no regex engine. A component has no host and so cannot.
+    let cap = simflags::Capabilities {
+        variable_filter: cfg!(feature = "capi"),
+        ..openmodelica_codegen_wasm_jit_runtime::sim_capabilities()
+    };
+    simflags::check(&flags, cap)?;
+    openmodelica_codegen_wasm_jit_runtime::apply_sim_flags(&flags);
+    // Installs the `-lv` log mask too, so the notices below are already filtered.
+    simflags::set_flags(flags);
+
     driver::set_log_sink(log_sink);
     // What `OpenModelica_fmuLoadResource` resolves against, as at instantiation:
     // the host preopens the artifact's resources as this component's root.
@@ -164,10 +175,29 @@ pub(crate) fn run(args: Vec<String>) -> Result<RunResult, String> {
 /// The `.mat` / `.plt` bytes, exactly as the standalone export serializes them
 /// (one writer, so the two cannot drift). `"empty"` writes nothing: the run was
 /// only asked for its integration.
+/// `capi` only: a component has no host to ask, and an `env` import it cannot
+/// resolve would stop it linking at all.
+#[cfg(feature = "capi")]
+#[link(wasm_import_module = "env")]
+unsafe extern "C" {
+    /// Whether the run's `-variableFilter` keeps this name; non-zero to keep.
+    fn rt_host_name_matches(ptr: *const u8, len: usize) -> i32;
+}
+
+#[cfg(feature = "capi")]
+fn host_keeps(name: &str) -> bool {
+    unsafe { rt_host_name_matches(name.as_ptr(), name.len()) != 0 }
+}
+
 fn write_result_file(m: &meta::SimMeta, result: &driver::RunResult) -> Vec<u8> {
     if m.output_format != "mat" && m.output_format != "plt" {
         return Vec::new();
     }
+    // No regex engine here, so the host answers per name; with no filter
+    // installed it keeps everything.
+    #[cfg(feature = "capi")]
+    let keep = m.output_keep(Some(&host_keeps));
+    #[cfg(not(feature = "capi"))]
     let keep = m.output_keep(None);
     // `params` is positional over the unfiltered `Param` signals; only the kept
     // ones are collected, in signal order, for the writer.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/common.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/common.rs
@@ -17,7 +17,7 @@ pub struct Inputs {
 }
 
 impl Inputs {
-    pub fn new(opts: &Options) -> Inputs {
+    pub fn new(opts: &Options<'_>) -> Inputs {
         let mut groups: Vec<(VarType, Vec<u32>, Vec<usize>)> = Vec::new();
         for (i, input) in opts.inputs.iter().enumerate() {
             let ty = input.ty.wire();
@@ -42,7 +42,7 @@ impl Inputs {
     }
 
     /// Evaluate every input at `time` and set it.
-    pub fn apply(&mut self, inst: &mut dyn Fmi3, opts: &Options, time: f64) -> Result<()> {
+    pub fn apply(&mut self, inst: &mut dyn Fmi3, opts: &Options<'_>, time: f64) -> Result<()> {
         for (i, input) in opts.inputs.iter().enumerate() {
             self.values[i] = input.value.eval(time);
         }
@@ -60,7 +60,7 @@ impl Inputs {
 pub fn initialize(
     inst: &mut dyn Fmi3,
     inputs: &mut Inputs,
-    opts: &Options,
+    opts: &Options<'_>,
 ) -> Result<()> {
     inst.enter_initialization_mode(opts.tolerance, opts.start_time, Some(opts.stop_time))?;
     for p in &opts.parameters {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/cs.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/cs.rs
@@ -12,7 +12,7 @@
 use crate::api::{Fmi3, Fmi3CoSimulation};
 use crate::common::{Inputs, event_iteration, initialize};
 use crate::record::Recorder;
-use crate::{Error, Options, Result};
+use crate::{Deadline, Error, Options, Result};
 use openmodelica_fmi::{InterfaceKind, ModelDescription};
 
 /// How a run ended.
@@ -36,7 +36,7 @@ pub struct Run {
 pub fn simulate(
     inst: &mut dyn Fmi3CoSimulation,
     md: &ModelDescription,
-    opts: &Options,
+    opts: &Options<'_>,
 ) -> Result<Run> {
     // Event Mode needs the FMU to have one; without it `fmi3EnterEventMode` is
     // not even callable and the FMU handles its events internally.
@@ -53,7 +53,7 @@ pub fn simulate(
     };
 
     let mut inputs = Inputs::new(opts);
-    let mut rec = Recorder::new(md);
+    let mut rec = Recorder::new(md, opts.keep);
     initialize(as_common(inst), &mut inputs, opts)?;
 
     let mut terminated_at = None;
@@ -71,10 +71,14 @@ pub fn simulate(
     rec.snapshot_parameters(as_common(inst))?;
     rec.sample(as_common(inst), opts.start_time)?;
 
+    let deadline = Deadline::arm(opts);
     let mut t = opts.start_time;
     let mut grid = opts.grid(step).skip(1);
     let mut next = grid.next();
     while let Some(target) = next {
+        if deadline.expired() {
+            return Err(Error::Alarm);
+        }
         if inputs.is_time_varying() {
             inputs.apply(as_common(inst), opts, t)?;
         }
@@ -149,7 +153,7 @@ pub fn simulate(
 const MAX_STALLED_STEPS: u32 = 100;
 
 /// A time this close to the communication point counts as having reached it.
-fn step_epsilon(opts: &Options) -> f64 {
+fn step_epsilon(opts: &Options<'_>) -> f64 {
     (opts.stop_time - opts.start_time).abs() * 1e-12
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/lib.rs
@@ -48,6 +48,8 @@ pub enum Error {
     Simulation(String),
     /// The FMU asked for termination during initialization.
     TerminatedAtInit,
+    /// `-alarm=N` expired.
+    Alarm,
     Cancelled,
 }
 
@@ -70,6 +72,7 @@ impl std::fmt::Display for Error {
             Error::TerminatedAtInit => {
                 write!(f, "the FMU requested termination during initialization")
             }
+            Error::Alarm => write!(f, "simulation aborted (-alarm)"),
             Error::Cancelled => write!(f, "cancelled"),
         }
     }
@@ -141,7 +144,7 @@ pub struct Parameter {
     pub value: f64,
 }
 
-pub struct Options {
+pub struct Options<'a> {
     pub start_time: f64,
     pub stop_time: f64,
     /// The output interval, and for Co-Simulation the communication step size.
@@ -164,13 +167,19 @@ pub struct Options {
     /// Asked at each output point: `true` ends the run where it stands, with
     /// the samples taken so far kept.
     pub cancelled: Option<fn() -> bool>,
+    /// `-alarm=N`: seconds of wall clock the run may take. C raises `SIGALRM`;
+    /// here omc is the process, so the masters report [`Error::Alarm`] instead.
+    pub alarm: Option<u32>,
+    /// `-variableFilter`: which variables the result file keeps; `None` keeps all.
+    /// Borrowed, since the caller owns the compiled regex; this crate has none.
+    pub keep: Option<&'a dyn Fn(&str) -> bool>,
 }
 
-impl Options {
+impl Options<'_> {
     /// The options an FMU is simulated with when the caller says nothing: its
     /// own `<DefaultExperiment>`, and 500 output points where it gives no step
     /// size.
-    pub fn from_model_description(md: &ModelDescription) -> Options {
+    pub fn from_model_description(md: &ModelDescription) -> Options<'static> {
         let e = md.default_experiment.unwrap_or_default();
         let start_time = e.start_time.unwrap_or(0.0);
         let stop_time = e.stop_time.unwrap_or(start_time + 1.0);
@@ -191,6 +200,8 @@ impl Options {
             inputs: Vec::new(),
             progress: None,
             cancelled: None,
+            alarm: None,
+            keep: None,
         }
     }
 
@@ -209,6 +220,37 @@ impl Options {
             // not divide the span still ends exactly at the stop time.
             if k == n { self.stop_time } else { self.start_time + k as f64 * step }
         })
+    }
+}
+
+/// The wall clock a run may take, from [`Options::alarm`]. The browser has no
+/// clock here and cancels through [`Options::cancelled`], so it never expires.
+pub(crate) struct Deadline {
+    #[cfg(not(target_arch = "wasm32"))]
+    until: Option<std::time::Instant>,
+}
+
+impl Deadline {
+    pub(crate) fn arm(opts: &Options<'_>) -> Deadline {
+        #[cfg(not(target_arch = "wasm32"))]
+        return Deadline {
+            until: opts
+                .alarm
+                .filter(|s| *s > 0)
+                .map(|s| std::time::Instant::now() + std::time::Duration::from_secs(s as u64)),
+        };
+        #[cfg(target_arch = "wasm32")]
+        {
+            let _ = opts;
+            Deadline {}
+        }
+    }
+
+    pub(crate) fn expired(&self) -> bool {
+        #[cfg(not(target_arch = "wasm32"))]
+        return self.until.is_some_and(|t| std::time::Instant::now() >= t);
+        #[cfg(target_arch = "wasm32")]
+        false
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/me.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/me.rs
@@ -12,7 +12,7 @@
 use crate::api::{Fmi3, Fmi3ModelExchange};
 use crate::common::{Inputs, event_iteration, initialize};
 use crate::record::Recorder;
-use crate::{Error, Options, Result, Solver};
+use crate::{Deadline, Error, Options, Result, Solver};
 use openmodelica_fmi::ModelDescription;
 use openmodelica_solvers::dassl::{Dassl, DasslStep};
 use openmodelica_solvers::events::StepEnd;
@@ -42,7 +42,7 @@ pub struct Run {
 struct FmuOde<'a> {
     inst: &'a mut dyn Fmi3ModelExchange,
     inputs: &'a mut Inputs,
-    opts: &'a Options,
+    opts: &'a Options<'a>,
     nominals: Vec<f64>,
     /// The ODE Jacobian's sparsity, out of `<ModelStructure>`: which states each
     /// state derivative depends on, coloured so one evaluation differences a
@@ -62,6 +62,12 @@ struct FmuOde<'a> {
     committed: Option<(f64, Vec<f64>)>,
     /// What the FMU actually said, behind the static message the solvers carry.
     failure: Option<Error>,
+    /// `-alarm`, polled here rather than only at the output points: a solver that
+    /// stops converging never reaches them.
+    deadline: Deadline,
+    /// Calls into the FMU since the deadline was last read — every one, not just
+    /// the derivatives: event indicators can cost what derivatives do.
+    polls: u64,
 }
 
 impl FmuOde<'_> {
@@ -93,11 +99,21 @@ impl FmuOde<'_> {
         self.failure.get_or_insert(e);
         "the FMU reported an error while being integrated"
     }
+
+    /// `-alarm`, checked every 64th call: reading the clock on each would be most
+    /// of a cheap model's evaluation.
+    fn past_deadline(&mut self) -> bool {
+        self.polls += 1;
+        self.polls % 64 == 0 && self.deadline.expired()
+    }
 }
 
 impl Ode for FmuOde<'_> {
     fn eval(&mut self, t: f64, y: &[f64], f: &mut [f64]) -> openmodelica_solvers::Result<()> {
         self.calls += 1;
+        if self.past_deadline() {
+            return Err(self.note(Error::Alarm));
+        }
         self.commit(t, y).map_err(|e| self.note(e))?;
         self.inst.get_continuous_state_derivatives(f).map_err(|e| self.note(e))
     }
@@ -105,6 +121,9 @@ impl Ode for FmuOde<'_> {
     fn eval_zc(&mut self, t: f64, y: &[f64], zc: &mut [f64]) -> openmodelica_solvers::Result<()> {
         if zc.is_empty() {
             return Ok(());
+        }
+        if self.past_deadline() {
+            return Err(self.note(Error::Alarm));
         }
         self.commit(t, y).map_err(|e| self.note(e))?;
         self.inst.get_event_indicators(zc).map_err(|e| self.note(e))
@@ -127,6 +146,10 @@ impl Ode for FmuOde<'_> {
     }
 
     fn jacobian_vector(&mut self, t: f64, y: &[f64], seed: &[f64], out: &mut [f64]) -> bool {
+        if self.past_deadline() {
+            self.failure.get_or_insert(Error::Alarm);
+            return false;
+        }
         if self.commit(t, y).is_err() {
             return false;
         }
@@ -234,7 +257,7 @@ impl Integrator {
         })
     }
 
-    fn set_experiment(&mut self, opts: &Options) {
+    fn set_experiment(&mut self, opts: &Options<'_>) {
         if let Integrator::Gbode(gb) = self {
             gb.set_experiment(opts.start_time, opts.stop_time, opts.step_size);
         }
@@ -306,10 +329,10 @@ impl Integrator {
 pub fn simulate(
     inst: &mut dyn Fmi3ModelExchange,
     md: &ModelDescription,
-    opts: &Options,
+    opts: &Options<'_>,
 ) -> Result<Run> {
     let mut inputs = Inputs::new(opts);
-    let mut rec = Recorder::new(md);
+    let mut rec = Recorder::new(md, opts.keep);
     {
         let common: &mut dyn Fmi3 = inst;
         initialize(common, &mut inputs, opts)?;
@@ -386,6 +409,8 @@ pub fn simulate(
         calls: 0,
         committed: None,
         failure: None,
+        deadline: Deadline::arm(opts),
+        polls: 0,
     };
     let mut t = opts.start_time;
     let mut next_event = info.next_event_time.unwrap_or(f64::INFINITY);
@@ -467,6 +492,9 @@ pub fn simulate(
             cancelled = true;
             break 'grid;
         }
+        if ode.deadline.expired() {
+            return Err(Error::Alarm);
+        }
     }
 
     let calls = ode.calls;
@@ -487,6 +515,6 @@ pub fn simulate(
 }
 
 /// Times this close to an output point count as having reached it.
-fn grid_epsilon(opts: &Options) -> f64 {
+fn grid_epsilon(opts: &Options<'_>) -> f64 {
     (opts.stop_time - opts.start_time).abs() * 1e-12
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/record.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/record.rs
@@ -122,11 +122,13 @@ fn element_names(name: &str, dimensions: &[usize]) -> Vec<String> {
 }
 
 impl Recorder {
-    pub fn new(md: &ModelDescription) -> Recorder {
+    pub fn new(md: &ModelDescription, keep: Option<&dyn Fn(&str) -> bool>) -> Recorder {
+        // Dropped here, not at write time: the sampling is the cost.
+        let wanted = |v: &Variable| is_recorded(v) && keep.is_none_or(|k| k(&v.name));
         let states: Vec<u32> = md.continuous_states();
         let mut columns = Vec::new();
         let mut recorded = Vec::new();
-        for v in md.variables.iter().filter(|v| is_recorded(v)) {
+        for v in md.variables.iter().filter(|v| wanted(v)) {
             let first = columns.len() + 1; // column 0 is time
             for name in element_names(&v.name, &extents(md, v)) {
                 columns.push(Column {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_web/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_web/src/lib.rs
@@ -353,7 +353,7 @@ fn describe(fmu: &Fmu) -> Value {
     })
 }
 
-fn options_from(md: &ModelDescription, o: &Value) -> Result<Options, Error> {
+fn options_from(md: &ModelDescription, o: &Value) -> Result<Options<'static>, Error> {
     let mut opts = Options::from_model_description(md);
     let num = |key: &str| o.get(key).and_then(Value::as_f64);
     opts.start_time = num("startTime").unwrap_or(opts.start_time);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/read_matlab4.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/read_matlab4.rs
@@ -20,6 +20,11 @@ use std::io::{Read, Seek, SeekFrom};
 // `std::fs::File` natively, an in-memory `Cursor` on the web target.
 type Src = openmodelica_wasi::fs::Reader;
 
+/// How much of data_2 is worth holding in memory. Under it the whole matrix is
+/// read once and every lookup is an index; over it only what the caller asks for
+/// is read, as the C reader always has.
+const MAX_CACHED_DATA2: u64 = 64 * 1024 * 1024;
+
 /// One entry from the `name`/`description`/`dataInfo` metadata tables.
 #[derive(Clone)]
 pub struct MatVariable {
@@ -417,12 +422,37 @@ impl MatReader {
         Ok(reader)
     }
 
-    /// Load and transpose data_2 into time-major order on first access.
+    /// Bytes one element of data_2 occupies on disk.
+    fn elem_size(&self) -> u64 {
+        if self.doublePrecision { 8 } else { 4 }
+    }
+
+    /// One element straight off the disk, without holding the matrix.
+    fn disk_val(&mut self, row: usize, col: usize) -> Option<f64> {
+        let elem = self.elem_size();
+        let at = match self.binTrans {
+            // Time-major on disk: row `row` is `nvar` elements, `col` into it.
+            true => row as u64 * self.nvar as u64 + col as u64,
+            // Variable-major: column `col` is `nrows` elements.
+            false => col as u64 * self.nrows as u64 + row as u64,
+        };
+        self.file.seek(SeekFrom::Start(self.var_offset + at * elem)).ok()?;
+        let ty = if self.doublePrecision { 0 } else { 10 };
+        read_doubles(ty, 1, &mut self.file).ok()?.first().copied()
+    }
+
+    /// How large data_2 is.
+    fn data2_bytes(&self) -> u64 {
+        self.nrows as u64 * self.nvar as u64 * self.elem_size()
+    }
+
+    /// Load and transpose data_2 into time-major order on first access. Only for
+    /// a matrix that fits in memory; past that the callers read off the disk.
     fn ensure_data2(&mut self) -> bool {
         if self.data2.is_some() {
             return true;
         }
-        if self.nrows == 0 || self.nvar == 0 {
+        if self.nrows == 0 || self.nvar == 0 || self.data2_bytes() > MAX_CACHED_DATA2 {
             return false;
         }
         let n = self.nrows * self.nvar;
@@ -456,32 +486,56 @@ impl MatReader {
     /// Single value of `varIndex` (1-based, sign for negative alias) at row
     /// `timeIndex`. Returns None on read error.
     fn single_val(&mut self, varIndex: i32, timeIndex: usize) -> Option<f64> {
-        if !self.ensure_data2() {
+        let absv = varIndex.unsigned_abs() as usize;
+        if absv == 0 || absv > self.nvar || timeIndex >= self.nrows {
             return None;
         }
-        let absv = varIndex.unsigned_abs() as usize;
-        let data2 = self.data2.as_ref()?;
-        let v = *data2.get(timeIndex * self.nvar + (absv - 1))?;
+        let v = if self.ensure_data2() {
+            *self.data2.as_ref()?.get(timeIndex * self.nvar + (absv - 1))?
+        } else {
+            self.disk_val(timeIndex, absv - 1)?
+        };
         Some(if varIndex < 0 { -v } else { v })
     }
 
     /// Full trajectory of a variable column (1-based index, sign for alias).
     pub fn read_vals(&mut self, varIndex: i32) -> Option<Vec<f64>> {
-        if !self.ensure_data2() {
+        let absv = varIndex.unsigned_abs() as usize;
+        if absv == 0 || absv > self.nvar || self.nrows == 0 {
             return None;
         }
-        let absv = varIndex.unsigned_abs() as usize;
-        let nvar = self.nvar;
-        let nrows = self.nrows;
-        let data2 = self.data2.as_ref()?;
-        Some(
-            (0..nrows)
-                .map(|i| {
-                    let v = data2[i * nvar + (absv - 1)];
-                    if varIndex < 0 { -v } else { v }
-                })
-                .collect(),
-        )
+        let (nvar, nrows) = (self.nvar, self.nrows);
+        let negate = varIndex < 0;
+        if self.ensure_data2() {
+            let data2 = self.data2.as_ref()?;
+            return Some(
+                (0..nrows)
+                    .map(|i| {
+                        let v = data2[i * nvar + (absv - 1)];
+                        if negate { -v } else { v }
+                    })
+                    .collect(),
+            );
+        }
+        let elem = self.elem_size();
+        let ty = if self.doublePrecision { 0 } else { 10 };
+        // Variable-major on disk: the column is one contiguous run.
+        if !self.binTrans {
+            let at = self.var_offset + (absv - 1) as u64 * nrows as u64 * elem;
+            self.file.seek(SeekFrom::Start(at)).ok()?;
+            let mut v = read_doubles(ty, nrows, &mut self.file).ok()?;
+            if negate {
+                v.iter_mut().for_each(|x| *x = -*x);
+            }
+            return Some(v);
+        }
+        // Time-major: the column is `nrows` elements `nvar` apart.
+        let mut out = Vec::with_capacity(nrows);
+        for i in 0..nrows {
+            let v = self.disk_val(i, absv - 1)?;
+            out.push(if negate { -v } else { v });
+        }
+        Some(out)
     }
 
     pub fn start_time(&mut self) -> f64 {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -1021,6 +1021,12 @@ pub struct SimMeta {
     /// `FMI2CS_initializeSolverData`: `-s` from `_flags.json`, else euler).
     /// Empty except for a CS export.
     pub cs_method: String,
+    /// The nonlinear/linear solver selection an FMU export hard-codes, as a simflags
+    /// argv fragment (`-nls=kinsol -lss=klu`). An importer has no channel to pass
+    /// these, so `--fmiFlags` is consumed at export and the FMU applies them when it
+    /// instantiates; the export links exactly the solver libraries they reach.
+    /// Empty except for an FMU export.
+    pub fmi_solver_flags: String,
     /// Relative/absolute tolerance for the adaptive integrators.
     pub tolerance: f64,
     /// Result file format (`"mat"`, `"empty"`).
@@ -1418,7 +1424,7 @@ impl SimMeta {
 // the crate dependency-free and trivially buildable for every target.
 
 const MAGIC: &[u8; 4] = b"OMSM";
-const VERSION: u32 = 17;
+const VERSION: u32 = 18;
 
 fn put_u32(o: &mut Vec<u8>, v: u32) {
     o.extend_from_slice(&v.to_le_bytes());
@@ -1532,6 +1538,7 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
     put_u32(&mut o, m.n_intervals);
     put_str(&mut o, &m.method);
     put_str(&mut o, &m.cs_method);
+    put_str(&mut o, &m.fmi_solver_flags);
     put_f64(&mut o, m.tolerance);
     put_str(&mut o, &m.output_format);
     put_str(&mut o, &m.prefix);
@@ -2015,6 +2022,7 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
     let n_intervals = r.u32()?;
     let method = r.string()?;
     let cs_method = r.string()?;
+    let fmi_solver_flags = r.string()?;
     let tolerance = r.f64()?;
     let output_format = r.string()?;
     let prefix = r.string()?;
@@ -2333,7 +2341,8 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
         }
     };
     Ok(SimMeta {
-        layout, start_time, stop_time, n_intervals, method, cs_method, tolerance, output_format, prefix,
+        layout, start_time, stop_time, n_intervals, method, cs_method, fmi_solver_flags, tolerance,
+        output_format, prefix,
         model_name, vars, jac_a, state_sets, fmi_vrs, zc_desc, rel_desc, params, attr_log,
         removed_init_desc, nls_warnings, sample_index, soti, sens_params, nls_vars, n_lin_systems, dae, clocks, lin, opt, inputs, recon, prof,
         parmod,
@@ -2358,6 +2367,7 @@ mod tests {
             n_intervals: 500,
             method: "dassl".to_string(),
             cs_method: "euler".to_string(),
+            fmi_solver_flags: "-nls=kinsol -lss=klu".to_string(),
             tolerance: 1e-6,
             output_format: "mat".to_string(),
             prefix: "MyModel".to_string(),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/simflags.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/simflags.rs
@@ -417,8 +417,14 @@ impl SimFlags {
 /// rather than running a different solver.
 #[derive(Clone, Copy, Debug)]
 pub struct Capabilities {
-    /// The runtime's SUNDIALS archives, which hold KINSOL as well as KLU.
+    /// SuiteSparse KLU, which is also IDA's default linear solver.
     pub klu: bool,
+    /// SUNDIALS KINSOL, the `-nls=kinsol` nonlinear solver.
+    pub kinsol: bool,
+    /// SuiteSparse UMFPACK.
+    pub umfpack: bool,
+    /// Lis, the iterative `-ls=lis`/`-lss=lis`.
+    pub lis: bool,
     pub ida: bool,
     pub cvode: bool,
     /// This runtime has a wall clock, so `-alarm` can be honoured.
@@ -435,16 +441,24 @@ pub struct Capabilities {
 
 /// Reject flag values this runtime cannot honour.
 pub fn check(f: &SimFlags, cap: Capabilities) -> Result<(), String> {
-    // KLU and UMFPACK ride on the same SuiteSparse archives.
-    if !cap.klu {
-        for (flag, name) in [
-            ("lss", (f.lss == Some(Lss::Klu)).then_some("klu").or((f.lss == Some(Lss::Umfpack)).then_some("umfpack"))),
-            ("ls", (f.ls == Some(Ls::Klu)).then_some("klu").or((f.ls == Some(Ls::Umfpack)).then_some("umfpack"))),
-            ("nlsLS", (f.nls_ls == Some(NlsLs::Klu)).then_some("klu")),
-        ] {
-            if let Some(name) = name {
-                return Err(format!("-{flag}={name}: this runtime has no SuiteSparse linear solver"));
-            }
+    // Each solver library is linked on its own, so each is its own question --
+    // the same one `Offer::With*` asks in the tables below.
+    for (flag, name, have) in [
+        ("nls", match f.nls {
+            Some(Nls::Kinsol) => Some("kinsol"),
+            Some(Nls::KinsolB) => Some("experimental-kinsol"),
+            _ => None,
+        }, cap.kinsol),
+        ("nlsLS", (f.nls_ls == Some(NlsLs::Klu)).then_some("klu"), cap.klu),
+        ("ls", (f.ls == Some(Ls::Klu)).then_some("klu"), cap.klu),
+        ("ls", (f.ls == Some(Ls::Umfpack)).then_some("umfpack"), cap.umfpack),
+        ("ls", (f.ls == Some(Ls::Lis)).then_some("lis"), cap.lis),
+        ("lss", (f.lss == Some(Lss::Klu)).then_some("klu"), cap.klu),
+        ("lss", (f.lss == Some(Lss::Umfpack)).then_some("umfpack"), cap.umfpack),
+        ("lss", (f.lss == Some(Lss::Lis)).then_some("lis"), cap.lis),
+    ] {
+        if let (Some(name), false) = (name, have) {
+            return Err(format!("-{flag}={name}: this runtime has no {name}"));
         }
     }
     if f.alarm.is_some() && !cap.alarm {
@@ -1290,7 +1304,10 @@ type Value<T> = (&'static str, T, Offer);
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Offer {
     Always,
-    WithSundials,
+    WithKlu,
+    WithKinsol,
+    WithUmfpack,
+    WithLis,
     WithIda,
     WithCvode,
     WithIpopt,
@@ -1303,7 +1320,10 @@ impl Offer {
     fn available(self, cap: Capabilities) -> bool {
         match self {
             Offer::Always => true,
-            Offer::WithSundials => cap.klu,
+            Offer::WithKlu => cap.klu,
+            Offer::WithKinsol => cap.kinsol,
+            Offer::WithUmfpack => cap.umfpack,
+            Offer::WithLis => cap.lis,
             Offer::WithIda => cap.ida,
             Offer::WithCvode => cap.cvode,
             Offer::WithIpopt => cap.optimization,
@@ -1332,8 +1352,8 @@ const SOLVERS: &[Value<Solver>] = &[
 /// `-nls`. Without the archives `kinsol` runs the runtime's own sparse Newton.
 const NLS_VALUES: &[Value<Nls>] = &[
     ("hybrid", Nls::Hybrid, Offer::Always),
-    ("kinsol", Nls::Kinsol, Offer::WithSundials),
-    ("experimental-kinsol", Nls::KinsolB, Offer::WithSundials),
+    ("kinsol", Nls::Kinsol, Offer::WithKinsol),
+    ("experimental-kinsol", Nls::KinsolB, Offer::WithKinsol),
     ("newton", Nls::Newton, Offer::Always),
     ("mixed", Nls::Mixed, Offer::Always),
     ("homotopy", Nls::Homotopy, Offer::Always),
@@ -1345,28 +1365,27 @@ const NLS_LS_VALUES: &[Value<NlsLs>] = &[
     ("totalpivot", NlsLs::TotalPivot, Offer::Never),
     ("lapack", NlsLs::Lapack, Offer::Never),
     ("rsparse", NlsLs::Rsparse, Offer::Always),
-    ("klu", NlsLs::Klu, Offer::WithSundials),
+    ("klu", NlsLs::Klu, Offer::WithKlu),
 ];
 
 /// `-ls`. `lapack` is partial-pivot LU falling back to the total-pivot search,
-/// which `totalpivot` goes straight to. `lis` rides the same archive bundle as
-/// klu/umfpack, hence the same capability.
+/// which `totalpivot` goes straight to.
 const LS_VALUES: &[Value<Ls>] = &[
     ("default", Ls::Default, Offer::Never),
     ("lapack", Ls::Lapack, Offer::Always),
-    ("lis", Ls::Lis, Offer::WithSundials),
+    ("lis", Ls::Lis, Offer::WithLis),
     ("totalpivot", Ls::TotalPivot, Offer::Always),
-    ("klu", Ls::Klu, Offer::WithSundials),
-    ("umfpack", Ls::Umfpack, Offer::WithSundials),
+    ("klu", Ls::Klu, Offer::WithKlu),
+    ("umfpack", Ls::Umfpack, Offer::WithUmfpack),
 ];
 
 /// `-lss`
 const LSS_VALUES: &[Value<Lss>] = &[
     ("default", Lss::Default, Offer::Never),
-    ("lis", Lss::Lis, Offer::WithSundials),
+    ("lis", Lss::Lis, Offer::WithLis),
     ("rsparse", Lss::Rsparse, Offer::Always),
-    ("klu", Lss::Klu, Offer::WithSundials),
-    ("umfpack", Lss::Umfpack, Offer::WithSundials),
+    ("klu", Lss::Klu, Offer::WithKlu),
+    ("umfpack", Lss::Umfpack, Offer::WithUmfpack),
 ];
 
 const CVODE_LMM_VALUES: &[Value<CvodeLmm>] = &[
@@ -1495,6 +1514,9 @@ mod tests {
 
     const NOTHING: Capabilities = Capabilities {
         klu: false,
+        kinsol: false,
+        umfpack: false,
+        lis: false,
         ida: false,
         cvode: false,
         alarm: false,
@@ -1504,6 +1526,9 @@ mod tests {
     };
     const EVERYTHING: Capabilities = Capabilities {
         klu: true,
+        kinsol: true,
+        umfpack: true,
+        lis: true,
         ida: true,
         cvode: true,
         alarm: true,
@@ -1532,7 +1557,9 @@ mod tests {
     fn unavailable_solvers_are_rejected_with_the_flag_named() {
         for (arg, needle) in [("-lss=klu", "-lss=klu"), ("-ls=klu", "-ls=klu"),
                               ("-nlsLS=klu", "-nlsLS=klu"), ("-lss=umfpack", "-lss=umfpack"),
-                              ("-ls=umfpack", "-ls=umfpack"),
+                              ("-ls=umfpack", "-ls=umfpack"), ("-ls=lis", "-ls=lis"),
+                              ("-lss=lis", "-lss=lis"), ("-nls=kinsol", "-nls=kinsol"),
+                              ("-nls=experimental-kinsol", "-nls=experimental-kinsol"),
                               ("-s=ida", "dassl"), ("-s=cvode", "dassl")] {
             let f = parse(&argv(&[arg])).expect("parses");
             let e = check(&f, NOTHING).expect_err("must reject");
@@ -1547,11 +1574,44 @@ mod tests {
         assert!(e.contains("`cvode`"), "{e}");
     }
 
+    /// An FMU is linked one solver library at a time, so having one must not imply
+    /// another.
+    #[test]
+    fn each_solver_library_is_gated_on_its_own() {
+        for (arg, cap) in [
+            ("-lss=klu", Capabilities { klu: true, ..NOTHING }),
+            ("-ls=umfpack", Capabilities { umfpack: true, ..NOTHING }),
+            ("-lss=lis", Capabilities { lis: true, ..NOTHING }),
+            ("-nls=kinsol", Capabilities { kinsol: true, ..NOTHING }),
+        ] {
+            let f = parse(&argv(&[arg])).expect("parses");
+            assert!(check(&f, cap).is_ok(), "{arg} with its own library");
+            // Every other library alone is not enough.
+            for other in [
+                Capabilities { klu: true, ..NOTHING },
+                Capabilities { umfpack: true, ..NOTHING },
+                Capabilities { lis: true, ..NOTHING },
+                Capabilities { kinsol: true, ..NOTHING },
+            ] {
+                if check(&f, other).is_ok() {
+                    assert_eq!(
+                        (other.klu, other.umfpack, other.lis, other.kinsol),
+                        (cap.klu, cap.umfpack, cap.lis, cap.kinsol),
+                        "{arg} accepted by the wrong library"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The solvers this runtime carries itself, as opposed to the ones a linked
+    /// library provides. `kinsol` is not among them: `NLS_VALUES` offers it only
+    /// `WithKinsol`.
     #[test]
     fn selectable_solvers_need_no_capability() {
         for arg in
-            ["-nls=kinsol", "-nls=hybrid", "-lss=rsparse", "-s=euler", "-s=dassl", "-s=gbode",
-             "-s=rungekutta"]
+            ["-nls=hybrid", "-nls=newton", "-nls=mixed", "-nls=homotopy", "-lss=rsparse",
+             "-s=euler", "-s=dassl", "-s=gbode", "-s=rungekutta"]
         {
             let f = parse(&argv(&[arg])).expect("parses");
             assert!(check(&f, NOTHING).is_ok(), "{arg}");

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi_libc/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi_libc/build.rs
@@ -2,9 +2,9 @@
 //! `src/lib.rs`: a `-fPIC` wasi-libc `libc.so`, ModelicaExternalC as a PIC dylink
 //! side module, and the vendored `wasi_snapshot_preview1` adapter.
 //!
-//! All inputs are provided by CMake via environment variables. This crate does
-//! not build wasi-libc or sundials itself — the CMake targets `rust_wasi_pic_sysroot`
-//! and `rust_sundials_wasm` handle that before cargo runs.
+//! All inputs are provided by CMake via environment variables. This crate does not
+//! build wasi-libc itself — the CMake target `rust_wasi_pic_sysroot` handles that
+//! before cargo runs.
 //!
 //! Failure in any step (sysroot missing, external-C clang failure) is a hard error.
 
@@ -44,150 +44,6 @@ fn main() {
         .unwrap_or_else(|e| panic!("failed to build the PIC usertab dummy dylink module: {e}"));
     copy(&usertab, &out_dir.join("usertab_dylink.wasm"));
 
-    // Only a CVODE/IDA Co-Simulation FMU needs this, so a build that never asked
-    // for sundials leaves an empty blob. Asking and failing is a hard error: the
-    // omc would look healthy and just refuse `-s=cvode` at export.
-    println!("cargo:rerun-if-env-changed=OMC_SUNDIALS_SOURCES");
-    let sundials_dest = out_dir.join("sundials_dylink.wasm");
-    if std::env::var_os("OMC_SUNDIALS_SOURCES").is_none() {
-        std::fs::write(&sundials_dest, []).expect("write empty sundials blob");
-    } else {
-        let module = build_sundials_dylink(&out_dir, &sysroot, triple).unwrap_or_else(|e| {
-            panic!(
-                "failed to build the SUNDIALS dylink module: {e}\n\
-                 This build asked for sundials (OMC_SUNDIALS_SOURCES is set), so the omc it \
-                 produces must be able to export a wasm FMU with -s=cvode/ida. Build it \
-                 without sundials if that is not wanted."
-            )
-        });
-        copy(&module, &sundials_dest);
-    }
-}
-
-/// The SUNDIALS/KLU API the drivers call. wasm-ld GCs from this list, keeping the
-/// module ~240 KB rather than the archives' 1.5 MB — so a driver calling something
-/// new gets an unresolved import at FMU-export time until it is added here. The
-/// wasip1 runtime links the archives instead and never notices.
-const SUNDIALS_EXPORTS: &[&str] = &[
-    "CVodeCreate", "CVodeInit", "CVodeReInit", "CVodeFree", "CVode", "CVodeSVtolerances",
-    "CVodeRootInit", "CVodeGetRootInfo", "CVodeSetUserData", "CVodeSetLinearSolver",
-    "CVodeSetJacFn", "CVodeSetInitStep", "CVodeSetMaxStep", "CVodeSetMinStep",
-    "CVodeSetNonlinearSolver", "CVodeSetMaxOrd", "CVodeSetMaxNumSteps", "CVodeSetMaxErrTestFails",
-    "CVodeSetMaxNonlinIters", "CVodeSetMaxConvFails", "CVodeSetStabLimDet",
-    "CVodeSetStopTime", "CVodeGetNumSteps", "CVodeGetNumRhsEvals", "CVodeGetNumJacEvals",
-    "CVodeGetNumErrTestFails", "CVodeGetNumNonlinSolvConvFails",
-    "IDACreate", "IDAInit", "IDAReInit", "IDAFree", "IDASolve", "IDACalcIC",
-    "IDASVtolerances", "IDARootInit", "IDAGetRootInfo", "IDASetUserData",
-    "IDASetLinearSolver", "IDASetJacFn", "IDASetId", "IDASetSuppressAlg",
-    "IDASetInitStep", "IDASetMaxOrd", "IDASetMaxNonlinIters", "IDASetMaxConvFails",
-    "IDASetMaxErrTestFails", "IDASetNonlinConvCoef", "IDASetLineSearchOffIC", "IDASetMaxStep",
-    "IDASetMaxNumItersIC", "IDASetMaxNumJacsIC", "IDASetMaxNumStepsIC",
-    "IDAGetConsistentIC", "IDAGetCurrentStep", "IDAGetActualInitStep", "IDAGetNumSteps",
-    "IDAGetNumResEvals", "IDAGetNumJacEvals", "IDAGetNumErrTestFails",
-    "IDAGetNumNonlinSolvConvFails", "IDASensInit", "IDASensReInit", "IDASensEEtolerances",
-    "IDASetSensParams", "IDASetSensDQMethod", "IDAGetSens",
-    "N_VNew_Serial", "N_VConst", "N_VDestroy", "N_VGetArrayPointer",
-    "N_VCloneVectorArray", "N_VDestroyVectorArray",
-    "SUNDenseMatrix", "SUNDenseMatrix_Data", "SUNSparseMatrix", "SUNSparseMatrix_Data",
-    "SUNSparseMatrix_IndexPointers", "SUNSparseMatrix_IndexValues", "SUNMatDestroy",
-    "SUNLinSol_Dense", "SUNLinSol_KLU", "SUNLinSol_SPGMR", "SUNLinSol_SPBCGS",
-    "SUNLinSol_SPTFQMR", "SUNLinSolFree",
-    "SUNNonlinSol_FixedPoint", "SUNNonlinSolFree",
-    // SUNDIALS 6 moved every object onto a SUNContext and added SUNLogger; the
-    // drivers create one per instance and route its four streams.
-    "SUNContext_Create", "SUNContext_Free", "SUNContext_GetLogger",
-    "SUNContext_PushErrHandler",
-    "SUNLogger_SetErrorFilename", "SUNLogger_SetWarningFilename",
-    "SUNLogger_SetInfoFilename", "SUNLogger_SetDebugFilename",
-];
-
-/// Compile SUNDIALS (CVODE + IDAS), its matrices/linear solvers and SuiteSparse/KLU to
-/// a PIC dylink side module, the form `wit_component::Linker` adds to an FMU. The
-/// archives CMake builds for the wasip1 runtime are not `-fPIC`, so a `--shared` link
-/// rejects them.
-fn build_sundials_dylink(out_dir: &Path, sysroot: &Path, triple: &str) -> Result<PathBuf, String> {
-    for v in ["OMC_SUNDIALS_SOURCES", "OMC_SUITESPARSE_SOURCES", "OMC_SUNDIALS_WASM_INCLUDE"] {
-        println!("cargo:rerun-if-env-changed={v}");
-    }
-    let sundials = PathBuf::from(std::env::var("OMC_SUNDIALS_SOURCES").map_err(|_| "OMC_SUNDIALS_SOURCES not set")?);
-    let ss = PathBuf::from(std::env::var("OMC_SUITESPARSE_SOURCES").map_err(|_| "OMC_SUITESPARSE_SOURCES not set")?);
-    // Generated by the wasm ExternalProject, so this also sequences us after it.
-    let config = PathBuf::from(std::env::var("OMC_SUNDIALS_WASM_INCLUDE").map_err(|_| "OMC_SUNDIALS_WASM_INCLUDE not set")?);
-    let config_h = config.join("sundials/sundials_config.h");
-    println!("cargo:rerun-if-changed={}", config_h.display());
-    if !config_h.exists() {
-        return Err(format!("{} does not exist; it is generated by the rust_sundials_collect \
-                            CMake target", config_h.display()));
-    }
-
-    // `f*.c` are the Fortran interfaces (duplicate `F2C_*_nonlinsol` symbols),
-    // `sundials_xbraid.c` needs braid.h, and `*mpi*.c` includes `mpi.h`
-    // unconditionally: none belongs in a host-free wasm module. (`sundials_logger.c`
-    // also reaches for `mpi.h`, but behind `#if SUNDIALS_MPI_ENABLED`.)
-    let src = sundials.join("src");
-    let mut srcs = Vec::new();
-    for dir in [
-        "cvode", "idas", "sundials", "nvector/serial",
-        "sunmatrix/dense", "sunmatrix/sparse", "sunmatrix/band",
-        "sunlinsol/dense", "sunlinsol/klu", "sunlinsol/spgmr", "sunlinsol/spbcgs",
-        "sunlinsol/sptfqmr", "sunnonlinsol/newton", "sunnonlinsol/fixedpoint",
-    ] {
-        let mut found = collect_c_files(&src.join(dir));
-        found.retain(|p| {
-            let n = p.file_name().and_then(|s| s.to_str()).unwrap_or("");
-            !n.starts_with('f') && n != "sundials_xbraid.c" && !n.contains("mpi")
-        });
-        if found.is_empty() {
-            return Err(format!("no sources in {}", src.join(dir).display()));
-        }
-        srcs.extend(found);
-    }
-    for dir in ["KLU/Source", "AMD/Source", "COLAMD/Source", "BTF/Source"] {
-        srcs.extend(collect_c_files(&ss.join(dir)));
-    }
-    srcs.push(ss.join("SuiteSparse_config/SuiteSparse_config.c"));
-    srcs.sort();
-    for s in &srcs {
-        println!("cargo:rerun-if-changed={}", s.display());
-    }
-
-    let raw = out_dir.join("sundials_dylink_raw.wasm");
-    let builtins = find_wasm_builtins().ok_or("no libclang_rt.builtins-wasm32.a found")?;
-    let clang = std::env::var("OMC_WASI_CLANG").unwrap_or_else(|_| "clang".to_owned());
-    let mut cmd = Command::new(&clang);
-    cmd.arg(format!("--target={triple}"))
-        .arg(format!("--sysroot={}", sysroot.display()))
-        .args(["-O2", "-fPIC", "-nodefaultlibs", "-mexec-model=reactor", "-DNDEBUG",
-               "-Wno-tautological-constant-out-of-range-compare"]);
-    for inc in [
-        sundials.join("include"), config, src.clone(), src.join("sundials"),
-        ss.join("KLU/Include"), ss.join("AMD/Include"), ss.join("COLAMD/Include"),
-        ss.join("BTF/Include"), ss.join("SuiteSparse_config"),
-    ] {
-        cmd.arg("-I").arg(inc);
-    }
-    cmd.args(&srcs)
-        .args(["-Wl,--experimental-pic", "-Wl,--shared", "-Wl,--no-entry", "-Wl,--allow-undefined"]);
-    for e in SUNDIALS_EXPORTS {
-        cmd.arg(format!("-Wl,--export={e}"));
-    }
-    // No `-lc`, as for modelicaexternalc: the libc calls stay `env` imports the FMU
-    // linker resolves. Linking `libc.so` records a `NEEDED libc.so` it has no library
-    // registered under that name for.
-    let status = cmd
-        .arg(&builtins)
-        .arg("-o")
-        .arg(&raw)
-        .status()
-        .map_err(|e| format!("spawn {clang}: {e}"))?;
-    if !status.success() {
-        return Err(format!("clang (sundials dylink) exited with {status}"));
-    }
-    let bytes = std::fs::read(&raw).map_err(|e| format!("read raw dylink: {e}"))?;
-    let out = out_dir.join("sundials_dylink_stripped.wasm");
-    std::fs::write(&out, strip_wasm_export(&bytes, "_initialize"))
-        .map_err(|e| format!("write dylink: {e}"))?;
-    Ok(out)
 }
 
 /// The preview1→preview2 reactor adapter: `OMC_WASI_P1_ADAPTER` from CMake.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi_libc/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasi_libc/src/lib.rs
@@ -14,15 +14,6 @@ pub static LIBC_PIC: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/libc_pic.
 /// The `wasi_snapshot_preview1` → preview2 reactor adapter.
 pub static WASI_P1_ADAPTER: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/wasi_snapshot_preview1.reactor.wasm"));
 
-/// SUNDIALS (CVODE + IDAS) and KLU as a PIC dylink side module, linked into an FMU
-/// only when its Co-Simulation driver needs them. Empty when this omc was built
-/// without a sundials source tree.
-pub static SUNDIALS_DYLINK: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/sundials_dylink.wasm"));
-
-/// Whether a wasm FMU can be given CVODE/IDA (the module above was built).
-pub fn sundials_available() -> bool {
-    !SUNDIALS_DYLINK.is_empty()
-}
 
 /// Whether external "C" in a host-free wasm FMU is supported (all three present).
 pub fn available() -> bool {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
@@ -100,10 +100,109 @@ fn main() {
             build_wasip1_interactive_runtime(&crate_dir, &runtime_dir, &out_dir, &hash, sundials_dir)
         });
         s.spawn(|| build_external_c_wasm(&crate_dir, &out_dir));
-        s.spawn(|| build_fmi3_me_adapter(&crate_dir, &out_dir));
+        s.spawn(|| {
+            let adapters = build_fmi3_me_adapter(&crate_dir, &out_dir, sundials_dir.is_some());
+            build_solver_dylinks(&out_dir, sundials_dir, &adapters);
+        });
+        s.spawn(|| build_wasip1_fused_adapter(&crate_dir, &out_dir, &hash, sundials_dir));
         s.spawn(|| build_native_fmu_loaders(&crate_dir, &out_dir));
         s.spawn(|| build_lapack_dylink(&crate_dir, &out_dir));
     });
+}
+
+/// Build the **fused** artifact runtime: the FMI 3.0 adapter, the in-wasm driver
+/// and the simulation runtime in one non-PIC `wasm32-wasip1` core module.
+///
+/// It links the solver archives statically, as the standalone runtimes do, so it needs
+/// none of the side modules a component FMU composes. Model-independent, so it is
+/// compiled once into the `.cwasm` cache.
+fn build_wasip1_fused_adapter(
+    crate_dir: &Path,
+    out_dir: &Path,
+    hash: &str,
+    sundials_dir: Option<&Path>,
+) {
+    let dest = out_dir.join("fmi3_fused_wasip1.wasm");
+    let stamp = out_dir.join("fmi3_fused_wasip1.wasm.hash");
+    println!("cargo:rerun-if-env-changed=OMC_FMI3_FUSED_WASIP1");
+    if let Ok(path) = std::env::var("OMC_FMI3_FUSED_WASIP1") {
+        copy(Path::new(&path), &dest);
+        std::fs::write(&stamp, format!("override:{path}")).ok();
+        return;
+    }
+    let adapter_dir = crate_dir
+        .parent()
+        .expect("crate has a parent dir")
+        .join("openmodelica_fmi3_wasm");
+    let features = match sundials_dir {
+        Some(_) => "me,cs,capi,sundials,host_lin_solve",
+        None => "me,cs,capi,host_lin_solve",
+    };
+    // The adapter's sources as well as the runtime's, and how it is built: any of
+    // them changing produces a different blob, and a stamp that misses one serves
+    // a stale blob that looks current.
+    let (digest, files) = hash_inputs(&adapter_dir, &[adapter_dir.join("wit")]);
+    for f in &files {
+        println!("cargo:rerun-if-changed={}", f.display());
+    }
+    let stamp_val =
+        format!("{hash}:{digest}:{features}:build-std,rustflags-opt3,immediate-abort");
+    if dest.exists()
+        && std::fs::metadata(&dest).map(|m| m.len() > 0).unwrap_or(false)
+        && std::fs::read_to_string(&stamp).ok().as_deref() == Some(stamp_val.as_str())
+    {
+        return;
+    }
+    // The runtime crate's own `.cargo/config.toml` flags, which an explicit
+    // RUSTFLAGS here replaces. `-Copt-level=3` in the flags and not a `--config`
+    // profile, which the crate's `opt-level = "s"` outranks: `rt_solve_nls` and
+    // minpack link in here, and the runtime's manifest sets 3 for them.
+    let rustflags = "-Clink-arg=--export-table -Clink-arg=--growable-table \
+                     -Clink-arg=--allow-undefined -Ctarget-feature=+simd128 -Copt-level=3";
+    let target = "wasm32-wasip1";
+    let target_dir = out_dir.join("adapter-fused-target");
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
+    let mut cmd = Command::new(cargo);
+    cmd.current_dir(&adapter_dir)
+        // `-Zbuild-std`: the crate's `panic = "immediate-abort"`, which the
+        // precompiled `core` does not satisfy. The dylink adapter builds the same
+        // way.
+        .args(["build", "-Z", "build-std=std,panic_abort", "--release", "--target", target])
+        .args(["--no-default-features", "--features", features])
+        .arg("--target-dir")
+        .arg(&target_dir)
+        // `--allow-undefined`: the model's `function*` are imports here, and the
+        // runtime's own cdylib artifact (unused) references the sink this crate
+        // defines. sccache goes with the outer build's other wrappers.
+        .env("RUSTFLAGS", rustflags)
+        .env_remove("CARGO_ENCODED_RUSTFLAGS")
+        .env_remove("CARGO_BUILD_RUSTFLAGS")
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
+        ;
+    match sundials_dir {
+        Some(d) => { cmd.env("OMC_SUNDIALS_WASM_DIR", d); }
+        None => { cmd.env_remove("OMC_SUNDIALS_WASM_DIR"); }
+    }
+    match run(&mut cmd, "cargo build (fused wasip1 adapter)") {
+        Ok(()) => {
+            let produced = target_dir
+                .join(target)
+                .join("release")
+                .join("openmodelica_fmi3_wasm.wasm");
+            if produced.exists() {
+                copy(&produced, &dest);
+                std::fs::write(&stamp, &stamp_val).ok();
+                return;
+            }
+            println!("cargo:warning=the fused wasip1 adapter produced no wasm");
+        }
+        // Not fatal: the dylink adapter still serves the artifact, one runtime copy
+        // short of SUNDIALS.
+        Err(e) => println!("cargo:warning=could not build the fused wasip1 adapter ({e})"),
+    }
+    std::fs::write(&dest, []).ok();
+    std::fs::write(&stamp, "missing").ok();
 }
 
 /// Build the FMI loader (`openmodelica_fmi_ls_wasm_to_native`, both versions) once per
@@ -449,6 +548,7 @@ fn build_lapack_dylink(crate_dir: &Path, out_dir: &Path) {
     }
 
     let (hash, files) = hash_inputs(&lapack_dir, &[]);
+    let hash = format!("{hash}-{}", wasm_opt_key());
     for f in &files {
         println!("cargo:rerun-if-changed={}", f.display());
     }
@@ -462,6 +562,7 @@ fn build_lapack_dylink(crate_dir: &Path, out_dir: &Path) {
     match build_lapack_wasm(&lapack_dir, out_dir) {
         Ok(produced) => {
             copy(&produced, &dest);
+            wasm_opt(&dest);
             std::fs::write(&stamp, &hash).ok();
         }
         Err(e) => panic!(
@@ -503,8 +604,593 @@ fn build_lapack_wasm(lapack_dir: &Path, out_dir: &Path) -> Result<PathBuf, Strin
 /// a dylink side module, linked with the per-model module at FMU-export time.
 /// Built here regardless of omc's own target arch: build scripts run on the host.
 /// Mandatory: a failed build aborts rather than shipping an omc without it.
-fn build_fmi3_me_adapter(crate_dir: &Path, out_dir: &Path) {
-    par_map(ADAPTER_VARIANTS, |v| build_fmi3_adapter(crate_dir, out_dir, v));
+/// Returns the two that import the solvers, me_cs first: its imports decide what the
+/// side modules export, and ME's have to be a subset.
+fn build_fmi3_me_adapter(crate_dir: &Path, out_dir: &Path, sundials: bool) -> [PathBuf; 2] {
+    par_map(ADAPTER_VARIANTS, |v| build_fmi3_adapter(crate_dir, out_dir, v, sundials));
+    [out_dir.join("fmi3_mecs_adapter.wasm"), out_dir.join("fmi3_me_adapter.wasm")]
+}
+
+/// `wasm-opt -O3` the module in place, when CMake found binaryen. Every exported FMU
+/// links these, and they are built once per omc build and stamped, so binaryen's
+/// optimizer costs the export nothing: ~11% off the module, and the solver libraries'
+/// inner loops get -O3 rather than only clang's.
+///
+/// The feature list comes from CMake (`WASM_OPT_FEATURES`) rather than `-all`: the
+/// release `strip` drops the `target_features` section binaryen would auto-detect
+/// from, so it defaults to MVP and rejects the bulk-memory/sign-ext ops these carry.
+/// A failure is not fatal -- the unoptimized module is correct.
+///
+/// Not applied to what `openmodelica_wasi_libc` hands over: `libc_pic` and
+/// `modelicaexternalc` are already optimized by wasi-libc and clang, and the vendored
+/// `wasi_snapshot_preview1` adapter is a wasmtime release artifact, not a side module
+/// of ours.
+fn wasm_opt(path: &Path) {
+    let Some(exe) = std::env::var_os("OMC_WASM_OPT").filter(|v| !v.is_empty()) else { return };
+    let tmp = path.with_extension("opt.tmp");
+    let mut cmd = Command::new(&exe);
+    cmd.arg("-O3");
+    for f in std::env::var("OMC_WASM_OPT_FEATURES").unwrap_or_default().split_whitespace() {
+        cmd.arg(f);
+    }
+    let ok = cmd
+        .arg(path)
+        .arg("-o")
+        .arg(&tmp)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+        && std::fs::metadata(&tmp).map(|m| m.len() > 0).unwrap_or(false);
+    if ok {
+        std::fs::rename(&tmp, path).ok();
+    } else {
+        std::fs::remove_file(&tmp).ok();
+        println!("cargo:warning=wasm-opt failed on {}; using it unoptimized", path.display());
+    }
+}
+
+/// Part of every stamp that covers a wasm-opt'd module: turning binaryen on or off
+/// has to rebuild them, and a cached blob from the other setting is not equivalent.
+fn wasm_opt_key() -> String {
+    match std::env::var("OMC_WASM_OPT").ok().filter(|v| !v.is_empty()) {
+        Some(exe) => format!("opt3:{exe}:{}", std::env::var("OMC_WASM_OPT_FEATURES").unwrap_or_default()),
+        None => "noopt".to_string(),
+    }
+}
+
+/// One selectable solver library: an FMU links `BASE_GROUP` plus whichever of these
+/// its `--fmiFlags` can reach, and a stub for each one left out.
+struct SolverGroup {
+    /// Blob basename, and `om_have_<name>` for the capability report.
+    name: &'static str,
+    archives: &'static [&'static str],
+    /// Prefixes of the adapter's imports this group owns. These have to *partition*
+    /// the entry points: SUNDIALS bundles a copy of the shared implementations into
+    /// every integrator archive, so asking what defines what would give `driver` and
+    /// `kinsol` their own copy of everything in `base`.
+    owns: &'static [&'static str],
+}
+
+/// Always linked when any other group is: the SUNDIALS core, vectors, matrices, the
+/// dense/Krylov/nonlinear solvers and KLU the others call into. Named for KLU, the
+/// only solver in it a flag selects on its own.
+const BASE_GROUP: SolverGroup = SolverGroup {
+    name: "klu",
+    archives: &[
+        "sundials_sunlinsolklu", "sundials_sunlinsoldense",
+        "sundials_sunlinsolspgmr", "sundials_sunlinsolspbcgs", "sundials_sunlinsolsptfqmr",
+        "sundials_sunnonlinsolnewton", "sundials_sunnonlinsolfixedpoint",
+        "sundials_sunmatrixsparse", "sundials_sunmatrixdense",
+        "sundials_nvecserial", "sundials_core",
+        "klu", "amd", "colamd", "btf", "suitesparseconfig",
+    ],
+    owns: &["N_V", "SUN", "klu_"],
+};
+
+/// PRIMME is not among them: the adapter is built without that feature, and its
+/// BLAS/LAPACK calls resolve against a Rust crate no side module has.
+const SOLVER_GROUPS: &[SolverGroup] = &[
+    SolverGroup {
+        name: "sundials_driver",
+        archives: &["sundials_idas", "sundials_cvode"],
+        owns: &["CVode", "IDA"],
+    },
+    SolverGroup { name: "kinsol", archives: &["sundials_kinsol"], owns: &["KIN"] },
+    SolverGroup {
+        name: "umfpack",
+        archives: &["umfpack", "amd", "suitesparseconfig"],
+        owns: &["umfpack_"],
+    },
+    SolverGroup { name: "lis", archives: &["lis"], owns: &["lis_"] },
+];
+
+/// Build one PIC side module per solver library, plus a stub for each.
+///
+/// The archives are the ones the wasip1 runtimes link statically: CMake compiles them
+/// `-fPIC` for exactly this, and wasm-ld relaxes those relocations away again in the
+/// static link, which comes out byte-identical.
+///
+/// Exports are read off `adapter`, the me_cs adapter that will import them -- the
+/// entry points each group `owns`, plus, for the base, whatever the others leave
+/// undefined. `--export-if-defined` both pulls the archive member in and keeps it, so
+/// a driver reaching for a new entry point needs no list here updated.
+///
+/// Empty blobs without the archives, so an FMU export rejects `-s=cvode` up front.
+fn build_solver_dylinks(out_dir: &Path, sundials_dir: Option<&Path>, adapters: &[PathBuf; 2]) {
+    let all: Vec<&SolverGroup> = core::iter::once(&BASE_GROUP).chain(SOLVER_GROUPS).collect();
+    println!("cargo:rerun-if-env-changed=OMC_WASM_OPT");
+    println!("cargo:rerun-if-env-changed=OMC_WASM_OPT_FEATURES");
+    println!("cargo:rerun-if-env-changed=OMC_SOLVER_DYLINK_DIR");
+    let override_dir = std::env::var_os("OMC_SOLVER_DYLINK_DIR").map(PathBuf::from);
+    if let Some(dir) = &override_dir {
+        for g in &all {
+            for kind in ["", "_stub"] {
+                let f = format!("solver_{}{kind}.wasm", g.name);
+                copy(&dir.join(&f), &out_dir.join(&f));
+            }
+        }
+        return;
+    }
+    if sundials_dir.is_none() {
+        for g in &all {
+            for kind in ["", "_stub"] {
+                std::fs::write(out_dir.join(format!("solver_{}{kind}.wasm", g.name)), [])
+                    .expect("write an empty solver blob");
+            }
+        }
+        std::fs::write(out_dir.join("solver_dylinks.hash"), "no-sundials").ok();
+        return;
+    }
+    // A warning here would ship an omc that looks healthy and refuses `-s=cvode`.
+    if let Err(e) = link_solver_dylinks(out_dir, sundials_dir.unwrap(), adapters, &all) {
+        panic!(
+            "failed to link the solver dylink side modules: {e}\n\
+             This build has the wasm solver archives (OMC_SUNDIALS_WASM_DIR is set), so the \
+             omc it produces must be able to export a wasm FMU with -s=cvode/ida. Configure \
+             with -DRUST_OMC_ENABLE_SUNDIALS=OFF if that is not wanted."
+        );
+    }
+}
+
+/// No `-lc`: that would record a `NEEDED libc.so` the component has no library under
+/// that name for, so the archives' libc calls stay `env` imports the FMU linker
+/// resolves against the PIC `libc.so` beside them. `--strip-all` drops the archives'
+/// DWARF, more bytes than their code; `dylink.0` survives it.
+const DYLINK_LINK_ARGS: &[&str] = &[
+    "--target=wasm32-wasip1",
+    "-fPIC",
+    "-nodefaultlibs",
+    "-nostartfiles",
+    "-Wl,--experimental-pic",
+    "-Wl,--shared",
+    "-Wl,--no-entry",
+    "-Wl,--allow-undefined",
+    "-Wl,--strip-all",
+];
+
+fn link_solver_dylinks(
+    out_dir: &Path,
+    sundials_dir: &Path,
+    adapters: &[PathBuf; 2],
+    all: &[&SolverGroup],
+) -> Result<(), String> {
+    let adapter = &adapters[0];
+    let lib = sundials_dir.join("lib");
+    let mut missing: Vec<&str> = all
+        .iter()
+        .flat_map(|g| g.archives)
+        .copied()
+        .filter(|l| !lib.join(format!("lib{l}.a")).exists())
+        .collect();
+    missing.sort();
+    missing.dedup();
+    if !missing.is_empty() {
+        return Err(format!(
+            "{} is missing {missing:?}; the wasm solver cross-compile failed (check the \
+             rust_sundials_collect CMake target)",
+            lib.display()
+        ));
+    }
+    let bytes = std::fs::read(adapter)
+        .map_err(|e| format!("read the me_cs adapter {}: {e}", adapter.display()))?;
+    if bytes.is_empty() {
+        return Err(format!("the me_cs adapter {} is empty", adapter.display()));
+    }
+    let adapter_imports = imports(&bytes);
+    let mut wanted: Vec<String> = adapter_imports
+        .iter()
+        .filter(|(m, _, kind, _)| m == "env" && *kind == FUNC)
+        .map(|(_, f, ..)| f.clone())
+        .collect();
+    wanted.sort();
+    wanted.dedup();
+    if !wanted.iter().any(|n| n.starts_with("CVode")) {
+        return Err(format!(
+            "the me_cs adapter {} imports no CVODE entry point, so it was built without its \
+             `sundials` feature and no side module could serve it",
+            adapter.display()
+        ));
+    }
+    let owned = |g: &SolverGroup| -> Vec<String> {
+        wanted.iter().filter(|n| g.owns.iter().any(|p| n.starts_with(p))).cloned().collect()
+    };
+
+    let clang = std::env::var("OMC_WASI_CLANG").unwrap_or_else(|_| "clang".to_owned());
+    let builtins = find_wasm_builtins().ok_or("no libclang_rt.builtins-wasm32.a found")?;
+    let libc = libc_exports()?;
+    let stamp = out_dir.join("solver_dylinks.hash");
+    let key = {
+        let mut h: u64 = 0xcbf29ce484222325;
+        let mut feed = |b: &[u8]| {
+            for x in b {
+                h ^= *x as u64;
+                h = h.wrapping_mul(0x100000001b3);
+            }
+        };
+        feed(archives_key(&lib).as_bytes());
+        feed(clang.as_bytes());
+        feed(wasm_opt_key().as_bytes());
+        for a in DYLINK_LINK_ARGS.iter().copied().chain(wanted.iter().map(|w| w.as_str())) {
+            feed(a.as_bytes());
+        }
+        for g in all {
+            feed(g.name.as_bytes());
+            for a in g.archives {
+                feed(a.as_bytes());
+            }
+            for o in g.owns {
+                feed(o.as_bytes());
+            }
+        }
+        format!("{h:016x}")
+    };
+    let current = |g: &SolverGroup| {
+        ["", "_stub"].iter().all(|k| {
+            out_dir
+                .join(format!("solver_{}{k}.wasm", g.name))
+                .metadata()
+                .map(|m| m.len() > 0)
+                .unwrap_or(false)
+        })
+    };
+    if all.iter().all(|g| current(g))
+        && std::fs::read_to_string(&stamp).ok().as_deref() == Some(key.as_str())
+    {
+        return Ok(());
+    }
+
+    // Pass 1: the leaf groups, whose roots are only what they own.
+    let mut base_roots = owned(&BASE_GROUP);
+    for g in SOLVER_GROUPS {
+        let module = link_group(out_dir, &lib, &clang, &builtins, g, &owned(g))?;
+        // They call into `base`, so what they leave open is part of its root set.
+        base_roots.extend(
+            imports(&module)
+                .into_iter()
+                .filter(|(m, ..)| m == "env" || m.starts_with("GOT."))
+                .map(|(_, f, ..)| f)
+                .filter(|f| !f.starts_with("__") && f != "memory" && !libc.contains(f)),
+        );
+    }
+    base_roots.sort();
+    base_roots.dedup();
+    let base = link_group(out_dir, &lib, &clang, &builtins, &BASE_GROUP, &base_roots)?;
+
+    // `--export-if-defined` skipping a name is what makes the libc and model-kernel
+    // imports harmless, and would as quietly drop a solver whose archive went missing
+    // or whose `owns` prefix names the wrong group.
+    let mut have = exported_names(&base);
+    for g in SOLVER_GROUPS {
+        have.extend(exported_names(&std::fs::read(group_path(out_dir, g, "")).unwrap_or_default()));
+    }
+    // Every adapter that imports the solvers, not just the one the roots came from:
+    // ME's import set has to stay a subset of me_cs's.
+    let prefixes: Vec<&str> = all.iter().flat_map(|g| g.owns).copied().collect();
+    for a in adapters {
+        let bytes = std::fs::read(a).map_err(|e| format!("read {}: {e}", a.display()))?;
+        let dropped: Vec<String> = imports(&bytes)
+            .into_iter()
+            .filter(|(m, _, kind, _)| m == "env" && *kind == FUNC)
+            .map(|(_, f, ..)| f)
+            .filter(|f| prefixes.iter().any(|p| f.starts_with(p)) && !have.contains(f))
+            .collect();
+        if !dropped.is_empty() {
+            return Err(format!(
+                "no group defines {dropped:?}, which {} imports; the archives in {} are \
+                 missing one, or a `SolverGroup::owns` prefix names the wrong group",
+                a.display(),
+                lib.display()
+            ));
+        }
+    }
+    // What `--allow-undefined` let through has to be there at FMU-export time.
+    let base_exports = exported_names(&base);
+    for g in SOLVER_GROUPS {
+        let module = std::fs::read(group_path(out_dir, g, "")).unwrap_or_default();
+        let open: Vec<String> = imports(&module)
+            .into_iter()
+            .filter(|(m, ..)| m == "env" || m.starts_with("GOT."))
+            .map(|(_, f, ..)| f)
+            .filter(|f| {
+                !f.starts_with("__")
+                    && f != "memory"
+                    && !libc.contains(f)
+                    && !base_exports.contains(f)
+            })
+            .collect();
+        if !open.is_empty() {
+            return Err(format!("the {} side module needs {open:?}, which neither the base \
+                                module nor libc.so exports", g.name));
+        }
+    }
+
+    // Signatures read off the adapter's own type section.
+    let types = func_types_as_c(&bytes);
+    let type_of: std::collections::BTreeMap<&str, u32> = adapter_imports
+        .iter()
+        .filter(|(m, _, kind, _)| m == "env" && *kind == FUNC)
+        .map(|(_, f, _, idx)| (f.as_str(), *idx))
+        .collect();
+    for g in all {
+        link_group_stub(out_dir, &clang, &builtins, g, &owned(g), &types, &type_of)?;
+    }
+    std::fs::write(&stamp, &key).ok();
+    Ok(())
+}
+
+fn group_path(out_dir: &Path, g: &SolverGroup, kind: &str) -> PathBuf {
+    out_dir.join(format!("solver_{}{kind}.wasm", g.name))
+}
+
+/// One group from its archives, exporting `roots` plus the `om_have_<name>` marker
+/// that tells the FMU's runtime the library is really there.
+fn link_group(
+    out_dir: &Path,
+    lib: &Path,
+    clang: &str,
+    builtins: &Path,
+    g: &SolverGroup,
+    roots: &[String],
+) -> Result<Vec<u8>, String> {
+    let marker = out_dir.join(format!("om_have_{}.c", g.name));
+    std::fs::write(&marker, format!("int om_have_{}(void) {{ return 1; }}\n", g.name))
+        .map_err(|e| format!("write {}: {e}", marker.display()))?;
+    let dest = group_path(out_dir, g, "");
+    let mut cmd = Command::new(clang);
+    cmd.args(DYLINK_LINK_ARGS).arg(format!("-L{}", lib.display()));
+    for a in g.archives {
+        cmd.arg(format!("-l{a}"));
+    }
+    for r in roots {
+        cmd.arg(format!("-Wl,--export-if-defined={r}"));
+    }
+    let status = cmd
+        .arg(&marker)
+        .arg(format!("-Wl,--export=om_have_{}", g.name))
+        .arg(builtins)
+        .arg("-o")
+        .arg(&dest)
+        .status()
+        .map_err(|e| format!("spawn {clang}: {e}"))?;
+    if !status.success() {
+        return Err(format!("{clang} ({} side module) exited with {status}", g.name));
+    }
+    wasm_opt(&dest);
+    std::fs::read(&dest).map_err(|e| format!("read {}: {e}", dest.display()))
+}
+
+/// The stand-in for a group an FMU was not given: every entry point it owns, with the
+/// adapter's signature and a trap body, and the marker answering 0. A trap is
+/// unreachable -- `simflags::check` rejects the solver on that very marker first.
+fn link_group_stub(
+    out_dir: &Path,
+    clang: &str,
+    builtins: &Path,
+    g: &SolverGroup,
+    owns: &[String],
+    types: &[(String, Vec<String>)],
+    type_of: &std::collections::BTreeMap<&str, u32>,
+) -> Result<(), String> {
+    let mut src = format!(
+        "/* Generated by openmodelica_wasm_jit's build script. */\n\
+         int om_have_{}(void) {{ return 0; }}\n",
+        g.name
+    );
+    for f in owns {
+        let idx = *type_of.get(f.as_str()).ok_or_else(|| format!("no import type for {f}"))?;
+        let (result, params) = types
+            .get(idx as usize)
+            .ok_or_else(|| format!("{f}: type index {idx} is outside the adapter's type section"))?;
+        if result.is_empty() || params.iter().any(|p| p.is_empty()) {
+            return Err(format!("{f} has a signature no C declaration can express"));
+        }
+        let args = if params.is_empty() {
+            "void".to_owned()
+        } else {
+            params
+                .iter()
+                .enumerate()
+                .map(|(i, t)| format!("{t} a{i}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        src.push_str(&format!("{result} {f}({args}) {{ __builtin_trap(); }}\n"));
+    }
+    let c = out_dir.join(format!("solver_{}_stub.c", g.name));
+    std::fs::write(&c, &src).map_err(|e| format!("write {}: {e}", c.display()))?;
+    let dest = group_path(out_dir, g, "_stub");
+    let mut cmd = Command::new(clang);
+    cmd.args(DYLINK_LINK_ARGS);
+    for f in owns.iter().map(|f| f.as_str()).chain([format!("om_have_{}", g.name).as_str()]) {
+        cmd.arg(format!("-Wl,--export={f}"));
+    }
+    let status = cmd
+        .arg(&c)
+        .arg(builtins)
+        .arg("-o")
+        .arg(&dest)
+        .status()
+        .map_err(|e| format!("spawn {clang}: {e}"))?;
+    if !status.success() {
+        return Err(format!("{clang} ({} stub) exited with {status}", g.name));
+    }
+    wasm_opt(&dest);
+    Ok(())
+}
+
+/// What the PIC `libc.so` the FMU linker adds beside the side modules has.
+fn libc_exports() -> Result<std::collections::BTreeSet<String>, String> {
+    let sysroot = std::env::var("OMC_WASI_PIC_SYSROOT")
+        .map_err(|_| "OMC_WASI_PIC_SYSROOT not set (CMake provides it)")?;
+    let libc = Path::new(&sysroot).join("lib/wasm32-wasip1/libc.so");
+    Ok(exported_names(
+        &std::fs::read(&libc).map_err(|e| format!("read {}: {e}", libc.display()))?,
+    ))
+}
+
+/// An import descriptor kind byte.
+const FUNC: u8 = 0x00;
+
+/// `(module, field, kind, typeidx)` per import; `typeidx` only means anything for
+/// `FUNC`. Sections are `(id byte, u32 size, payload)`; an import is two names, a
+/// kind byte, then that kind's descriptor.
+fn imports(module: &[u8]) -> Vec<(String, String, u8, u32)> {
+    let mut out = Vec::new();
+    sections(module, |id, start| {
+        if id != 2 {
+            return;
+        }
+        let mut p = start;
+        for _ in 0..leb(module, &mut p) {
+            let m = name(module, &mut p);
+            let f = name(module, &mut p);
+            let kind = *module.get(p).unwrap_or(&0);
+            p += 1;
+            let mut idx = 0;
+            match kind {
+                FUNC => idx = leb(module, &mut p),
+                0x01 => {
+                    p += 1;
+                    limits(module, &mut p);
+                }
+                0x02 => limits(module, &mut p),
+                _ => p += 2,
+            }
+            out.push((m, f, kind, idx));
+        }
+    });
+    out
+}
+
+/// Each function type in `module`'s type section as a C `(result, params)`. wasm's
+/// numeric types are C's on this ABI, so a stub with the same signature defines the
+/// import correctly.
+fn func_types_as_c(module: &[u8]) -> Vec<(String, Vec<String>)> {
+    fn ctype(b: u8) -> &'static str {
+        match b {
+            0x7f => "int",
+            0x7e => "long long",
+            0x7d => "float",
+            0x7c => "double",
+            _ => "",
+        }
+    }
+    let mut out = Vec::new();
+    sections(module, |id, start| {
+        if id != 1 {
+            return;
+        }
+        let mut p = start;
+        for _ in 0..leb(module, &mut p) {
+            // 0x60 is the function-type tag; nothing else appears in these modules.
+            let tag = *module.get(p).unwrap_or(&0);
+            p += 1;
+            if tag != 0x60 {
+                out.push((String::new(), Vec::new()));
+                continue;
+            }
+            let mut params = Vec::new();
+            for _ in 0..leb(module, &mut p) {
+                params.push(ctype(*module.get(p).unwrap_or(&0)).to_owned());
+                p += 1;
+            }
+            let n_res = leb(module, &mut p);
+            let result = match n_res {
+                0 => "void".to_owned(),
+                1 => {
+                    let t = ctype(*module.get(p).unwrap_or(&0)).to_owned();
+                    p += 1;
+                    t
+                }
+                _ => {
+                    for _ in 0..n_res {
+                        p += 1;
+                    }
+                    String::new()
+                }
+            };
+            out.push((result, params));
+        }
+    });
+    out
+}
+
+/// The names `module` exports, of every kind.
+fn exported_names(module: &[u8]) -> std::collections::BTreeSet<String> {
+    let mut out = std::collections::BTreeSet::new();
+    sections(module, |id, start| {
+        if id != 7 {
+            return;
+        }
+        let mut p = start;
+        for _ in 0..leb(module, &mut p) {
+            let n = name(module, &mut p);
+            p += 1; // kind
+            leb(module, &mut p); // index
+            out.insert(n);
+        }
+    });
+    out
+}
+
+fn sections(module: &[u8], mut f: impl FnMut(u8, usize)) {
+    let mut p = 8; // magic + version
+    while p + 1 < module.len() {
+        let id = module[p];
+        p += 1;
+        let size = leb(module, &mut p) as usize;
+        f(id, p);
+        p = (p + size).min(module.len());
+    }
+}
+
+fn leb(b: &[u8], p: &mut usize) -> u32 {
+    let (mut v, mut shift) = (0u32, 0);
+    while let Some(&x) = b.get(*p) {
+        *p += 1;
+        v |= ((x & 0x7f) as u32) << shift;
+        if x & 0x80 == 0 {
+            break;
+        }
+        shift += 7;
+    }
+    v
+}
+
+fn name(b: &[u8], p: &mut usize) -> String {
+    let n = leb(b, p) as usize;
+    let end = (*p + n).min(b.len());
+    let s = String::from_utf8_lossy(&b[*p..end]).into_owned();
+    *p = end;
+    s
+}
+
+fn limits(b: &[u8], p: &mut usize) {
+    let flags = leb(b, p);
+    leb(b, p);
+    if flags & 1 != 0 {
+        leb(b, p);
+    }
 }
 
 /// One FMI3 adapter build: a WIT world selected by Cargo features, from the same
@@ -522,14 +1208,20 @@ struct AdapterVariant {
 /// Co-Simulation too (its imports are a `co-simulation-fmu`'s exactly, its exports
 /// a superset). ME stays separate: it imports only `callbacks`, so an ME-only host
 /// that cannot supply `intermediate-update-callbacks` would fail to instantiate a
-/// me_cs component. The `_sundials` variant adds CVODE/IDA and is picked only for a
-/// `method=` needing it.
+/// me_cs component -- and only me_cs embeds a driver, so only it asks for SUNDIALS.
 const ADAPTER_VARIANTS: &[AdapterVariant] = &[
-    AdapterVariant { name: "me", label: "ME", cargo_args: &[] },
-    AdapterVariant { name: "mecs", label: "me_cs", cargo_args: &["--no-default-features", "--features", "me,cs"] },
+    // Model Exchange integrates nothing, but its initialisation and residuals run the
+    // same nonlinear and linear solvers, and the export hard-codes which ones into the
+    // metadata -- so it asks for the libraries too, minus the integrator.
     AdapterVariant {
-        name: "mecs_sundials",
-        label: "me_cs+SUNDIALS",
+        name: "me",
+        label: "ME",
+        cargo_args: &["--no-default-features", "--features", "me,sundials"],
+    },
+    // One me_cs adapter, with the solver bundle as imports `SOLVER_LIBRARIES` resolves.
+    AdapterVariant {
+        name: "mecs",
+        label: "me_cs",
         cargo_args: &["--no-default-features", "--features", "me,cs,sundials"],
     },
     // The same me_cs adapter with an FMI 3.0 C API instead of the component's WIT
@@ -543,7 +1235,7 @@ const ADAPTER_VARIANTS: &[AdapterVariant] = &[
     },
 ];
 
-fn build_fmi3_adapter(crate_dir: &Path, out_dir: &Path, v: &AdapterVariant) {
+fn build_fmi3_adapter(crate_dir: &Path, out_dir: &Path, v: &AdapterVariant, sundials: bool) {
     let name = format!("fmi3_{}_adapter", v.name);
     let dest = out_dir.join(format!("{name}.wasm"));
     let stamp = out_dir.join(format!("{name}.wasm.hash"));
@@ -566,7 +1258,7 @@ fn build_fmi3_adapter(crate_dir: &Path, out_dir: &Path, v: &AdapterVariant) {
     for f in &files {
         println!("cargo:rerun-if-changed={}", f.display());
     }
-    let hash = format!("{digest}-{}", v.name);
+    let hash = format!("{digest}-{}-{sundials}-{}", v.name, wasm_opt_key());
     if dest.exists()
         && std::fs::metadata(&dest).map(|m| m.len() > 0).unwrap_or(false)
         && std::fs::read_to_string(&stamp).ok().as_deref() == Some(&hash)
@@ -574,9 +1266,10 @@ fn build_fmi3_adapter(crate_dir: &Path, out_dir: &Path, v: &AdapterVariant) {
         return;
     }
 
-    match build_dylink_adapter(&adapter_dir, out_dir, v) {
+    match build_dylink_adapter(&adapter_dir, out_dir, v, sundials) {
         Ok(produced) => {
             copy(&produced, &dest);
+            wasm_opt(&dest);
             std::fs::write(&stamp, &hash).ok();
         }
         Err(e) => {
@@ -609,7 +1302,7 @@ fn build_fmi3_adapter(crate_dir: &Path, out_dir: &Path, v: &AdapterVariant) {
 /// `-Zcodegen-backend=llvm` because the workspace default cranelift cannot target
 /// wasm and RUSTFLAGS here replaces the crate's `.cargo/config.toml`; `+simd128`
 /// for the faer kernels the dense solve reaches, as in `liblapack.wasm`.
-fn build_dylink_adapter(adapter_dir: &Path, out_dir: &Path, v: &AdapterVariant) -> Result<PathBuf, String> {
+fn build_dylink_adapter(adapter_dir: &Path, out_dir: &Path, v: &AdapterVariant, sundials: bool) -> Result<PathBuf, String> {
     let target = "wasm32-unknown-unknown";
     // Separate target dirs: the worlds differ only by feature, and sharing one
     // would rebuild the crate on every alternation.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
@@ -353,6 +353,25 @@ pub mod array_abi {
     }
 }
 
+/// The run's `-variableFilter`, compiled. Set for a run whose result file is
+/// written inside wasm (an artifact), where the pattern cannot be applied.
+#[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
+thread_local! {
+    static OUTPUT_FILTER: std::cell::RefCell<Option<openmodelica_util::System::Regex>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Install (or clear) the filter `rt_host_name_matches` answers from.
+#[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
+pub fn set_output_filter(re: Option<openmodelica_util::System::Regex>) {
+    OUTPUT_FILTER.with(|f| *f.borrow_mut() = re);
+}
+
+#[cfg(all(feature = "jit", not(feature = "engine-wasmer"), not(target_arch = "wasm32")))]
+fn output_filter_keeps(name: &str) -> bool {
+    OUTPUT_FILTER.with(|f| f.borrow().as_ref().is_none_or(|re| re.is_match(name)))
+}
+
 // Native rsparse solve behind the `env.rt_host_lin_solve` import, which the native
 // interactive runtime calls from `rt_solve_lin_sparse_cached`. Symbolic analysis
 // cached per system `handle`; `count()` feeds `stats.lin_solves`.
@@ -548,6 +567,22 @@ pub fn add_host_builtins<T: 'static>(linker: &mut wasmtime::Linker<T>) -> Result
                 Some(dst) => take_reinits_into(dst, max as usize),
                 None => 0,
             }
+        },
+    ))?;
+    // `-variableFilter` for a runtime that serializes its own result file: it has
+    // no regex engine, so it asks here, once per variable as the file is laid out.
+    // No filter installed keeps everything, so the import is always answerable.
+    wt(linker.func_wrap(
+        "env",
+        "rt_host_name_matches",
+        |mut caller: wasmtime::Caller<'_, T>, ptr: u32, len: u32| -> i32 {
+            let Some(wasmtime::Extern::Memory(mem)) = caller.get_export("memory") else { return 1 };
+            let data = mem.data(&caller);
+            let name = data
+                .get(ptr as usize..(ptr + len) as usize)
+                .map(|b| String::from_utf8_lossy(b).into_owned())
+                .unwrap_or_default();
+            output_filter_keeps(&name) as i32
         },
     ))?;
     // Solve the CSC system in the caller's (the runtime's) shared memory; the

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/lib.rs
@@ -15,7 +15,49 @@ pub static FMI3_ME_ADAPTER: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/fm
 /// Both interfaces in one component, and what a Co-Simulation FMU carries too: its
 /// imports are a `co-simulation-fmu`'s exactly and its exports a superset, so it
 /// substitutes for one — cheaper than a fourth adapter blob in every omc.
+/// The SUNDIALS-backed solvers come with it, as imports [`SOLVER_LIBRARIES`] resolves.
 pub static FMI3_MECS_ADAPTER: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/fmi3_mecs_adapter.wasm"));
+
+/// One solver library an exported FMU can be given, as a PIC dylink side module: the
+/// same wasm archives the wasip1 runtimes link statically, re-linked `--shared` and
+/// reduced to the entry points [`FMI3_MECS_ADAPTER`] imports from it.
+pub struct SolverLibrary {
+    /// The dylink library name, and the `om_have_<name>` marker the FMU's runtime
+    /// reads to report what it was given.
+    pub name: &'static str,
+    /// Linked when the FMU's flags can reach this solver.
+    pub module: &'static [u8],
+    /// Linked instead when they cannot: the same entry points, each a trap, and
+    /// `om_have_<name>` answering 0 so `simflags::check` rejects the solver first.
+    pub stub: &'static [u8],
+}
+
+macro_rules! solver_library {
+    ($name:literal) => {
+        SolverLibrary {
+            name: $name,
+            module: include_bytes!(concat!(env!("OUT_DIR"), "/solver_", $name, ".wasm")),
+            stub: include_bytes!(concat!(env!("OUT_DIR"), "/solver_", $name, "_stub.wasm")),
+        }
+    };
+}
+
+/// The solver libraries, `klu` first: it is the shared SUNDIALS core, vectors,
+/// matrices and dense/Krylov/nonlinear solvers the others call into, so it is linked
+/// whenever any of them is. Every blob is empty when this omc was built without the
+/// wasm solver archives.
+pub static SOLVER_LIBRARIES: &[SolverLibrary] = &[
+    solver_library!("klu"),
+    solver_library!("sundials_driver"),
+    solver_library!("kinsol"),
+    solver_library!("umfpack"),
+    solver_library!("lis"),
+];
+
+/// Whether an exported wasm FMU can be given the SUNDIALS-backed solvers.
+pub fn sundials_dylink_available() -> bool {
+    !SOLVER_LIBRARIES[0].module.is_empty()
+}
 
 /// The me_cs adapter as a plain dylink library exporting the FMI 3.0 C API
 /// (`om_fmi3*`), for the artifact form a host links itself: being fixed, it is
@@ -23,11 +65,12 @@ pub static FMI3_MECS_ADAPTER: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/
 pub static FMI3_MECS_CAPI_ADAPTER: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/fmi3_mecs_capi_adapter.wasm"));
 
-/// The me_cs world with CVODE/IDA in the embedded driver, for an FMU exported with
-/// `method="cvode"`/`"ida"`; the calls are imports
-/// `openmodelica_wasi_libc::SUNDIALS_DYLINK` resolves.
-pub static FMI3_MECS_SUNDIALS_ADAPTER: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/fmi3_mecs_sundials_adapter.wasm"));
+/// The **fused** artifact runtime: the FMI 3.0 adapter, the in-wasm driver and the
+/// simulation runtime in one non-PIC `wasm32-wasip1` module, with the SUNDIALS
+/// archives linked in (the dylink adapter cannot have them — see
+/// `build_wasip1_fused_adapter`). Empty when the wasip1 target was unavailable at
+/// build time, in which case the dylink adapter serves the artifact instead.
+pub static FMI3_FUSED_WASIP1: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/fmi3_fused_wasip1.wasm"));
 
 /// `openmodelica_lapack` as a PIC dylink side module, linked into an FMU only when
 /// the model's `external "FORTRAN 77"` calls need it.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_stub.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_stub.rs
@@ -41,3 +41,8 @@ pub fn prepare_native_externals(_model: &SimModel, _sigs: &[crate::sig::ExtCallS
 pub fn run(_model: &SimModel, _meta: &openmodelica_sim_meta::SimMeta) -> std::result::Result<RunResult, String> {
     return Err(NO_ENGINE.to_string())
 }
+
+/// No engine here, so nothing to precompile.
+pub fn precompile_fixed_blobs(_dir: &std::path::Path) -> std::result::Result<Vec<String>, String> {
+    Ok(Vec::new())
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -1512,3 +1512,7 @@ impl Drop for InWasmSession {
     }
 }
 
+/// Only the wasmtime backend keeps an on-disk artifact cache.
+pub fn precompile_fixed_blobs(_dir: &std::path::Path) -> std::result::Result<Vec<String>, String> {
+    Ok(Vec::new())
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -72,6 +72,12 @@ fn alarm_secs() -> u32 {
 /// as no longer says. The engine detail stays: its backtrace is where it stuck.
 fn map_alarm(e: String) -> String {
     match ALARM_FIRED.with(|f| f.replace(false)) {
+        // `OMC_WASM_ALARM_BACKTRACE` keeps the trap instead: with a short `-alarm`
+        // the interruption is a sample of a slow run, and its wasm backtrace says
+        // which function that run is spending itself in.
+        true if std::env::var_os("OMC_WASM_ALARM_BACKTRACE").is_some() => {
+            format!("{}: {e}", sim_driver::ALARM_ABORT_ERR)
+        }
         true => sim_driver::ALARM_ABORT_ERR.to_string(),
         false => e,
     }
@@ -179,6 +185,10 @@ fn aot_cache_key(blob: &[u8], epoch: bool) -> u64 {
     h.finish()
 }
 
+fn aot_cache_name(tag: &str, key: u64) -> String {
+    format!("wasmjit-{tag}-{key:016x}.cwasm")
+}
+
 fn aot_cache_path(tag: &str, key: u64) -> std::path::PathBuf {
     let home = openmodelica_util::Settings::getHomeDir(false);
     let dir = if home.is_empty() {
@@ -188,20 +198,40 @@ fn aot_cache_path(tag: &str, key: u64) -> std::path::PathBuf {
         std::fs::create_dir_all(&d).ok().map(|_| d)
     };
     let dir = dir.unwrap_or_else(std::env::temp_dir);
-    dir.join(format!("wasmjit-{tag}-{key:016x}.cwasm"))
+    dir.join(aot_cache_name(tag, key))
+}
+
+/// The same artifact as shipped with omc, if the build precompiled it. The
+/// per-user cache is filled on first use, so sixteen omc processes started at
+/// once each compile these before any writes them. The key still covers the
+/// engine configuration: a run that overrides it misses this and compiles.
+fn aot_installed_path(tag: &str, key: u64) -> Option<std::path::PathBuf> {
+    let root = openmodelica_util::Settings::getInstallationDirectoryPath().ok()?;
+    let p = std::path::Path::new(&*root)
+        .join("lib")
+        .join("omc")
+        .join("cache")
+        .join(aot_cache_name(tag, key));
+    p.is_file().then_some(p)
 }
 
 /// Compile a *fixed* wasm blob through the on-disk AOT cache: the `external "C"`
 /// side libraries take ~0.7 s to compile against ~6 ms to load the artifact.
 fn aot_module(engine: &wasmtime::Engine, tag: &str, blob: &[u8], epoch: bool) -> std::result::Result<wasmtime::Module, String> {
-    let path = aot_cache_path(tag, aot_cache_key(blob, epoch));
-    // Try the AOT artifact first (microseconds). `deserialize_file` is unsafe
-    // because it trusts the artifact; it is one we produced under the cache dir,
-    // and wasmtime validates version/config compatibility (erroring otherwise).
-    if path.exists()
-        && let Ok(m) = unsafe { wasmtime::Module::deserialize_file(engine, &path) }
+    let key = aot_cache_key(blob, epoch);
+    let path = aot_cache_path(tag, key);
+    // Try the AOT artifact first (microseconds): the one the build installed, else
+    // the one a previous run left in the per-user cache. `deserialize_file` is
+    // unsafe because it trusts the artifact; both are ones an OpenModelica build or
+    // run produced, and wasmtime validates version/config compatibility (erroring
+    // otherwise, which falls through to compiling).
+    for cached in [aot_installed_path(tag, key), path.exists().then(|| path.clone())]
+        .into_iter()
+        .flatten()
     {
-        return Ok(m);
+        if let Ok(m) = unsafe { wasmtime::Module::deserialize_file(engine, &cached) } {
+            return Ok(m);
+        }
     }
     // Incompatible/corrupt cache (e.g. a wasmtime upgrade): recompile over it.
     let module = wts(wasmtime::Module::new(engine, blob))?;
@@ -241,6 +271,57 @@ pub fn library_module(
     };
     memo.lock().unwrap_or_else(|e| e.into_inner()).insert(key, (engine.clone(), m.clone()));
     Ok(m)
+}
+
+/// Compile every fixed blob into `dir`, for the build to install beside omc.
+///
+/// The names are [`aot_cache_path`]'s, so [`aot_module`] finds them; a blob the
+/// build did not produce is skipped.
+pub fn precompile_fixed_blobs(dir: &std::path::Path) -> std::result::Result<Vec<String>, String> {
+    std::fs::create_dir_all(dir).map_err(|e| format!("{}: {e}", dir.display()))?;
+    // `alarm_secs()` is 0 here, so this is the plain (non-epoch) engine — the one
+    // a run uses unless it asked for the hard alarm.
+    let engine = sim_engine();
+    let mut blobs: Vec<(String, &[u8])> = vec![
+        ("runtime".to_string(), runtime_blob()),
+        ("fused".to_string(), crate::FMI3_FUSED_WASIP1),
+        ("lib-fmi3adapter".to_string(), crate::FMI3_MECS_CAPI_ADAPTER),
+        ("lib-lapack".to_string(), crate::LAPACK_DYLINK),
+        ("lib-libc.so".to_string(), openmodelica_wasi_libc::LIBC_PIC),
+        ("lib-modelicaexternalc".to_string(), openmodelica_wasi_libc::EXTERNAL_C_DYLINK),
+        ("lib-usertab".to_string(), openmodelica_wasi_libc::USERTAB_DYLINK),
+    ];
+    blobs.retain(|(_, b)| !b.is_empty());
+    let current: Vec<String> =
+        blobs.iter().map(|(tag, blob)| aot_cache_name(tag, aot_cache_key(blob, false))).collect();
+    // What an earlier build left for a blob that has since changed. Keyed by the
+    // blob's hash, so it will never be looked up again; without this every change
+    // adds another artifact to the install.
+    if let Ok(rd) = std::fs::read_dir(dir) {
+        for stale in rd.flatten().map(|e| e.path()).filter(|p| {
+            p.extension().is_some_and(|e| e == "cwasm")
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with("wasmjit-") && !current.iter().any(|c| c == n))
+        }) {
+            let _ = std::fs::remove_file(stale);
+        }
+    }
+    let mut written = Vec::new();
+    for (tag, blob) in blobs {
+        let name = aot_cache_name(&tag, aot_cache_key(blob, false));
+        // Rebuilt on every build, so skip what is already there: only a blob that
+        // actually changed is worth minutes of Cranelift.
+        if dir.join(&name).is_file() {
+            continue;
+        }
+        let module = wts(wasmtime::Module::new(engine, blob))?;
+        let bytes = wts(module.serialize())?;
+        let path = dir.join(&name);
+        std::fs::write(&path, &bytes).map_err(|e| format!("{}: {e}", path.display()))?;
+        written.push(name);
+    }
+    Ok(written)
 }
 
 fn load_or_compile_runtime(epoch: bool) -> std::result::Result<wasmtime::Module, String> {
@@ -1326,83 +1407,7 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
     }
     let inst_time = t_inst.elapsed();
     let rt_alloc = wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc"))?;
-    // `-nls`/`-nlsLS`/`-ls`/`-lss`: the host-driven runtime links no flag store of
-    // its own, so hand it the selectors. The session sets the same ones from the
-    // argv it receives.
-    if let Ok(set) = rt_inst.get_typed_func::<(u32, u32, u32, u32), ()>(&mut store, "rt_set_solvers") {
-        let codes = openmodelica_sim_meta::simflags::with_flags(|f| f.solver_codes());
-        wts(set.call(&mut store, codes))?;
-    }
-    // `-newtonFTol`/`-newtonXTol`/`-newtonMaxStepFactor`: the nonlinear solvers that
-    // read them run in-wasm whichever driver owns the run.
-    if let Ok(set) = rt_inst.get_typed_func::<(f64, f64, f64), ()>(&mut store, "rt_set_newton_tuning") {
-        let t = openmodelica_sim_meta::simflags::with_flags(|f| {
-            openmodelica_sim_meta::simflags::newton_tuning(f)
-        });
-        wts(set.call(&mut store, t))?;
-    }
-    // `-lvMaxWarn`: the warnings it caps are printed in-wasm.
-    if let Ok(set) = rt_inst.get_typed_func::<u32, ()>(&mut store, "rt_set_max_warn") {
-        let n = openmodelica_sim_meta::simflags::with_flags(|f| f.max_warn.unwrap_or(3));
-        wts(set.call(&mut store, n))?;
-    }
-    // `-nlsJacTestATol` / `-nlsJacTestRTol`: the derivative test runs in-wasm.
-    if let Ok(set) = rt_inst.get_typed_func::<(f64, f64), ()>(&mut store, "rt_set_jac_test_tolerances") {
-        let t = openmodelica_sim_meta::simflags::with_flags(|f| {
-            openmodelica_sim_meta::simflags::jac_test_tolerances(f)
-        });
-        wts(set.call(&mut store, t))?;
-    }
-    // `-svdCount` / `-svdSigma` / `-svdTol`: `LOG_NLS_SVD` runs inside the nonlinear solver.
-    if let Ok(set) = rt_inst.get_typed_func::<(u32, f64, f64), ()>(&mut store, "rt_set_svd") {
-        let (c, sigma, tol) = openmodelica_sim_meta::simflags::with_flags(|f| {
-            openmodelica_sim_meta::simflags::svd_params(f)
-        });
-        wts(set.call(&mut store, (c.max(0) as u32, sigma, tol)))?;
-    }
-    // `-saveInitialGuess_system`: the nonlinear solver writes the file itself.
-    if let Ok(set) = rt_inst.get_typed_func::<(i32, u32, u32), ()>(&mut store, "rt_set_save_initial_guess") {
-        let req = openmodelica_sim_meta::simflags::with_flags(|f| f.save_initial_guess.clone());
-        match req.map(|(p, i)| (format!("{p}\0{}", crate::host::absolute_path(&p)), i)) {
-            Some((names, idx)) => {
-                let ptr = wts(rt_alloc.call(&mut store, names.len() as u32))?;
-                wts(memory.write(&mut store, ptr as usize, names.as_bytes()))?;
-                wts(set.call(&mut store, (idx, ptr, names.len() as u32)))?;
-            }
-            None => wts(set.call(&mut store, (-1, 0, 0)))?,
-        }
-    }
-    // `-ils` / `-homotopyOnFirstTry`: a local approach sweeps inside `rt_solve_nls`.
-    if let Ok(set) = rt_inst.get_typed_func::<(u32, u32), ()>(&mut store, "rt_set_homotopy") {
-        let h = openmodelica_sim_meta::simflags::with_flags(|f| {
-            openmodelica_sim_meta::simflags::homotopy_codes(f)
-        });
-        wts(set.call(&mut store, h))?;
-    }
-    // The arc-length solver's `-hom*` constants.
-    if let Ok(set) = rt_inst
-        .get_typed_func::<(f64, f64, f64, f64, f64, f64, f64, f64, f64, u32, u32, u32, u32, u32), ()>(
-            &mut store, "rt_set_homotopy_tuning",
-        )
-    {
-        let h = openmodelica_sim_meta::simflags::with_flags(openmodelica_sim_meta::simflags::hom_tuning);
-        wts(set.call(&mut store, (
-            h.adapt_bend, h.h_eps, h.tau_dec, h.tau_dec_pred, h.tau_inc, h.tau_inc_threshold,
-            h.tau_max, h.tau_min, h.tau_start, h.max_lambda_steps, h.max_newton_steps, h.max_tries,
-            h.orthogonal_backtrace as u32, h.neg_start_dir as u32,
-        )))?;
-    }
-    // Same for `-lv`: the nonlinear solver logs from inside the module.
-    let log_mask = openmodelica_sim_meta::simflags::with_flags(|f| f.log_mask);
-    if let Ok(set) = rt_inst.get_typed_func::<(u32, u32), ()>(&mut store, "rt_set_log_streams") {
-        wts(set.call(&mut store, (log_mask as u32, (log_mask >> 32) as u32)))?;
-    }
-    // The linear/nonlinear systems are solved in-wasm, so their `LOG_STATS_V`
-    // statistics are measured there; hand the module the host clock and arm them.
-    if let Ok(set) = rt_inst.get_typed_func::<u32, ()>(&mut store, "rt_stats_start") {
-        let on = openmodelica_sim_meta::omclog::mask_has(log_mask, openmodelica_sim_meta::omclog::STATS_V);
-        wts(set.call(&mut store, on as u32))?;
-    }
+    let log_mask = push_runtime_flags(&mut store, rt_inst, memory, &rt_alloc)?;
     // The iteration-variable names, which only the metadata has: the per-model
     // roster is cleared, then pushed per system.
     let diag_on = openmodelica_sim_meta::omclog::mask_has(log_mask, openmodelica_sim_meta::omclog::NLS_NEWTON_DIAGNOSTICS);
@@ -1929,9 +1934,115 @@ impl Drop for InWasmSession {
 
 /// A loaded artifact: the runtime, the FMI3 adapter and the model kernel sharing
 /// one linear memory, with the adapter's `om_fmi3*`/`om_sim_run` reachable.
+/// Hand a runtime instance the run's flags.
+///
+/// The runtime module links no flag store of its own, so whoever drives the run
+/// has to push the selectors in. Both hosts of a run need this: the ordinary
+/// simulation path below, and [`DylinkFmu::load`] — an artifact's in-wasm session
+/// parses the same flags but applies them to the runtime copy the *adapter*
+/// carries, and the model's own equations call this instance instead. Without it
+/// their nonlinear systems solve with whatever the defaults are.
+///
+/// Returns the `-lv` mask, which callers reuse for the per-model rosters.
+fn push_runtime_flags(
+    store: &mut Store,
+    rt_inst: wasmtime::Instance,
+    memory: wasmtime::Memory,
+    rt_alloc: &wasmtime::TypedFunc<u32, u32>,
+) -> std::result::Result<u64, String> {
+    // `-nls`/`-nlsLS`/`-ls`/`-lss`: the host-driven runtime links no flag store of
+    // its own, so hand it the selectors. The session sets the same ones from the
+    // argv it receives.
+    if let Ok(set) = rt_inst.get_typed_func::<(u32, u32, u32, u32), ()>(&mut *store, "rt_set_solvers") {
+        let codes = openmodelica_sim_meta::simflags::with_flags(|f| f.solver_codes());
+        wts(set.call(&mut *store, codes))?;
+    }
+    // `-newtonFTol`/`-newtonXTol`/`-newtonMaxStepFactor`: the nonlinear solvers that
+    // read them run in-wasm whichever driver owns the run.
+    if let Ok(set) = rt_inst.get_typed_func::<(f64, f64, f64), ()>(&mut *store, "rt_set_newton_tuning") {
+        let t = openmodelica_sim_meta::simflags::with_flags(|f| {
+            openmodelica_sim_meta::simflags::newton_tuning(f)
+        });
+        wts(set.call(&mut *store, t))?;
+    }
+    // `-lvMaxWarn`: the warnings it caps are printed in-wasm.
+    if let Ok(set) = rt_inst.get_typed_func::<u32, ()>(&mut *store, "rt_set_max_warn") {
+        let n = openmodelica_sim_meta::simflags::with_flags(|f| f.max_warn.unwrap_or(3));
+        wts(set.call(&mut *store, n))?;
+    }
+    // `-nlsJacTestATol` / `-nlsJacTestRTol`: the derivative test runs in-wasm.
+    if let Ok(set) = rt_inst.get_typed_func::<(f64, f64), ()>(&mut *store, "rt_set_jac_test_tolerances") {
+        let t = openmodelica_sim_meta::simflags::with_flags(|f| {
+            openmodelica_sim_meta::simflags::jac_test_tolerances(f)
+        });
+        wts(set.call(&mut *store, t))?;
+    }
+    // `-svdCount` / `-svdSigma` / `-svdTol`: `LOG_NLS_SVD` runs inside the nonlinear solver.
+    if let Ok(set) = rt_inst.get_typed_func::<(u32, f64, f64), ()>(&mut *store, "rt_set_svd") {
+        let (c, sigma, tol) = openmodelica_sim_meta::simflags::with_flags(|f| {
+            openmodelica_sim_meta::simflags::svd_params(f)
+        });
+        wts(set.call(&mut *store, (c.max(0) as u32, sigma, tol)))?;
+    }
+    // `-saveInitialGuess_system`: the nonlinear solver writes the file itself.
+    if let Ok(set) = rt_inst.get_typed_func::<(i32, u32, u32), ()>(&mut *store, "rt_set_save_initial_guess") {
+        let req = openmodelica_sim_meta::simflags::with_flags(|f| f.save_initial_guess.clone());
+        match req.map(|(p, i)| (format!("{p}\0{}", crate::host::absolute_path(&p)), i)) {
+            Some((names, idx)) => {
+                let ptr = wts(rt_alloc.call(&mut *store, names.len() as u32))?;
+                wts(memory.write(&mut *store, ptr as usize, names.as_bytes()))?;
+                wts(set.call(&mut *store, (idx, ptr, names.len() as u32)))?;
+            }
+            None => wts(set.call(&mut *store, (-1, 0, 0)))?,
+        }
+    }
+    // `-ils` / `-homotopyOnFirstTry`: a local approach sweeps inside `rt_solve_nls`.
+    if let Ok(set) = rt_inst.get_typed_func::<(u32, u32), ()>(&mut *store, "rt_set_homotopy") {
+        let h = openmodelica_sim_meta::simflags::with_flags(|f| {
+            openmodelica_sim_meta::simflags::homotopy_codes(f)
+        });
+        wts(set.call(&mut *store, h))?;
+    }
+    // The arc-length solver's `-hom*` constants.
+    if let Ok(set) = rt_inst
+        .get_typed_func::<(f64, f64, f64, f64, f64, f64, f64, f64, f64, u32, u32, u32, u32, u32), ()>(
+            &mut *store, "rt_set_homotopy_tuning",
+        )
+    {
+        let h = openmodelica_sim_meta::simflags::with_flags(openmodelica_sim_meta::simflags::hom_tuning);
+        wts(set.call(&mut *store, (
+            h.adapt_bend, h.h_eps, h.tau_dec, h.tau_dec_pred, h.tau_inc, h.tau_inc_threshold,
+            h.tau_max, h.tau_min, h.tau_start, h.max_lambda_steps, h.max_newton_steps, h.max_tries,
+            h.orthogonal_backtrace as u32, h.neg_start_dir as u32,
+        )))?;
+    }
+    // `env.rt_host_lin_solve` is defined by `add_host_builtins`, so a module that
+    // links both paths should take the native one: measured 1.3-2.7x the in-wasm
+    // solver on ScalableTestSuite's large sparse systems. A host without it (the
+    // browser) leaves this unset and the module solves in-wasm.
+    if let Ok(set) = rt_inst.get_typed_func::<u32, ()>(&mut *store, "rt_set_host_lin_solve") {
+        wts(set.call(&mut *store, 1))?;
+    }
+    // Same for `-lv`: the nonlinear solver logs from inside the module.
+    let log_mask = openmodelica_sim_meta::simflags::with_flags(|f| f.log_mask);
+    if let Ok(set) = rt_inst.get_typed_func::<(u32, u32), ()>(&mut *store, "rt_set_log_streams") {
+        wts(set.call(&mut *store, (log_mask as u32, (log_mask >> 32) as u32)))?;
+    }
+    // The linear/nonlinear systems are solved in-wasm, so their `LOG_STATS_V`
+    // statistics are measured there; hand the module the host clock and arm them.
+    if let Ok(set) = rt_inst.get_typed_func::<u32, ()>(&mut *store, "rt_stats_start") {
+        let on = openmodelica_sim_meta::omclog::mask_has(log_mask, openmodelica_sim_meta::omclog::STATS_V);
+        wts(set.call(&mut *store, on as u32))?;
+    }
+    Ok(log_mask)
+}
+
 pub struct DylinkFmu {
     store: Store,
-    loaded: crate::dylink_engine::Loaded,
+    /// The adapter as a PIC dylink library relocated into the model's memory.
+    loaded: Option<crate::dylink_engine::Loaded>,
+    /// The fused artifact runtime as an ordinary instance ([`DylinkFmu::load_fused`]).
+    fused: Option<wasmtime::Instance>,
     memory: wasmtime::Memory,
     alloc: wasmtime::TypedFunc<u32, u32>,
     /// The model, held so the store keeps it for as long as the adapter can call it.
@@ -2102,6 +2213,10 @@ impl DylinkFmu {
             .get_table(&mut store, "__indirect_function_table")
             .ok_or_else(|| "CodegenWasmJit: runtime has no table export".to_string())?;
         crate::host::set_sim_memory(memory);
+        // The model's equations call *this* instance's `rt_solve_nls`, not the copy
+        // the adapter carries, so the run's flags have to reach it too.
+        let rt_alloc_fn = wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc"))?;
+        push_runtime_flags(&mut store, rt_inst, memory, &rt_alloc_fn)?;
         let ext_rt = crate::dylink_engine::ExtRt {
             str_new: wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_str_new"))?,
             str_data: wts(rt_inst.get_typed_func::<u32, u32>(&mut store, "rt_str_data"))?,
@@ -2198,7 +2313,187 @@ impl DylinkFmu {
         let loaded =
             crate::dylink_engine::load(&mut store, engine, memory, table, &ext_rt.alloc, &[Library::builtin("fmi3adapter", adapter)], &host)?;
         crate::host::set_shadow_stack(loaded.shadow_stack());
-        Ok(DylinkFmu { store, loaded, memory, alloc: ext_rt.alloc, _instance: Some(model_inst) })
+        Ok(DylinkFmu {
+            store,
+            loaded: Some(loaded),
+            fused: None,
+            memory,
+            alloc: ext_rt.alloc,
+            _instance: Some(model_inst),
+        })
+    }
+
+    /// Load the artifact against the **fused** runtime: one non-PIC `wasm32-wasip1`
+    /// module holding the simulation runtime, the in-wasm driver and the FMI
+    /// adapter, with the SUNDIALS archives linked in.
+    ///
+    /// The dylink form binds the model to a *second* runtime copy, built with
+    /// different features from the one the driver runs on; here there is one copy, so
+    /// the model's equations and the driver solve with the same code. It reaches the
+    /// same solvers, as imports the FMU's side modules resolve.
+    ///
+    /// The two modules import each other — the driver calls the model's
+    /// `function*`, the model imports `rt.memory` — which wasmtime cannot
+    /// instantiate. The model's side is served by host trampolines bound to the
+    /// instance once it exists, so the fused module goes first and nothing in the
+    /// generated code has to change.
+    pub fn load_fused(
+        model: &[u8],
+        ext: &[ArtifactLib],
+        external_c: bool,
+        lapack: bool,
+        resources: &str,
+    ) -> std::result::Result<DylinkFmu, String> {
+        let fused_bytes = crate::FMI3_FUSED_WASIP1;
+        if fused_bytes.is_empty() {
+            return Err("CodegenWasmJit: this omc has no fused wasip1 artifact runtime".to_string());
+        }
+        crate::host::lin_solve::reset(); // drop the previous run's host-side LSS cache
+        let engine = sim_engine();
+        let mut linker = wasmtime::Linker::new(engine);
+        add_host_builtins(&mut linker)?;
+        wasi_shim::add_to_linker(&mut linker)?;
+        // Fixed and model-independent: compiled once into the on-disk cache.
+        let fused_module = aot_module(engine, "fused", fused_bytes, alarm_secs() != 0)?;
+        let mut store = wasmtime::Store::new(engine, WasiCtx::new(resources, Vec::new()));
+
+        // Everything the fused module takes from the model, forwarded once the
+        // model exists. Untyped: the signature is whatever the import declares, so
+        // a new model entry point needs nothing here.
+        let model_cell: std::sync::Arc<std::sync::Mutex<Option<wasmtime::Instance>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(None));
+        for imp in fused_module.imports() {
+            if !matches!(imp.module(), "env" | "model") {
+                continue;
+            }
+            let Some(ty) = imp.ty().func().cloned() else { continue };
+            let (module, name) = (imp.module().to_string(), imp.name().to_string());
+            // Not everything under `env` comes from the model: `add_host_builtins`
+            // serves the runtime's own host imports (`rt_host_lin_solve` and the
+            // rest) there too, and those stay the host's.
+            if linker.get(&mut store, &module, &name).is_ok() {
+                continue;
+            }
+            let cell = model_cell.clone();
+            let want = name.clone();
+            let f = wasmtime::Func::new(&mut store, ty, move |mut caller, args, rets| {
+                let inst = cell
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .ok_or_else(|| wasmtime::Error::msg("the artifact's model is not instantiated"))?;
+                let f = inst.get_func(&mut caller, &want).ok_or_else(|| {
+                    wasmtime::Error::msg(format!("the artifact's model has no `{want}`"))
+                })?;
+                f.call(&mut caller, args, rets)
+            });
+            wts(linker.define(&store, &module, &name, f))?;
+        }
+
+        let fused_inst = wts(linker.instantiate(&mut store, &fused_module))?;
+        let memory = fused_inst
+            .get_memory(&mut store, "memory")
+            .ok_or_else(|| "CodegenWasmJit: the fused runtime has no `memory` export".to_string())?;
+        crate::host::set_sim_memory(memory);
+        let alloc = wts(fused_inst.get_typed_func::<u32, u32>(&mut store, "rt_alloc"))?;
+        // The host's `rt` names first, so the loop below leaves them alone: the
+        // fused module carries the runtime crate whole and so exports some of what
+        // the host serves (`rt_uri_to_filename`, `rt_ext_stack_save`), which on the
+        // dylink path the host owns because the runtime module only imports them.
+        define_print_import(&mut linker, memory)?;
+        let str_new = wts(fused_inst.get_typed_func::<u32, u32>(&mut store, "rt_str_new"))?;
+        let str_data = wts(fused_inst.get_typed_func::<u32, u32>(&mut store, "rt_str_data"))?;
+        crate::host::define_uri_import(&mut linker, memory, str_new, str_data)?;
+        // `rt` for the model, one export at a time rather than `Linker::instance`,
+        // which would collide with those.
+        let exports: Vec<(String, wasmtime::Extern)> = fused_inst
+            .exports(&mut store)
+            .map(|e| (e.name().to_string(), e.into_extern()))
+            .collect();
+        for (name, ext) in exports {
+            if linker.get(&mut store, "rt", &name).is_err() {
+                wts(linker.define(&store, "rt", &name, ext))?;
+            }
+        }
+        // The model's equations call this instance's `rt_solve_nls`; it is also the
+        // one the driver runs on, so the run's flags reach both at once.
+        push_runtime_flags(&mut store, fused_inst, memory, &alloc)?;
+
+        let model_module = wts(wasmtime::Module::new(engine, model))?;
+        // The model's `external "C"`: PIC side libraries relocated into this
+        // module's memory, the same set and order the dylink path loads.
+        if external_c || !ext.is_empty() || (lapack && !crate::LAPACK_DYLINK.is_empty()) {
+            use crate::dylink_engine::Library;
+            let table = fused_inst
+                .get_table(&mut store, "__indirect_function_table")
+                .ok_or_else(|| "CodegenWasmJit: the fused runtime has no table export".to_string())?;
+            let ext_rt = crate::dylink_engine::ExtRt {
+                str_new: wts(fused_inst.get_typed_func::<u32, u32>(&mut store, "rt_str_new"))?,
+                str_data: wts(fused_inst.get_typed_func::<u32, u32>(&mut store, "rt_str_data"))?,
+                release: wts(fused_inst.get_typed_func::<u32, ()>(&mut store, "rt_release"))?,
+                alloc: alloc.clone(),
+                free: wts(fused_inst.get_typed_func::<u32, ()>(&mut store, "rt_free"))?,
+                record_new: wts(fused_inst.get_typed_func::<(u32, u32), u32>(&mut store, "rt_record_new"))?,
+                nls: Some(NlsHooks {
+                    recovering: wts(fused_inst.get_typed_func::<(), i32>(&mut store, "rt_nls_recovering"))?,
+                    note: wts(fused_inst.get_typed_func::<(), ()>(&mut store, "rt_nls_note_assert"))?,
+                }),
+            };
+            let mut ext_libs: Vec<Library> = Vec::new();
+            if external_c {
+                let libc = openmodelica_wasi_libc::LIBC_PIC;
+                if libc.is_empty() {
+                    return Err("CodegenWasmJit: this omc was built without the PIC wasi-libc, so it \
+                                cannot load an artifact whose model uses external \"C\""
+                        .to_string());
+                }
+                ext_libs.push(Library::builtin("libc.so", libc));
+            }
+            for l in ext {
+                ext_libs.push(Library { name: l.name.clone(), bytes: l.bytes.clone(), fixed: l.fixed });
+            }
+            if external_c {
+                ext_libs.push(Library::builtin("modelicaexternalc", openmodelica_wasi_libc::EXTERNAL_C_DYLINK));
+                if !openmodelica_wasi_libc::USERTAB_DYLINK.is_empty() {
+                    ext_libs.push(Library::builtin("usertab", openmodelica_wasi_libc::USERTAB_DYLINK));
+                }
+            }
+            if lapack && !crate::LAPACK_DYLINK.is_empty() {
+                ext_libs.push(Library::builtin("lapack", crate::LAPACK_DYLINK));
+            }
+            let mut utilities = crate::dylink_engine::modelica_utilities_imports(&mut store, &ext_rt);
+            if ext.iter().any(|l| l.name == NATIVE_STUB) {
+                utilities.insert(
+                    "om_ext_native_call".to_string(),
+                    native_ext_host_import(&mut store, engine, memory, &ext_rt, resources),
+                );
+            }
+            let libs = crate::dylink_engine::load(
+                &mut store, engine, memory, table, &ext_rt.alloc, &ext_libs, &utilities,
+            )?;
+            crate::host::set_shadow_stack(libs.shadow_stack());
+            let wanted: Vec<String> = model_module
+                .imports()
+                .filter(|i| i.module() == "ext")
+                .map(|i| i.name().to_string())
+                .collect();
+            for name in wanted {
+                let f = libs.func_or_addr(&mut store, &name).ok_or_else(|| {
+                    format!("CodegenWasmJit: the artifact's model needs `external \"C\"` function `{name}`, \
+                             which none of the libraries beside it defines")
+                })?;
+                wts(linker.define(&store, "ext", &name, f))?;
+            }
+        }
+        let model_inst = wts(linker.instantiate(&mut store, &model_module))?;
+        *model_cell.lock().unwrap_or_else(|e| e.into_inner()) = Some(model_inst);
+        Ok(DylinkFmu {
+            store,
+            loaded: None,
+            fused: Some(fused_inst),
+            memory,
+            alloc,
+            _instance: Some(model_inst),
+        })
     }
 
     /// Scratch in the shared memory, for the arrays an FMI call passes by pointer.
@@ -2233,10 +2528,7 @@ impl DylinkFmu {
     /// Call one of the adapter's exports. The FMI 3.0 entry points all take and
     /// return machine words, so the parameters cross as `Val`.
     pub fn call(&mut self, name: &str, args: &[wasmtime::Val]) -> std::result::Result<i32, String> {
-        let f = *self
-            .loaded
-            .func(name)
-            .ok_or_else(|| format!("CodegenWasmJit: the artifact's adapter has no `{name}`"))?;
+        let f = self.entry(name)?;
         let mut out = [wasmtime::Val::I32(0)];
         f.call(&mut self.store, args, &mut out).map_err(|e| format!("{name}: {e:#}"))?;
         match out[0] {
@@ -2247,10 +2539,18 @@ impl DylinkFmu {
 
     /// The same, for an entry point that returns nothing.
     pub fn call_void(&mut self, name: &str, args: &[wasmtime::Val]) -> std::result::Result<(), String> {
-        let f = *self
-            .loaded
-            .func(name)
-            .ok_or_else(|| format!("CodegenWasmJit: the artifact's adapter has no `{name}`"))?;
+        let f = self.entry(name)?;
         f.call(&mut self.store, args, &mut []).map_err(|e| format!("{name}: {e:#}"))
+    }
+
+    /// One of the adapter's entry points, wherever the adapter lives: an export of
+    /// the relocated dylink library, or of the fused instance.
+    fn entry(&mut self, name: &str) -> std::result::Result<wasmtime::Func, String> {
+        let missing = || format!("CodegenWasmJit: the artifact's adapter has no `{name}`");
+        match (&self.loaded, self.fused) {
+            (Some(l), _) => l.func(name).copied().ok_or_else(missing),
+            (None, Some(inst)) => inst.get_func(&mut self.store, name).ok_or_else(missing),
+            _ => Err(missing()),
+        }
     }
 }

--- a/OMCompiler/Compiler/Template/CodegenFMU3.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU3.tpl
@@ -472,25 +472,26 @@ match simCode
 case SIMCODE(modelInfo=modelInfo) then
 match modelInfo
 case MODELINFO(vars=SIMVARS(stateVars=stateVars)) then
+  let numScalarStates = SimCodeUtil.numScalarElems(stateVars)
   <<
   <ModelVariables>
     <%TimeVariable3(simCode)%>
-    <%vars.stateVars |> var => Variable3(var, simCode, stateVars) ;separator="\n"%>
-    <%vars.derivativeVars |> var => Variable3(var, simCode, stateVars) ;separator="\n"%>
-    <%vars.algVars |> var => Variable3(var, simCode, stateVars) ;separator="\n"%>
-    <%vars.discreteAlgVars |> var => Variable3(var, simCode, stateVars) ;separator="\n"%>
-    <%vars.paramVars |> var => Variable3(var, simCode, stateVars) ;separator="\n"%>
-    <%vars.aliasVars |> var => Variable3(var, simCode, stateVars) ;separator="\n"%>
-    <%vars.intAlgVars |> var => Variable3(var, simCode, stateVars) ;separator="\n"%>
-    <%vars.intParamVars |> var => Variable3(var, simCode, stateVars) ;separator="\n"%>
-    <%vars.intAliasVars |> var => Variable3(var, simCode, stateVars) ;separator="\n"%>
-    <%vars.boolAlgVars |> var => Variable3(var, simCode, stateVars) ;separator="\n"%>
-    <%vars.boolParamVars |> var => Variable3(var, simCode, stateVars) ;separator="\n"%>
-    <%vars.boolAliasVars |> var => Variable3(var, simCode, stateVars) ;separator="\n"%>
-    <%vars.stringAlgVars |> var => Variable3(var, simCode, stateVars) ;separator="\n"%>
-    <%vars.stringParamVars |> var => Variable3(var, simCode, stateVars) ;separator="\n"%>
-    <%vars.stringAliasVars |> var => Variable3(var, simCode, stateVars) ;separator="\n"%>
-    <%vars.extObjVars |> var => Variable3(var, simCode, stateVars) ;separator="\n"%>
+    <%vars.stateVars |> var => Variable3(var, simCode, numScalarStates) ;separator="\n"%>
+    <%vars.derivativeVars |> var => Variable3(var, simCode, numScalarStates) ;separator="\n"%>
+    <%vars.algVars |> var => Variable3(var, simCode, numScalarStates) ;separator="\n"%>
+    <%vars.discreteAlgVars |> var => Variable3(var, simCode, numScalarStates) ;separator="\n"%>
+    <%vars.paramVars |> var => Variable3(var, simCode, numScalarStates) ;separator="\n"%>
+    <%vars.aliasVars |> var => Variable3(var, simCode, numScalarStates) ;separator="\n"%>
+    <%vars.intAlgVars |> var => Variable3(var, simCode, numScalarStates) ;separator="\n"%>
+    <%vars.intParamVars |> var => Variable3(var, simCode, numScalarStates) ;separator="\n"%>
+    <%vars.intAliasVars |> var => Variable3(var, simCode, numScalarStates) ;separator="\n"%>
+    <%vars.boolAlgVars |> var => Variable3(var, simCode, numScalarStates) ;separator="\n"%>
+    <%vars.boolParamVars |> var => Variable3(var, simCode, numScalarStates) ;separator="\n"%>
+    <%vars.boolAliasVars |> var => Variable3(var, simCode, numScalarStates) ;separator="\n"%>
+    <%vars.stringAlgVars |> var => Variable3(var, simCode, numScalarStates) ;separator="\n"%>
+    <%vars.stringParamVars |> var => Variable3(var, simCode, numScalarStates) ;separator="\n"%>
+    <%vars.stringAliasVars |> var => Variable3(var, simCode, numScalarStates) ;separator="\n"%>
+    <%vars.extObjVars |> var => Variable3(var, simCode, numScalarStates) ;separator="\n"%>
     <%SimCodeUtil.getFMI3Clocks(simCode) |> clk => Clock3(clk, FMUType) ;separator="\n"%>
     <%EventIndicatorVariables3(simCode)%>
   </ModelVariables>
@@ -521,7 +522,7 @@ template TimeVariable3(SimCode simCode)
   >>
 end TimeVariable3;
 
-template Variable3(SimVar simVar, SimCode simCode, list<SimVar> stateVars)
+template Variable3(SimVar simVar, SimCode simCode, String numScalarStates)
  "Generates a typed variable element for FMI 3.0."
 ::=
 match simVar
@@ -538,7 +539,7 @@ case SIMVAR(name = name, exportVar = exportVar, type_ = T_ARRAY(ty = arrayElemen
   else
   match arrayElementType
     case T_REAL(__) then
-      '<Float64 <%VariableCommonAttributes3(simVar, simCode)%><%DerivativeAttribute3(simVar, simCode, stateVars)%><%ArrayStartString3(simVar)%>><%Dimensions3(simVar)%></Float64>'
+      '<Float64 <%VariableCommonAttributes3(simVar, simCode)%><%DerivativeAttribute3(simVar, simCode, numScalarStates)%><%ArrayStartString3(simVar)%>><%Dimensions3(simVar)%></Float64>'
     case T_INTEGER(__) then
       '<Int32 <%VariableCommonAttributes3(simVar, simCode)%><%ArrayStartString3(simVar)%>><%Dimensions3(simVar)%></Int32>'
     case T_BOOL(__) then
@@ -562,7 +563,7 @@ case SIMVAR(__) then
   else
   match type_
     case T_REAL(__) then
-      '<Float64 <%VariableCommonAttributes3(simVar, simCode)%><%DerivativeAttribute3(simVar, simCode, stateVars)%><%StartString2(simVar)%><%MinString2(simVar)%><%MaxString2(simVar)%><%NominalString2(simVar)%><%UnitString2(simVar)%><%relativeQuantity(simVar)%><%CloseWithAliases3("Float64", simVar, simCode)%>'
+      '<Float64 <%VariableCommonAttributes3(simVar, simCode)%><%DerivativeAttribute3(simVar, simCode, numScalarStates)%><%StartString2(simVar)%><%MinString2(simVar)%><%MaxString2(simVar)%><%NominalString2(simVar)%><%UnitString2(simVar)%><%relativeQuantity(simVar)%><%CloseWithAliases3("Float64", simVar, simCode)%>'
     case T_INTEGER(__) then
       '<Int32 <%VariableCommonAttributes3(simVar, simCode)%><%StartString2(simVar)%><%MinString2(simVar)%><%MaxString2(simVar)%><%CloseWithAliases3("Int32", simVar, simCode)%>'
     case T_BOOL(__) then
@@ -699,21 +700,17 @@ case SIMVAR(__) then
   >>
 end BinaryVariableAttributes3;
 
-template DerivativeAttribute3(SimVar simVar, SimCode simCode, list<SimVar> stateVars)
+template DerivativeAttribute3(SimVar simVar, SimCode simCode, String numScalarStates)
  "Generates the derivative attribute (FMI 3.0 references the *valueReference* of
   the state variable). For the C runtime the state value references precede the
   state derivative value references contiguously in the real block, hence the
   state value reference is the derivative value reference minus the number of
-  states."
+  states. Scalar elements, not list entries: the new backend leaves a
+  non-scalarized array state as one entry (and one `varInfo.numStateVars`)."
 ::=
 match simVar
 case SIMVAR(varKind = STATE_DER(__)) then
-  match simCode
-  case SIMCODE(modelInfo = MODELINFO(vars = SIMVARS(stateVars = stateVarsList))) then
-    // per-scalar state count, so the derivative VR minus it yields the state VR
-    // (works for non-scalarized array states too).
-    ' derivative="<%intSub(stringInt(SimCodeUtil.getFMI3ValueReference(simVar, simCode)), SimCodeUtil.numScalarElems(stateVarsList))%>"'
-  else ''
+  ' derivative="<%intSub(stringInt(SimCodeUtil.getFMI3ValueReference(simVar, simCode)), stringInt(numScalarStates))%>"'
 else ''
 end DerivativeAttribute3;
 

--- a/testsuite/openmodelica/fmi/CoSimulation/3.0/Makefile
+++ b/testsuite/openmodelica/fmi/CoSimulation/3.0/Makefile
@@ -2,7 +2,10 @@ TEST = ../../../../rtest -v
 
 TESTFILES = \
 fmi3_cs_01.mos \
-fmi3_msl_clocked_drive.mos
+fmi3_msl_clocked_drive.mos \
+fmi3_wasm_solver_absent.mos \
+fmi3_wasm_solver_libraries.mos \
+fmi3_wasm_solver_me.mos
 
 # Dependency files that are not .mo .mos or Makefile
 # Add them here or they will be cleaned.

--- a/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_solver_absent.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_solver_absent.mos
@@ -1,0 +1,34 @@
+// name: fmi3_wasm_solver_absent.mos
+// keywords: FMI 3.0 export wasm Co-Simulation kinsol solver
+// status: correct
+// suite: wasm
+// teardown_command: rm -rf M_absent.fmu M_absent.fmu.log M_absent_artifact M_absent_res.mat om-wasm-include-*
+//
+// The other end of per-solver linking: flags that reach no solver library leave the
+// FMU carrying none of them, each served by a stub whose `om_have_<library>` answers
+// 0. `simflags::check` then rejects the request against the FMU's own capability
+// report, so the stub bodies -- which trap -- stay unreachable.
+
+setCommandLineOptions("--simCodeTarget=wasm-jit --fmiFlags=default"); getErrorString();
+loadFile("fmi3_wasm_solver_libraries.mo"); getErrorString();
+buildModelFMU(MixedSystems, fileNamePrefix="M_absent", fmuType="cs", version="3.0", platforms={"wasm"}); getErrorString();
+simulate(MixedSystems, stopTime=1.0, numberOfIntervals=20, resimulateExecutable="M_absent.fmu", simflags="-nls=kinsol"); getErrorString();
+// Result:
+// true
+// ""
+// true
+// ""
+// "M_absent.fmu"
+// "Notification: Building FMU for platform 'wasm' (1/1).
+// Notification: Finished FMU for platform 'wasm' (1/1).
+// "
+// record SimulationResult
+//     resultFile = "",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 20, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'MixedSystems', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-nls=kinsol'",
+//     messages = "Simulation execution failed for model: MixedSystems
+// LOG_STDOUT        | info    | wasm artifact loaded (compiled from the component)
+// LOG_ERROR         | error   | -nls=kinsol: this runtime has no kinsol
+// "
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_solver_libraries.mo
+++ b/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_solver_libraries.mo
@@ -1,0 +1,11 @@
+model MixedSystems
+  Real x(start = 1, fixed = true);
+  Real a, b, c;
+  Real y;
+equation
+  der(x) = -x + y;
+  a + 2*b - c = 1 + x;
+  2*a - b + c = 2;
+  a - b + 3*c = sin(time);
+  y^3 + y = 1 + a;
+end MixedSystems;

--- a/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_solver_libraries.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_solver_libraries.mos
@@ -1,0 +1,51 @@
+// name: fmi3_wasm_solver_libraries.mos
+// keywords: FMI 3.0 export wasm Co-Simulation kinsol solver
+// status: correct
+// suite: wasm
+// teardown_command: rm -rf M_kinsol.fmu M_kinsol.fmu.log M_kinsol_artifact M_kinsol_res.mat ref_res.mat ref.log ref.wasm diff_kinsol* om-wasm-include-*
+//
+// A Co-Simulation wasm FMU links one PIC side module per solver library, chosen
+// from the `--fmiFlags` it is exported with. `nls:kinsol` gives it KINSOL and the
+// shared SUNDIALS/KLU base it calls into, so the FMU integrates with KINSOL and has
+// to agree with the same model simulated directly.
+
+setCommandLineOptions("--simCodeTarget=wasm-jit"); getErrorString();
+loadFile("fmi3_wasm_solver_libraries.mo"); getErrorString();
+
+simulate(MixedSystems, stopTime=1.0, numberOfIntervals=20, fileNamePrefix="ref"); getErrorString();
+
+setCommandLineOptions("--fmiFlags=nls:kinsol"); getErrorString();
+buildModelFMU(MixedSystems, fileNamePrefix="M_kinsol", fmuType="cs", version="3.0", platforms={"wasm"}); getErrorString();
+simulate(MixedSystems, stopTime=1.0, numberOfIntervals=20, resimulateExecutable="M_kinsol.fmu", simflags="-nls=kinsol"); getErrorString();
+diffSimulationResults("M_kinsol_res.mat", "ref_res.mat", "diff_kinsol", 1e-6, 1e-6);
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "ref_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 20, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ref', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// true
+// ""
+// "M_kinsol.fmu"
+// "Warning: Adding unknown FMU simulation flag \"nls\" .
+// Notification: Building FMU for platform 'wasm' (1/1).
+// Notification: Finished FMU for platform 'wasm' (1/1).
+// "
+// record SimulationResult
+//     resultFile = "M_kinsol.fmu_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 20, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'MixedSystems', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-nls=kinsol'",
+//     messages = "LOG_STDOUT        | info    | wasm artifact loaded (compiled from the component)
+// LOG_STDOUT        | info    | in-wasm simulation (dassl) wrote 502 rows
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// (true, {})
+// endResult

--- a/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_solver_me.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_solver_me.mos
@@ -1,0 +1,39 @@
+// name: fmi3_wasm_solver_me.mos
+// keywords: FMI 3.0 export wasm Model Exchange kinsol solver
+// status: correct
+// suite: wasm
+// teardown_command: rm -rf ME_kinsol.fmu ME_kinsol.fmu.log ME_kinsol_artifact ME_plain.fmu ME_plain.fmu.log ME_plain_artifact om-wasm-include-*
+//
+// Model Exchange integrates nothing, but its initialisation and residuals run the
+// same nonlinear and linear solvers, and an importer has no channel to pass
+// simulation flags -- so the export hard-codes the selection into the model
+// metadata and links exactly the libraries it reaches. `nls:kinsol` therefore costs
+// an ME FMU KINSOL and the shared base; default flags cost it neither.
+
+setCommandLineOptions("--simCodeTarget=wasm-jit"); getErrorString();
+loadFile("fmi3_wasm_solver_libraries.mo"); getErrorString();
+
+setCommandLineOptions("--fmiFlags=nls:kinsol"); getErrorString();
+buildModelFMU(MixedSystems, fileNamePrefix="ME_kinsol", fmuType="me", version="3.0", platforms={"wasm"}); getErrorString();
+
+setCommandLineOptions("--fmiFlags=default"); getErrorString();
+buildModelFMU(MixedSystems, fileNamePrefix="ME_plain", fmuType="me", version="3.0", platforms={"wasm"}); getErrorString();
+// Result:
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// "ME_kinsol.fmu"
+// "Warning: Adding unknown FMU simulation flag \"nls\" .
+// Notification: Building FMU for platform 'wasm' (1/1).
+// Notification: Finished FMU for platform 'wasm' (1/1).
+// "
+// true
+// ""
+// "ME_plain.fmu"
+// "Notification: Building FMU for platform 'wasm' (1/1).
+// Notification: Finished FMU for platform 'wasm' (1/1).
+// "
+// endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_wasm_native_record.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_wasm_native_record.mos
@@ -52,7 +52,7 @@ diffSimulationResults("art_cs.mat", "plain_res.mat", "d_cs", 1e-9, 1e-9);
 // record SimulationResult
 //     resultFile = "art_cs.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 10, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ExtNativeRecord', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s fmi3:cs -r=art_cs.mat'",
-//     messages = "LOG_STDOUT        | info    | wasm artifact loaded (model kernel 0.0 MB linked against the cached adapter)
+//     messages = "LOG_STDOUT        | info    | wasm artifact loaded (model kernel linked against the cached adapter)
 // LOG_STDOUT        | info    | CoSimulation instantiated
 // LOG_STDOUT        | info    | CoSimulation run: 500 communication steps, 0 events, 0 early returns, 501 samples
 // LOG_SUCCESS       | info    | The simulation finished successfully.


### PR DESCRIPTION
A `--fmuDirectory` artifact bound the model to the standalone runtime module and loaded the FMI adapter beside it as a PIC dylink library carrying its own second copy of that runtime, built from different features. The model's equations solved in one copy, the driver in the other, and only the adapter's ever saw the run's flags.

`OpenIPSL.Tests.Controls.PSAT.TG.TGTypeII_test` (three non-linear systems, one of size 26) took 161830 ms for the 166 rows the same export writes in 155 ms once there is one copy. Library testing hit the 480 s `ulimitExe` on ~450 models a run, which is where the wasm-jit job's 6d8h against 2d went.

`build_wasip1_fused_adapter` builds the adapter, the in-wasm driver and the runtime as one non-PIC `wasm32-wasip1` module, and `DylinkFmu::load_fused` binds the model's `rt_*` to it. `OMC_WASM_FUSED_ARTIFACT=0` falls back to the dylink adapter. Host trampolines bound after the model instantiates break the cycle between the two, so nothing in the generated code changes.

The fused module links the solver archives statically, as the standalone runtimes do, and so has CVODE, IDA, KINSOL, KLU, UMFPACK and Lis without composing anything.

| model | dylink | fused |
| --- | --- | --- |
| TGTypeII_test, 166 rows | 161830 ms | 155 ms |
| tiny model, export + 3 runners | 0.409 s | 0.306 s |

Alongside it, on the same path:

* The FMI masters honour `-alarm`, polled on every call into the FMU rather than at the output points a stuck solver never reaches.
* `Form::Dylink` runs folded no output into the run's log, so every `LOG_*` line, assert and NLS warning a model printed was lost.
* The run's flags reach the instance the model calls, so `-nls`, `-nlsLS`, `-newton*`, `-hom*` and `-lv` stop being ignored.
* `-variableFilter` applies to a resimulated artifact. Nothing is translated there, so the `simulate()` argument could not reach the run: the masters filter their columns, and the in-wasm writer asks the host per name through `rt_host_name_matches`, having no regex engine.
* Which sparse solver runs is the host's to say (`rt_set_host_lin_solve`) rather than a build-time feature. Native rsparse measured 1.3-2.7x the in-wasm one on ScalableTestSuite's advection models; a host without one leaves it off.
* The build precompiles the model-independent blobs and installs them under `lib/omc/cache`, read before `$HOME/.openmodelica/cache`. Sixteen omc processes on a cold cache went 16 s to 6 s, writing nothing to `$HOME`.
* An unzipped export compiles its component once and hands it to the runs that follow instead of each compiling it again.

Two are not artifact-specific:

* `DerivativeAttribute3` counted the state list once per variable, making an FMI 3.0 `modelDescription.xml` quadratic -- `SimpleAdvection_N_12800` spent 77.8 s there. `varInfo.numStateVars` is the same number in O(1).
* The mat reader loaded the whole of `data_2` to read the four columns a comparison against a reference asks for. Over 64 MiB it now reads what the caller points at, as the C reader always has.

One me_cs adapter serves every component FMU, built with the SUNDIALS feature that `mecs_sundials` used to carry alone, so `method=cvode|ida` works for any export rather than only one that asked at export time.

An exported FMU now reaches the same solvers a `simulate()` run does, and carries only the ones its flags can select.

`_sundials_cflags` gains `-fPIC`, so one archive set serves both users: wasm-ld relaxes the GOT/`__memory_base` relocations away again in the runtimes' static link, which comes out byte-identical (AMD: objects 45907 -> 46669 B, linked output identical), while a `--experimental-pic --shared` link accepts nothing else. The side modules are therefore *linked* from those archives instead of `openmodelica_wasi_libc` recompiling ~250 SUNDIALS/SuiteSparse `.c` files, and a 105-name hand-maintained export list is gone: the roots are read off the me_cs adapter's own import section and passed as `--export-if-defined`, so libc and model-kernel names in the same set are skipped and a driver reaching for a new entry point needs no list updated.

Five composable groups, not one blob, because an FMU that integrates with dassl should not carry Lis:

| group | archives | stripped |
| --- | --- | --- |
| `klu` | core, nvector, sunmatrix, dense/Krylov/nonlinsol | 127 KB | | `sundials_driver` | cvode, idas | 122 KB |
| `kinsol` | kinsol | 26 KB |
| `umfpack` | umfpack, amd | 139 KB |
| `lis` | lis | 335 KB |

`klu` is the shared core the others call into, so it comes along with any of them; its roots are its own plus whatever the leaves leave undefined. `owns` must *partition* the entry points rather than ask which archive defines what -- SUNDIALS bundles a copy of the shared implementations into every integrator archive, so rooting each group with the full set duplicated 89 KB and made `klu`+`driver` bigger than the single blob it replaced. Three build-time checks close that: every solver import is defined by exactly one group, every leaf resolves against `klu` plus `libc.so`, and `klu` resolves against `libc.so`.

`SUNLinSol_SPGMR`/`SPBCGS`/`SPTFQMR` and the SUNNonlinearSolver implementations had no archive of their own -- the wasm build never named those five targets, and the wasip1 runtime resolves them only because of that bundling. They are built and collected now, which is what makes a clean partition possible.

Which groups an FMU gets comes from its `--fmiFlags`, and each one left out is served by a stub: the entry points that group owns, with the adapter's own signature read off its type section and a trap body, plus `om_have_<group>` answering 0. `capabilities()` reads those markers, so `simflags::check` rejects the solver before a trap is reachable ("-nls=kinsol: this runtime has no kinsol") rather than aborting the instance.

`Capabilities.klu` splits into `klu`/`kinsol`/`umfpack`/`lis` and `Offer::WithSundials` into four, because the libraries now arrive separately. `check` was also letting `-nls=kinsol`, `-ls=lis` and `-lss=lis` through on a runtime without them, which the tables two hundred lines above already marked `WithSundials`.

Model Exchange gets them too. It integrates nothing, but its initialisation and residuals run the same nonlinear and linear solvers, and it exports no `om:sim/simulation` to pass flags through -- so `--fmiFlags`' `nls`/`nlsLS`/`ls`/`lss` are consumed at export into `SimMeta.fmi_solver_flags` and applied by `new_state()`, which both instantiate paths share. `-s` stays out of that set; `cs_method` already carries it, and only Co-Simulation integrates. `sim_run::run` prepends the baked flags to the caller's argv rather than applying them separately, since `apply_flags` sets the whole selection at once and a second call would wipe them. The `FmuKernel` cache key gains them for the same reason: it is baked into the kernel's metadata, so a re-export that changed the flags has to lower again.

| FMU (zipped) | before | after |
| --- | --- | --- |
| CS, default flags | 993 KB | 572 KB |
| CS, `nls:kinsol` | 993 KB | 958 KB |
| CS, `lss:lis` | 993 KB | 1062 KB |
| ME, default flags | 857 KB | 857 KB |
| ME, `nls:kinsol` | n/a | 1643 KB |

Finally, wasm-opt. The eight modules every FMU links are built once per omc build and stamped, so binaryen is paid here rather than per export: 5068 KB to 4552 KB, 10%. `liblapack` is the largest single one at 2023 KB and the one whose dense solves most want an optimizer beyond rustc's. A composed component cannot be opt'd at all (binaryen does not parse components), and a generated model kernel gains only 4% for up to 2 s, so neither is touched. `libc_pic` and `modelicaexternalc` measured 1% -- wasi-libc and clang already optimize them -- and `usertab` is 400 bytes.

The artifact-loaded log line drops its size under
`--running-testsuite`, as its timing already did: it moves whenever the adapter or kernel is rebuilt, and a baseline that records it fails on changes that are not about the test.

`-variableFilter`'s host matcher is a `capi`-only import: a componentized adapter has no host, and an `env` import it cannot resolve stops it linking (`fmu_component_links_without_a_host`).

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
