### PR TITLE
Speed up the Rust omc's compile pipeline

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -1108,6 +1108,18 @@ function(omc_rust_setup_codegen)
   if(RUST_OMC_ENABLE_SUNDIALS)
     list(APPEND _rust_omc_features openmodelica_codegen_wasm_jit/sundials)
   endif()
+  # Cross builds keep the system allocator: mimalloc compiles C sources.
+  if(RUST_OMC_TARGET STREQUAL "")
+    set(_rust_omc_allocator_default "mimalloc")
+  else()
+    set(_rust_omc_allocator_default "system")
+  endif()
+  set(RUST_OMC_ALLOCATOR "${_rust_omc_allocator_default}"
+      CACHE STRING "Global allocator for the Rust omc: system, mimalloc or jemalloc.")
+  set_property(CACHE RUST_OMC_ALLOCATOR PROPERTY STRINGS system mimalloc jemalloc)
+  if(NOT RUST_OMC_ALLOCATOR STREQUAL "system")
+    list(APPEND _rust_omc_features ${RUST_OMC_ALLOCATOR})
+  endif()
   list(JOIN _rust_omc_features "," _rust_omc_features_csv)
   set(RUST_OMC_CDYLIB_FEATURES --no-default-features --features ${_rust_omc_features_csv})
 

--- a/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/lib.rs
@@ -148,7 +148,10 @@ pub extern "C" fn omc_cli_run(argc: c_int, argv: *const *const c_char) -> c_int 
             .collect()
     };
     let arglist = std::sync::Arc::new(args.into_iter().collect());
