### PR TITLE
Add cvode and ida to the FMI web ME solvers

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -1441,6 +1441,10 @@ function(omc_rust_fmi_driver_module)
     VERBATIM)
   # rust_wasm recreates ${_web_dir}, so the copy has to follow it.
   add_dependencies(rust_fmi_driver rust_wasm)
+  # `openmodelica_fmi_web/build.rs` links the wasm SUNDIALS itself, for cvode/ida.
+  if(TARGET rust_sundials_collect)
+    add_dependencies(rust_fmi_driver rust_sundials_collect)
+  endif()
 endfunction()
 
 # Assemble the Qt OMShell web page. Unlike the egui/dioxus pages (Rust crates the

--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -267,6 +267,7 @@ openmodelica_fmi3_wasm/wit/fmi3-scheduled-execution.wit
 openmodelica_fmi3_wasm/wit/fmi3-types.wit
 openmodelica_fmi3_wasm/wit/world.wit
 openmodelica_fmi_driver/Cargo.toml
+openmodelica_fmi_driver/build.rs
 openmodelica_fmi_driver/examples/fmuprobe.rs
 openmodelica_fmi_driver/examples/fmusim.rs
 openmodelica_fmi_driver/src/api.rs
@@ -289,6 +290,7 @@ openmodelica_fmi_ls_wasm_to_native/src/fmi2.rs
 openmodelica_fmi_ls_wasm_to_native/src/lib.rs
 openmodelica_fmi_web/Cargo.lock
 openmodelica_fmi_web/Cargo.toml
+openmodelica_fmi_web/build.rs
 openmodelica_fmi_web/src/lib.rs
 openmodelica_frontend/Cargo.toml
 openmodelica_frontend/src/Globals.rs
@@ -427,6 +429,7 @@ openmodelica_solvers/src/lib.rs
 openmodelica_solvers/src/omclog.rs
 openmodelica_solvers/src/simflags.rs
 openmodelica_solvers/src/sundials.rs
