### PR TITLE
[NB] exclude mixed (discrete-coupled) loops from the direct linear solve

### DIFF
--- a/OMCompiler/Compiler/NSimCode/NSimStrongComponent.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimStrongComponent.mo
@@ -816,13 +816,17 @@ public
             jacobian := NONE();
           end if;
 
-          if comp.linear and isSome(jacobian) and not comp.homotopy
+          if comp.linear and isSome(jacobian) and not comp.homotopy and not comp.mixed
              and not List.any(eqns, isForOrGenericResidual)
              and not jacobianHasGenericLoopCalls(Util.getOption(jacobian))
              and allLinVarsFound then
             // Linear torn systems with an analytic Jacobian get solved directly (A*x=b)
-            // instead of via Newton (#16458). Homotopy, for-loop/generic residuals, and
-            // generic_loop_calls Jacobians fall back below -- unsupported by this codegen path.
+            // instead of via Newton (#16458). Homotopy, for-loop/generic residuals,
+            // generic_loop_calls Jacobians, and mixed (discrete-coupled, e.g. ideal-diode
+            // switching networks) systems fall back below -- a one-shot direct solve has
+            // no damping across the discrete state, and coarser NBackend tearing than OB's
+            // for these networks makes that chatter across event iterations instead of
+            // settling (see newInst-newBackend library-testing regressions after #16463).
             linSystem := LINEAR_SYSTEM(
               index         = simCodeIndices.equationIndex,
               mixed         = comp.mixed,

--- a/testsuite/simulation/modelica/NBackend/tearing/minimalTearing.mos
+++ b/testsuite/simulation/modelica/NBackend/tearing/minimalTearing.mos
@@ -25,8 +25,7 @@ simulate(minimalTearing); getErrorString();
 // record SimulationResult
 //     resultFile = "minimalTearing_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'minimalTearing', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_STDOUT        | warning | The default linear solver fails, the fallback solver with total pivoting is started at time 0.000000. That might raise performance issues, for more information use -lv LOG_LS.
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;


### PR DESCRIPTION
#16463 started routing linear torn loops through a direct A*x=b solve instead of Newton, but didn't check comp.mixed (already computed as "has discrete variables") -- so discrete-coupled loops like ideal-diode switching networks got promoted too. A one-shot direct solve has no damping across the discrete state, and NBackend's tearing for these networks is coarser than OB's (e.g. Rectifier: NBackend size 7-10 torn sets vs OB's size-1), so the exact solve chatters between two diode configurations every event iteration instead of settling -- the "default linear solver fails, fallback with total pivoting" warnings followed by "too many event iterations" seen across nearly every Modelica-version electrical switching example in the newInst-newBackend library-testing regressions after #16463.

Verified locally: Modelica.Electrical.Analog.Examples.Rectifier, .HeatingRectifier's diode loop (partially -- a separate issue remains, see follow-up), PowerConverters.Examples.ACDC.RectifierBridge2Pulse. DiodeBridge2Pulse, and Mechanics.Rotational.Examples.CoupledClutches all now simulate cleanly where they previously crashed. Full NBackend testsuite (~280 tests across 21 subdirectories, including ModelicaTest and ScalableTestsuite) passes clean; minimalTearing.mos rebaselined since it no longer needs the fallback-solver warning at all now that its deliberately-mixed loop correctly stays off the direct-solve path.