### PR TITLE
FMU documentation, and icons from base classes

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -238,6 +238,7 @@ openmodelica_ext_native_marshal/src/lib.rs
 openmodelica_fmi/Cargo.toml
 openmodelica_fmi/examples/fmuinfo.rs
 openmodelica_fmi/src/description.rs
+openmodelica_fmi/src/figures.rs
 openmodelica_fmi/src/lib.rs
 openmodelica_fmi/src/lswasm.rs
 openmodelica_fmi/src/parse/mod.rs

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -2773,14 +2773,22 @@ fn add_resource(entries: &mut Vec<(String, Vec<u8>)>, path: &str) {
 
 /// Ship `dir` as the FMU's `terminalsAndIcons/`: the XML SimCode wrote and the icons
 /// the OMGraphics renderer put beside it, as the C export's `fmutmp` subtree is.
-fn add_terminals(entries: &mut Vec<(String, Vec<u8>)>, dir: &str) {
+/// Ship everything under `dir` as `prefix/<path below dir>`, recursively: the
+/// staged `documentation/` (whose images keep the modelica:// URI's own directory
+/// structure) and `terminalsAndIcons/`.
+fn add_directory(entries: &mut Vec<(String, Vec<u8>)>, dir: &str, prefix: &str) {
     if dir.is_empty() {
         return;
     }
+    let dir = dir.trim_end_matches('/');
     let Ok(files) = openmodelica_wasi::fs::read_dir(dir) else { return };
     for e in files {
-        if let Ok(bytes) = openmodelica_wasi::fs::read(&format!("{}/{}", dir.trim_end_matches('/'), e.name)) {
-            entries.push((format!("terminalsAndIcons/{}", e.name), bytes));
+        let path = format!("{dir}/{}", e.name);
+        let name = format!("{prefix}/{}", e.name);
+        if e.is_dir {
+            add_directory(entries, &path, &name);
+        } else if let Ok(bytes) = openmodelica_wasi::fs::read(&path) {
+            entries.push((name, bytes));
         }
     }
 }
@@ -2890,11 +2898,11 @@ pub fn emitMeFmu(
     fmu_path: ArcStr,
     _guid: ArcStr,
     model_description: ArcStr,
-    extra_files: Arc<List<(ArcStr, ArcStr)>>,
+    documentation_dir: ArcStr,
     terminals_dir: ArcStr,
     simulation_flags_json: ArcStr,
 ) -> Result<()> {
-    emit_fmu(sim_code, fmu_path, model_description, extra_files, terminals_dir, simulation_flags_json, FMI3_ME_ADAPTER, "ME")
+    emit_fmu(sim_code, fmu_path, model_description, documentation_dir, terminals_dir, simulation_flags_json, FMI3_ME_ADAPTER, "ME")
 }
 
 /// Co-Simulation: the FMU integrates itself, so the adapter embeds the driver.
@@ -2908,11 +2916,11 @@ pub fn emitCsFmu(
     fmu_path: ArcStr,
     _guid: ArcStr,
     model_description: ArcStr,
-    extra_files: Arc<List<(ArcStr, ArcStr)>>,
+    documentation_dir: ArcStr,
     terminals_dir: ArcStr,
     simulation_flags_json: ArcStr,
 ) -> Result<()> {
-    emit_fmu(sim_code, fmu_path, model_description, extra_files, terminals_dir, simulation_flags_json, FMI3_MECS_ADAPTER, "CS")
+    emit_fmu(sim_code, fmu_path, model_description, documentation_dir, terminals_dir, simulation_flags_json, FMI3_MECS_ADAPTER, "CS")
 }
 
 /// me_cs: one component exporting both interfaces (the wasm equivalent of a
@@ -2922,11 +2930,11 @@ pub fn emitMeCsFmu(
     fmu_path: ArcStr,
     _guid: ArcStr,
     model_description: ArcStr,
-    extra_files: Arc<List<(ArcStr, ArcStr)>>,
+    documentation_dir: ArcStr,
     terminals_dir: ArcStr,
     simulation_flags_json: ArcStr,
 ) -> Result<()> {
-    emit_fmu(sim_code, fmu_path, model_description, extra_files, terminals_dir, simulation_flags_json, FMI3_MECS_ADAPTER, "me_cs")
+    emit_fmu(sim_code, fmu_path, model_description, documentation_dir, terminals_dir, simulation_flags_json, FMI3_MECS_ADAPTER, "me_cs")
 }
 
 /// Say that the FMU answers `fmi3GetDirectionalDerivative` when the model was
@@ -3329,7 +3337,7 @@ fn emit_fmu(
     sim_code: SimCode::SimCode,
     fmu_path: ArcStr,
     model_description: ArcStr,
-    extra_files: Arc<List<(ArcStr, ArcStr)>>,
+    documentation_dir: ArcStr,
     terminals_dir: ArcStr,
     simulation_flags_json: ArcStr,
     adapter: &[u8],
@@ -3390,10 +3398,8 @@ fn emit_fmu(
             ("modelDescription.xml".to_string(), announce_directional_derivatives(&model_description, &model).into_bytes()),
         ];
         if !bare {
-            for (name, content) in lst(&extra_files) {
-                entries.push((name.to_string(), content.as_bytes().to_vec()));
-            }
-            add_terminals(&mut entries, &terminals_dir);
+            add_directory(&mut entries, &documentation_dir, "documentation");
+            add_directory(&mut entries, &terminals_dir, "terminalsAndIcons");
         }
         // What the FMU was built with, where C's carries what its runtime reads.
         if !simulation_flags_json.is_empty() {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/description.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/description.rs
@@ -459,6 +459,18 @@ pub struct ModelDescription {
 }
 
 impl ModelDescription {
+    /// The OpenModelica `<Figures>` annotation, parsed. Empty when the model
+    /// declared none.
+    pub fn figures(&self) -> Vec<crate::figures::Figure> {
+        crate::figures::figures(&self.tool_annotations)
+    }
+
+    /// The OpenModelica `<Visualization>` annotation naming the `_visual.xml`
+    /// scene in `resources/`.
+    pub fn visualization(&self) -> Option<crate::figures::Visualization> {
+        crate::figures::visualization(&self.tool_annotations)
+    }
+
     pub(crate) fn build_index(&mut self) {
         self.vr_index.clear();
         for (i, v) in self.variables.iter().enumerate() {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/figures.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/figures.rs
@@ -1,0 +1,209 @@
+//! The OpenModelica `<Figures>` and `<Visualization>` tool annotations.
+//!
+//! FMI has nowhere for "which plots describe this model", so the export writes
+//! them under `<Annotations><Tool name="OpenModelica">` and
+//! [`crate::ToolAnnotation`] keeps the XML. An unknown `version` yields nothing
+//! rather than a guess.
+
+use crate::ToolAnnotation;
+use roxmltree::{Document, Node};
+
+const TOOL: &str = "OpenModelica";
+const VERSION: &str = "1";
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Curve {
+    /// The x variable; empty means time.
+    pub x: String,
+    pub y: String,
+    pub legend: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Axis {
+    pub label: String,
+    pub unit: String,
+    pub min: Option<f64>,
+    pub max: Option<f64>,
+    /// `scale="Log"`; linear otherwise.
+    pub log: bool,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Plot {
+    pub title: String,
+    pub preferred: bool,
+    /// `<TerminalRef terminal=…>`, for a plot named by terminal rather than by
+    /// explicit curves.
+    pub terminal: Option<String>,
+    pub curves: Vec<Curve>,
+    pub x: Option<Axis>,
+    pub y: Option<Axis>,
+    pub y2: Option<Axis>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Figure {
+    pub title: String,
+    pub group: String,
+    pub preferred: bool,
+    pub caption: String,
+    pub plots: Vec<Plot>,
+}
+
+/// `<Visualization file=…>`: the `_visual.xml` scene in `resources/`.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Visualization {
+    pub file: String,
+}
+
+fn openmodelica_xml(annotations: &[ToolAnnotation]) -> Option<&str> {
+    annotations.iter().find(|t| t.name == TOOL).map(|t| t.xml.as_str())
+}
+
+/// True when the element's `version` is absent or the one we read.
+fn known_version(n: Node) -> bool {
+    n.attribute("version").is_none_or(|v| v == VERSION)
+}
+
+fn text_attr(n: Node, name: &str) -> String {
+    n.attribute(name).unwrap_or_default().to_string()
+}
+
+fn num_attr(n: Node, name: &str) -> Option<f64> {
+    n.attribute(name).and_then(|v| v.trim().parse().ok())
+}
+
+fn children<'a>(n: Node<'a, 'a>, tag: &'a str) -> impl Iterator<Item = Node<'a, 'a>> {
+    n.children().filter(move |c| c.is_element() && c.tag_name().name() == tag)
+}
+
+fn axis(plot: Node, role: &str) -> Option<Axis> {
+    let a = children(plot, "Axis").find(|a| a.attribute("role") == Some(role))?;
+    Some(Axis {
+        label: text_attr(a, "label"),
+        unit: text_attr(a, "unit"),
+        min: num_attr(a, "min"),
+        max: num_attr(a, "max"),
+        log: a.attribute("scale") == Some("Log"),
+    })
+}
+
+fn plot(p: Node) -> Option<Plot> {
+    let curves: Vec<Curve> = children(p, "Curve")
+        .filter_map(|c| {
+            let y = c.attribute("y")?;
+            (!y.is_empty()).then(|| Curve {
+                x: text_attr(c, "x"),
+                y: y.to_string(),
+                legend: text_attr(c, "legend"),
+            })
+        })
+        .collect();
+    // A plot named only by a terminal has nothing to draw here; a host that
+    // resolves terminals can still read the reference off the annotation.
+    if curves.is_empty() {
+        return None;
+    }
+    Some(Plot {
+        title: text_attr(p, "title"),
+        preferred: p.attribute("preferred") == Some("true"),
+        terminal: children(p, "TerminalRef").next().and_then(|t| t.attribute("terminal")).map(str::to_string),
+        curves,
+        x: axis(p, "x"),
+        y: axis(p, "y"),
+        y2: axis(p, "y2"),
+    })
+}
+
+/// The figures the OpenModelica annotation declares, in the order it wrote them.
+pub fn figures(annotations: &[ToolAnnotation]) -> Vec<Figure> {
+    let Some(xml) = openmodelica_xml(annotations) else { return Vec::new() };
+    let Ok(doc) = Document::parse(xml) else { return Vec::new() };
+    let Some(root) = children(doc.root_element(), "Figures").next() else { return Vec::new() };
+    if !known_version(root) {
+        return Vec::new();
+    }
+    children(root, "Figure")
+        .filter_map(|f| {
+            let plots: Vec<Plot> = children(f, "Plot").filter_map(plot).collect();
+            if plots.is_empty() {
+                return None;
+            }
+            Some(Figure {
+                title: text_attr(f, "title"),
+                group: text_attr(f, "group"),
+                preferred: f.attribute("preferred") == Some("true"),
+                caption: children(f, "Caption")
+                    .next()
+                    .and_then(|c| c.text())
+                    .unwrap_or_default()
+                    .to_string(),
+                plots,
+            })
+        })
+        .collect()
+}
+
+/// The `_visual.xml` scene the model exported, if it did.
+pub fn visualization(annotations: &[ToolAnnotation]) -> Option<Visualization> {
+    let xml = openmodelica_xml(annotations)?;
+    let doc = Document::parse(xml).ok()?;
+    let v = children(doc.root_element(), "Visualization").next()?;
+    if !known_version(v) {
+        return None;
+    }
+    let file = v.attribute("file")?;
+    (!file.is_empty()).then(|| Visualization { file: file.to_string() })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn annotations(inner: &str) -> Vec<ToolAnnotation> {
+        vec![ToolAnnotation { name: TOOL.to_string(), xml: format!("<Tool name=\"OpenModelica\">{inner}</Tool>") }]
+    }
+
+    #[test]
+    fn reads_a_figure() {
+        let a = annotations(
+            r#"<Figures version="1"><Figure title="F" preferred="true">
+                 <Plot title="P"><Axis role="y" label="angle" unit="rad" scale="Log" min="0"/>
+                   <Curve y="a.b.c" legend="one"/><Curve y="d" x="e"/></Plot>
+                 <Caption>why</Caption></Figure></Figures>"#,
+        );
+        let f = figures(&a);
+        assert_eq!(f.len(), 1);
+        assert!(f[0].preferred);
+        assert_eq!(f[0].caption, "why");
+        assert_eq!(f[0].plots[0].curves[0], Curve { x: String::new(), y: "a.b.c".into(), legend: "one".into() });
+        assert_eq!(f[0].plots[0].curves[1].x, "e");
+        let y = f[0].plots[0].y.as_ref().unwrap();
+        assert!(y.log && y.min == Some(0.0) && y.unit == "rad");
+        assert!(f[0].plots[0].x.is_none());
+    }
+
+    #[test]
+    fn skips_a_plot_with_no_curves_and_an_unknown_version() {
+        assert!(figures(&annotations(r#"<Figures version="1"><Figure><Plot title="P"/></Figure></Figures>"#)).is_empty());
+        assert!(figures(&annotations(r#"<Figures version="2"><Figure><Plot><Curve y="a"/></Plot></Figure></Figures>"#)).is_empty());
+    }
+
+    #[test]
+    fn reads_the_visualization() {
+        assert_eq!(
+            visualization(&annotations(r#"<Visualization version="1" file="M_visual.xml"/>"#)),
+            Some(Visualization { file: "M_visual.xml".into() })
+        );
+        assert_eq!(visualization(&annotations(r#"<Visualization version="9" file="x.xml"/>"#)), None);
+        assert_eq!(visualization(&annotations("")), None);
+    }
+
+    #[test]
+    fn no_openmodelica_annotation_is_not_an_error() {
+        let other = vec![ToolAnnotation { name: "Other".into(), xml: "<Tool name=\"Other\"/>".into() }];
+        assert!(figures(&other).is_empty());
+        assert!(visualization(&other).is_none());
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/lib.rs
@@ -6,12 +6,14 @@
 //! is host-free — the browser omc reads an FMU exactly as the native one does.
 
 pub mod description;
+pub mod figures;
 #[cfg(feature = "component")]
 pub mod lswasm;
 mod parse;
 mod platform;
 
 pub use description::*;
+pub use figures::{Axis, Curve, Figure, Plot, Visualization};
 pub use parse::model_description;
 pub use platform::{Platform, host_platform};
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_web/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_web/src/lib.rs
@@ -10,7 +10,7 @@
 //! Strings cross as JSON in one buffer ([`om_fmi_out_ptr`]/[`om_fmi_out_len`]);
 //! sample values are read straight out of the recorder's buffer.
 
-use openmodelica_fmi::{Causality, Fmu, InterfaceKind, ModelDescription, VarType, Variability};
+use openmodelica_fmi::{Causality, Fmu, Initial, InterfaceKind, ModelDescription, VarType, Variability};
 use openmodelica_fmi_driver::api::{Fmi3CoSimulation, Fmi3ModelExchange};
 use openmodelica_fmi_driver::record::Recorder;
 use openmodelica_fmi_driver::wasm_host::{HostFmu, KIND_CO_SIMULATION, KIND_MODEL_EXCHANGE};
@@ -150,6 +150,41 @@ pub extern "C" fn om_fmi_resource_names() -> i32 {
         let Some(fmu) = s.fmu.as_ref() else { return fail("no FMU is loaded") };
         let names: Vec<&str> = fmu.resources().collect();
         set_out(serde_json::to_string(&names).unwrap_or_else(|_| "[]".into()));
+        1
+    })
+}
+
+/// The FMU icon — `terminalsAndIcons/icon.svg` if there is one, else `icon.png`.
+/// Bytes in the binary buffer, name as JSON in the out buffer; `0` for no icon.
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi_icon() -> i32 {
+    with(|s| {
+        let Some(fmu) = s.fmu.as_ref() else { return fail("no FMU is loaded") };
+        for name in ["terminalsAndIcons/icon.svg", "terminalsAndIcons/icon.png"] {
+            if let Some(bytes) = fmu.read(name) {
+                s.binary = bytes.into_owned();
+                set_out(json!({"name": name}).to_string());
+                return 1;
+            }
+        }
+        fail("the FMU carries no terminalsAndIcons icon")
+    })
+}
+
+/// `{"entry":…, "files":[…]}` in the out buffer: the documentation entry point
+/// (`index.html`, or FMI 1.0's `_main.html`) and the names beside it, which the
+/// caller pulls through [`om_fmi_select_file`]. `0` when there is none.
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi_documentation() -> i32 {
+    with(|s| {
+        let Some(fmu) = s.fmu.as_ref() else { return fail("no FMU is loaded") };
+        let entry = ["documentation/index.html", "documentation/_main.html"]
+            .into_iter()
+            .find(|n| fmu.read(n).is_some());
+        let Some(entry) = entry else { return fail("the FMU carries no documentation") };
+        let files: Vec<&str> =
+            fmu.names().iter().map(String::as_str).filter(|n| n.starts_with("documentation/")).collect();
+        set_out(json!({"entry": entry, "files": files}).to_string());
         1
     })
 }
@@ -327,9 +362,25 @@ fn describe(fmu: &Fmu) -> Value {
                 "start": v.start.as_ref().and_then(|s| s.first_f64()),
                 "numeric": v.ty.is_numeric(),
                 "settable": v.is_settable(),
+                // Together these name an editable start value: `derivative` the
+                // state, `initial` whether the start is the model's.
+                "derivative": v.derivative,
+                "initial": v.initial.map(|i| match i {
+                    Initial::Exact => "exact",
+                    Initial::Approx => "approx",
+                    Initial::Calculated => "calculated",
+                }),
             })
         })
         .collect();
+    // Alias name -> the variable carrying the data: an <Alias> shares its
+    // variable's valueReference, so only the variable is ever recorded.
+    let aliases: Value = md
+        .variables
+        .iter()
+        .flat_map(|v| v.aliases.iter().map(move |a| (a.name.clone(), Value::from(v.name.clone()))))
+        .collect::<serde_json::Map<String, Value>>()
+        .into();
     json!({
         "fmiVersion": md.fmi_version_string,
         "modelName": md.model_name,
@@ -345,9 +396,13 @@ fn describe(fmu: &Fmu) -> Value {
             "stepSize": e.step_size,
             "tolerance": e.tolerance,
         },
+        "version": md.version,
         "numberOfContinuousStates": md.number_of_continuous_states(),
         "numberOfEventIndicators": md.number_of_event_indicators,
         "variables": variables,
+        "aliases": aliases,
+        "figures": md.figures().iter().map(figure_json).collect::<Vec<_>>(),
+        "visualization": md.visualization().map(|v| json!({"file": v.file})),
         // Not the FMU's: what a run of it can be given, for the page's chooser.
         "solvers": Solver::all().iter()
             .map(|s| json!({"name": s.as_str(), "description": s.description()}))
@@ -355,6 +410,29 @@ fn describe(fmu: &Fmu) -> Value {
         "toolAnnotations": md.tool_annotations.iter()
             .map(|a| json!({"name": a.name, "xml": a.xml}))
             .collect::<Vec<_>>(),
+    })
+}
+
+fn figure_json(f: &openmodelica_fmi::Figure) -> Value {
+    let axis = |a: &Option<openmodelica_fmi::Axis>| {
+        a.as_ref().map(|a| json!({
+            "label": a.label, "unit": a.unit, "min": a.min, "max": a.max, "log": a.log,
+        }))
+    };
+    json!({
+        "title": f.title,
+        "group": f.group,
+        "preferred": f.preferred,
+        "caption": f.caption,
+        "plots": f.plots.iter().map(|p| json!({
+            "title": p.title,
+            "preferred": p.preferred,
+            "terminal": p.terminal,
+            "curves": p.curves.iter()
+                .map(|c| json!({"x": c.x, "y": c.y, "legend": c.legend}))
+                .collect::<Vec<_>>(),
+            "x": axis(&p.x), "y": axis(&p.y), "y2": axis(&p.y2),
+        })).collect::<Vec<_>>(),
     })
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_omgraphics/src/OMGraphics.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_omgraphics/src/OMGraphics.rs
@@ -1213,16 +1213,26 @@ fn find_icon_object(root: &J) -> J {
     None
 }
 
-fn icon_from_json(root: &J) -> Icon {
-    let mut icon = Icon::default();
+/// A class's Icon layer is its base classes' unioned with its own, the base
+/// classes' drawn first (behind); most of MSL draws its icon that way.
+fn collect_icon(root: &J, icon: &mut Icon, depth: u32) {
+    if depth > 32 {
+        return; // a malformed instance must not recurse forever
+    }
+    for e in root.get("elements").items() {
+        let e = Some(e);
+        if e.get("$kind").as_str() == "extends" {
+            collect_icon(&e.get("baseClass"), icon, depth + 1);
+        }
+    }
     let Some(icon_obj) = find_icon_object(root) else {
-        return icon;
+        return;
     };
     let icon_obj = Some(icon_obj);
 
     let ext = icon_obj.get("coordinateSystem").get("extent");
     if ext.len() >= 2 {
-        icon.extent = parse_extent(&ext);
+        icon.extent = parse_extent(&ext); // the most derived declaration wins
     }
 
     for g in icon_obj.get("graphics").items() {
@@ -1236,6 +1246,11 @@ fn icon_from_json(root: &J) -> Icon {
             icon.graphics.push(s);
         }
     }
+}
+
+fn icon_from_json(root: &J) -> Icon {
+    let mut icon = Icon::default();
+    collect_icon(root, &mut icon, 0);
     icon
 }
 
@@ -1272,7 +1287,7 @@ struct PlacedConnector {
     y1: f64,
     x2: f64,
     y2: f64,
-    icon: J,
+    ty: J,
 }
 
 /// The type path with non-alphanumerics turned into underscores.
@@ -1317,7 +1332,6 @@ fn collect_placed_connectors(root: &J) -> Vec<PlacedConnector> {
         let Some(b) = placement_box(&ext) else {
             continue; // no placement -> not drawn
         };
-        let icon = t.get("annotation").get("Icon");
         out.push(PlacedConnector {
             name: e.get("name").as_str(),
             icon_base_name: icon_base_name_of(&t.get("name").as_str()),
@@ -1325,7 +1339,7 @@ fn collect_placed_connectors(root: &J) -> Vec<PlacedConnector> {
             y1: b[1],
             x2: b[2],
             y2: b[3],
-            icon: if icon.is_object() { icon } else { None },
+            ty: t,
         });
     }
     out
@@ -1334,7 +1348,7 @@ fn collect_placed_connectors(root: &J) -> Vec<PlacedConnector> {
 fn connector_icon(handle: i32, index: i32) -> Option<Icon> {
     let cs = collect_placed_connectors(&ModelInstanceReference::get(handle));
     let c = cs.get(usize::try_from(index).ok()?)?;
-    let icon = icon_from_json(&c.icon);
+    let icon = icon_from_json(&c.ty);
     if icon.graphics.is_empty() { None } else { Some(icon) }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/README.md
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/README.md
@@ -50,7 +50,7 @@ out of jco's own wrappers, so the two cannot drift.
 | `fmi-worker.js` | owns the driver and the FMU for the length of a run |
 | `driver.js` | the driver module, and the FMI calls it imports |
 | `fmu-core.js` | jco transpilation, and the core exports past its glue |
-| `fmu.js` | the ZIP and `modelDescription.xml`, for what the page displays |
+| `fmu.js` | writing an archive back out, and the documentation as DOM |
 | `wasi.js` | a WASI preview1 host, so the result file is written like any other |
 | `selftest.html` | `?fmu=<url>&interface=me|cs&solver=<name>` — the whole path, headless |
 
@@ -66,6 +66,38 @@ FMI logo, copied unmodified from
 usage terms forbid altering it and ask for a white background, which is why the
 launcher gives that one icon a white chip instead of recolouring the artwork.
 
+## Who opens the FMU
+
+The driver does, once. `openmodelica_fmi` unpacks the archive and parses
+`modelDescription.xml` in the worker, and `om_fmi_info` hands the page the whole
+description as JSON — variables, interfaces, the default experiment, the
+`<Alias>` map, the OpenModelica `<Figures>` and `<Visualization>` annotations.
+The page reads no XML and unpacks no ZIP to show an FMU, and anything else built
+on the crate gets the same reading.
+
+`om_fmi_icon` and `om_fmi_documentation` pull the two things that are files
+rather than metadata, and `om_fmi_select_file` fetches any other entry on demand
+— the `_visual.xml` scene and its CAD files, for instance.
+
+The one thing still opened on the page is the **native repack**, which writes a
+*new* archive out of the old one: `readZip`/`writeZip` exist for that, and
+nothing on the wasm side writes archives.
+
+The **icon** is FMI 3.0's `terminalsAndIcons/icon.png`, with `icon.svg` preferred
+when the FMU ships one, and it sits beside the FMU summary. It comes from the
+standard location, so any exporter's FMU shows one — not just OpenModelica's.
+
+The **documentation** is `documentation/index.html` (`_main.html` for FMI 1.0),
+in a third column with a chevron that collapses it to a rail, the same as the
+simulator page. Turning it into nodes stays here because it is DOM work: it may
+be a whole HTML document or a bare fragment, and only the body is used, since the
+FMU's own `<style>` would restyle the page around it and its `<script>` is not
+ours to run. Images are inlined as `data:` URIs, because nothing inside an
+archive the browser never unpacked has a URL — resolution is relative, so a page
+reaching `../terminalsAndIcons/icon.svg` gets it. Links that do not resolve — a
+`modelica://Some.Class` reference to a library that did not travel with the FMU —
+lose their href rather than pretend to work.
+
 ## Results
 
 Samples are recorded for every numeric variable that can change. The download
@@ -73,6 +105,13 @@ button in the header writes the usual OpenModelica `.mat` through WASI and hands
 it over — the same file OMPlot and `omc-diff` read for a simulated model. It is
 written when asked for rather than after every run, since serialising the whole
 result is the expensive part and most runs are only ever plotted.
+
+A cref in a figure or in the 3D scene often names an FMI 3.0 `<Alias>` rather
+than the variable holding the data — an alias shares its base variable's
+`valueReference`, so only the base name is recorded, and the bus signals a figure
+tends to reference (`axis1.axisControlBus.angle`) are nearly all aliases. Both
+resolve through the `aliases` map `om_fmi_info` reports before giving up on a
+name.
 
 Inputs are expressions in `t` (`sin(2*PI*t)`, `t < 1 ? 0 : 1`) evaluated by the
 driver wherever the solver asks for a value; parameters are constants applied

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/driver.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/driver.js
@@ -131,12 +131,46 @@ export class Driver {
       this.exports.om_fmi_free(p, path.length);
       if (got) files.set(name, this.binary());
     }
+    this.resources = files;
+    this.info.icon = this.icon();
+    this.info.documentation = this.documentation();
     this.component = await loadComponent(component, { files, onLog: this.onLog });
     // Wire the component up now rather than when Simulate is pressed: wiring
     // the modules is the expensive half, and every later run reuses this
     // instance through `fmi3Reset`.
     await this.warm(this.info.coSimulation ? 'cs' : 'me');
     return this.info;
+  }
+
+  // One file out of the archive, or null. The page never unpacks the FMU itself:
+  // the driver already has it open.
+  file(name) {
+    const path = this.encoder.encode(name);
+    const p = this.pass(path);
+    const got = this.exports.om_fmi_select_file(p, path.length);
+    this.exports.om_fmi_free(p, path.length);
+    return got ? this.binary() : null;
+  }
+
+  // The FMU icon (terminalsAndIcons/icon.svg, else icon.png), or null.
+  icon() {
+    if (!this.exports.om_fmi_icon()) return null;
+    return { name: this.out().name, bytes: this.binary() };
+  }
+
+  // The documentation entry point and the files beside it, or null. Small enough
+  // to hand over whole — it is a page and the images it shows.
+  documentation() {
+    if (!this.exports.om_fmi_documentation()) return null;
+    const { entry, files } = this.out();
+    const map = new Map();
+    // The icons too: the generated page puts the FMU icon in its heading, which
+    // is a relative reference out of documentation/.
+    for (const name of [...files, 'terminalsAndIcons/icon.svg', 'terminalsAndIcons/icon.png']) {
+      const bytes = this.file(name);
+      if (bytes) map.set(name, bytes);
+    }
+    return { entry, files: map };
   }
 
   // Instantiate an interface before it is run, so pressing Simulate does not

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/fmi-worker.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/fmi-worker.js
@@ -38,6 +38,10 @@ async function handle(kind, args) {
       if (!driver) throw new Error('no FMU is loaded');
       return driver.warm(args.kind);
     }
+    case 'file': {
+      if (!driver) throw new Error('no FMU is loaded');
+      return driver.file(args.name);
+    }
     case 'run': {
       if (!driver) throw new Error('no FMU is loaded');
       const result = await driver.run(args.options);

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/fmu.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/fmu.js
@@ -1,15 +1,17 @@
-// Loading of FMI-LS-WASM FMUs: ZIP extraction and modelDescription.xml parsing.
-// Instantiating the component — transpiling it with jco and reaching its core
-// exports — is `fmu-core.js`; what the page shows about an FMU is parsed here.
-
-import { loadComponent } from './fmu-core.js';
+// Writing an FMU back out, and its documentation as DOM.
+//
+// Reading one is the driver's job: `openmodelica_fmi` unpacks the archive and
+// parses `modelDescription.xml` in the worker. What is left here is the half no
+// wasm entry point covers — the native repack writes a new archive — and the
+// half that only means anything in a browser.
 
 async function inflateRaw(bytes) {
   const s = new Blob([bytes]).stream().pipeThrough(new DecompressionStream('deflate-raw'));
   return new Uint8Array(await new Response(s).arrayBuffer());
 }
 
-// Minimal ZIP reader over the central directory. Stored and deflated entries only.
+// Minimal ZIP reader over the central directory, for the one path that needs
+// every entry in hand: the native repack. Stored and deflated entries only.
 export async function readZip(buf) {
   const dv = new DataView(buf), u8 = new Uint8Array(buf), dec = new TextDecoder();
   let eocd = -1;
@@ -104,188 +106,67 @@ export async function writeZip(files) {
   return new Blob([...local, ...central, new Uint8Array(end.buffer)]);
 }
 
-// FMI 3.0 variable element name -> the get/set suffix used by the WIT methods.
-// Enumeration is an Int64 in FMI 3.0.
-const TYPES = {
-  Float32: 'Float32', Float64: 'Float64',
-  Int8: 'Int8', Int16: 'Int16', Int32: 'Int32', Int64: 'Int64',
-  UInt8: 'UInt8', UInt16: 'UInt16', UInt32: 'UInt32', UInt64: 'UInt64',
-  Boolean: 'Boolean', String: 'String', Binary: 'Binary',
-  Enumeration: 'Int64', Clock: 'Clock',
+const MIME = {
+  png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif',
+  svg: 'image/svg+xml', bmp: 'image/bmp', webp: 'image/webp', avif: 'image/avif',
 };
-const NUMERIC = new Set(['Float32', 'Float64', 'Int8', 'Int16', 'Int32', 'Int64',
-  'UInt8', 'UInt16', 'UInt32', 'UInt64', 'Boolean', 'Enumeration']);
+const mimeOf = (name) => MIME[(name.split('.').pop() || '').toLowerCase()] || 'application/octet-stream';
 
-const attr = (e, n) => (e && e.hasAttribute(n) ? e.getAttribute(n) : null);
-const numAttr = (e, n) => { const v = attr(e, n); return v == null || v === '' ? null : parseFloat(v); };
-const boolAttr = (e, n) => { const v = attr(e, n); return v == null ? null : v === 'true' || v === '1'; };
-
-function iface(e) {
-  if (!e) return null;
-  return {
-    modelIdentifier: attr(e, 'modelIdentifier') || '',
-    needsExecutionTool: boolAttr(e, 'needsExecutionTool') === true,
-    hasEventMode: boolAttr(e, 'hasEventMode') === true,
-    canHandleVariableCommunicationStepSize: boolAttr(e, 'canHandleVariableCommunicationStepSize') !== false,
-    fixedInternalStepSize: numAttr(e, 'fixedInternalStepSize'),
-    providesDirectionalDerivatives: boolAttr(e, 'providesDirectionalDerivatives') === true,
-  };
+function dataUri(bytes, name) {
+  let s = '';
+  for (let i = 0; i < bytes.length; i += 0x8000) s += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
+  return `data:${mimeOf(name)};base64,${btoa(s)}`;
 }
 
-// The OpenModelica <Figures> vendor annotation. Absent / unknown-version /
-// malformed degrades to []: such an FMU is plotted the ordinary way, never rejected.
-function parseFigures(root) {
-  const viz = root.querySelector(':scope > Annotations > Tool[name="OpenModelica"] > Figures');
-  if (!viz) return [];
-  const version = attr(viz, 'version');
-  if (version != null && version !== '1') return [];   // unknown schema: ignore, don't guess
-  const axis = (plot, role) => {
-    const a = plot.querySelector(`:scope > Axis[role="${role}"]`);
-    if (!a) return null;
-    return {
-      label: attr(a, 'label') || '', unit: attr(a, 'unit') || '',
-      min: numAttr(a, 'min'), max: numAttr(a, 'max'),
-      log: (attr(a, 'scale') || 'Linear') === 'Log',
-    };
-  };
-  const figures = [];
-  for (const f of viz.querySelectorAll(':scope > Figure')) {
-    const plots = [];
-    for (const p of f.querySelectorAll(':scope > Plot')) {
-      const curves = [];
-      for (const c of p.querySelectorAll(':scope > Curve')) {
-        const y = attr(c, 'y'); if (!y) continue;
-        curves.push({ x: attr(c, 'x') || '', y, legend: attr(c, 'legend') || '' });
-      }
-      const tr = p.querySelector(':scope > TerminalRef');
-      if (!curves.length) continue;   // TerminalRef-only plot: skip, we render explicit curves
-      plots.push({
-        title: attr(p, 'title') || '', preferred: boolAttr(p, 'preferred') === true,
-        terminal: tr ? attr(tr, 'terminal') : null, curves,
-        x: axis(p, 'x'), y: axis(p, 'y'), y2: axis(p, 'y2'),
-      });
-    }
-    if (!plots.length) continue;
-    const cap = f.querySelector(':scope > Caption');
-    figures.push({
-      title: attr(f, 'title') || '', group: attr(f, 'group') || '',
-      preferred: boolAttr(f, 'preferred') === true,
-      caption: cap ? cap.textContent : '', plots,
-    });
+// Resolve `href` against `base` (a directory inside the archive) the way a browser
+// would, so `../terminalsAndIcons/icon.svg` in documentation/index.html reaches the
+// icon. Null for anything that is not a path inside the archive.
+function resolveInZip(base, href) {
+  if (!href || /^[a-z][a-z0-9+.-]*:/i.test(href) || href.startsWith('#')) return null;
+  const parts = href.startsWith('/') ? [] : base.split('/').filter(Boolean);
+  for (const seg of href.replace(/^\//, '').split('/')) {
+    if (seg === '' || seg === '.') continue;
+    if (seg === '..') { if (!parts.length) return null; parts.pop(); }
+    else parts.push(seg);
   }
-  return figures;
+  return parts.join('/');
 }
 
-// The OpenModelica <Visualization> annotation naming the _visual.xml resource, or null.
-function parseVisualization(root) {
-  const v = root.querySelector(':scope > Annotations > Tool[name="OpenModelica"] > Visualization');
-  if (!v) return null;
-  const version = attr(v, 'version');
-  if (version != null && version !== '1') return null;
-  const file = attr(v, 'file');
-  return file ? { file } : null;
+// The icon the driver took out of terminalsAndIcons/, as a data URI for an <img>.
+export function iconDataUri(icon) {
+  return icon && icon.bytes ? dataUri(icon.bytes, icon.name) : null;
 }
 
-export function parseModelDescription(xml) {
-  const doc = new DOMParser().parseFromString(xml, 'application/xml');
-  const perr = doc.querySelector('parsererror');
-  if (perr) throw new Error('modelDescription.xml is not well-formed: ' + perr.textContent.trim());
-  const root = doc.documentElement;
-  if (root.tagName !== 'fmiModelDescription') throw new Error('modelDescription.xml: root element is not fmiModelDescription');
-  const fmiVersion = attr(root, 'fmiVersion') || '';
-  if (!fmiVersion.startsWith('3.')) throw new Error(`FMI version ${fmiVersion || '?'} is not supported; this simulator requires FMI 3.0`);
-
-  const variables = [];
-  // FMI 3.0 <Alias> name -> primary name; many visualization crefs are aliases.
-  const aliases = new Map();
-  const mv = root.querySelector('ModelVariables');
-  for (const e of mv ? Array.from(mv.children) : []) {
-    const type = TYPES[e.tagName];
-    if (!type) continue;
-    // String and Binary carry their start in a <Start value="…"/> child.
-    const startEl = e.querySelector(':scope > Start');
-    const startAttr = attr(e, 'start');
-    const start = startEl ? attr(startEl, 'value')
-      : startAttr == null ? null : startAttr.trim().split(/\s+/)[0];
-    const name = attr(e, 'name') || '';
-    variables.push({
-      name,
-      vr: parseInt(attr(e, 'valueReference'), 10),
-      tag: e.tagName,
-      type,
-      numeric: NUMERIC.has(e.tagName),
-      causality: attr(e, 'causality') || 'local',
-      variability: attr(e, 'variability') || (e.tagName.startsWith('Float') ? 'continuous' : 'discrete'),
-      start,
-      initial: attr(e, 'initial'),
-      unit: attr(e, 'unit') || attr(e, 'displayUnit') || '',
-      description: attr(e, 'description') || '',
-      derivative: attr(e, 'derivative'),
-    });
-    for (const al of e.querySelectorAll(':scope > Alias')) {
-      const an = attr(al, 'name');
-      if (an) aliases.set(an, name);
-    }
+// The FMU's documentation as HTML, from what the driver handed over: the entry
+// point and the files beside it. It may be a whole document or a bare fragment;
+// only the body survives, since the FMU's <style> would restyle the page around
+// it and its <script> is not ours to run. Images are inlined — nothing inside an
+// archive the browser never unpacked has a URL.
+export function documentationHtml(doc_) {
+  if (!doc_) return null;
+  const { entry, files } = doc_;
+  if (!entry || !files || !files.get(entry)) return null;
+  const base = entry.slice(0, entry.lastIndexOf('/'));
+  const doc = new DOMParser().parseFromString(new TextDecoder().decode(files.get(entry)), 'text/html');
+  doc.querySelectorAll('script, style, link, meta, base, iframe, object, embed').forEach((e) => e.remove());
+  // Parsing is inert, but the result goes into the page through innerHTML, where an
+  // `onerror=` the FMU wrote would run. The FMU is a file someone was handed.
+  for (const e of doc.querySelectorAll('*')) {
+    for (const a of [...e.attributes]) if (a.name.toLowerCase().startsWith('on')) e.removeAttributeNode(a);
   }
-
-  const de = root.querySelector('DefaultExperiment');
-  const ms = root.querySelector('ModelStructure');
-  return {
-    modelName: attr(root, 'modelName') || '',
-    fmiVersion,
-    instantiationToken: attr(root, 'instantiationToken') || '',
-    description: attr(root, 'description') || '',
-    generationTool: attr(root, 'generationTool') || '',
-    version: attr(root, 'version') || '',
-    me: iface(root.querySelector('ModelExchange')),
-    cs: iface(root.querySelector('CoSimulation')),
-    se: iface(root.querySelector('ScheduledExecution')),
-    defaultExperiment: {
-      startTime: de ? numAttr(de, 'startTime') : null,
-      stopTime: de ? numAttr(de, 'stopTime') : null,
-      stepSize: de ? numAttr(de, 'stepSize') : null,
-      tolerance: de ? numAttr(de, 'tolerance') : null,
-    },
-    variables,
-    aliases,
-    nStates: ms ? ms.querySelectorAll(':scope > ContinuousStateDerivative').length : 0,
-    nEventIndicators: ms ? ms.querySelectorAll(':scope > EventIndicator').length : 0,
-    figures: parseFigures(root),
-    visualization: parseVisualization(root),
-  };
-}
-
-// The text of an FMU resource (path relative to resources/), or null.
-export function readResource(files, name) {
-  const bytes = files.get('resources/' + name);
-  return bytes ? new TextDecoder().decode(bytes) : null;
-}
-
-// The wasm component lives at binaries/wasm32-wasip2/<modelIdentifier>.wasm; fall
-// back to the single .wasm in that directory when the identifier does not match.
-export function findComponent(files, md) {
-  const dir = 'binaries/wasm32-wasip2/';
-  const ids = [md.cs, md.me, md.se].filter(Boolean).map((i) => i.modelIdentifier);
-  for (const id of ids) {
-    const bytes = files.get(`${dir}${id}.wasm`);
-    if (bytes) return bytes;
+  for (const img of doc.querySelectorAll('img[src], source[src]')) {
+    const src = img.getAttribute('src');
+    if (/^(data|https?):/i.test(src)) continue;
+    const name = resolveInZip(base, src);
+    const bytes = name && files.get(name);
+    if (bytes) img.setAttribute('src', dataUri(bytes, name));
+    else img.remove();                       // an image that did not travel with the FMU
   }
-  const candidates = [...files.keys()].filter((n) => n.startsWith(dir) && n.endsWith('.wasm'));
-  if (candidates.length === 1) return files.get(candidates[0]);
-  if (!candidates.length) throw new Error(`no wasm component found in ${dir} (is this an FMI-LS-WASM FMU?)`);
-  throw new Error(`no component matching modelIdentifier ${ids.join('/')} in ${dir}`);
+  for (const a of doc.querySelectorAll('a[href]')) {
+    if (/^https?:/i.test(a.getAttribute('href'))) { a.target = '_blank'; a.rel = 'noopener'; }
+    else a.removeAttribute('href');          // modelica:// class links mean nothing here
+  }
+  const html = doc.body.innerHTML.trim();
+  return html || null;
 }
 
-// Read an FMU. `withComponent` transpiles and instantiates the wasm component
-// here as well, which the page does not need: it shows what the model
-// description says and leaves running the FMU to the worker.
-export async function loadFmu(buf, { onLog, withComponent = false } = {}) {
-  const files = await readZip(buf);
-  const mdFile = files.get('modelDescription.xml');
-  if (!mdFile) throw new Error('modelDescription.xml is missing from the archive');
-  const md = parseModelDescription(new TextDecoder().decode(mdFile));
-  if (!withComponent) return { md, files, component: null, instance: null };
-  const component = await loadComponent(findComponent(files, md), { files, onLog });
-  const instance = async () => ({ md, ...(await component.probe()) });
-  return { md, files, component, instance };
-}

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/index.html
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/index.html
@@ -15,6 +15,9 @@
 
   /* FMU summary, or the drop target when nothing is loaded yet. */
   .info { padding:2px 12px 12px; }
+  /* The FMU icon from terminalsAndIcons/, sized as the generated library
+     documentation sizes it. Floated so the summary keeps its grid. */
+  .fmu-icon { float:right; width:32px; height:32px; object-fit:contain; margin:0 0 4px 12px; }
   /* A button, so click and Enter open the file dialog. */
   .drop { display:block; width:calc(100% - 24px); margin:10px 12px; background:transparent;
     border:1.5px dashed var(--border); border-radius:8px; cursor:pointer;
@@ -53,6 +56,27 @@
   .log-body .error, .log-body .fatal, .log-body .host { color:var(--err); }
   .log-body .empty { color:var(--muted); font-family:inherit; }
 
+  /* Documentation column, shown only when the screen is wide enough (see below).
+     Mirrors the simulator page: a chevron collapses it, and collapsed it stays a
+     thin rail whose chevron reopens it, so it is never lost. */
+  .docs { display:none; flex-direction:column; min-height:0; border-left:1px solid var(--border); }
+  .docs-head { display:flex; align-items:center; gap:6px; padding-right:4px; flex:0 0 auto; }
+  .docs-head .section-label { flex:1 1 auto; }
+  .doc-toggle { background:transparent; border:0; color:var(--muted); cursor:pointer;
+    padding:6px 8px; display:inline-flex; align-items:center; justify-content:center; }
+  .doc-toggle:hover { color:var(--fg); }
+  .doc-toggle svg { width:16px; height:16px; display:block; transition:transform .15s; }
+  .doc-expand { display:none; }                 /* the collapsed-rail reopen button (desktop) */
+  .doc-body { flex:1 1 auto; overflow-y:auto; padding:4px 14px 16px; font-size:13.5px; line-height:1.5; }
+  .doc-body.empty { color:var(--muted); display:grid; place-items:center; text-align:center; }
+  .doc-body img, .doc-body svg { max-width:100%; height:auto; }
+  .doc-body a { color:var(--accent); }
+  .doc-body table { border-collapse:collapse; max-width:100%; display:block; overflow-x:auto; }
+  .doc-body td, .doc-body th { border:1px solid var(--border); padding:3px 6px; }
+  .doc-body pre, .doc-body code { font-family:ui-monospace,Menlo,Consolas,monospace; font-size:12.5px; }
+  .doc-body h1, .doc-body h2, .doc-body h3, .doc-body h4 { color:var(--fg); font-size:1.05em; margin:.8em 0 .3em; }
+  .doc-body .svgiconhead { width:24px; height:24px; object-fit:contain; vertical-align:middle; }
+
   @media (max-width:820px), (orientation:portrait) {
     main { grid-template-columns:1fr; }
     .left { border-right:0; border-bottom:1px solid var(--border); overflow:visible; }
@@ -60,6 +84,24 @@
     #icPanel { max-height:none; }
     header .status { order:3; flex-basis:100%; white-space:normal; }
     .log-pane { height:auto; max-height:40vh; }
+    /* Documentation flows at the end of the page (scroll down to reach it). */
+    .docs { display:block; border-left:0; border-top:1px solid var(--border); }
+    .doc-body { overflow:visible; }
+    .doc-body.empty { min-height:80px; }
+    /* Collapsed: keep the header strip (with its reopen chevron), hide the body. */
+    body.docs-hidden .doc-body { display:none; }
+    body.docs-hidden .docs-head .doc-toggle svg { transform:rotate(180deg); }
+  }
+
+  /* Landscape screens: a third column for the FMU's documentation. */
+  @media (min-width:821px) and (orientation:landscape) {
+    main { grid-template-columns:minmax(340px,30%) 1fr minmax(260px,22%); }
+    .docs { display:flex; }
+    /* Collapsed: the column becomes a thin rail with a reopen chevron. */
+    body.docs-hidden main { grid-template-columns:minmax(340px,38%) 1fr 34px; }
+    body.docs-hidden .docs-head, body.docs-hidden .doc-body { display:none; }
+    body.docs-hidden .doc-expand { display:flex; flex:1 1 auto; align-items:flex-start;
+      justify-content:center; width:100%; padding:10px 0; }
   }
 </style>
 <script type="importmap">
@@ -133,6 +175,19 @@
       <div class="log-body" id="log"><span class="empty">No messages.</span></div>
     </div>
   </div>
+
+  <div class="docs" id="docs">
+    <div class="docs-head">
+      <span class="section-label">Documentation</span>
+      <button class="doc-toggle" id="docCollapse" title="Hide documentation" aria-label="Hide documentation">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg>
+      </button>
+    </div>
+    <div class="doc-body empty" id="docBody">No FMU loaded.</div>
+    <button class="doc-toggle doc-expand" id="docExpand" title="Show documentation" aria-label="Show documentation">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 6l-6 6 6 6"/></svg>
+    </button>
+  </div>
 </main>
 
 <div class="modal-backdrop" id="nativeBackdrop" hidden>
@@ -157,7 +212,7 @@
 </div>
 
 <script type="module">
-import { loadFmu, readResource, findComponent, writeZip } from './fmu.js';
+import { readZip, writeZip, iconDataUri, documentationHtml } from './fmu.js';
 import { loaderIndex, loaderBytes, compileForPlatform } from '../fmu-aot.js';
 import { Session } from './session.js';
 import { COLORS, createCharts, escapeHtml, unitHTML } from '../plot.js';
@@ -169,6 +224,7 @@ const el = (id) => document.getElementById(id);
 const statusEl = el('status'), runBtn = el('run'), openBtn = el('open'), fileEl = el('file');
 const downloadEl = el('download');
 const infoEl = el('info'), dropEl = el('drop'), icGrid = el('icGrid'), icEmpty = el('icEmpty');
+const docBody = el('docBody');
 const chartsEl = el('charts'), chartsEmpty = el('chartsEmpty'), logEl = el('log');
 const charts = createCharts(chartsEl);
 const ifaceEl = el('interface'), startEl = el('start'), stopEl = el('stop'), stepEl = el('step'),
@@ -184,6 +240,7 @@ let lastRec = null;     // the most recent simulation record, for re-rendering
 let viewMode = 'auto';  // 'auto' -> figures when the FMU has them, else all vars
 let animView = null;    // shared 3D animation panel, if the FMU carries a <Visualization>
 let resultName = null;  // the last run's result file, or null when there is none
+let archive = null;     // the .fmu bytes, kept only for the native repack
 
 const setStatus = (text, cls = '') => { statusEl.textContent = text; statusEl.className = 'status ' + cls; };
 const num = (v, d) => { const n = parseFloat(v); return isFinite(n) ? n : d; };
@@ -258,21 +315,23 @@ async function openFile(file) {
     const buf = await file.arrayBuffer();
     const t0 = performance.now();
     if (animView) animView.hide();
-    // The page keeps the model description (the figures, the animation, the
-    // native export read it); the driver in the worker gets the archive.
-    fmu = await loadFmu(buf, { onLog: (status, text) => log(status, text) });
-    const probe = await session.load(buf.slice(0));
+    // The driver opens the archive; this copy is only for the native repack.
+    archive = new Uint8Array(buf.slice(0));
+    const probe = await session.load(buf);
     const ms = Math.round(performance.now() - t0);
+    fmu = { md: probe };
     renderInfo(file.name, probe);
+    renderDoc(documentationHtml(probe.documentation));
     renderFields();
     applyDefaults();
     runBtn.disabled = false;
     syncNativeDialog();
     setStatus(`${fmu.md.modelName || file.name} loaded in ${ms} ms — the FMU reports FMI ${probe.fmiVersion}.`);
   } catch (e) {
-    fmu = null;
+    fmu = null; archive = null;
     runBtn.disabled = true;
     syncNativeDialog();
+    renderDoc(null, 'No FMU loaded.');
     setStatus(`${file.name}: ${e.message}`, 'err');
     log('host', `load failed: ${e.stack || e.message}`);
   }
@@ -281,21 +340,22 @@ async function openFile(file) {
 // An interface counts as available only when the model description declares it
 // and the component actually exports it.
 const kinds = (probe) => [
-  fmu.md.cs && probe.coSimulation ? { id: 'cs', label: 'Co-Simulation' } : null,
-  fmu.md.me && probe.modelExchange ? { id: 'me', label: 'Model Exchange' } : null,
+  probe.coSimulation ? { id: 'cs', label: 'Co-Simulation' } : null,
+  probe.modelExchange ? { id: 'me', label: 'Model Exchange' } : null,
 ].filter(Boolean);
 
 function renderInfo(fileName, probe) {
   const md = fmu.md;
   const tag = (on, text) => `<span class="tag${on ? '' : ' off'}">${text}</span>`;
   const row = (k, v) => (v ? `<dt>${k}</dt><dd>${escapeHtml(v)}</dd>` : '');
-  infoEl.innerHTML = `<dl class="kv">
+  const icon = iconDataUri(md.icon);
+  infoEl.innerHTML = `${icon ? `<img class="fmu-icon" src="${icon}" alt="">` : ''}<dl class="kv">
     ${row('Model', md.modelName || fileName)}
     ${row('Description', md.description)}
     ${row('Generated by', md.generationTool)}
     ${row('FMI', md.fmiVersion + (md.version ? ' · model version ' + md.version : ''))}
-    <dt>Interfaces</dt><dd>${tag(!!md.cs, 'Co-Simulation')}${tag(!!md.me, 'Model Exchange')}${md.se ? tag(false, 'Scheduled Execution (unsupported)') : ''}</dd>
-    <dt>Variables</dt><dd>${md.variables.length}${md.nStates ? ` · ${md.nStates} continuous states` : ''}${md.nEventIndicators ? ` · ${md.nEventIndicators} event indicators` : ''}</dd>
+    <dt>Interfaces</dt><dd>${tag(!!md.coSimulation, 'Co-Simulation')}${tag(!!md.modelExchange, 'Model Exchange')}${md.scheduledExecution ? tag(false, 'Scheduled Execution (unsupported)') : ''}</dd>
+    <dt>Variables</dt><dd>${md.variables.length}${md.numberOfContinuousStates ? ` · ${md.numberOfContinuousStates} continuous states` : ''}${md.numberOfEventIndicators ? ` · ${md.numberOfEventIndicators} event indicators` : ''}</dd>
   </dl>`;
 
   renderSolvers(probe.solvers);
@@ -325,7 +385,7 @@ function onIfaceChange() {
   // only; a Co-Simulation FMU integrates itself. The Event Mode toggle applies
   // to a CS FMU that advertises the capability.
   solverEl.hidden = solverLabel.hidden = ifaceEl.value !== 'me';
-  const showEventMode = ifaceEl.value === 'cs' && !!(fmu && fmu.md.cs && fmu.md.cs.hasEventMode);
+  const showEventMode = ifaceEl.value === 'cs' && !!(fmu && fmu.md.coSimulation && fmu.md.coSimulation.hasEventMode);
   eventModeLabel.hidden = eventModeCell.hidden = !showEventMode;
   // Instantiating the component for this interface takes longer than the run
   // does for a small FMU; get it out of the way while the options are set.
@@ -339,9 +399,7 @@ function renderFields() {
   const md = fmu.md;
   fields = [];
   icGrid.replaceChildren();
-  const stateVrs = new Set(md.variables
-    .filter((v) => v.derivative != null)
-    .map((v) => parseInt(v.derivative, 10)));
+  const stateVrs = new Set(md.variables.filter((v) => v.derivative != null).map((v) => v.derivative));
   const isStart = (v) => stateVrs.has(v.vr) && (v.initial === 'exact' || v.initial === 'approx');
   const wanted = md.variables.filter((v) =>
     (v.causality === 'input') ||
@@ -354,12 +412,12 @@ function renderFields() {
     const nm = document.createElement('div');
     nm.className = 'nm';
     const kindLabel = isStart(v) ? 'start value' : v.causality;
-    nm.title = `${v.name}${v.description ? ' — ' + v.description : ''} (${kindLabel}, ${v.tag})`;
+    nm.title = `${v.name}${v.description ? ' — ' + v.description : ''} (${kindLabel}, ${v.type})`;
     nm.innerHTML = escapeHtml(v.name)
       + (isInput ? '<span class="in">f(t)</span>' : isStart(v) ? '<span class="in">start</span>' : '');
     const input = document.createElement('input');
     // An input must be driven; a parameter with no declared start is left unset.
-    input.value = v.start != null ? v.start : isInput ? (v.tag === 'Boolean' ? 'false' : '0') : '';
+    input.value = v.start != null ? v.start : isInput ? (v.type === 'Boolean' ? 'false' : '0') : '';
     input.placeholder = input.value === '' ? 'unset' : '';
     input.spellcheck = false;
     const unit = document.createElement('span');
@@ -405,7 +463,7 @@ function collectFields() {
     f.input.classList.remove('bad');
     const src = f.input.value.trim();
     if (f.kind === 'parameter' && f.v.start == null && src === '') continue;
-    if (f.v.tag === 'String') {
+    if (f.v.type === 'String') {
       log('warning', `${f.v.name}: string variables cannot be set yet; ignoring.`);
       continue;
     }
@@ -428,7 +486,7 @@ runBtn.onclick = () => {
   // loaded FMU.
   if (!session.cancel()) {
     session.terminate();
-    fmu = null;
+    fmu = null; archive = null;
     runBtn.disabled = true;
     hideResultFile();
     syncNativeDialog();
@@ -550,17 +608,22 @@ function updateFigToggle() {
   figToggle.textContent = (viewMode === 'all') ? 'Figures' : 'All variables';
 }
 
+// An FMI 3.0 <Alias> is an alternative name sharing another variable's
+// valueReference, so only the base name is ever recorded. Bus signals — which is
+// what a figure or a 3D scene usually references — are nearly all aliases.
+const resolveAlias = (name, have) => (have(name) ? name : ((fmu.md.aliases || {})[name] || name));
+
 // Build the 3D scene from the FMU's <Visualization> resource and the run's data,
 // via the shared anim core. CAD shapes whose modelica:// URI isn't in the FMU are skipped.
 async function renderAnimation(rec) {
   const viz = fmu && fmu.md.visualization;
-  const xml = viz && readResource(fmu.files, viz.file);
-  if (!xml) { if (animView) animView.hide(); return; }
+  const text = viz && await session.file('resources/' + viz.file);
+  if (!text) { if (animView) animView.hide(); return; }
+  const xml = new TextDecoder().decode(text);
   const byName = new Map(rec.columns.map((c) => [c.name, c]));
-  const aliases = fmu.md.aliases || new Map();
   // A cref is a recorded column or a static parameter, possibly via an <Alias>.
   const lookup = (name) => {
-    const n = byName.has(name) || (rec.parameters && rec.parameters.has(name)) ? name : (aliases.get(name) || name);
+    const n = resolveAlias(name, (k) => byName.has(k) || !!(rec.parameters && rec.parameters.has(k)));
     const c = byName.get(n);
     if (c) return c.values;
     const p = rec.parameters && rec.parameters.get(n);
@@ -569,8 +632,16 @@ async function renderAnimation(rec) {
   try {
     const built = await buildAnimData(xml, rec.time, lookup);
     if (!built) { if (animView) animView.hide(); return; }
-    // CAD shapes: read the embedded DXF resource (basename of the type URI).
-    attachCadMeshes(built.shapes, (type) => readResource(fmu.files, type.split(/[\\/]/).pop()));
+    // CAD shapes: the embedded DXF resource, named by the basename of the type
+    // URI. Fetched up front — attachCadMeshes resolves them synchronously.
+    const cad = new Map();
+    for (const sh of built.shapes) {
+      const name = sh.type && sh.type.split(/[\\/]/).pop();
+      if (!name || cad.has(name) || !/\.(dxf|stl|obj)$/i.test(name)) continue;
+      const bytes = await session.file('resources/' + name);
+      cad.set(name, bytes ? new TextDecoder().decode(bytes) : null);
+    }
+    attachCadMeshes(built.shapes, (type) => cad.get(type.split(/[\\/]/).pop()) || null);
     if (built.missing && built.missing.length) {
       log('warning', `3D view: ${built.missing.length} shape variable(s) not found in the FMU result (rendered with 0) — e.g. ${built.missing.slice(0, 3).join(', ')}`);
     }
@@ -628,8 +699,9 @@ function renderFigures(rec, finite) {
     fig.plots.forEach((plot, pi) => {
       const curves = [];
       plot.curves.forEach((cv) => {
-        const yc = byName.get(cv.y); if (!yc) return;
-        const xc = cv.x ? byName.get(cv.x) : null;
+        const has = (k) => byName.has(k);
+        const yc = byName.get(resolveAlias(cv.y, has)); if (!yc) return;
+        const xc = cv.x ? byName.get(resolveAlias(cv.x, has)) : null;
         curves.push({ label: cv.legend || cv.y, unit: yc.unit || '', color: COLORS[curves.length % COLORS.length],
                       xs: xc ? Float64Array.from(xc.values) : xs, ys: yc.values, xName: cv.x || 'time' });
       });
@@ -698,10 +770,12 @@ nativeGo.onclick = async () => {
   if (!fmu || !picked.length) return;
   nativeDialog.close();
   nativeGo.disabled = nativeBtn.disabled = true;
-  const id = (fmu.md.cs || fmu.md.me).modelIdentifier;
+  const id = (fmu.md.coSimulation || fmu.md.modelExchange).modelIdentifier;
   try {
-    const component = findComponent(fmu.files, fmu.md);
-    const files = new Map(fmu.files);
+    const files = await readZip(archive.buffer.slice(archive.byteOffset, archive.byteOffset + archive.byteLength));
+    const component = files.get(`binaries/wasm32-wasip2/${id}.wasm`)
+      || [...files.entries()].find(([n]) => n.startsWith('binaries/wasm32-wasip2/') && n.endsWith('.wasm'))?.[1];
+    if (!component) throw new Error('no wasm component found in binaries/wasm32-wasip2');
     for (const platform of picked) {
       const entry = loaders.find((e) => e.platform === platform);
       setStatus(`Compiling for ${platform}…`, 'busy');
@@ -722,7 +796,47 @@ nativeGo.onclick = async () => {
   }
 };
 
-addEventListener('resize', () => charts.redraw());
+// Documentation collapse/expand, driven from inside the widget: a chevron in the
+// doc header hides it; when collapsed it leaves a thin rail (desktop) or header
+// strip (mobile) whose chevron reopens it. Collapsing widens the charts.
+let docsUserToggled = false;   // once the user decides, stop auto-collapsing
+function reflowDocs() {
+  charts.redraw();                                   // chart width changed
+  if (animView) animView.resize();
+}
+function toggleDocs() {
+  docsUserToggled = true;
+  document.body.classList.toggle('docs-hidden');
+  reflowDocs();
+}
+// Landscape screens narrower than the full 3-column layout start with the doc
+// column collapsed to its rail (the chevron stays, so it's never lost) rather
+// than vanishing. Wide screens start expanded; the user's choice overrides both.
+function autoDocs() {
+  if (docsUserToggled) return;
+  const landscape = window.matchMedia('(orientation:landscape)').matches && window.innerWidth >= 821;
+  const wantHidden = landscape && window.innerWidth < 1300;
+  if (document.body.classList.contains('docs-hidden') === wantHidden) return;
+  document.body.classList.toggle('docs-hidden', wantHidden);
+  reflowDocs();
+}
+el('docCollapse').addEventListener('click', toggleDocs);
+el('docExpand').addEventListener('click', toggleDocs);
+autoDocs();
+
+// The FMU's own documentation, shown in the page's theme rather than its own.
+function renderDoc(html, empty = 'This FMU carries no documentation.') {
+  if (!html) {
+    docBody.className = 'doc-body empty';
+    docBody.textContent = empty;
+    return;
+  }
+  docBody.className = 'doc-body';
+  docBody.innerHTML = html;
+  docBody.scrollTop = 0;
+}
+
+addEventListener('resize', () => { charts.redraw(); autoDocs(); });
 </script>
 </body>
 </html>

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/session.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/session.js
@@ -57,6 +57,10 @@ export class Session {
     return this.send('load', { archive, cancelFlag: flag }, [archive]);
   }
 
+  file(name) {
+    return this.send('file', { name });
+  }
+
   run(options) {
     if (this.cancelFlag) Atomics.store(this.cancelFlag, 0, 0);
     return this.send('run', { options });

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -4933,15 +4933,6 @@ algorithm
     return;
   end if;
 
-  // FMI 3.0 graphical user annotations (issue #15686 task 9): render the model
-  // Icon to icons/<modelIdentifier>.svg and add a <GraphicalRepresentation> to
-  // terminalsAndIcons.xml. Done here (after translateModel, before the FMU is
-  // packed) for the C target; the OMGraphics renderer consumes the in-memory
-  // model-instance annotation reference (issue #15219).
-  if FMUVersion == "3.0" and Config.simCodeTarget() == "C" then
-    generateFMI3GraphicalRepresentation(className, fmutmp, filenameprefix);
-  end if;
-
   if Config.simCodeTarget() == "Cpp" then
     System.removeDirectory("binaries");
     for platform in platforms loop

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -975,9 +975,8 @@ public function emitWasmFMU
   input String FMUType;
   input Absyn.Program program;
 protected
-  String guid, modelDescriptionStr, simulationFlagsJson, htmlFile, htmlContent;
-  String fmutmp, terminalsDir = "";
-  list<tuple<String,String>> extraFiles = {};
+  String guid, modelDescriptionStr, simulationFlagsJson;
+  String fmutmp = "", terminalsDir = "", documentationDir = "";
   list<SimCode.FmiTerminal> terminals;
   // `--fmuDirectory`: an export for an OpenModelica importer, which reads the
   // model description and the artifact and nothing else.
@@ -987,6 +986,15 @@ algorithm
   // translation has no callTargetTemplatesFMU around it to have set it.
   setGlobalRoot(Global.optionSimCode, SOME(simCode));
   guid := System.getUUIDStr();
+  if not bareExport then
+    // The C export's scratch directory, which terminalsAndIcons/ and documentation/
+    // are staged in; old contents would be shipped verbatim.
+    fmutmp := Util.hashFileNamePrefix(simCode.fileNamePrefix) + ".fmutmp";
+    if System.directoryExists(fmutmp) and not System.removeDirectory(fmutmp) then
+      Error.addInternalError("Failed to remove directory: " + fmutmp, sourceInfo());
+      fail();
+    end if;
+  end if;
   // The same templates the C target uses, so the XML is byte-identical to it. No
   // sourceFiles: a wasm FMU carries no C. The XML declaration comes from
   // fmuModelDescriptionFile, which the C target reaches these through.
@@ -1000,12 +1008,6 @@ algorithm
     // terminalsAndIcons/ by the C target's route: SimCode writes the XML, then the
     // OMGraphics renderer adds the <GraphicalRepresentation> and the icons beside it.
     if not bareExport then
-      // The C export's scratch directory; old contents would be shipped verbatim.
-      fmutmp := Util.hashFileNamePrefix(simCode.fileNamePrefix) + ".fmutmp";
-      if System.directoryExists(fmutmp) and not System.removeDirectory(fmutmp) then
-        Error.addInternalError("Failed to remove directory: " + fmutmp, sourceInfo());
-        fail();
-      end if;
       terminalsDir := fmutmp + "/terminalsAndIcons/";
       terminals := SimCodeUtil.getFMI3Terminals(simCode);
       if not listEmpty(terminals) then
@@ -1020,20 +1022,18 @@ algorithm
       ExecStat.execStat("FMU terminalsAndIcons.xml");
     end if;
   end if;
-  if not bareExport then
-    (htmlFile, htmlContent) := htmlDocumentation(program, simCode, FMUVersion);
-    if htmlFile <> "" then
-      extraFiles := ("documentation/" + htmlFile, htmlContent) :: extraFiles;
-    end if;
+  // After the icons, so the page references the one terminalsAndIcons/ holds.
+  if not bareExport and writeFMUDocumentation(program, simCode, FMUVersion, fmutmp) then
+    documentationDir := fmutmp + "/documentation/";
     ExecStat.execStat("FMU documentation");
   end if;
   simulationFlagsJson := wasmFMUSimulationFlagsJson(simCode);
   if FMI.isFMIMEType(FMUType) and FMI.isFMICSType(FMUType) then
-    CodegenWasmJit.emitMeCsFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, extraFiles, terminalsDir, simulationFlagsJson);
+    CodegenWasmJit.emitMeCsFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, documentationDir, terminalsDir, simulationFlagsJson);
   elseif FMI.isFMICSType(FMUType) then
-    CodegenWasmJit.emitCsFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, extraFiles, terminalsDir, simulationFlagsJson);
+    CodegenWasmJit.emitCsFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, documentationDir, terminalsDir, simulationFlagsJson);
   else
-    CodegenWasmJit.emitMeFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, extraFiles, terminalsDir, simulationFlagsJson);
+    CodegenWasmJit.emitMeFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, documentationDir, terminalsDir, simulationFlagsJson);
   end if;
   setGlobalRoot(Global.optionSimCode, NONE());
 end emitWasmFMU;
@@ -1055,10 +1055,9 @@ algorithm
   setGlobalRoot(Global.optionSimCode, SOME(simCode));
   () := match (simCode,fmuTarget)
     local
-      String str, newdir, newpath, resourcesDir, dirname, htmlFile;
+      String str, newdir, newpath, resourcesDir, dirname;
       String fmutmp;
       String guid;
-      String htmlContent;
       list<SimCode.FmiTerminal> terminals;
       Boolean b;
       Boolean needSundials = false;
@@ -1171,13 +1170,6 @@ algorithm
               Error.addInternalError("Failed to move " + simCode.fileNamePrefix + "_info.json file", sourceInfo());
             end if;
           end if;
-        end if;
-
-        // create optional html documentation directory
-        (htmlFile, htmlContent) := htmlDocumentation(program, simCode, FMUVersion);
-        if htmlFile <> "" then
-          Util.createDirectoryTree(fmutmp + "/documentation/");
-          System.writeFile(fmutmp + "/documentation/" + htmlFile, htmlContent);
         end if;
 
         SimCodeUtil.resetFunctionIndex();
@@ -1316,6 +1308,16 @@ algorithm
         end if;
 
         Tpl.tplNoret(function CodegenFMU.translateModel(in_a_FMUVersion=FMUVersion, in_a_FMUType=FMUType, in_a_sourceFiles=model_desc_src_files), simCode);
+
+        // FMI 3.0 graphical user annotations (issue #15686 task 9): the template
+        // above wrote terminalsAndIcons.xml, this adds the icons beside it. Before
+        // the documentation, which shows the icon it produced.
+        if FMUVersion == "3.0" then
+          CevalScriptBackend.generateFMI3GraphicalRepresentation(simCode.modelInfo.name, fmutmp, simCode.fileNamePrefix);
+        end if;
+        if writeFMUDocumentation(program, simCode, FMUVersion, fmutmp) then
+          ExecStat.execStat("FMU documentation");
+        end if;
 
         // Add the _part*.c files to the list of source files. We do not know how many of them there are until
         // we have called CodegenFMU.translateModel. Which means the list of source files passed to
@@ -1491,20 +1493,38 @@ algorithm
   setGlobalRoot(Global.optionSimCode, NONE());
 end callTargetTemplatesFMU;
 
-protected function htmlDocumentation
-  "The FMU's documentation/ page, from the model's Documentation annotation
+// `svgiconhead` is sized as the generated library documentation sizes it: a
+// little larger than the class name it sits beside, not a banner.
+protected constant String FMU_DOCUMENTATION_CSS = "
+  :root { color-scheme: light dark; }
+  body { margin: 0 auto; padding: 1.5rem; max-width: 50rem; line-height: 1.5;
+         font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+  h1 { font-size: 1.5rem; margin: 0 0 .2rem; }
+  .svgiconhead { height: 32px; width: 32px; object-fit: contain; vertical-align: middle; }
+  .fmu-desc { margin: 0 0 1.5rem; font-style: italic; opacity: .8; }
+  img { max-width: 100%; height: auto; }
+  table { border-collapse: collapse; }
+  td, th { border: 1px solid; border-color: color-mix(in srgb, currentColor 30%, transparent);
+           padding: .2rem .5rem; }
+  pre, code { font-family: ui-monospace, Menlo, Consolas, monospace; }
+";
+
+protected function writeFMUDocumentation
+  "Write the FMU's documentation/ directory under `fmutmp`: a standalone HTML page
+  built from the model's Documentation annotation
   (e.g) annotation(Documentation(info=\"<html> </html>\",
                                  revisions=\"<html> </html>\",
                                  __OpenModelica_infoHeader = \"<html> </html>\"))
-  An empty file name means the model carries no such annotation.
-  "
+  plus the modelica:// images it references, so the page needs nothing outside the
+  FMU. FMI 3.0 pages also show the icon rendered to terminalsAndIcons/.
+  False when the model carries no such annotation and nothing was written."
   input Absyn.Program program;
   input SimCode.SimCode simCode;
   input String FMUVersion;
-  output String fileName = "";
-  output String content = "";
+  input String fmutmp;
+  output Boolean written = false;
 protected
-  String info, revisions, infoHeader;
+  String info, revisions, infoHeader, docDir, name, page, icon;
 algorithm
   (info, revisions, infoHeader) := ProgramUtil.getNamedAnnotationExp(simCode.modelInfo.name, program, Absyn.IDENT("Documentation"), SOME(("","","")),Interactive.getDocumentationAnnotationString);
 
@@ -1512,13 +1532,96 @@ algorithm
     return;
   end if;
 
-  fileName := if FMUVersion == "1.0" then "_main.html" else "index.html";
-  content := infoHeader + "\n"
-             + "<h1>" + AbsynUtil.pathString(simCode.modelInfo.name) + "</h1>\n"
-             + "<p> <i>" + simCode.modelInfo.description + "</i> </p>\n"
-             + "<h4> <u> Information </u> </h4>" + info + "\n"
-             + "<h4> <u> Revisions </u> </h4>" + revisions + "\n";
-end htmlDocumentation;
+  name := Util.escapeModelicaStringToXmlString(AbsynUtil.pathString(simCode.modelInfo.name));
+  // terminalsAndIcons/ is FMI 3.0 only, and holds an icon only for a model whose
+  // icon layer had something to draw.
+  icon := if FMUVersion == "3.0" and System.regularFileExists(fmutmp + "/terminalsAndIcons/icon.svg")
+          then "<img class=\"svgiconhead\" src=\"../terminalsAndIcons/icon.svg\" alt=\"\"> " else "";
+
+  page := "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n"
+          + "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
+          + "<title>" + name + "</title>\n"
+          + "<style>" + FMU_DOCUMENTATION_CSS + "</style>\n"
+          + "</head>\n<body>\n"
+          + "<h1>" + icon + name + "</h1>\n"
+          + (if stringEmpty(simCode.modelInfo.description) then ""
+             else "<p class=\"fmu-desc\">" + Util.escapeModelicaStringToXmlString(simCode.modelInfo.description) + "</p>\n")
+          + fmuDocumentationSection("", infoHeader)
+          + fmuDocumentationSection("Information", info)
+          + fmuDocumentationSection("Revisions", revisions)
+          + "</body>\n</html>\n";
+
+  docDir := fmutmp + "/documentation/";
+  Util.createDirectoryTree(docDir);
+  page := copyFMUDocumentationResources(program, page, docDir);
+  System.writeFile(docDir + (if FMUVersion == "1.0" then "_main.html" else "index.html"), page);
+  written := true;
+end writeFMUDocumentation;
+
+protected function fmuDocumentationSection
+  "One section of the documentation page: nothing at all when the annotation
+  string is empty, so a model documenting only `info` gets no dangling Revisions
+  heading. The strings are whole HTML documents in Modelica; the page they go
+  into already has its own <html>, so the wrapper is dropped rather than nested."
+  input String heading "empty for an unheaded section";
+  input String html;
+  output String section = "";
+protected
+  String body;
+  Integer len;
+algorithm
+  body := System.trim(html);
+  // Modelica writes these as \"<html> ... </html>\"; some models leave the tags off,
+  // and \"<html></html>\" documents nothing at all.
+  if StringUtil.startsWith(System.tolower(body), "<html>") then
+    len := stringLength(body);
+    body := if len > 6 then substring(body, 7, len) else "";
+    len := stringLength(body);
+    if StringUtil.endsWith(System.tolower(body), "</html>") then
+      body := if len > 7 then substring(body, 1, len - 7) else "";
+    end if;
+    body := System.trim(body);
+  end if;
+  if stringEmpty(body) then
+    return;
+  end if;
+  section := (if stringEmpty(heading) then "" else "<h2>" + heading + "</h2>\n") + body + "\n";
+end fmuDocumentationSection;
+
+protected function copyFMUDocumentationResources
+  "Copy every modelica:// resource the documentation references into `docDir` and
+  point the page at the copy, so it displays without the library it came from. The
+  URI keeps its own path (modelica://Modelica/Resources/Images/x.png becomes
+  documentation/Modelica/Resources/Images/x.png), which keeps two same-named images
+  in different libraries apart. Only URIs naming a file are touched, so a
+  modelica://Some.Class link is left alone."
+  input Absyn.Program program;
+  input output String page;
+  input String docDir;
+protected
+  list<String> uris;
+  String source, classname, relative, target;
+algorithm
+  // A URI cannot contain any of these unencoded, so tokenizing on them lifts the
+  // URIs out of the markup without needing to parse it.
+  uris := List.uniqueOnTrue(list(u for u guard StringUtil.startsWith(u, "modelica://")
+                                 in System.strtok(page, "\"'<> \t\n\r")), stringEq);
+  for uri in uris loop
+    try
+      (_, classname, relative) := System.uriToClassAndPath(uri);
+      source := ProgramUtil.getFullPathFromUri(program, uri, false);
+      if System.regularFileExists(source) then
+        target := classname + relative;
+        Util.createDirectoryTree(docDir + System.dirname(target));
+        if System.copyFile(source, docDir + target) then
+          page := System.stringReplace(page, uri, target);
+        end if;
+      end if;
+    else
+      // A broken documentation link is not worth failing the export over.
+    end try;
+  end for;
+end copyFMUDocumentationResources;
 
 protected function callTargetTemplatesXML
 "Generate target code by passing the SimCode data structure to templates."

--- a/OMCompiler/Compiler/Template/CodegenWasmJit.mo
+++ b/OMCompiler/Compiler/Template/CodegenWasmJit.mo
@@ -128,7 +128,7 @@ function emitMeFmu
   input String fmuPath;
   input String guid;
   input String modelDescription;
-  input list<tuple<String,String>> extraFiles "further (path inside the FMU, content) entries: documentation";
+  input String documentationDir "directory shipped as documentation/ (index.html and the images it references); empty for none";
   input String terminalsDir "directory shipped as terminalsAndIcons/ (the XML and the rendered icons); empty for none";
   input String simulationFlagsJson "--fmiFlags as CodegenFMU renders it, empty when there are none";
 algorithm
@@ -144,7 +144,7 @@ function emitCsFmu
   input String fmuPath;
   input String guid;
   input String modelDescription;
-  input list<tuple<String,String>> extraFiles "further (path inside the FMU, content) entries: documentation";
+  input String documentationDir "directory shipped as documentation/ (index.html and the images it references); empty for none";
   input String terminalsDir "directory shipped as terminalsAndIcons/ (the XML and the rendered icons); empty for none";
   input String simulationFlagsJson "--fmiFlags as CodegenFMU renders it, empty when there are none";
 algorithm
@@ -160,7 +160,7 @@ function emitMeCsFmu
   input String fmuPath;
   input String guid;
   input String modelDescription;
-  input list<tuple<String,String>> extraFiles "further (path inside the FMU, content) entries: documentation";
+  input String documentationDir "directory shipped as documentation/ (index.html and the images it references); empty for none";
   input String terminalsDir "directory shipped as terminalsAndIcons/ (the XML and the rendered icons); empty for none";
   input String simulationFlagsJson "--fmiFlags as CodegenFMU renders it, empty when there are none";
 algorithm

--- a/OMCompiler/Compiler/runtime/OMGraphics.cpp
+++ b/OMCompiler/Compiler/runtime/OMGraphics.cpp
@@ -838,12 +838,24 @@ const Json *findIconObject(const Json &root)
 
 } // namespace
 
-Icon iconFromJson(const Json &root)
+/* A class's Icon layer is its base classes' unioned with its own, the base
+ * classes' drawn first (behind); most of MSL draws its icon that way. Bounded
+ * depth so a malformed instance cannot recurse forever. */
+static void collectIcon(const Json &root, Icon &icon, int depth)
 {
-  Icon icon;
-  const Json *iconObj = findIconObject(root);
-  if (!iconObj) return icon;
+  if (depth > 32) return;
+  const Json &els = root.get("elements");
+  if (els.isArray()) {
+    for (size_t i = 0; i < els.size(); ++i) {
+      const Json &e = els.at(i);
+      if (e.get("$kind").asString() == "extends") collectIcon(e.get("baseClass"), icon, depth + 1);
+    }
+  }
 
+  const Json *iconObj = findIconObject(root);
+  if (!iconObj) return;
+
+  /* The most derived declaration wins for the coordinate system. */
   const Json &cs = iconObj->get("coordinateSystem");
   if (cs.isObject()) {
     const Json &ext = cs.get("extent");
@@ -865,6 +877,12 @@ Icon iconFromJson(const Json &root)
       if (parseShape(name, elements, s)) icon.graphics.push_back(s);
     }
   }
+}
+
+Icon iconFromJson(const Json &root)
+{
+  Icon icon;
+  collectIcon(root, icon, 0);
   return icon;
 }
 

--- a/OMCompiler/Compiler/runtime/OMGraphics_omc.cpp
+++ b/OMCompiler/Compiler/runtime/OMGraphics_omc.cpp
@@ -134,12 +134,13 @@ const Json &rootForHandle(int handle)
 
 /* A placed connector component of the model: its instance name, the icon file
  * base name derived from its type, the placement bounding box (icon coordinates)
- * and a pointer to its type's Icon annotation (into the cached tree). */
+ * and a pointer to its type (into the cached tree). The type, not the Icon it
+ * declares itself: a connector inherits its icon like any other class. */
 struct PlacedConnector {
   std::string name;
   std::string iconBaseName;
   double x1, y1, x2, y2;
-  const Json *icon; /* points into g_cachedRoot */
+  const Json *type; /* points into g_cachedRoot */
 };
 
 /* base name for a connector icon file: the type path with non-alphanumerics
@@ -189,8 +190,7 @@ std::vector<PlacedConnector> collectPlacedConnectors(const Json &root)
     c.name = e.get("name").asString();
     c.iconBaseName = iconBaseNameOf(t.get("name").asString());
     c.x1 = box[0]; c.y1 = box[1]; c.x2 = box[2]; c.y2 = box[3];
-    const Json &ic = t.get("annotation").get("Icon");
-    c.icon = ic.isObject() ? &ic : NULL;
+    c.type = &t;
     out.push_back(c);
   }
   return out;
@@ -276,8 +276,8 @@ const char* OMGraphics_placedConnectorInfo(int handle, int index)
 const char* OMGraphics_placedConnectorIconSVG(int handle, int index)
 {
   std::vector<PlacedConnector> cs = collectPlacedConnectors(rootForHandle(handle));
-  if (index < 0 || index >= (int) cs.size() || !cs[index].icon) return gcString("");
-  OMGraphics::Icon icon = OMGraphics::iconFromJson(*cs[index].icon);
+  if (index < 0 || index >= (int) cs.size() || !cs[index].type) return gcString("");
+  OMGraphics::Icon icon = OMGraphics::iconFromJson(*cs[index].type);
   if (icon.graphics.empty()) return gcString("");
   return gcString(OMGraphics::renderIconSVG(icon));
 }
@@ -299,8 +299,8 @@ int OMGraphics_writeIconPNGFromHandle(int handle, const char *modelName, const c
 int OMGraphics_writePlacedConnectorIconPNG(int handle, int index, const char *path)
 {
   std::vector<PlacedConnector> cs = collectPlacedConnectors(rootForHandle(handle));
-  if (index < 0 || index >= (int) cs.size() || !cs[index].icon) return 0;
-  OMGraphics::Icon icon = OMGraphics::iconFromJson(*cs[index].icon);
+  if (index < 0 || index >= (int) cs.size() || !cs[index].type) return 0;
+  OMGraphics::Icon icon = OMGraphics::iconFromJson(*cs[index].type);
   if (icon.graphics.empty()) return 0;
   return writeBinaryFile(path, OMGraphics::renderIconPNG(icon)) ? 1 : 0;
 }

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_23.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_23.mos
@@ -47,14 +47,34 @@ readFile("fmi_attributes_23_index.html"); getErrorString();
 // "
 // 0
 // ""
-// "<html><h2>TestModel</h2></html>
+// "<!DOCTYPE html>
+// <html lang=\"en\">
+// <head>
+// <meta charset=\"utf-8\">
+// <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+// <title>fmi_attributes_23</title>
+// <style>
+//   :root { color-scheme: light dark; }
+//   body { margin: 0 auto; padding: 1.5rem; max-width: 50rem; line-height: 1.5;
+//          font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+//   h1 { font-size: 1.5rem; margin: 0 0 .2rem; }
+//   .svgiconhead { height: 32px; width: 32px; object-fit: contain; vertical-align: middle; }
+//   .fmu-desc { margin: 0 0 1.5rem; font-style: italic; opacity: .8; }
+//   img { max-width: 100%; height: auto; }
+//   table { border-collapse: collapse; }
+//   td, th { border: 1px solid; border-color: color-mix(in srgb, currentColor 30%, transparent);
+//            padding: .2rem .5rem; }
+//   pre, code { font-family: ui-monospace, Menlo, Consolas, monospace; }
+// </style>
+// </head>
+// <body>
 // <h1>fmi_attributes_23</h1>
-// <p> <i>model description text example </i> </p>
-// <h4> <u> Information </u> </h4><html>
-//   <p>The linear resistor connects the branch voltage <em>v</em> with the branch current <em>i</em> by <em>i*R = v</em>. The Resistance <em>R</em> is allowed to be positive, zero, or negative.</p>
-//   </html>
-// <h4> <u> Revisions </u> </h4><html>
-//   <ul>
+// <p class=\"fmu-desc\">model description text example </p>
+// <h2>TestModel</h2>
+// <h2>Information</h2>
+// <p>The linear resistor connects the branch voltage <em>v</em> with the branch current <em>i</em> by <em>i*R = v</em>. The Resistance <em>R</em> is allowed to be positive, zero, or negative.</p>
+// <h2>Revisions</h2>
+// <ul>
 //   <li><em> August 07, 2009   </em>
 //          by Anton Haumer<br> temperature dependency of resistance added<br>
 //          </li>
@@ -65,7 +85,8 @@ readFile("fmi_attributes_23_index.html"); getErrorString();
 //          by Christoph Clauss<br> initially implemented<br>
 //          </li>
 //   </ul>
-//   </html>
+// </body>
+// </html>
 // "
 // ""
 // endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/Makefile
@@ -15,8 +15,10 @@ fmi3_builddescription.mos \
 fmi3_causalize_protected.mos \
 fmi3_clocks.mos \
 fmi3_directional_derivatives.mos \
+fmi3_documentation.mos \
 fmi3_fmustate.mos \
 fmi3_graphics.mos \
+fmi3_graphics_inherited.mos \
 fmi3_msl_adder4.mos \
 fmi3_msl_engine1a.mos \
 fmi3_terminals_alias_nb.mos \

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_documentation.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_documentation.mos
@@ -1,0 +1,69 @@
+// name: fmi3_documentation.mos
+// keywords: FMI 3.0 export documentation html images modelica uri icon
+// status: correct
+// teardown_command: rm -rf DocPkg DocM.fmu DocM.fmutmp/ DocM.log DocM_info.json DocM_FMU.libs DocM_FMU.makefile DocM_external_functions.json resources index.html
+//
+// The FMU's documentation/ directory. index.html is a standalone HTML page (the
+// Documentation annotation's own <html> wrapper is dropped rather than nested,
+// and an empty section gets no heading), every modelica:// image it references is
+// copied in beside it keeping the URI's own path — so two same-named images from
+// different libraries cannot collide — and the page shows the icon the graphical
+// representation rendered to terminalsAndIcons/.
+//
+// The package lives on disk because a modelica:// URI resolves against the file
+// the class was loaded from; a loadString class has none.
+
+system("mkdir -p DocPkg/Resources/Images"); getErrorString();
+writeFile("DocPkg/Resources/Images/box.svg", "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 8 8\"><rect width=\"8\" height=\"8\"/></svg>"); getErrorString();
+writeFile("DocPkg/package.mo", "package DocPkg
+  model DocM \"a documented model\"
+    Real x(start = 1);
+  equation
+    der(x) = -x;
+    annotation(
+      Icon(graphics = {Rectangle(extent = {{-80,-60},{80,60}}, fillColor = {170,213,255}, fillPattern = FillPattern.Solid, lineColor = {0,0,127})}),
+      Documentation(info = \"<html><p>See <img src=\\\"modelica://DocPkg/Resources/Images/box.svg\\\"> and <a href=\\\"modelica://DocPkg.DocM\\\">this class</a>.</p></html>\"));
+  end DocM;
+end DocPkg;"); getErrorString();
+
+loadFile("DocPkg/package.mo"); getErrorString();
+buildModelFMU(DocPkg.DocM, version="3.0", fmuType="me"); getErrorString();
+
+// The image travelled under the URI's own path, beside the entry point.
+system("unzip -l DocM.fmu | grep -oE \"documentation/[A-Za-z/]+[.][a-z]+\" | sort"); getErrorString();
+
+// A standalone page: doctype, charset, title, and no nested <html> from the
+// annotation. The heading leads with the icon from terminalsAndIcons/, the <img>
+// points at the copied image, and the unresolvable modelica:// class link keeps
+// its href for a reader to see.
+system("unzip -cqq DocM.fmu documentation/index.html | grep -oiE \"<!DOCTYPE html>|charset=.utf-8.|<title>[^<]*|<h1>.*</h1>|<h2>[^<]*|src=.DocPkg[^\\\"]*.|href=.modelica[^\\\"]*.|</html>\""); getErrorString();
+
+// Result:
+// 0
+// ""
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// "DocM.fmu"
+// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// Notification: Building FMU for platform 'static' (1/1).
+// Notification: Finished FMU for platform 'static' (1/1).
+// "
+// documentation/DocPkg/Resources/Images/box.svg
+// documentation/index.html
+// 0
+// ""
+// <!DOCTYPE html>
+// charset="utf-8"
+// <title>DocPkg.DocM
+// <h1><img class="svgiconhead" src="../terminalsAndIcons/icon.svg" alt=""> DocPkg.DocM</h1>
+// <h2>Information
+// src="DocPkg/Resources/Images/box.svg"
+// href="modelica://DocPkg.DocM"
+// </html>
+// 0
+// ""
+// endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_graphics_inherited.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_graphics_inherited.mos
@@ -1,0 +1,55 @@
+// name: fmi3_graphics_inherited.mos
+// keywords: FMI 3.0 export graphics icon annotations inheritance extends
+// status: correct
+// teardown_command: rm -rf Inherited.fmu Inherited.fmutmp/ Inherited.log Inherited_info.json Inherited_FMU.libs Inherited_FMU.makefile Inherited_external_functions.json resources index.html
+//
+// A model's Icon layer is the union of its base classes' and its own, with the
+// base classes' graphics painted first. Most of the Modelica Standard Library
+// gets its icon that way (extends Modelica.Icons.Example and friends): the class
+// carries no Icon annotation of its own, so reading only its own annotation
+// renders nothing and the FMU ends up with no terminalsAndIcons/icon.png at all.
+
+loadString("
+partial model IconBase
+  annotation(Icon(coordinateSystem(extent = {{-100,-100},{100,100}}), graphics = {
+    Ellipse(extent = {{-100,-100},{100,100}}, lineColor = {75,138,73}, fillColor = {255,255,255}, fillPattern = FillPattern.Solid),
+    Polygon(points = {{-36,60},{64,0},{-36,-60}}, lineColor = {0,0,255}, fillColor = {75,138,73}, fillPattern = FillPattern.Solid)}));
+end IconBase;
+
+model Inherited \"an icon inherited from a base class\"
+  extends IconBase;
+  Real x(start = 1);
+equation
+  der(x) = -x;
+  annotation(Icon(graphics = {Text(extent = {{-90,-30},{90,30}}, textString = \"%name\")}));
+end Inherited;
+"); getErrorString();
+
+buildModelFMU(Inherited, version="3.0", fmuType="me"); getErrorString();
+
+// The icon exists at all, which it did not when only the class's own annotation
+// was read.
+system("unzip -l Inherited.fmu | grep -oE \"terminalsAndIcons/icon[.](png|svg)\" | sort"); getErrorString();
+
+// Both layers are in it, the base class's first (painted behind) and the model's
+// own %name text last.
+system("unzip -cqq Inherited.fmu terminalsAndIcons/icon.svg | grep -oE \"<ellipse|<polygon|>Inherited<\""); getErrorString();
+
+// Result:
+// true
+// ""
+// "Inherited.fmu"
+// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// Notification: Building FMU for platform 'static' (1/1).
+// Notification: Finished FMU for platform 'static' (1/1).
+// "
+// terminalsAndIcons/icon.png
+// terminalsAndIcons/icon.svg
+// 0
+// ""
+// <ellipse
+// <polygon
+// >Inherited<
+// 0
+// ""
+// endResult


### PR DESCRIPTION
The FMU's `documentation/` was a fragment with the model's own `<html>` nested inside it, no charset, and every `modelica://` image left unresolved. It is now a standalone page: doctype, charset, title, a small stylesheet, and no heading for a section the model leaves empty. The images it references travel with it, under the URI's own path (`documentation/Modelica/Resources/Images/...`), which keeps two same-named images from different libraries apart. An FMI 3.0 page leads its heading with the icon, sized the way the generated library documentation sizes it; FMI 2.0 has no `terminalsAndIcons/` to point at.

`OMGraphics` read only a class's own `Icon` annotation, so a model inheriting its icon -- `extends Modelica.Icons.Example`, which is most of the MSL -- rendered empty and got no `terminalsAndIcons/icon.png` at all. The icon layer is now the union of the base classes' and the class's own, base graphics behind. Placed connectors had the same gap. Both implementations are fixed: `runtime/OMGraphics.cpp` for the bootstrapped omc, `openmodelica_omgraphics` for the Rust one.

The C target's `generateFMI3GraphicalRepresentation` moves into `SimCodeMain`, so both targets render the icons before the documentation and the page can reference the one the export produced.

fmi-simulator shows both: a documentation column with the simulator page's chevron and rail, and the icon beside the FMU summary. A cref in a figure or in the 3D scene resolves through the FMI 3.0 `<Alias>` map, which is what a bus signal like `axis1.axisControlBus.angle` is -- an alias shares its variable's valueReference, so only the variable is ever recorded.

Reading an FMU moves to the driver, which already had the archive open: the page no longer unzips it or parses `modelDescription.xml` a second time. `openmodelica_fmi` gained a reader for the OpenModelica `<Figures>` and `<Visualization>` annotations, `om_fmi_info` reports those and the aliases, and `om_fmi_icon` / `om_fmi_documentation` serve the two things that are files rather than metadata. `fmu.js` keeps what writes an archive back out, which the native repack needs and no wasm entry point does.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
