### PR TITLE
wasm-jit: serve NBackend's LINEARSYSTEM blocks

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -60,7 +60,7 @@ use crate::CodegenWasmJitFunctions::{
     ProfPlan, ScatterGroup, SimCtx, SimSlot, WTy, WTyVal, compile_function, compile_linear_system, compile_linear_system_analytic,
     compile_linear_system_analytic_csc, compile_linear_system_symbolic,
     ClockInit, ClockUpdate,
-    NlsResidual, NlsResiduals, backup_known_outputs, restore_known_outputs,
+    NlsResidual, NlsResiduals, backup_known_outputs, residual_rows, restore_known_outputs,
     emit_nls_load_body, emit_nls_jac_body, emit_nls_jac_csc_body, nls_use_sparse,
     emit_entwined_assign, emit_generic_assign, emit_resizable_assign,
     emit_nls_residual_body, emit_solve_nls_call, external_import_sig, external_known,
@@ -8536,14 +8536,8 @@ fn lower_linear_system_body(
 ) -> Result<()> {
     use SimCode::SimEqSystem as E;
     let mut inner: Vec<Arc<SimCode::SimEqSystem>> = Vec::new();
-    let mut res_exps: Vec<&Arc<DAE::Exp>> = Vec::new();
-    for e in lst(&lsystem.residual) {
-        match &**e {
-            E::SES_RESIDUAL { exp, .. } => res_exps.push(exp),
-            _ => inner.push(e.clone()),
-        }
-    }
-    let torn = !res_exps.is_empty();
+    let residuals = lin_residuals(lsystem, &mut inner);
+    let torn = !residuals.is_empty();
     let vars: Vec<Arc<DAE::ComponentRef>> = lst(&lsystem.vars).map(|v| v.name.clone()).collect();
     let n = vars.len();
 
@@ -8591,7 +8585,7 @@ fn lower_linear_system_body(
 
     // Prefer analytic-Jacobian assembly (C's method 1); probe only when there is no
     // usable Jacobian (its slots were registered by `build_lin_jac_infos`).
-    if lin_jac_usable(lsystem, res_exps.len()) {
+    if lin_jac_usable(lsystem, residual_rows(&residuals)) {
         let (seed_offs, result_offs) = {
             let vars = &ctx.sim()?.vars;
             lin_jac_offsets(lsystem, vars, n)?
@@ -8613,20 +8607,20 @@ fn lower_linear_system_body(
         if use_sparse {
             if let Some((colptr, rowidx)) = lin_jac_csc_pattern(lsystem, n) {
                 return compile_linear_system_analytic_csc(
-                    ctx, lsystem.index, &vars, &res_exps, &seed_offs, &result_offs, &colptr, &rowidx,
+                    ctx, lsystem.index, &vars, &residuals, &seed_offs, &result_offs, &colptr, &rowidx,
                     &mut lower_inner, &mut lower_constant, &mut lower_column,
                 );
             }
         }
         return compile_linear_system_analytic(
-            ctx, &vars, &res_exps, &seed_offs, &result_offs,
+            ctx, &vars, &residuals, &seed_offs, &result_offs,
             &mut lower_inner, &mut lower_constant, &mut lower_column, use_sparse, lsystem.index,
         );
     }
 
     // C keys `method` off `ls.jacobianMatrix` alone, not off whether it assembles
     // `A` from one.
-    compile_linear_system(ctx, &vars, &res_exps, &mut lower_inner, use_sparse, lsystem.jacobianMatrix.is_some(), lsystem.index)
+    compile_linear_system(ctx, &vars, &residuals, &mut lower_inner, use_sparse, lsystem.jacobianMatrix.is_some(), lsystem.index)
 }
 
 /// Whether a torn linear system uses the sparse solver (C's density/size
@@ -9430,10 +9424,45 @@ fn nls_lambda_extra(nlsystem: &SimCode::NonlinearSystem) -> u32 {
     u32::from(is_homotopy_lambda(lst(&nlsystem.crefs).last()))
 }
 
+/// `nls_parts` for a linear system: the residuals, which may be array-valued and so
+/// carry their `res_index`, and the inner (torn) equations, into `inner`.
+fn lin_residuals(
+    lsystem: &SimCode::LinearSystem,
+    inner: &mut Vec<Arc<SimCode::SimEqSystem>>,
+) -> Vec<NlsResidual> {
+    use SimCode::SimEqSystem as E;
+    let mut residuals = Vec::new();
+    for e in lst(&lsystem.residual) {
+        match &**e {
+            E::SES_RESIDUAL { exp, res_index, .. } => residuals.push(match exp_array_rows(exp) {
+                Some(rows) => NlsResidual::Array { exp: exp.clone(), res_index: *res_index, rows },
+                None => NlsResidual::Scalar { exp: exp.clone(), res_index: *res_index },
+            }),
+            E::SES_FOR_RESIDUAL { iterators, exp, res_index, .. } => residuals.push(NlsResidual::For {
+                iterators: lst(iterators).cloned().collect(),
+                exp: exp.clone(),
+                res_index: *res_index,
+            }),
+            E::SES_GENERIC_RESIDUAL { iterators, scal_indices, exp, res_index, .. } => {
+                residuals.push(NlsResidual::Generic {
+                    iterators: lst(iterators).cloned().collect(),
+                    scal_indices: lst(scal_indices).copied().collect(),
+                    exp: exp.clone(),
+                    res_index: *res_index,
+                })
+            }
+            _ => inner.push(e.clone()),
+        }
+    }
+    residuals
+}
+
 /// Torn linear system usable for analytic assembly: square Jacobian with one seed
 /// per iteration variable and `JAC_VAR` results covering every residual row
-/// (`n_res` = number of `SES_RESIDUAL`). The `nls_jac_usable` analogue for linear.
-fn lin_jac_usable(lsystem: &SimCode::LinearSystem, n_res: usize) -> bool {
+/// (`n_res` = the residual vector's row count). The `nls_jac_usable` analogue for
+/// linear.
+fn lin_jac_usable(lsystem: &SimCode::LinearSystem, n_res: Option<usize>) -> bool {
+    let Some(n_res) = n_res else { return false };
     let Some(jm) = &lsystem.jacobianMatrix else { return false };
     if lst(&jm.columns).next().is_none_or(|c| lst(&c.columnEqns).next().is_none()) || !jac_lowerable(jm) {
         return false;
@@ -9914,10 +9943,9 @@ fn build_linz_jac_fn(
     Ok(func)
 }
 
-/// Number of scalar `SES_RESIDUAL` in a linear system (its `A x = b` row count).
-fn lin_n_res(lsystem: &SimCode::LinearSystem) -> usize {
-    use SimCode::SimEqSystem as E;
-    lst(&lsystem.residual).filter(|e| matches!(&***e, E::SES_RESIDUAL { .. })).count()
+/// A linear system's `A x = b` row count, `None` if it is not static.
+fn lin_n_res(lsystem: &SimCode::LinearSystem) -> Option<usize> {
+    residual_rows(&lin_residuals(lsystem, &mut Vec::new()))
 }
 
 /// Usable torn linear systems, deduped by index. `lin_jac_scratch_f64` (reserve)
@@ -9989,8 +10017,32 @@ fn build_lin_jac_infos(
     let mut cursor = layout.nls_jac_off + nls_jac_scratch_f64(sim_code) * 8;
     for sys in lin_jac_systems(sim_code) {
         let jm = sys.jacobianMatrix.as_ref().unwrap();
-        for sv in lst(&jm.seedVars).chain(jac_column_vars(jm).iter()) {
-            Arc::make_mut(&mut var_map.vars).insert(sim_cref_key(&sv.name)?, SimSlot { off: cursor, wty: WTy::F64, negate: Neg::None, heap: false });
+        let column_vars = jac_column_vars(jm);
+        // As in `register_jac_slots`: an array base listed beside its elements gets
+        // no slot, an access to it reaches the elements' through `array_acc`.
+        let mut bases: HashSet<String> = HashSet::new();
+        for sv in lst(&jm.seedVars).chain(column_vars.iter()) {
+            if let Some((base, _)) = array_element_of(&sv.name)? {
+                bases.insert(base);
+            }
+        }
+        for sv in lst(&jm.seedVars).chain(column_vars.iter()) {
+            let key = sim_cref_key(&sv.name)?;
+            if bases.contains(&key) {
+                continue;
+            }
+            let off = cursor;
+            Arc::make_mut(&mut var_map.vars).insert(key, SimSlot { off, wty: WTy::F64, negate: Neg::None, heap: false });
+            for g in array_element_keys(&sv.name)? {
+                var_map.array_acc.entry(g.base).or_default().push(AccElem {
+                    subs: g.subs,
+                    pieces: g.pieces,
+                    off,
+                    wty: WTy::F64,
+                    neg: Neg::None,
+                    heap: false,
+                });
+            }
             cursor += 8;
         }
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -7455,7 +7455,7 @@ pub(crate) use generic_calls::{
 mod sim_systems;
 pub(crate) use sim_systems::{
     LSS_MAX_DENSITY, LSS_MIN_SIZE, NLSS_MAX_DENSITY, NLSS_MIN_SIZE, NlsResidual, NlsResiduals,
-    backup_known_outputs, restore_known_outputs,
+    backup_known_outputs, residual_rows, restore_known_outputs,
     compile_linear_system, compile_linear_system_analytic, compile_linear_system_analytic_csc,
     compile_linear_system_symbolic, emit_linz_jac_body, emit_nls_jac_body, emit_nls_jac_csc_body,
     emit_ls_bracket, emit_nls_load_body, emit_nls_residual_body, emit_solve_nls_call, lin_jac_coloring,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -23,18 +23,51 @@ use super::*;
 fn emit_residual_eval(
     ctx: &mut FnCtx,
     base: u32,
-    res_exps: &[&Arc<DAE::Exp>],
+    residuals: &[NlsResidual],
     dest_off: u32,
     lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
 ) -> Result<()> {
+    use we::Instruction as I;
     lower_inner(ctx)?;
-    for (k, exp) in res_exps.iter().enumerate() {
-        ctx.emit(we::Instruction::LocalGet(base));
-        let w = compile_exp(ctx, exp)?;
-        coerce(ctx, w, WTy::F64);
-        ctx.emit(we::Instruction::F64Store(mem_arg(dest_off + (k as u32) * 8, 3)));
+    // As in `emit_nls_residual_body`: sequential rows while every residual is a
+    // scalar, `res_index` rows once an array-valued one makes the two differ.
+    let all_scalar = residuals.iter().all(|r| matches!(r, NlsResidual::Scalar { .. }));
+    for (i, res) in residuals.iter().enumerate() {
+        match res {
+            NlsResidual::Scalar { exp, res_index } => {
+                let row = if all_scalar { i as u32 } else { *res_index as u32 };
+                ctx.emit(I::LocalGet(base));
+                let w = compile_exp(ctx, exp)?;
+                coerce(ctx, w, WTy::F64);
+                ctx.emit(I::F64Store(mem_arg(dest_off + row * 8, 3)));
+            }
+            NlsResidual::Array { exp, res_index, rows } => {
+                let w = compile_exp(ctx, exp)?;
+                if w != WTy::I32 {
+                    return Err("CodegenWasmJit: array residual did not evaluate to an array");
+                }
+                let arr = ctx.alloc_temp(WTy::I32);
+                ctx.emit(I::LocalTee(arr));
+                ctx.emit(I::Call(rt_index("rt_array_data")?));
+                let data = ctx.alloc_temp(WTy::I32);
+                ctx.emit(I::LocalSet(data));
+                for k in 0..*rows as u32 {
+                    ctx.emit(I::LocalGet(base));
+                    ctx.emit(I::LocalGet(data));
+                    ctx.emit(I::F64Load(mem_arg(k * 8, 3)));
+                    ctx.emit(I::F64Store(mem_arg(dest_off + (*res_index as u32 + k) * 8, 3)));
+                }
+                release_temp_array(ctx, arr)?;
+            }
+            _ => return Err("CodegenWasmJit: SES_LINEAR for/generic residual"),
+        }
     }
     Ok(())
+}
+
+/// Rows of the residual vector, `None` if a for-residual makes it a run-time count.
+pub(crate) fn residual_rows(residuals: &[NlsResidual]) -> Option<usize> {
+    residuals.iter().map(|r| r.rows()).sum()
 }
 
 /// A nonlinear system residual: a scalar `SES_RESIDUAL`, a `SES_FOR_RESIDUAL`
@@ -685,7 +718,7 @@ pub(crate) fn emit_nls_jac_csc_body(
 pub(crate) fn compile_linear_system(
     ctx: &mut FnCtx,
     iter_vars: &[Arc<DAE::ComponentRef>],
-    res_exps: &[&Arc<DAE::Exp>],
+    residuals: &[NlsResidual],
     lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
     use_sparse: bool,
     method1: bool,
@@ -695,7 +728,7 @@ pub(crate) fn compile_linear_system(
     if n == 0 {
         return Ok(());
     }
-    if res_exps.len() != n {
+    if residual_rows(residuals) != Some(n) {
         return Err("CodegenWasmJit: linear system unknown/residual count mismatch");
     }
     // Resolve each unknown to its (real) SimData slot offset.
@@ -757,7 +790,7 @@ pub(crate) fn compile_linear_system(
     // --- b = -r(x0): residual at the probe point into res0, then negate into b. ---
     emit_aux_x(ctx, base, aux_off, &slots)?;
     emit_init_x0(ctx, base, x0_off, &slots, method1)?;
-    emit_residual_eval(ctx, base, res_exps, res0_off, lower_inner)?;
+    emit_residual_eval(ctx, base, residuals, res0_off, lower_inner)?;
     for i in 0..n {
         let i = i as u32;
         ctx.emit(we::Instruction::LocalGet(base));
@@ -783,7 +816,7 @@ pub(crate) fn compile_linear_system(
     ctx.emit(we::Instruction::F64Const(1.0f64.into()));
     ctx.emit(we::Instruction::F64Add);
     ctx.emit(we::Instruction::F64Store(mem_arg(0, 3)));
-    emit_residual_eval(ctx, base, res_exps, rescol_off, lower_inner)?;
+    emit_residual_eval(ctx, base, residuals, rescol_off, lower_inner)?;
     // A[col*n + i] = rescol[i] - res0[i], the column address computed from `col`.
     for i in 0..n {
         let i_u = i as u32;
@@ -816,8 +849,8 @@ pub(crate) fn compile_linear_system(
 
     // --- solve, scatter, recover the torn variables, free the scratch. `res0` is
     // spent by now, so the step check reuses it. ---
-    let m1 = method1.then_some(Method1 { res_off: res0_off, res_exps });
-    emit_lin_solve_scatter(ctx, base, b_off, aux_off, n, &slots, use_sparse, m1, index, lower_inner)
+    let m1 = method1.then_some(Method1 { res_off: res0_off, residuals });
+    emit_lin_solve_scatter(ctx, base, b_off, aux_off, n, &slots, use_sparse, m1, index, lower_inner, None)
 }
 
 /// The `(index, time)` a solver's warnings need.
@@ -950,18 +983,18 @@ fn emit_scatter_recover_free(
     Ok(())
 }
 
-/// A method-1 system's step check: `res_exps` re-evaluated at the step, into the
+/// A method-1 system's step check: `residuals` re-evaluated at the step, into the
 /// scratch at `res_off`.
 struct Method1<'a> {
     res_off: u32,
-    res_exps: &'a [&'a Arc<DAE::Exp>],
+    residuals: &'a [NlsResidual],
 }
 
 /// Take the step `dx` at `base+b_off`, recover the torn variables there, and hold
 /// it to C's method-1 residual test (`rt_ls_check_step`). A rejected step is redone
-/// with total pivoting on the same `A` — `solve_linear_system`'s `LS_DEFAULT`
-/// fallback, which C reaches by re-assembling from the stepped unknowns. The retry
-/// is a second pass of this same body, so it recomputes what C recomputes.
+/// with total pivoting — `solve_linear_system`'s `LS_DEFAULT` fallback, whose
+/// `solveTotalPivot` re-assembles `A` and `b` at the stepped unknowns, which is what
+/// `reassemble` emits. The retry is a second pass of this same body.
 #[allow(clippy::too_many_arguments)]
 fn emit_lin_step(
     ctx: &mut FnCtx,
@@ -973,6 +1006,7 @@ fn emit_lin_step(
     index: i32,
     m1: &Method1,
     lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+    reassemble: Option<&mut dyn FnMut(&mut FnCtx) -> Result<()>>,
 ) -> Result<()> {
     use we::Instruction as I;
     let data = ctx.sim()?.data_local;
@@ -995,7 +1029,7 @@ fn emit_lin_step(
         ctx.emit(I::F64Add);
         ctx.emit(I::F64Store(mem_arg(slots[j], 3)));
     }
-    emit_residual_eval(ctx, base, m1.res_exps, m1.res_off, lower_inner)?;
+    emit_residual_eval(ctx, base, m1.residuals, m1.res_off, lower_inner)?;
 
     if let Some(retry) = retry {
         ctx.emit(I::LocalGet(retry));
@@ -1025,6 +1059,9 @@ fn emit_lin_step(
             ctx.emit(I::I32Const(2));
             ctx.emit(I::I32Eq);
             emit_lin_unsolved(ctx, index, base)?;
+            if let Some(reassemble) = reassemble {
+                reassemble(ctx)?;
+            }
             ctx.emit(I::LocalGet(base)); // a_ptr, untouched by the solve
             ctx.emit(I::LocalGet(base));
             ctx.emit(I::I32Const(b_off as i32));
@@ -1062,6 +1099,7 @@ fn emit_lin_solve_scatter(
     m1: Option<Method1>,
     index: i32,
     lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+    reassemble: Option<&mut dyn FnMut(&mut FnCtx) -> Result<()>>,
 ) -> Result<()> {
     use we::Instruction as I;
     ctx.emit(I::LocalGet(base)); // a_ptr (a_off == 0)
@@ -1081,7 +1119,7 @@ fn emit_lin_solve_scatter(
     ctx.emit(I::Call(rt_index(solver)?));
     emit_lin_unsolved(ctx, index, base)?;
     match &m1 {
-        Some(m1) => emit_lin_step(ctx, base, b_off, n, slots, use_sparse, index, m1, lower_inner),
+        Some(m1) => emit_lin_step(ctx, base, b_off, n, slots, use_sparse, index, m1, lower_inner, reassemble),
         None => emit_scatter_recover_free(ctx, base, b_off, n, slots, lower_inner),
     }
 }
@@ -1096,7 +1134,7 @@ fn emit_lin_solve_scatter(
 pub(crate) fn compile_linear_system_analytic(
     ctx: &mut FnCtx,
     iter_vars: &[Arc<DAE::ComponentRef>],
-    res_exps: &[&Arc<DAE::Exp>],
+    residuals: &[NlsResidual],
     seed_offs: &[u32],
     result_offs: &[u32],
     lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
@@ -1110,7 +1148,7 @@ pub(crate) fn compile_linear_system_analytic(
     if n == 0 {
         return Ok(());
     }
-    if res_exps.len() != n || seed_offs.len() != n || result_offs.len() != n {
+    if residual_rows(residuals) != Some(n) || seed_offs.len() != n || result_offs.len() != n {
         return Err("CodegenWasmJit: analytic linear system size/Jacobian mismatch");
     }
     let mut slots: Vec<u32> = Vec::with_capacity(n);
@@ -1152,19 +1190,17 @@ pub(crate) fn compile_linear_system_analytic(
         ctx.emit(I::I32Store(mem_arg(res_tab_off + (i as u32) * 4, 2)));
     }
 
-    let store_slot = |ctx: &mut FnCtx, off: u32, val: f64| {
-        ctx.emit(I::LocalGet(data));
-        ctx.emit(I::F64Const(val.into()));
-        ctx.emit(I::F64Store(mem_arg(off, 3)));
-    };
-    // A is constant, so the probe point only matters for the residual the step is
-    // taken from.
-    emit_init_x0(ctx, base, xold_off, &slots, true)?;
     for &soff in seed_offs {
-        store_slot(ctx, soff, 0.0);
+        ctx.emit(I::LocalGet(data));
+        ctx.emit(I::F64Const(0.0f64.into()));
+        ctx.emit(I::F64Store(mem_arg(soff, 3)));
     }
-    // b = -r(xold): residual (inner + res_exps) into b, then negate in place.
-    emit_residual_eval(ctx, base, res_exps, b_off, lower_inner)?;
+    // C's `solveLapack` evaluates the Jacobian before it overwrites the unknowns
+    // with `aux_x`, so `A` is taken where the equations left them, not at `xold`.
+    emit_lin_jac(ctx, base, n, seed_tab_off, res_tab_off, lower_constant, lower_column)?;
+    emit_init_x0(ctx, base, xold_off, &slots, true)?;
+    // b = -r(xold): residual (inner + residuals) into b, then negate in place.
+    emit_residual_eval(ctx, base, residuals, b_off, lower_inner)?;
     for i in 0..n as u32 {
         ctx.emit(I::LocalGet(base));
         ctx.emit(I::LocalGet(base));
@@ -1173,7 +1209,30 @@ pub(crate) fn compile_linear_system_analytic(
         ctx.emit(I::F64Store(mem_arg(b_off + i * 8, 3)));
     }
 
-    // Constant Jacobian equations (evaluated once, with the torn vars set).
+    let m1 = Method1 { res_off, residuals };
+    let mut reassemble =
+        |c: &mut FnCtx| emit_lin_jac(c, base, n, seed_tab_off, res_tab_off, lower_constant, lower_column);
+    // A method-1 system probes at the previous solution, so `xold` is C's `aux_x`.
+    emit_lin_solve_scatter(
+        ctx, base, b_off, xold_off, n, &slots, use_sparse, Some(m1), index, lower_inner,
+        Some(&mut reassemble),
+    )
+}
+
+/// C's `evalJacobian` for a torn linear system: the constant equations, then one
+/// seeded pass per column, into the column-major `A` at `base+0`. The column body is
+/// emitted once, indexing the caller's seed/result tables.
+fn emit_lin_jac(
+    ctx: &mut FnCtx,
+    base: u32,
+    n: usize,
+    seed_tab_off: u32,
+    res_tab_off: u32,
+    lower_constant: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+    lower_column: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
+) -> Result<()> {
+    use we::Instruction as I;
+    let data = ctx.sim()?.data_local;
     lower_constant(ctx)?;
 
     // `data + tab[idx*4 + tab_off]` — address of the slot named by index table
@@ -1189,8 +1248,7 @@ pub(crate) fn compile_linear_system_analytic(
         ctx.emit(I::I32Add);
     };
 
-    // for j in 0..n: seed[j]=1, zero results, run column eqns, A[j*n+i]=result[i],
-    // reset seed[j]=0. Column body emitted once; the two inner loops keep code O(1).
+    // for j in 0..n: seed[j]=1, zero results, run column eqns, A[j*n+i]=result[i].
     let jloc = ctx.alloc_temp(WTy::I32);
     let iloc = ctx.alloc_temp(WTy::I32);
     ctx.emit(I::I32Const(0));
@@ -1266,10 +1324,7 @@ pub(crate) fn compile_linear_system_analytic(
     ctx.emit(I::Br(0));
     ctx.emit(I::End);
     ctx.emit(I::End);
-
-    let m1 = Method1 { res_off, res_exps };
-    // A method-1 system probes at the previous solution, so `xold` is C's `aux_x`.
-    emit_lin_solve_scatter(ctx, base, b_off, xold_off, n, &slots, use_sparse, Some(m1), index, lower_inner)
+    Ok(())
 }
 
 /// Greedy distance-1 column coloring (Curtis-Powell-Reid) of the CSC pattern:
@@ -1333,7 +1388,7 @@ pub(crate) fn compile_linear_system_analytic_csc(
     ctx: &mut FnCtx,
     handle: i32,
     iter_vars: &[Arc<DAE::ComponentRef>],
-    res_exps: &[&Arc<DAE::Exp>],
+    residuals: &[NlsResidual],
     seed_offs: &[u32],
     result_offs: &[u32],
     colptr: &[i32],
@@ -1347,7 +1402,7 @@ pub(crate) fn compile_linear_system_analytic_csc(
     if n == 0 {
         return Ok(());
     }
-    if res_exps.len() != n || seed_offs.len() != n || result_offs.len() != n
+    if residual_rows(residuals) != Some(n) || seed_offs.len() != n || result_offs.len() != n
         || colptr.len() != n + 1
     {
         return Err("CodegenWasmJit: analytic-CSC linear system size mismatch");
@@ -1415,19 +1470,11 @@ pub(crate) fn compile_linear_system_analytic_csc(
         ctx.emit(I::F64Const(val.into()));
         ctx.emit(I::F64Store(mem_arg(off, 3)));
     };
-    emit_init_x0(ctx, base, xold_off, &slots, true)?;
     for &soff in seed_offs {
         store_slot(ctx, soff, 0.0);
     }
-    // b = -r(xold).
-    emit_residual_eval(ctx, base, res_exps, b_off, lower_inner)?;
-    for i in 0..n as u32 {
-        ctx.emit(I::LocalGet(base));
-        ctx.emit(I::LocalGet(base));
-        ctx.emit(I::F64Load(mem_arg(b_off + i * 8, 3)));
-        ctx.emit(I::F64Neg);
-        ctx.emit(I::F64Store(mem_arg(b_off + i * 8, 3)));
-    }
+    // C's `solveKlu` evaluates the Jacobian before it overwrites the unknowns with
+    // `aux_x`, so `A` is taken where the equations left them, not at `xold`.
     lower_constant(ctx)?;
 
     // Address `data + seed_tab[idx]` for run-time index `idx`.
@@ -1583,6 +1630,17 @@ pub(crate) fn compile_linear_system_analytic_csc(
     ctx.emit(I::End); // color loop
     ctx.emit(I::End); // color block
 
+    emit_init_x0(ctx, base, xold_off, &slots, true)?;
+    // b = -r(xold).
+    emit_residual_eval(ctx, base, residuals, b_off, lower_inner)?;
+    for i in 0..n as u32 {
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::LocalGet(base));
+        ctx.emit(I::F64Load(mem_arg(b_off + i * 8, 3)));
+        ctx.emit(I::F64Neg);
+        ctx.emit(I::F64Store(mem_arg(b_off + i * 8, 3)));
+    }
+
     // rt_solve_lin_sparse_cached(handle, colptr, rowidx, values, b, x, n, nnz, time).
     ctx.emit(I::I32Const(handle));
     ctx.emit(I::LocalGet(base));
@@ -1603,8 +1661,8 @@ pub(crate) fn compile_linear_system_analytic_csc(
     emit_sim_time(ctx)?;
     ctx.emit(I::Call(rt_index("rt_solve_lin_sparse_cached")?));
     emit_lin_unsolved(ctx, handle, base)?;
-    let m1 = Method1 { res_off, res_exps };
-    emit_lin_step(ctx, base, b_off, n, &slots, true, handle, &m1, lower_inner)
+    let m1 = Method1 { res_off, residuals };
+    emit_lin_step(ctx, base, b_off, n, &slots, true, handle, &m1, lower_inner, None)
 }
 
 /// C's linear sparse-solver selection: density below `lssMaxDensity` (default

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -2630,6 +2630,13 @@ pub extern "C" fn rt_linsolve(a_ptr: u32, b_ptr: u32, x_ptr: u32, n: u32, eq_ind
     }
     let a = unsafe { core::slice::from_raw_parts(a_ptr as *const f64, n * n) };
     let b = unsafe { core::slice::from_raw_parts_mut(b_ptr as *mut f64, n) };
+    if omclog::active(omclog::LS_V) {
+        if x_ptr != 0 {
+            ls_print_vector("Vector old x", unsafe { core::slice::from_raw_parts(x_ptr as *const f64, n) });
+        }
+        ls_print_matrix("Matrix A", a, n);
+        ls_print_vector("Vector b", b);
+    }
     // `-ls=totalpivot` skips straight to the total-pivot search; LAPACK (C's
     // `dgesv`, and the default) is partial-pivot LU with that as its singular
     // fallback. `-ls=umfpack` only gets here having found the matrix singular.
@@ -2688,6 +2695,29 @@ fn lis_initial_guess(x_ptr: u32, n: usize) -> alloc::vec::Vec<f64> {
         0 => alloc::vec![0.0f64; n],
         p => unsafe { core::slice::from_raw_parts(p as *const f64, n) }.to_vec(),
     }
+}
+
+/// C's `_omc_printVector`.
+fn ls_print_vector(name: &str, v: &[f64]) {
+    omclog::info(omclog::LS_V, true, name);
+    for (i, x) in v.iter().enumerate() {
+        omclog::info(omclog::LS_V, false, &alloc::format!("[{:2}] {}", i + 1, omclog::g(*x, 20, 12)));
+    }
+    omclog::close(omclog::LS_V);
+}
+
+/// C's `_omc_printMatrix`, a column-major `n`×`n` printed by rows.
+fn ls_print_matrix(name: &str, a: &[f64], n: usize) {
+    omclog::info(omclog::LS_V, true, name);
+    for i in 0..n {
+        let mut row = alloc::string::String::new();
+        for j in 0..n {
+            row.push_str(&omclog::g(a[j * n + i], 10, 6));
+            row.push(' ');
+        }
+        omclog::info(omclog::LS_V, false, &row);
+    }
+    omclog::close(omclog::LS_V);
 }
 
 /// C's per-solver `Start solving Linear System …` line.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -2972,8 +2972,18 @@ fn save_pre_real(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Re
     e.write_bytes(sim_data + layout.pre_real_off, &buf)
 }
 
-/// C's `rotateRingBuffer` + `overwriteOldSimulationData`: the live reals become
-/// `localData[1]`. Only a method-1 linear system reads them (its `aux_x`).
+/// C's per-step `rotateRingBuffer` + `continueSimulationData`
+/// (`perform_simulation.c.inc`), which every driver's step opens with; `--daeMode`
+/// with states skips it, as C does.
+fn rotate_old_real(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+    if layout.dae_mode() && layout.n_states > 0 {
+        return Ok(());
+    }
+    save_old_real(e, sim_data, layout)
+}
+
+/// C's `overwriteOldSimulationData`: the live reals become `localData[1]`. Only a
+/// method-1 linear system reads them (its `aux_x`).
 fn save_old_real(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
     if !layout.has_old_real {
         return Ok(());
@@ -4550,6 +4560,7 @@ impl Driver for EulerDriver {
                 return Ok(Advance::Cancelled);
             }
             did_step = true;
+            rotate_old_real(e, sim_data, layout)?;
             // The last row lands exactly on `stop`: the terminal step.
             let time =
                 self.pending_time.take().unwrap_or(if self.row == n_steps { stop } else { grid(self.row) });
@@ -5824,6 +5835,7 @@ impl Driver for DasslDriver {
                     return Ok(Advance::Cancelled);
                 }
                 did_step = true;
+                rotate_old_real(e, sim_data, layout)?;
                 let time =
                     self.pending_tout.take().unwrap_or(if self.row == n_steps { stop } else { grid(self.row) });
                 self.retry.open(e, self.rows.len());
@@ -5911,6 +5923,7 @@ impl Driver for DasslDriver {
                 break Advance::Cancelled;
             }
             did_step = true;
+            rotate_old_real(e, sim_data, layout)?;
             self.retry.open(e, self.rows.len());
             // IDID=-1: DASKR hit its per-call work quota before TOUT — resume with
             // INFO(1)=1, up to a cap. INFO(3)=1 keeps a call to one step, so this is
@@ -7511,7 +7524,7 @@ impl SolverCore {
                 self.nfe = ctx.nfe;
                 return Ok(Step::Cancelled);
             }
-            save_old_real(e, sim_data, layout)?; // C's `rotateRingBuffer`
+            rotate_old_real(e, sim_data, layout)?;
             // Mode 0: hold relations across the DASKR solve so its residual/Jacobian
             // probes are smooth (C's `solveContinuous`); events/outputs refresh them.
             write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
@@ -8200,7 +8213,7 @@ impl Driver for EventsDriver {
                 let mut evaluated = false;
                 // Handle every event (state or sample) up to `tout`, earliest first.
                 loop {
-                    save_old_real(e, sim_data, layout)?; // C's `rotateRingBuffer`
+                    rotate_old_real(e, sim_data, layout)?;
                     let te = self.samp.next_time();
                     let tc = self.sync.next_time();
                     let mut subtarget = tout;
@@ -8705,6 +8718,7 @@ impl Driver for CvodeDriver {
                     return Ok(Advance::Cancelled);
                 }
                 did_step = true;
+                rotate_old_real(e, sim_data, layout)?;
                 let time =
                     self.pending_tout.take().unwrap_or(if self.row == n_steps { stop } else { grid(self.row) });
                 self.retry.open(e, self.rows.len());
@@ -8775,6 +8789,7 @@ impl Driver for CvodeDriver {
                 break Advance::Cancelled;
             }
             did_step = true;
+            rotate_old_real(e, sim_data, layout)?;
             self.retry.open(e, self.rows.len());
             let tout =
                 self.pending_tout.take().unwrap_or(if self.row == n_steps { stop } else { grid(self.row) });
@@ -9651,6 +9666,7 @@ impl Driver for IdaDriver {
                     return Ok(Advance::Cancelled);
                 }
                 did_step = true;
+                rotate_old_real(e, sim_data, layout)?;
                 let time =
                     self.pending_tout.take().unwrap_or(if self.row == n_steps { stop } else { grid(self.row) });
                 self.retry.open(e, self.rows.len());
@@ -9720,6 +9736,7 @@ impl Driver for IdaDriver {
                 break Advance::Cancelled;
             }
             did_step = true;
+            rotate_old_real(e, sim_data, layout)?;
             self.retry.open(e, self.rows.len());
             let tout = self
                 .pending_tout

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -4970,7 +4970,7 @@ template jacCrefs(ComponentRef cr, Context context, Integer ix, Text &sub)
          case v as SIMVAR(varKind=BackendDAE.SEED_VAR()) then
            if stringEq(sub, "") then 'jacobian->seedVars[<%v.index%>]<%crefCCommentWithVariability(v)%>'
            else '(&(jacobian->seedVars[<%v.index%>]))<%&sub%><%crefCCommentWithVariability(v)%>'
-         else crefOld(cr, ix)
+         else crefOldSub(cr, ix, &sub)
 end jacCrefs;
 
 template jacSparsityIndex(ComponentRef cr, Context context)
@@ -5018,6 +5018,12 @@ end cref;
   used in Compiler/Template/CodegenFMU.tpl"
 ::=
 let &sub = buffer ""
+  crefOldSub(cr, ix, &sub)
+end crefOld;
+
+template crefOldSub(ComponentRef cr, Integer ix, Text &sub)
+ "crefOld for a cref whose subscripts the caller already peeled off into &sub."
+::=
   match cr
   case CREF_IDENT(ident = "xloc") then crefStr(cr)
   case CREF_IDENT(ident = "time") then 'data->localData[<%ix%>]->timeValue'
@@ -5025,7 +5031,7 @@ let &sub = buffer ""
   case CREF_IDENT(ident = "__HOM_LAMBDA") then "data->simulationInfo->lambda"
   case WILD(__) then ''
   else crefToCStr(cr, ix, false, false, &sub)
-end crefOld;
+end crefOldSub;
 
 /* public */ template crefPre(ComponentRef cr)
  "Generates C equivalent name for component reference.

--- a/testsuite/.gitignore
+++ b/testsuite/.gitignore
@@ -8,6 +8,7 @@
 *.mos_temp*
 *.mos.result.xml
 *.mo.result.xml
+*.wasm
 /failed.*
 difftool/lex.yy.c
 difftool/lex.yy.wsl.c

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -67,6 +67,7 @@ simulationnewbackend-differentation.log \
 simulationnewbackend-event_handling.log \
 simulationnewbackend-functions.log \
 simulationnewbackend-index_reduction.log \
+simulationnewbackend-init_xml.log \
 simulationnewbackend-initialization.log \
 simulationnewbackend-ModelicaTest.log \
 simulationnewbackend-msl.log \
@@ -383,6 +384,9 @@ simulationnewbackend-functions.log: omc-diff
 	@echo $@ done
 simulationnewbackend-index_reduction.log: omc-diff
 	$(MAKE) -C simulation/modelica/NBackend/index_reduction/ -f Makefile test > $@
+	@echo $@ done
+simulationnewbackend-init_xml.log: omc-diff
+	$(MAKE) -C simulation/modelica/NBackend/init_xml/ -f Makefile test > $@
 	@echo $@ done
 simulationnewbackend-initialization.log: omc-diff
 	$(MAKE) -C simulation/modelica/NBackend/initialization/ -f Makefile test > $@

--- a/testsuite/partest/runtests.pl
+++ b/testsuite/partest/runtests.pl
@@ -96,7 +96,8 @@ my %suite_enabled = (
   metamodelica => 1,  # Needs MetaModelica code generation, i.e. the C runtime.
   '63bit'      => 1,  # Needs a 63/64-bit Modelica Integer.
   antlr        => 1,  # Expects ANTLR's syntax error positions and wording.
-  cSources     => 1,  # Inspects the generated C files, which only the C target writes.
+  cSources     => 1,  # Inspects the generated C files and the init XML beside them,
+                      # which only the C target writes.
   fmuCSources  => 1,  # Inspects sources/ inside an FMU, which only the C export has.
   stackoverflow => 1, # Recurses until the stack runs out; needs MMC's SEGV-handler
                       # recovery, which the Rust port has no equivalent of.

--- a/testsuite/simulation/modelica/NBackend/ScalableTestsuite/BreakerNetwork.mos
+++ b/testsuite/simulation/modelica/NBackend/ScalableTestsuite/BreakerNetwork.mos
@@ -14,14 +14,22 @@ diffSimulationResults("ScalableTestSuite.Electrical.BreakerCircuits.ScaledExperi
 // true
 // ""
 // record SimulationResult
-//     resultFile = "",
+//     resultFile = "ScalableTestSuite.Electrical.BreakerCircuits.ScaledExperiments.BreakerNetwork_N_10_M_10_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 2.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ScalableTestSuite.Electrical.BreakerCircuits.ScaledExperiments.BreakerNetwork_N_10_M_10', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "Simulation execution failed for model: ScalableTestSuite.Electrical.BreakerCircuits.ScaledExperiments.BreakerNetwork_N_10_M_10
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_ASSERT        | debug   | Solving non-linear system 95 failed at time=0.405464767457428.
-// |                 | |       | For more information please use -lv LOG_NLS.
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_STDOUT        | info    | Breaker 10 opens at time = 0.405465
+// LOG_STDOUT        | info    | Breaker 9 opens at time = 0.405465
+// LOG_STDOUT        | info    | Breaker 8 opens at time = 0.405465
+// LOG_STDOUT        | info    | Breaker 7 opens at time = 0.405465
+// LOG_STDOUT        | info    | Breaker 6 opens at time = 0.405465
+// LOG_STDOUT        | info    | Breaker 5 opens at time = 0.405465
+// LOG_STDOUT        | info    | Breaker 4 opens at time = 0.405465
+// LOG_STDOUT        | info    | Breaker 3 opens at time = 0.405465
+// LOG_STDOUT        | info    | Breaker 2 opens at time = 0.405465
+// LOG_STDOUT        | info    | Breaker 1 opens at time = 0.405465
+// LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
 // ""
-// (false, {"source.p.i", "source.n.v", "der(firstOrder.y)", "G[9].v", "G[9].p.i", "G[9].LossPower", "G[8].v", "G[8].p.i", "G[8].LossPower", "G[7].v", "G[7].p.i", "G[7].LossPower", "G[6].v", "G[6].p.i", "G[6].LossPower", "G[5].v", "G[5].p.i", "G[5].LossPower", "G[4].v", "G[4].p.i", "G[4].LossPower", "G[3].v", "G[3].p.i", "G[3].LossPower", "G[2].v", "G[2].p.i", "G[2].LossPower", "G[1].p.i", "G[1].LossPower", "G[11].v", "G[11].p.i", "G[11].LossPower", "G[10].v", "G[10].p.i", "G[10].LossPower", "B[9].v", "B[9].open", "B[9].G", "B[8].v", "B[8].open", "B[8].G", "B[7].v", "B[7].open", "B[7].G", "B[6].v", "B[6].open", "B[6].G", "B[5].v", "B[5].open", "B[5].G", "B[4].v", "B[4].open", "B[4].G", "B[3].v", "B[3].open", "B[3].G", "B[2].v", "B[2].open", "B[2].G", "B[1].v", "B[1].open", "B[1].G", "B[10].v", "B[10].open", "B[10].G"})
+// (true, {})
 // endResult

--- a/testsuite/simulation/modelica/NBackend/ScalableTestsuite/DistributionSystemModelicaIndividual.mos
+++ b/testsuite/simulation/modelica/NBackend/ScalableTestsuite/DistributionSystemModelicaIndividual.mos
@@ -12,11 +12,8 @@ res := OpenModelica.Scripting.compareSimulationResults("ScalableTestSuite.Electr
   "ScalableTestSuite.Electrical.DistributionSystemDC.ScaledExperiments.DistributionSystemModelicaIndividual_N_10_M_10_diff.csv",0.01,0.0001,
   {"secondary_2_2.LossPower"});
 
-// #16458: NB must select the sparse solver for this system's nonlinear block
-// (density well below the 0.1 nonlinear threshold), same as OB does -- not
-// silently fall back to dense LAPACK.
-system("grep -c 'matrixFormat = OMC_MATRIX_SPARSE' ScalableTestSuite.Electrical.DistributionSystemDC.ScaledExperiments.DistributionSystemModelicaIndividual_N_10_M_10_02nls.c > sparse_count.txt");
-readFile("sparse_count.txt");
+// The solver NB picks for this system's torn loop is checked in
+// DistributionSystemModelicaIndividualSparse.mos, which reads the generated C.
 
 // Result:
 // true
@@ -30,7 +27,4 @@ readFile("sparse_count.txt");
 // end SimulationResult;
 // ""
 // {"Files Equal!"}
-// 1
-// "0
-// "
 // endResult

--- a/testsuite/simulation/modelica/NBackend/ScalableTestsuite/DistributionSystemModelicaIndividualSparse.mos
+++ b/testsuite/simulation/modelica/NBackend/ScalableTestsuite/DistributionSystemModelicaIndividualSparse.mos
@@ -1,0 +1,25 @@
+// name: DistributionSystemModelicaIndividual_N_10_M_10 sparse solver selection
+// keywords: NewBackend
+// status: correct
+// cflags: --newBackend
+// suite: cSources
+
+// #16458: NB must select the sparse solver for this system's torn loop (density
+// well below the 0.2 linear threshold), same as OB does.
+
+loadModel(ScalableTestSuite); getErrorString();
+
+translateModel(ScalableTestSuite.Electrical.DistributionSystemDC.ScaledExperiments.DistributionSystemModelicaIndividual_N_10_M_10); getErrorString();
+
+system("grep -c 'matrixFormat = OMC_MATRIX_SPARSE' ScalableTestSuite.Electrical.DistributionSystemDC.ScaledExperiments.DistributionSystemModelicaIndividual_N_10_M_10_03lsy.c > sparse_count.txt");
+readFile("sparse_count.txt");
+
+// Result:
+// true
+// ""
+// true
+// ""
+// 0
+// "1
+// "
+// endResult

--- a/testsuite/simulation/modelica/NBackend/ScalableTestsuite/Makefile
+++ b/testsuite/simulation/modelica/NBackend/ScalableTestsuite/Makefile
@@ -5,6 +5,7 @@ ManyEvents.mos \
 ManyEventsManyConditions.mos \
 TransmissionLineModelica.mos \
 DistributionSystemModelicaIndividual.mos \
+DistributionSystemModelicaIndividualSparse.mos \
 Table.mos \
 TimeTable.mos \
 Verification_Table.mos \

--- a/testsuite/simulation/modelica/NBackend/init_xml/01_real_array_var.mos
+++ b/testsuite/simulation/modelica/NBackend/init_xml/01_real_array_var.mos
@@ -1,6 +1,7 @@
 // name: 01_real_array_var
 // keywords: NewBackend
 // status: correct
+// suite: cSources
 // teardown_command: rm -f *RealArrayVariable*
 //
 // Check if init XML has array variable for x with size=5

--- a/testsuite/simulation/modelica/NBackend/init_xml/02_int_param_array_var.mos
+++ b/testsuite/simulation/modelica/NBackend/init_xml/02_int_param_array_var.mos
@@ -1,6 +1,7 @@
 // name: 02_int_param_array_var
 // keywords: NewBackend
 // status: correct
+// suite: cSources
 // teardown_command: rm -f *ParameterArrayVariable*
 //
 // Check if init XML has array variable for integer parameter array

--- a/testsuite/simulation/modelica/NBackend/init_xml/03_real_state_array_var.mos
+++ b/testsuite/simulation/modelica/NBackend/init_xml/03_real_state_array_var.mos
@@ -1,6 +1,7 @@
 // name: 03_real_state_array_var
 // keywords: NewBackend
 // status: correct
+// suite: cSources
 // teardown_command: rm -f *StateArrayVariable*
 //
 // Check if init XML has array variable for real state array x with size=p.

--- a/testsuite/simulation/modelica/NBackend/init_xml/04_real_matrix_var.mos
+++ b/testsuite/simulation/modelica/NBackend/init_xml/04_real_matrix_var.mos
@@ -1,6 +1,7 @@
 // name: 04_real_matrix_var
 // keywords: NewBackend
 // status: correct
+// suite: cSources
 // teardown_command: rm -f *MatrixArrayVariable*
 //
 // Check if init XML has array variable for real matrix A of size (3,2)

--- a/testsuite/simulation/modelica/NBackend/init_xml/05_int_multi_dim_array_var.mos
+++ b/testsuite/simulation/modelica/NBackend/init_xml/05_int_multi_dim_array_var.mos
@@ -1,6 +1,7 @@
 // name: 05_int_multi_dim_array_var
 // keywords: NewBackend
 // status: correct
+// suite: cSources
 // teardown_command: rm -f *MultiDimArrayVar*
 //
 // Check if init XML has array variable for integer array variable A of size

--- a/testsuite/simulation/modelica/NBackend/init_xml/06_array_alias_var.mos
+++ b/testsuite/simulation/modelica/NBackend/init_xml/06_array_alias_var.mos
@@ -2,6 +2,7 @@
 // keywords: NewBackend
 // status: correct
 // teardown_command: rm -f *ArrayAliasVar*
+// suite: cSources
 // suite: disabled
 //
 // Check if init XML generates correct alias variable ID for alias variable

--- a/testsuite/simulation/modelica/NBackend/init_xml/07_array_attributes.mos
+++ b/testsuite/simulation/modelica/NBackend/init_xml/07_array_attributes.mos
@@ -1,6 +1,7 @@
 // name: 07_array_attributes
 // keywords: NewBackend
 // status: correct
+// suite: cSources
 // teardown_command: rm -f *ArrayAttributes_*
 //
 // Check if init XML generates correct attributes for array variables

--- a/testsuite/simulation/modelica/NBackend/initialization/TestInversePlant.mos
+++ b/testsuite/simulation/modelica/NBackend/initialization/TestInversePlant.mos
@@ -104,7 +104,19 @@ package TestInversePlant
 end TestInversePlant;"); getErrorString();
 
 setCommandLineOptions("--allowNonStandardModelica=initialSimplified -d=dumpSimCode"); getErrorString();
-simulate(TestInversePlant.BackwardOffDesignHomotopy); getErrorString();
+// NB gives these homotopy systems an analytic Jacobian with more columns than the
+// system has iteration variables; each runtime then picks its own numeric solver,
+// so whether the initialization converges depends on the target. Only the
+// Jacobian-generation warnings are the same everywhere.
+echo(false);
+res := simulate(TestInversePlant.BackwardOffDesignHomotopy);
+msg := res.messages;
+echo(true);
+getErrorString();
+regexBool(msg, "Analytic Jacobian of non-linear system 0 is 25x33");
+regexBool(msg, "Analytic Jacobian of non-linear system 1 is 15x17");
+regexBool(msg, "Analytic Jacobian of non-linear system 2 is 28x35");
+regexBool(msg, "Sparsity pattern for non-linear system 2 is not regular");
 
 // Result:
 // true
@@ -974,20 +986,10 @@ simulate(TestInversePlant.BackwardOffDesignHomotopy); getErrorString();
 // 	outVars: isInitialLambda0 (Boolean, )  , 
 // 	functionArguments: 
 // 	variableDeclarations: isInitialLambda0 (Boolean, )  , 
-// record SimulationResult
-//     resultFile = "",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'TestInversePlant.BackwardOffDesignHomotopy', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "Simulation execution failed for model: TestInversePlant.BackwardOffDesignHomotopy
-// LOG_STDOUT        | warning | Analytic Jacobian of non-linear system 0 is 25x33, but the system has 25 iteration variables. This indicates that something went wrong during Jacobian generation. Using a numeric Jacobian instead.
-// LOG_STDOUT        | warning | Analytic Jacobian of non-linear system 1 is 15x17, but the system has 15 iteration variables. This indicates that something went wrong during Jacobian generation. Using a numeric Jacobian instead.
-// LOG_STDOUT        | warning | Analytic Jacobian of non-linear system 2 is 28x35, but the system has 28 iteration variables. This indicates that something went wrong during Jacobian generation. Using a numeric Jacobian instead.
-// LOG_STDOUT        | warning | Sparsity pattern for non-linear system 2 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
-// LOG_ASSERT        | debug   | Solving non-linear system 43 failed at time=0.
-// |                 | |       | For more information please use -lv LOG_NLS.
-// LOG_ASSERT        | error   | Failed to solve the initialization problem with global homotopy with equidistant step size.
-// LOG_ASSERT        | debug   | Unable to solve initialization problem.
-// LOG_ASSERT        | info    | simulation terminated by an assertion at initialization
-// "
-// end SimulationResult;
+// true
 // ""
+// true
+// true
+// true
+// true
 // endResult


### PR DESCRIPTION
NBackend started emitting genuine `SES_LINEAR` blocks in #16463, which put the wasm-jit runtime's method-1 (analytic-Jacobian) linear path under load for the first time and turned up three divergences from the C runtime.

| C runtime | wasm-jit before |
| --- | --- |
| `solveLapack`/`solveKlu` evaluate the Jacobian, then overwrite the unknowns with `aux_x` for the residual | assembled `A` at `aux_x`, after the overwrite | | `solveTotalPivot` re-assembles `A` and `b` at the rejected step | reused the `A` of the step that was rejected | | `rotateRingBuffer` + `continueSimulationData` open every step | only `EventsDriver` rotated; `aux_x` was frozen at its post-initialization value everywhere else |

A "linear" torn loop is only linear in its iteration variables, so `A` does depend on where it is taken: a loop NBackend flags linear can still have a nonlinear residual, and then the solve is one Newton step whose Jacobian point matters. `solveSingleEquation` drifted to y(1) = 0.215 against C's 0.607 for exactly that reason; it now matches C to the last digit.

Also:

- Linear-system residuals go through `NlsResidual`, so an array-valued `SES_RESIDUAL` addresses `res[res_index]` rather than `res[i]` - the same distinction #16463 fixed in `CodegenC.tpl`. `SlidingMass3D` has a scalar residual followed by two 3-element ones and used to be rejected outright.
- `build_lin_jac_infos` registers array-access entries for an array Jacobian variable and skips the base, as `register_jac_slots` does, so a column equation naming the whole array resolves.
- `rt_linsolve` prints `Vector old x` / `Matrix A` / `Vector b` under `-lv LOG_LS_V`, C's `_omc_printVector` / `_omc_printMatrix`.

Fixes the wasm-jit stage for `solveSingleEquation`, `simpleNonlinearLoop`, `static_IR`, `ComplexTest` and `SlidingMass3D`.

## [C] A Jacobian for-loop dropped its array subscript

`jacCrefs` handed a cref that is not a seed/result/tmp variable to `crefOld`, which opens its own empty `&sub` buffer, so the subscripts the caller had already peeled off were thrown away. A for-loop Jacobian equation over an array model variable then read element 1 for every iteration:

```c
/* $pDER.$RES_SIM_19[$i1] = B[$i1].G * $SEED.B[$i1].v - ... */
(&jacobian->resultVars[84])[i1 - 1] =
  (realVars[realVarsIndex[166]] /* B[1].G */) * ...
```

`BreakerNetwork` is where that bites: the ten breakers open one event iteration apart, so between them `B[1].G` is the closed conductance (1e6) while `B[10].G` is the open one (1e-6), and kinsol was handed a Jacobian entry twelve orders of magnitude off. It ground to the iteration limit and returned `NLS_SOLVED_LESS_ACCURACY`, which the generated code reports as a failed solve. With the subscript kept, the model simulates to the end and `diffSimulationResults` matches the reference file, so its recorded C failure is rebaselined away.

## Testsuite

- `TestInversePlant` recorded C's initialization failure. NB gives its homotopy systems an analytic Jacobian with more columns than the system has iteration variables, so each runtime falls back on a numeric one and picks its own solver; the test now asserts the Jacobian-generation warnings, which are the same on every target.
- The `OMC_MATRIX_SPARSE` count of #16458 moves out of `DistributionSystemModelicaIndividual` into its own test tagged `suite: cSources`, so it runs only where C sources exist. It also counts in `_03lsy.c`: #16463 made the block a linear system, and the `_02nls.c` it used to read has held no systems since.
- The `init_xml` tests are tagged `cSources` for the same reason, and the top-level makefile grew the rule that makes partest find them at all. They have never run.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