+openmodelica_solvers/src/sundials_ode.rs
 openmodelica_solvers/src/symsolver.rs
 openmodelica_susan/Cargo.toml
 openmodelica_susan/src/main.rs

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/build.rs
@@ -1,0 +1,21 @@
+//! Decides whether the Model Exchange master gets CVODE and IDA
+//! (`cfg(sundials)`), which is what `Solver::all` offers them on.
+//!
+//! The same two variables `openmodelica_solvers` reads, both prepared by
+//! `.cmake/rust_omc.cmake`. That crate owns the bindings and links the archives;
+//! here they only select the cfg, so the two stay in step.
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(sundials)");
+    println!("cargo:rerun-if-env-changed=OMC_SUNDIALS_WASM_DIR");
+    println!("cargo:rerun-if-env-changed=OMC_SUNDIALS_NATIVE_DIR");
+    let os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let have = match std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() {
+        // wasm32-unknown-unknown has no libc for SUNDIALS to call.
+        Ok("wasm32") => os == "wasi" && std::env::var_os("OMC_SUNDIALS_WASM_DIR").is_some(),
+        _ => std::env::var_os("OMC_SUNDIALS_NATIVE_DIR").is_some(),
+    };
+    if have {
+        println!("cargo:rustc-cfg=sundials");
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/examples/fmusim.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/examples/fmusim.rs
@@ -2,7 +2,7 @@
 //! the masters, natively.
 //!
 //! Options: `--me`/`--cs`, `--start`, `--stop`, `--step`, `--tolerance`,
-//! `--solver dassl|gbode|euler|rungekutta`, `--input vr=expr`, `--parameter vr=value`,
+//! `--solver <name>` (`Solver::all`), `--input vr=expr`, `--parameter vr=value`,
 //! `--output file.mat`, `--csv` (the trajectory on stdout), `--log`,
 //! `--difference-jacobian` (ignore what the FMU offers).
 
@@ -66,8 +66,10 @@ fn parse_args() -> Result<Args, String> {
             "--output" => a.output = Some(PathBuf::from(value()?)),
             "--solver" => {
                 let name = value()?;
-                a.solver = Solver::parse(&name)
-                    .ok_or_else(|| format!("unknown solver `{name}`"))?;
+                a.solver = Solver::parse(&name).ok_or_else(|| {
+                    let have: Vec<&str> = Solver::all().iter().map(|s| s.as_str()).collect();
+                    format!("unknown solver `{name}`; this build has {}", have.join(", "))
+                })?;
             }
             "--input" | "--parameter" => {
                 let v = value()?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/lib.rs
@@ -100,6 +100,10 @@ pub enum Solver {
     /// model wants.
     #[default]
     Dassl,
+    /// SUNDIALS CVODE, in the BDF/Newton configuration `cvode_solver.c` builds.
+    Cvode,
+    /// SUNDIALS IDA, given the ODE as the residual `y' - f(t, y)`.
+    Ida,
     /// The generic Runge-Kutta solver, under the `-gb*` flags.
     Gbode,
     Euler,
@@ -107,24 +111,45 @@ pub enum Solver {
 }
 
 impl Solver {
+    /// Every solver this build can run, in the order to offer them: CVODE and
+    /// IDA only where SUNDIALS was linked in.
+    pub fn all() -> &'static [Solver] {
+        const SUNDIALS: &[Solver] = &[
+            Solver::Dassl, Solver::Cvode, Solver::Ida, Solver::Gbode, Solver::Euler,
+            Solver::RungeKutta,
+        ];
+        const PLAIN: &[Solver] =
+            &[Solver::Dassl, Solver::Gbode, Solver::Euler, Solver::RungeKutta];
+        if cfg!(sundials) { SUNDIALS } else { PLAIN }
+    }
+
     pub fn as_str(self) -> &'static str {
         match self {
             Solver::Dassl => "dassl",
+            Solver::Cvode => "cvode",
+            Solver::Ida => "ida",
             Solver::Gbode => "gbode",
             Solver::Euler => "euler",
             Solver::RungeKutta => "rungekutta",
         }
     }
 
-    /// The name as a `-s=` flag or the page's selector spells it.
+    /// What a chooser puts next to the name.
+    pub fn description(self) -> &'static str {
+        match self {
+            Solver::Dassl => "BDF with root finding, the default for a model too",
+            Solver::Cvode => "SUNDIALS BDF, Newton over a dense Jacobian",
+            Solver::Ida => "SUNDIALS BDF over the residual y' - f(t, y)",
+            Solver::Gbode => "Runge-Kutta, under the -gb* flags",
+            Solver::Euler => "fixed step",
+            Solver::RungeKutta => "fixed step, RK4",
+        }
+    }
+
+    /// The name as a `-s=` flag or the page's selector spells it, out of
+    /// [`all`](Solver::all).
     pub fn parse(name: &str) -> Option<Solver> {
-        Some(match name {
-            "dassl" => Solver::Dassl,
-            "gbode" => Solver::Gbode,
-            "euler" => Solver::Euler,
-            "rungekutta" => Solver::RungeKutta,
-            _ => return None,
-        })
+        Solver::all().iter().copied().find(|s| s.as_str() == name)
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/me.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/me.rs
@@ -18,6 +18,8 @@ use openmodelica_solvers::dassl::{Dassl, DasslStep};
 use openmodelica_solvers::events::StepEnd;
 use openmodelica_solvers::fixedstep::{FixedKind, FixedStep};
 use openmodelica_solvers::gbode::{GbStep, Gbode};
+#[cfg(sundials)]
+use openmodelica_solvers::sundials_ode::{CvodeOde, IdaOde, SunStep};
 use openmodelica_solvers::Ode;
 
 pub struct Run {
@@ -220,13 +222,17 @@ pub fn jacobian_sparsity(md: &ModelDescription, states: &[u32]) -> (Vec<Vec<u32>
     (colors, rows_by_col)
 }
 
-/// The solvers a Model Exchange run can use. `gbode` brings its own step-size
-/// control and root search; the fixed-step ones step the output grid and bisect
-/// afterwards.
+/// The solvers a Model Exchange run can use. `gbode`, CVODE and IDA bring their
+/// own step-size control and root search; the fixed-step ones step the output
+/// grid and bisect afterwards.
 enum Integrator {
     Dassl(Box<Dassl>),
     Gbode(Box<Gbode>),
     Fixed(FixedStep),
+    #[cfg(sundials)]
+    Cvode(Box<CvodeOde>),
+    #[cfg(sundials)]
+    Ida(Box<IdaOde>),
 }
 
 impl Integrator {
@@ -254,6 +260,20 @@ impl Integrator {
             Solver::RungeKutta => {
                 Integrator::Fixed(FixedStep::new(FixedKind::RungeKutta, nx, nz))
             }
+            #[cfg(sundials)]
+            Solver::Cvode => {
+                Integrator::Cvode(Box::new(CvodeOde::new(nx, nz, tolerance, nominals)))
+            }
+            #[cfg(sundials)]
+            Solver::Ida => Integrator::Ida(Box::new(IdaOde::new(nx, nz, tolerance, nominals))),
+            // Unreachable through `Solver::all`, which does not offer them here.
+            #[cfg(not(sundials))]
+            Solver::Cvode | Solver::Ida => {
+                return Err(Error::Unsupported(format!(
+                    "`{}`: this build has no SUNDIALS",
+                    solver.as_str()
+                )));
+            }
         })
     }
 
@@ -266,8 +286,13 @@ impl Integrator {
     /// DASKR carries its own history, which an event invalidates.
 
     fn set_nominals(&mut self, nominals: &[f64]) {
-        if let Integrator::Gbode(gb) = self {
-            gb.set_nominals(nominals);
+        match self {
+            Integrator::Gbode(gb) => gb.set_nominals(nominals),
+            #[cfg(sundials)]
+            Integrator::Cvode(cv) => cv.set_nominals(nominals),
+            #[cfg(sundials)]
+            Integrator::Ida(ida) => ida.set_nominals(nominals),
+            _ => {}
         }
     }
 
@@ -295,6 +320,16 @@ impl Integrator {
                 StepEnd::Root(te) => Ok(Some(te)),
                 StepEnd::Reached => Ok(None),
             },
+            #[cfg(sundials)]
+            Integrator::Cvode(cv) => match cv.step(ode, target.min(limit), t, y)? {
+                SunStep::Root(te) => Ok(Some(te)),
+                SunStep::Reached => Ok(None),
+            },
+            #[cfg(sundials)]
+            Integrator::Ida(ida) => match ida.step(ode, target.min(limit), t, y)? {
+                SunStep::Root(te) => Ok(Some(te)),
+                SunStep::Reached => Ok(None),
+            },
         }
     }
 
@@ -304,6 +339,10 @@ impl Integrator {
             Integrator::Dassl(d) => d.restart(),
             Integrator::Gbode(gb) => gb.restart(),
             Integrator::Fixed(_) => {}
+            #[cfg(sundials)]
+            Integrator::Cvode(cv) => cv.restart(),
+            #[cfg(sundials)]
+            Integrator::Ida(ida) => ida.restart(),
         }
     }
 
@@ -313,6 +352,10 @@ impl Integrator {
             Integrator::Dassl(d) => d.jacobians,
             Integrator::Gbode(gb) => gb.stats().calls_jacobian,
             Integrator::Fixed(_) => 0,
+            #[cfg(sundials)]
+            Integrator::Cvode(cv) => cv.counters().jac_evals,
+            #[cfg(sundials)]
+            Integrator::Ida(ida) => ida.counters().jac_evals,
         }
     }
 
@@ -321,6 +364,10 @@ impl Integrator {
             Integrator::Dassl(d) => d.steps,
             Integrator::Gbode(gb) => gb.stats().steps,
             Integrator::Fixed(fs) => fs.steps,
+            #[cfg(sundials)]
+            Integrator::Cvode(cv) => cv.counters().steps,
+            #[cfg(sundials)]
+            Integrator::Ida(ida) => ida.counters().steps,
         }
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_web/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_web/build.rs
@@ -1,0 +1,54 @@
+//! Links the wasm SUNDIALS/KLU archives into this module, which is what gives
+//! the Model Exchange master `-s=cvode` and `-s=ida` in the browser.
+//!
+//! `openmodelica_solvers` owns the bindings but links nothing on wasm: the
+//! archives belong to whoever produces the final module, and for this page that
+//! is here. Without `OMC_SUNDIALS_WASM_DIR` the page is offered the solvers that
+//! need no SUNDIALS.
+
+use std::path::Path;
+
+/// Archives in link order: each entry may only depend on later ones. SUNDIALS
+/// ships one archive per module, so each has to be listed; the KLU set comes
+/// along because the bindings name `SUNLinSol_KLU`.
+const LIBS: &[&str] = &[
+    // IDAS, not IDA: same entry points plus the forward-sensitivity ones, as the
+    // C runtime links it.
+    "sundials_idas",
+    "sundials_cvode",
+    "sundials_sunlinsolklu",
+    "sundials_sunlinsoldense",
+    "sundials_sunmatrixsparse",
+    "sundials_sunmatrixdense",
+    "sundials_nvecserial",
+    "sundials_core",
+    "klu",
+    "amd",
+    "colamd",
+    "btf",
+    "suitesparseconfig",
+];
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=OMC_SUNDIALS_WASM_DIR");
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("wasi") {
+        return;
+    }
+    let Some(dir) = std::env::var_os("OMC_SUNDIALS_WASM_DIR") else { return };
+    let lib = Path::new(&dir).join("lib");
+    let missing: Vec<_> = LIBS.iter().filter(|l| !lib.join(format!("lib{l}.a")).exists()).collect();
+    if !missing.is_empty() {
+        panic!(
+            "OMC_SUNDIALS_WASM_DIR={} is missing {missing:?}; the sundials wasm \
+             cross-compile failed (check the rust_sundials_wasm CMake target)",
+            lib.display()
+        );
+    }
+    println!("cargo:rustc-link-search=native={}", lib.display());
+    for l in LIBS {
+        println!("cargo:rustc-link-lib=static={l}");
+        // Cargo tracks this crate's sources, not what `wasm-ld` takes from the
+        // archives; without this a rebuilt archive is silently not linked.
+        println!("cargo:rerun-if-changed={}", lib.join(format!("lib{l}.a")).display());
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_web/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_web/src/lib.rs
@@ -178,7 +178,8 @@ pub extern "C" fn om_fmi_info() -> i32 {
 
 /// Simulate, with the options the page passes as JSON:
 /// `{"interface":"me"|"cs", "startTime":…, "stopTime":…, "stepSize":…,
-///   "tolerance":…, "solver":"gbode"|"euler"|"rungekutta", "eventMode":bool,
+///   "tolerance":…, "solver": one of the `solvers` [`om_fmi_info`] lists,
+///   "eventMode":bool,
 ///   "loggingOn":bool, "parameters":[{"vr":…,"value":…}],
 ///   "inputs":[{"vr":…,"expr":"sin(t)"}], "resultFile":"…"}`.
 #[unsafe(no_mangle)]
@@ -347,6 +348,10 @@ fn describe(fmu: &Fmu) -> Value {
         "numberOfContinuousStates": md.number_of_continuous_states(),
         "numberOfEventIndicators": md.number_of_event_indicators,
         "variables": variables,
+        // Not the FMU's: what a run of it can be given, for the page's chooser.
+        "solvers": Solver::all().iter()
+            .map(|s| json!({"name": s.as_str(), "description": s.description()}))
+            .collect::<Vec<_>>(),
         "toolAnnotations": md.tool_annotations.iter()
             .map(|a| json!({"name": a.name, "xml": a.xml}))
             .collect::<Vec<_>>(),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/lib.rs
@@ -28,6 +28,8 @@ pub mod simflags;
 pub mod symsolver;
 #[cfg(sundials)]
 pub mod sundials;
+#[cfg(sundials)]
+pub mod sundials_ode;
 
 /// Whether this build has the real CVODE and IDA linked in (`build.rs`).
 pub const CVODE: bool = cfg!(sundials);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/sundials_ode.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/sundials_ode.rs
@@ -1,0 +1,397 @@
+//! `-s=cvode` and `-s=ida` for anything that can be an [`Ode`], the way
+//! [`crate::dassl`] drives DASKR: IDA gets the ODE as the residual
+//! `y' - f(t, y)`, and the zero-crossings are both integrators' own root
+//! functions, so an event is located by SUNDIALS rather than bisected after it.
+//!
+//! Neither can be built before the first step, which is where the initial point
+//! is known; the model is reached from the callbacks through a `user_data`
+//! context parked on the stack for the length of one.
+
+use alloc::vec;
+use alloc::vec::Vec;
+use core::ffi::{c_int, c_void};
+
+use crate::sundials::{
+    self, Counters, Cvode, Ida, IdaLs, IdaOptions, NVector, Stop, nv_data,
+};
+use crate::{Ode, Result};
+
+/// How far one step got.
+pub enum SunStep {
+    /// `target` reached.
+    Reached,
+    /// A root was located at this time; the states are the ones there.
+    Root(f64),
+}
+
+/// Resumes allowed after the work quota runs out, which only allows more work
+/// on the same trajectory.
+const WORK_RETRIES: u32 = 10_000;
+
+struct Ctx<'a> {
+    ode: &'a mut dyn Ode,
+    n: usize,
+    n_zc: usize,
+    /// `f(t, y)`, which IDA's residual subtracts from `y'`.
+    f: &'a mut [f64],
+    failed: Option<&'static str>,
+}
+
+unsafe extern "C" fn rhs(t: f64, y: NVector, ydot: NVector, user: *mut c_void) -> c_int {
+    let c = unsafe { &mut *(user as *mut Ctx) };
+    let n = c.n;
+    let (y, f) = unsafe {
+        (core::slice::from_raw_parts(nv_data(y), n), core::slice::from_raw_parts_mut(nv_data(ydot), n))
+    };
+    let r = c.ode.eval(t, y, f);
+    fail(c, r)
+}
+
+unsafe extern "C" fn roots(t: f64, y: NVector, gout: *mut f64, user: *mut c_void) -> c_int {
+    let c = unsafe { &mut *(user as *mut Ctx) };
+    let (n, n_zc) = (c.n, c.n_zc);
+    let (y, g) = unsafe {
+        (core::slice::from_raw_parts(nv_data(y), n), core::slice::from_raw_parts_mut(gout, n_zc))
+    };
+    let r = c.ode.eval_zc(t, y, g);
+    fail(c, r)
+}
+
+unsafe extern "C" fn ida_res(
+    t: f64,
+    yy: NVector,
+    yp: NVector,
+    rr: NVector,
+    user: *mut c_void,
+) -> c_int {
+    let c = unsafe { &mut *(user as *mut Ctx) };
+    let n = c.n;
+    let (y, yp, r) = unsafe {
+        (
+            core::slice::from_raw_parts(nv_data(yy), n),
+            core::slice::from_raw_parts(nv_data(yp), n),
+            core::slice::from_raw_parts_mut(nv_data(rr), n),
+        )
+    };
+    if let Err(e) = c.ode.eval(t, y, c.f) {
+        c.failed = Some(e);
+        return -1;
+    }
+    for i in 0..n {
+        r[i] = yp[i] - c.f[i];
+    }
+    0
+}
+
+unsafe extern "C" fn ida_roots(
+    t: f64,
+    yy: NVector,
+    _yp: NVector,
+    gout: *mut f64,
+    user: *mut c_void,
+) -> c_int {
+    unsafe { roots(t, yy, gout, user) }
+}
+
+fn fail(c: &mut Ctx, r: Result<()>) -> c_int {
+    match r {
+        Ok(()) => 0,
+        Err(e) => {
+            c.failed = Some(e);
+            -1
+        }
+    }
+}
+
+/// C's `dasslTolerances`: the per-state nominal scales the absolute tolerance.
+fn abs_tolerances(tolerance: f64, n: usize, nominals: &[f64]) -> Vec<f64> {
+    (0..n)
+        .map(|i| tolerance * nominals.get(i).copied().unwrap_or(1.0).abs().max(1e-32))
+        .collect()
+}
+
+fn add(a: Counters, b: Counters) -> Counters {
+    Counters {
+        steps: a.steps + b.steps,
+        rhs_evals: a.rhs_evals + b.rhs_evals,
+        jac_evals: a.jac_evals + b.jac_evals,
+        err_test_fails: a.err_test_fails + b.err_test_fails,
+        conv_test_fails: a.conv_test_fails + b.conv_test_fails,
+    }
+}
+
+/// What the next step owes the integrator, both settled in `prepare`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Pending {
+    None,
+    /// The states moved behind SUNDIALS' back.
+    Reinit,
+    /// New nominals, and the tolerance vector is set only at construction.
+    Rebuild,
+}
+
+/// `-s=cvode`: CVODE with its own root finding, over an [`Ode`].
+pub struct CvodeOde {
+    cv: Option<Cvode>,
+    n: usize,
+    n_zc: usize,
+    tolerance: f64,
+    nominals: Vec<f64>,
+    pending: Pending,
+    /// Counters from the memory blocks a rebuild dropped.
+    past: Counters,
+}
+
+impl CvodeOde {
+    pub fn new(n: usize, n_zc: usize, tolerance: f64, nominals: &[f64]) -> CvodeOde {
+        CvodeOde {
+            cv: None,
+            n,
+            n_zc,
+            tolerance,
+            nominals: nominals.to_vec(),
+            pending: Pending::Rebuild,
+            past: Counters::default(),
+        }
+    }
+
+    pub fn restart(&mut self) {
+        if self.pending == Pending::None {
+            self.pending = Pending::Reinit;
+        }
+    }
+
+    pub fn set_nominals(&mut self, nominals: &[f64]) {
+        if self.nominals != nominals {
+            self.nominals = nominals.to_vec();
+            self.pending = Pending::Rebuild;
+        }
+    }
+
+    pub fn counters(&self) -> Counters {
+        match self.cv.as_ref() {
+            Some(cv) => add(self.past, cv.counters()),
+            None => self.past,
+        }
+    }
+
+    /// Integrate from `(t, y)` toward `target`.
+    pub fn step(
+        &mut self,
+        ode: &mut dyn Ode,
+        target: f64,
+        t: &mut f64,
+        y: &mut [f64],
+    ) -> Result<SunStep> {
+        if y.is_empty() {
+            *t = target;
+            return Ok(SunStep::Reached);
+        }
+        self.prepare(*t, y)?;
+        let (n, n_zc) = (self.n, self.n_zc);
+        let cv = self.cv.as_mut().expect("prepare built it");
+        let mut ctx = Ctx { ode, n, n_zc, f: &mut [], failed: None };
+        if !cv.set_user_data(&mut ctx as *mut Ctx as *mut c_void) {
+            return Err("cvode: the context could not be bound");
+        }
+        let mut retries = 0;
+        let stop = loop {
+            match cv.step(t, target) {
+                Stop::Failed(sundials::CV_TOO_MUCH_WORK) if retries < WORK_RETRIES => retries += 1,
+                other => break other,
+            }
+        };
+        if let Some(e) = ctx.failed {
+            return Err(e);
+        }
+        y.copy_from_slice(cv.y());
+        match stop {
+            Stop::Reached | Stop::Stepped => Ok(SunStep::Reached),
+            Stop::Root => Ok(SunStep::Root(*t)),
+            Stop::Failed(flag) => Err(cvode_failure(flag)),
+        }
+    }
+
+    fn prepare(&mut self, t: f64, y: &[f64]) -> Result<()> {
+        match core::mem::replace(&mut self.pending, Pending::None) {
+            Pending::None => Ok(()),
+            Pending::Reinit => {
+                let cv = self.cv.as_mut().expect("Reinit follows a build");
+                cv.y_mut().copy_from_slice(y);
+                match cv.reinit(t) {
+                    true => Ok(()),
+                    false => Err("cvode: the integrator could not be restarted"),
+                }
+            }
+            Pending::Rebuild => {
+                if let Some(cv) = self.cv.take() {
+                    self.past = add(self.past, cv.counters());
+                }
+                let atol = abs_tolerances(self.tolerance, self.n, &self.nominals);
+                let root = (self.n_zc > 0).then_some(roots as sundials::RootFn);
+                let config = crate::simflags::with_flags(crate::simflags::cvode_config);
+                self.cv = Some(
+                    Cvode::new(t, y, self.tolerance, &atol, self.n_zc, rhs, root, config)
+                        .ok_or("cvode: the integrator could not be created")?,
+                );
+                Ok(())
+            }
+        }
+    }
+}
+
+/// `-s=ida`: IDA over the residual `y' - f(t, y)`, with its own root finding.
+pub struct IdaOde {
+    ida: Option<Ida>,
+    n: usize,
+    n_zc: usize,
+    tolerance: f64,
+    nominals: Vec<f64>,
+    /// The residual's scratch for `f(t, y)`.
+    f: Vec<f64>,
+    pending: Pending,
+    past: Counters,
+}
+
+impl IdaOde {
+    pub fn new(n: usize, n_zc: usize, tolerance: f64, nominals: &[f64]) -> IdaOde {
+        IdaOde {
+            ida: None,
+            n,
+            n_zc,
+            tolerance,
+            nominals: nominals.to_vec(),
+            f: vec![0.0; n],
+            pending: Pending::Rebuild,
+            past: Counters::default(),
+        }
+    }
+
+    pub fn restart(&mut self) {
+        if self.pending == Pending::None {
+            self.pending = Pending::Reinit;
+        }
+    }
+
+    pub fn set_nominals(&mut self, nominals: &[f64]) {
+        if self.nominals != nominals {
+            self.nominals = nominals.to_vec();
+            self.pending = Pending::Rebuild;
+        }
+    }
+
+    pub fn counters(&self) -> Counters {
+        match self.ida.as_ref() {
+            Some(ida) => add(self.past, ida.counters()),
+            None => self.past,
+        }
+    }
+
+    pub fn step(
+        &mut self,
+        ode: &mut dyn Ode,
+        target: f64,
+        t: &mut f64,
+        y: &mut [f64],
+    ) -> Result<SunStep> {
+        if y.is_empty() {
+            *t = target;
+            return Ok(SunStep::Reached);
+        }
+        self.prepare(ode, *t, y)?;
+        let (n, n_zc) = (self.n, self.n_zc);
+        let ida = self.ida.as_mut().expect("prepare built it");
+        let mut ctx = Ctx { ode, n, n_zc, f: &mut self.f, failed: None };
+        if !ida.set_user_data(&mut ctx as *mut Ctx as *mut c_void) {
+            return Err("ida: the context could not be bound");
+        }
+        let mut retries = 0;
+        let stop = loop {
+            match ida.step(t, target, false) {
+                Stop::Failed(sundials::IDA_TOO_MUCH_WORK) if retries < WORK_RETRIES => retries += 1,
+                other => break other,
+            }
+        };
+        if let Some(e) = ctx.failed {
+            return Err(e);
+        }
+        y.copy_from_slice(ida.y());
+        match stop {
+            Stop::Reached | Stop::Stepped => Ok(SunStep::Reached),
+            Stop::Root => Ok(SunStep::Root(*t)),
+            Stop::Failed(flag) => Err(ida_failure(flag)),
+        }
+    }
+
+    /// IDA wants a consistent `y'` at every start, which for an ODE is `f(t, y)`.
+    fn prepare(&mut self, ode: &mut dyn Ode, t: f64, y: &[f64]) -> Result<()> {
+        let pending = core::mem::replace(&mut self.pending, Pending::None);
+        if pending == Pending::None {
+            return Ok(());
+        }
+        let mut yp = vec![0.0; self.n];
+        ode.eval(t, y, &mut yp)?;
+        if pending == Pending::Reinit {
+            let ida = self.ida.as_mut().expect("Reinit follows a build");
+            ida.y_mut().copy_from_slice(y);
+            ida.yp_mut().copy_from_slice(&yp);
+            return match ida.reinit(t) {
+                true => Ok(()),
+                false => Err("ida: the integrator could not be restarted"),
+            };
+        }
+        if let Some(ida) = self.ida.take() {
+            self.past = add(self.past, ida.counters());
+        }
+        let atol = abs_tolerances(self.tolerance, self.n, &self.nominals);
+        let root = (self.n_zc > 0).then_some(ida_roots as sundials::IdaRootFn);
+        // Always dense: `-idaLS=klu` wants a sparsity pattern, which an ODE handed
+        // over as a residual does not have.
+        let opts = IdaOptions {
+            max_order: crate::simflags::with_flags(|f| f.max_order),
+            ..IdaOptions::default()
+        };
+        self.ida = Some(
+            Ida::new(
+                t, y, &yp, self.tolerance, &atol, self.n_zc, ida_res, root, IdaLs::Dense, 0, None,
+                &opts,
+            )
+            .ok_or("ida: the integrator could not be created")?,
+        );
+        Ok(())
+    }
+}
+
+/// `cvode_solver.c`'s messages for the flags a run can end on.
+fn cvode_failure(flag: c_int) -> &'static str {
+    match flag {
+        sundials::CV_TOO_MUCH_WORK => "cvode: the solver took the maximum number of steps before reaching the output point",
+        -2 => "cvode: the error tolerances are too small",
+        -3 => "cvode: the error test failed repeatedly, or with |h| = hmin",
+        -4 => "cvode: the corrector could not converge",
+        -5 => "cvode: the linear solver setup failed",
+        -6 => "cvode: the linear solver failed to solve",
+        -9 => "cvode: the right-hand side failed on the first call",
+        -10 => "cvode: the right-hand side failed repeatedly",
+        sundials::CV_RTFUNC_FAIL => "cvode: the zero-crossing functions failed",
+        _ => "cvode: the integrator failed",
+    }
+}
+
+/// `ida_solver.c`'s messages for the flags a run can end on.
+fn ida_failure(flag: c_int) -> &'static str {
+    match flag {
+        sundials::IDA_TOO_MUCH_WORK => "ida: the solver took the maximum number of steps before reaching the output point",
+        -2 => "ida: the error tolerances are too small",
+        sundials::IDA_ERR_FAIL => "ida: the error test failed repeatedly, or with |h| = hmin",
+        sundials::IDA_CONV_FAIL => "ida: the corrector could not converge",
+        -5 => "ida: the linear solver initialization failed",
+        sundials::IDA_LSETUP_FAIL => "ida: the linear solver setup failed",
+        -7 => "ida: the linear solver failed to solve",
+        -8 => "ida: the residual function failed in an unrecoverable way",
+        -9 => "ida: the residual function failed on the first call",
+        -10 => "ida: the residual function failed repeatedly",
+        sundials::IDA_RTFUNC_FAIL => "ida: the zero-crossing functions failed",
+        _ => "ida: the integrator failed",
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/README.md
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/README.md
@@ -11,10 +11,14 @@ server is involved — the FMU is unpacked, compiled and run inside the page.
 The masters are OpenModelica's own, in Rust: `openmodelica_fmi_driver`, built for
 `wasm32-wasip1` as `openmodelica_fmi_web.wasm`. Model Exchange integrates with
 the same solvers a compiled Modelica model runs under (`openmodelica_solvers`:
-gbode and the fixed-step ones), so an FMU is stepped, error-controlled and
-root-searched exactly like a model; Co-Simulation drives `fmi3DoStep` and takes
-the FMU up on early return, handling each event at the time the FMU stopped at
-rather than at the next communication point.
+DASSL, gbode, the fixed-step ones, and CVODE/IDA where the module was linked
+against SUNDIALS), so an FMU is stepped, error-controlled and root-searched
+exactly like a model; Co-Simulation drives `fmi3DoStep` and takes the FMU up on
+early return, handling each event at the time the FMU stopped at rather than at
+the next communication point.
+
+The page's solver chooser is built from the list the module reports, so it can
+never offer one that build does not have.
 
 A run is one call into that module and cannot be interrupted, so it happens in a
 worker (`fmi-worker.js`); the Cancel button drops the worker, after which the
@@ -48,7 +52,7 @@ out of jco's own wrappers, so the two cannot drift.
 | `fmu-core.js` | jco transpilation, and the core exports past its glue |
 | `fmu.js` | the ZIP and `modelDescription.xml`, for what the page displays |
 | `wasi.js` | a WASI preview1 host, so the result file is written like any other |
-| `selftest.html` | `?fmu=<url>&interface=me|cs` — the whole path, headless |
+| `selftest.html` | `?fmu=<url>&interface=me|cs&solver=<name>` — the whole path, headless |
 
 `vendor/` holds the transpiler and the WASI preview2 shim. It is not in git: the
 CMake web target downloads both pinned npm tarballs (see

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/index.html
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/index.html
@@ -114,12 +114,7 @@
       <label for="step" id="stepLabel">Step size</label><input id="step" value="0.1" />
       <label for="tol">Tolerance</label><input id="tol" value="1e-6" />
       <label for="solver" id="solverLabel" title="The integrator the master runs the FMU with (Model Exchange only; a Co-Simulation FMU brings its own)" hidden>Solver</label>
-      <select id="solver" class="wide" hidden>
-        <option value="dassl">dassl — BDF, the default for a model too</option>
-        <option value="gbode">gbode — Runge-Kutta, under the -gb* flags</option>
-        <option value="euler">euler — fixed step</option>
-        <option value="rungekutta">rungekutta — fixed step, RK4</option>
-      </select>
+      <select id="solver" class="wide" hidden></select>
       <label for="eventMode" id="eventModeLabel" title="Report events to the master algorithm (Event Mode) instead of handling them inside the FMU" hidden>Event mode</label>
       <label class="chk wide" id="eventModeCell" title="Report events to the master algorithm (Event Mode) instead of handling them inside the FMU" hidden><input type="checkbox" id="eventMode" checked /></label>
     </div>
@@ -303,6 +298,8 @@ function renderInfo(fileName, probe) {
     <dt>Variables</dt><dd>${md.variables.length}${md.nStates ? ` · ${md.nStates} continuous states` : ''}${md.nEventIndicators ? ` · ${md.nEventIndicators} event indicators` : ''}</dd>
   </dl>`;
 
+  renderSolvers(probe.solvers);
+
   const avail = kinds(probe);
   if (!avail.length) throw new Error('the component exports neither a Co-Simulation nor a Model Exchange interface');
   ifaceEl.replaceChildren();
@@ -310,6 +307,15 @@ function renderInfo(fileName, probe) {
   ifaceEl.disabled = avail.length < 2;
   ifaceEl.value = avail[0].id;
   onIfaceChange();
+}
+
+// What the driver was built with, so the page never offers a solver the master
+// would refuse.
+function renderSolvers(solvers) {
+  const keep = solverEl.value;
+  solverEl.replaceChildren();
+  for (const s of solvers || []) solverEl.append(new Option(`${s.name} — ${s.description}`, s.name));
+  if ([...solverEl.options].some((o) => o.value === keep)) solverEl.value = keep;
 }
 
 ifaceEl.onchange = onIfaceChange;

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/selftest.html
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/selftest.html
@@ -5,7 +5,7 @@
   Runs an FMU through the driver without any of the page's interface, so the
   browser half can be checked from a script:
 
-      selftest.html?fmu=<url>&interface=me|cs&stop=<time>
+      selftest.html?fmu=<url>&interface=me|cs&stop=<time>&solver=<name>
 
   It prints one line per step and ends with `SELFTEST ok` or `SELFTEST failed`.
   The outcome is also requested from the server as `/__selftest?...`, so a
@@ -32,6 +32,7 @@ const params = new URLSearchParams(location.search);
 const url = params.get('fmu');
 const kind = params.get('interface') || 'cs';
 const stop = params.get('stop') ? Number(params.get('stop')) : undefined;
+const solver = params.get('solver') || undefined;
 
 let batches = 0;
 const session = new Session({
@@ -47,9 +48,13 @@ try {
   const info = await session.load(archive);
   say(`FMI ${info.fmiVersion} ${info.modelName}: ${info.numberOfContinuousStates} states, ` +
       `${info.numberOfEventIndicators} event indicators, ${info.variables.length} variables`);
+  say(`solvers: ${info.solvers.map((s) => s.name).join(' ')}`);
+  if (solver && !info.solvers.some((s) => s.name === solver)) {
+    throw new Error(`this driver has no ${solver} solver`);
+  }
 
   const t0 = performance.now();
-  const result = await session.run({ interface: kind, stopTime: stop });
+  const result = await session.run({ interface: kind, stopTime: stop, solver });
   const ms = Math.round(performance.now() - t0);
   say(`${kind}: ${result.rows} rows, ${result.columns.length} columns in ${ms} ms`);
   say(`summary ${JSON.stringify(result.summary)}`);
@@ -62,13 +67,13 @@ try {
   // had. Without shared memory there is nothing to ask through, so the check
   // only runs where the page is cross-origin isolated.
   if (session.cancel !== undefined && typeof SharedArrayBuffer === 'function') {
-    const long = session.run({ interface: kind, stopTime: (stop ?? 1) * 200 });
+    const long = session.run({ interface: kind, stopTime: (stop ?? 1) * 200, solver });
     setTimeout(() => session.cancel(), 400);
     const stopped = await long;
     say(`cancelled after ${stopped.rows} rows (cancelled=${stopped.summary.cancelled})`);
     if (!stopped.summary.cancelled) throw new Error('the run did not stop when asked');
     // The FMU is still loaded: another run must work.
-    const again = await session.run({ interface: kind, stopTime: stop });
+    const again = await session.run({ interface: kind, stopTime: stop, solver });
     say(`after cancelling: ${again.rows} rows`);
     if (!again.rows) throw new Error('the FMU was lost when the run was cancelled');
   }


### PR DESCRIPTION
`openmodelica_solvers::sundials_ode` drives the existing CVODE/IDA handles from an `Ode`, the way `dassl` drives DASKR: IDA gets the ODE as the residual `y' - f(t, y)`, and the zero-crossings are both integrators' own root functions, so an event is located by SUNDIALS rather than bisected after it. Neither is built before the first step, which is where the initial point is known.

`openmodelica_fmi_web` now links the wasm SUNDIALS archives itself (`openmodelica_solvers` links nothing on wasm), so the browser module has the two solvers. `Solver::all` reports what the build actually got and `om_fmi_info` publishes it, so the page's chooser, `fmusim --solver` and `selftest.html?solver=` all follow the module instead of each keeping a list. `selftest.html` gained the `solver` parameter.

Checked on an event-rich ME FMU, natively and headless in the page: dassl, cvode, ida and gbode all find the same 10 state events at the same times and agree on the final state to ~1e-9.

CVODE calls the FMU once per output point rather than interpolating, because `Cvode::step` sets `CVodeSetStopTime(tout)` — which is what `cvode_solver.c` does too, so it is left alone.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