-    match catch_unwind(AssertUnwindSafe(|| openmodelica_backend_main::Main::main(arglist))) {
+    let status = catch_unwind(AssertUnwindSafe(|| openmodelica_backend_main::Main::main(arglist)));
+    // `process::exit` drops no thread-local, so flush the buffered writers here.
+    openmodelica_util::File::flush_all_registered();
+    match status {
         Ok(Ok(())) => 0,
         // Mirror the launcher's old inline `run()`: flush stdout, report on
         // stderr and exit 1. The MetaModelica exception carries no payload worth

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
@@ -625,6 +625,14 @@ struct GenCtx {
     /// boundaries alongside `variant_shapes`/`match_refbound`. See the `Var` arm
     /// of [`emit_exp`].
     place_mode: HashMap<String, PlaceMode>,
+    /// While set, a read of an owned plain local is emitted as `&*name` rather
+    /// than `name.clone()`. Armed by [`emit_match`] for a `match_deref!` subject.
+    borrow_reads: bool,
+    /// Base names the enclosing assignment writes; a `match` in its RHS must not
+    /// borrow a subject the statement is about to overwrite.
+    assign_lhs_names: HashSet<String>,
+    /// Per-element borrow decision for a tuple subject. Empty = all elements.
+    borrow_mask: Vec<bool>,
     /// Stack of enclosing loop labels (innermost last), one entry per active
     /// `for`/`while` loop. `Some(label)` when the loop was emitted with an
     /// explicit `'__loopN:` label because its body contains a `break`/`continue`
@@ -732,6 +740,9 @@ impl GenCtx {
             pat_bind_rename: HashMap::new(),
             pat_lit_counter: 0,
             place_mode: HashMap::new(),
+            borrow_reads: false,
+            assign_lhs_names: HashSet::new(),
+            borrow_mask: Vec::new(),
             loop_label_stack: Vec::new(),
         }
     }
@@ -6053,6 +6064,96 @@ fn clear_last_use(exp: &mut TypedExp) {
     }
 }
 
+/// Base names of every read `mark_last_uses` marked as a move; a borrowed
+/// subject would still be live there.
+fn collect_moved_names(exp: &TypedExp, out: &mut HashSet<String>) {
+    match exp {
+        TypedExp::Var { name, segments, last_use, .. } => {
+            // Only a whole-binding read is moved; `emit_exp`'s `Var` arm clones
+            // out of any other place.
+            if *last_use
+                && segments.len() <= 1
+                && !name.contains('.')
+                && segments.iter().all(|s| s.subscripts.is_empty())
+            {
+                out.insert(var_base_name(name, segments));
+            }
+            for seg in segments { for sub in &seg.subscripts { collect_moved_names(sub, out); } }
+        }
+        TypedExp::Lit(_) | TypedExp::Todo(_) => {}
+        TypedExp::BinOp { lhs, rhs, .. } => { collect_moved_names(lhs, out); collect_moved_names(rhs, out); }
+        TypedExp::UnOp { operand, .. } => collect_moved_names(operand, out),
+        TypedExp::Call { args, named_args, .. }
+        | TypedExp::Constructor { args, named_args, .. }
+        | TypedExp::PartEval { args, named_args, .. } => {
+            for a in args { collect_moved_names(a, out); }
+            for (_, a) in named_args { collect_moved_names(a, out); }
+        }
+        TypedExp::If { cond, then_, elseif, else_, .. } => {
+            collect_moved_names(cond, out); collect_moved_names(then_, out); collect_moved_names(else_, out);
+            for (c, e) in elseif { collect_moved_names(c, out); collect_moved_names(e, out); }
+        }
+        TypedExp::Cons { head, tail, .. } => { collect_moved_names(head, out); collect_moved_names(tail, out); }
+        TypedExp::Tuple(elems) | TypedExp::Array { elems, .. } => {
+            for e in elems { collect_moved_names(e, out); }
+        }
+        TypedExp::Range { start, step, stop, .. } => {
+            collect_moved_names(start, out); collect_moved_names(stop, out);
+            if let Some(s) = step { collect_moved_names(s, out); }
+        }
+        TypedExp::Reduction { body, iterators, .. } => {
+            collect_moved_names(body, out);
+            for it in iterators {
+                collect_moved_names(&it.range, out);
+                if let Some(g) = &it.guard { collect_moved_names(g, out); }
+            }
+        }
+        TypedExp::Match { input, cases, .. } => {
+            collect_moved_names(input, out);
+            for case in cases {
+                if let Some(g) = &case.guard { collect_moved_names(g, out); }
+                for (_, _, d, _) in &case.locals {
+                    if let Some(d) = d { collect_moved_names(d, out); }
+                }
+                for st in &case.stmts { collect_moved_names_stmt(st, out); }
+                collect_moved_names(&case.result, out);
+            }
+        }
+    }
+}
+
+fn collect_moved_names_stmt(stmt: &TypedStmt, out: &mut HashSet<String>) {
+    match stmt {
+        TypedStmt::Assign { rhs, .. } => collect_moved_names(rhs, out),
+        TypedStmt::NoRetCall { call } => collect_moved_names(call, out),
+        TypedStmt::If { cond, then_, elseif, else_ } => {
+            collect_moved_names(cond, out);
+            for st in then_ { collect_moved_names_stmt(st, out); }
+            for st in else_ { collect_moved_names_stmt(st, out); }
+            for (c, body) in elseif {
+                collect_moved_names(c, out);
+                for st in body { collect_moved_names_stmt(st, out); }
+            }
+        }
+        TypedStmt::For { range, body, .. } => {
+            collect_moved_names(range, out);
+            for st in body { collect_moved_names_stmt(st, out); }
+        }
+        TypedStmt::While { cond, body } => {
+            collect_moved_names(cond, out);
+            for st in body { collect_moved_names_stmt(st, out); }
+        }
+        TypedStmt::Try { body, else_body } => {
+            for st in body { collect_moved_names_stmt(st, out); }
+            for st in else_body { collect_moved_names_stmt(st, out); }
+        }
+        TypedStmt::Failure { body } => {
+            for st in body { collect_moved_names_stmt(st, out); }
+        }
+        TypedStmt::Return | TypedStmt::Break | TypedStmt::Continue | TypedStmt::Todo(_) => {}
+    }
+}
+
 fn clear_last_use_stmt(stmt: &mut TypedStmt) {
     match stmt {
         TypedStmt::Assign { rhs, .. } => clear_last_use(rhs),
@@ -8343,6 +8444,9 @@ fn unescape_mm_string(s: &str) -> String {
 }
 
 fn emit_exp<'a>(exp: &TypedExp, is_const: bool, ctx: &mut GenCtx, top_level: &'a BTreeMap<String, NameNode<'a>>) -> String {
+    // Borrow mode applies to this node only; the tuple arm re-arms it per element.
+    let borrow_here = std::mem::take(&mut ctx.borrow_reads);
+    let borrow_mask = std::mem::take(&mut ctx.borrow_mask);
     match exp {
         TypedExp::Lit(Lit::Int(v))  => v.to_string(),
         // MetaModelica `Real` literal — wrap in `metamodelica::Real` (alias for
@@ -8946,6 +9050,12 @@ fn emit_exp<'a>(exp: &TypedExp, is_const: bool, ctx: &mut GenCtx, top_level: &'a
                 // refcount bump anyway.
                 _ if node_last_use && is_plain_local && owned
                     && !matches!(effective_ty, Ty::Array(_)) => var_str,
+                // Borrow-only read (a `match_deref!` subject). Restricted to the
+                // types the arm patterns already deref through, so `&&T` reaches
+                // the same `&T` as `&Arc<T>` did.
+                _ if borrow_here && is_plain_local && owned
+                    && (is_arc_wrapped(effective_ty, ctx) || matches!(effective_ty, Ty::List(_))) =>
+                    format!("&*{var_str}"),
                 _ => format!("{var_str}.clone()"),
             };
             // `emit_var` reported an inline `RefCell::borrow()` guard (an
@@ -9686,7 +9796,11 @@ fn emit_exp<'a>(exp: &TypedExp, is_const: bool, ctx: &mut GenCtx, top_level: &'a
         }
 
         TypedExp::Tuple(elems) => {
-            let parts: Vec<String> = elems.iter().map(|e| emit_exp(e, is_const, ctx, top_level)).collect();
+            let parts: Vec<String> = elems.iter().enumerate().map(|(i, e)| {
+                ctx.borrow_reads = borrow_here && borrow_mask.get(i).copied().unwrap_or(true);
+                emit_exp(e, is_const, ctx, top_level)
+            }).collect();
+            ctx.borrow_reads = false;
             format!("({})", parts.join(", "))
         }
 
@@ -14279,7 +14393,6 @@ fn emit_range<'a>(start: &TypedExp, step: Option<&TypedExp>, stop: &TypedExp, is
 }
 
 fn emit_match<'a>(kind: &MatchKind, input: &TypedExp, cases: &[TypedCase], as_binding: Option<&str>, is_const: bool, ctx: &mut GenCtx, top_level: &'a BTreeMap<String, NameNode<'a>>) -> String {
-    let raw_input_str = emit_exp(input, is_const, ctx, top_level);
     let mut input_ty = input.ty();
     // MetaModelica scalar-context rule: a multi-output (tuple-typed) call whose
     // result is matched against patterns that *structurally require a non-tuple
@@ -14307,6 +14420,56 @@ fn emit_match<'a>(kind: &MatchKind, input: &TypedExp, cases: &[TypedCase], as_bi
     let first_elem_ty = if let Ty::Tuple(elems) = &input_ty { elems.first().cloned() } else { None };
     let take_first = first_elem_ty.is_some()
         && cases.iter().any(|c| pat_requires_non_tuple(&c.pattern));
+    // Emit the subject in borrow mode when `match_deref!` takes it by `&`, on the
+    // same type `use_match_deref` uses below.
+    let deref_ty = if take_first { first_elem_ty.clone().unwrap() } else { input_ty.clone() };
+    // Anything that can write the subject while the borrow is held rules it out:
+    // an arm that reassigns or moves it (the `rest = match rest …` list walk), the
+    // enclosing assignment's target, an `as`-binding, the tail-call lowering.
+    let mut subject_names = HashSet::new();
+    collect_exp_names(input, &mut subject_names);
+    let mut written = HashSet::new();
+    for case in cases {
+        stmts_assigned_var_names(&case.stmts, &mut written);
+        exp_assigned_var_names(&case.result, &mut written);
+        if let Some(g) = &case.guard { collect_moved_names(g, &mut written); }
+        for st in &case.stmts { collect_moved_names_stmt(st, &mut written); }
+        collect_moved_names(&case.result, &mut written);
+    }
+    // A pattern binding a whole subject would see `&&T` where it used to get
+    // `&Arc<T>`, changing what `.clone()` yields; keep those owned.
+    fn pat_binds_whole(p: &TypedPat) -> bool {
+        matches!(p, TypedPat::Var(_) | TypedPat::As { .. } | TypedPat::Index { .. }
+                    | TypedPat::FieldAccess { .. } | TypedPat::Todo(_))
+    }
+    let (borrowable, borrow_mask) = if let TypedExp::Tuple(elems) = input {
+        let mut mask = vec![true; elems.len()];
+        let mut ok = true;
+        for case in cases {
+            match &case.pattern {
+                TypedPat::Tuple(ps) if ps.len() == elems.len() => {
+                    for (i, p) in ps.iter().enumerate() {
+                        if pat_binds_whole(p) { mask[i] = false; }
+                    }
+                }
+                TypedPat::Wildcard => {}
+                _ => ok = false,
+            }
+        }
+        (ok && mask.iter().any(|b| *b), mask)
+    } else {
+        (!cases.iter().any(|c| pat_binds_whole(&c.pattern)), Vec::new())
+    };
+    let borrow_scrutinee = borrowable
+        && matches!(kind, MatchKind::Match)
+        && as_binding.is_none()
+        && ctx.tail_lowering.is_none()
+        && !subject_names.iter().any(|n| written.contains(n) || ctx.assign_lhs_names.contains(n))
+        && match_uses_match_deref(&deref_ty, cases, ctx, top_level);
+    ctx.borrow_reads = borrow_scrutinee;
+    ctx.borrow_mask = if borrow_scrutinee { borrow_mask } else { Vec::new() };
+    let raw_input_str = emit_exp(input, is_const, ctx, top_level);
+    ctx.borrow_reads = false;
     let raw_input_str = if take_first {
         input_ty = first_elem_ty.unwrap();
         format!("({raw_input_str}).0")
@@ -20248,6 +20411,14 @@ fn emit_stmt<'a>(
     }
 
     use typedexp::TypedStmt as S;
+    // Publish this statement's assignment targets for `emit_match`.
+    let saved_assign_lhs = if let S::Assign { lhs, .. } = stmt {
+        let mut names = HashSet::new();
+        pat_assigned_names(lhs, &mut names);
+        Some(std::mem::replace(&mut ctx.assign_lhs_names, names))
+    } else {
+        None
+    };
     match stmt {
         S::Assign { lhs, rhs } => {
             // True when the RHS is an arrayCreateNoInit call.  Slots of the
@@ -20997,6 +21168,9 @@ fn emit_stmt<'a>(
             _ => writeln!(out, "{indent}continue;").unwrap(),
         },
         S::Todo(s)  => writeln!(out, "{indent}/* todo stmt: {} */", s.chars().take(60).collect::<String>()).unwrap(),
+    }
+    if let Some(saved) = saved_assign_lhs {
+        ctx.assign_lhs_names = saved;
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/File.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/File.rs
@@ -10,10 +10,11 @@
 //
 //   * `pub struct File` is a clonable handle whose contents are shared via
 //     `Arc<Mutex<FileInner>>`. Cloning the `Arc` *is* the reference count.
-//   * `FileInner` owns an optional `std::fs::File` plus the on-disk file name
-//     and current write escape mode. When the last `Arc` is dropped the
-//     `std::fs::File` is dropped too — the C destructor's `fclose` happens
-//     for free.
+//   * `FileInner` owns an optional `BufWriter<std::fs::File>` plus the on-disk
+//     file name and current write escape mode. When the last `Arc` is dropped
+//     the writer is dropped too, flushing — the C destructor's `fclose`
+//     happens for free. The buffer stands in for the stdio buffering the C
+//     runtime's `fputs` gets for free.
 //
 // Note on the constructor's `fromID: Option<Integer>` parameter: in the C
 // runtime this is a void* pretending to be `Option<Integer>` — either NULL
@@ -43,7 +44,7 @@ use std::collections::HashMap;
 #[cfg(not(target_arch = "wasm32"))]
 use std::fs::OpenOptions;
 #[cfg(not(target_arch = "wasm32"))]
-use std::io::{Seek, SeekFrom, Write};
+use std::io::{BufWriter, Seek, SeekFrom, Write};
 use std::sync::{Arc, Mutex};
 
 use metamodelica::Result;
@@ -75,7 +76,7 @@ pub enum Escape {
 
 struct FileInner {
     #[cfg(not(target_arch = "wasm32"))]
-    file: Option<std::fs::File>,
+    file: Option<BufWriter<std::fs::File>>,
     // wasm has no OS filesystem: buffer the content in memory and flush it to the
     // VFS. `mode` (None = not open) gates writes/seek like the native `Option<File>`;
     // `pos` is the read/write cursor for seek/tell, so seek-then-write backpatching
@@ -227,7 +228,7 @@ pub fn open(file: File, filename: ArcStr, mode: Mode) -> Result<()> {
                 .open(filename.as_str()),
         }
         .map_err(|e| "File.open: Failed to open file {filename} with mode {mode:?}: {e}")?;
-        guard.file = Some(handle);
+        guard.file = Some(BufWriter::with_capacity(64 * 1024, handle));
         guard.name = filename;
         Ok(())
     }
@@ -483,8 +484,29 @@ pub fn releaseReference(file: File) -> Result<()> {
 }
 
 pub fn writeSpace(file: File, n: i32) -> Result<()> {
-    for _ in 0..n {
-        write(file.clone(), literal!(" "))?;
+    const BLANKS: [u8; 64] = [b' '; 64];
+    let mut guard = file.inner.lock().unwrap();
+    let mut left = n.max(0) as usize;
+    while left > 0 {
+        let k = left.min(BLANKS.len());
+        guard.write_bytes(&BLANKS[..k], "writeSpace")?;
+        left -= k;
     }
     Ok(())
+}
+
+/// Flush every file the reference registry still holds, for callers leaving
+/// through `process::exit`, which runs no thread-local destructor.
+pub fn flush_all_registered() {
+    FILE_REGISTRY.with(|r| {
+        for f in r.borrow().values() {
+            let Ok(mut guard) = f.inner.lock() else { continue };
+            #[cfg(not(target_arch = "wasm32"))]
+            if let Some(w) = guard.file.as_mut() {
+                let _ = w.flush();
+            }
+            #[cfg(target_arch = "wasm32")]
+            guard.flush_to_vfs();
+        }
+    });
 }


### PR DESCRIPTION
Three independent changes, measured with min-of-4 interleaved runs on ScalableTestSuite DistributionSystemModelica_N_20_M_20 (t) and SteamPipe_N_160 (t2), and BuildingSystems BuildingThermal1Zone1D (t3). The models come from the library-testing database, where the backend is 23.8 ks of the 19800-model corpus. Figures are new/old:

| phase | t | t2 | t3 |
| --- | --- | --- | --- |
| frontend | 0.70 | 0.80 | 0.79 |
| backend | 0.82 | 1.00 | 0.93 |
| simcode | 0.82 | 0.91 | 0.89 |
| templates | 0.22 | 0.25 | 0.21 |
| translateModel | 0.51 | 0.74 | 0.88 |

**Buffer the `File` external object.** `FileInner` held a bare `std::fs::File`, so every `File.write` a Susan template makes was one `write(2)` — 2634643 of them for a single translateModel. The C runtime's `om_file_write` uses `fputs` on a `FILE*` and gets stdio buffering for free. `BufWriter`'s `Seek` impl flushes before seeking and counts the buffer in `stream_position`, so `Tpl`'s `File.tell` indentation bookkeeping is unchanged, and nothing calls `File.seek`. omc leaves through `process::exit`, which runs no thread-local destructor, so `omc_cli_run` flushes the still-registered files the way C's `exit()` flushes stdio.

**Default the global allocator to mimalloc**, via a new `RUST_OMC_ALLOCATOR` over the cdylib features that were already there. omc allocates ~108 M times per translateModel; mimalloc is worth ~18% of an allocation-heavy backend and nothing on one dominated by `BackendDAEEXT`, which is hand-written and barely allocates (hence t2 above). Cross builds keep the system allocator, since mimalloc compiles C sources.

**Borrow the `match_deref!` subject instead of cloning it.** The lowering reads every variable with `.clone()`, so a match paid an `Arc` refcount pair for its subject just to select an arm, even though the arms re-read the original binding; `crefPrefixOf` did it twice per recursion level. `emit_exp` now emits `&*name` when `emit_match` arms the mode. It is guarded off wherever the subject can be written while the borrow is held — an arm that moves or reassigns it, the enclosing assignment's target, an `as`-binding, the tail-call lowering — and per position wherever a pattern binds one whole, as that binding would see `&&T` rather than `&Arc<T>`. 27609 subject reads borrow, worth ~2-3% of the backend on its own.

Verified: the generated C, `modelDescription.xml` and `_info.json` are byte-identical apart from the model GUID and timestamp, and 1593 tests over flattening/scodeinst, flattening/algorithms-functions, openmodelica/instance-API and simulation/modelica/tearing leave the same 7 pre-existing failures as before.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
