### PR TITLE
Run Dynawo's models from a wasm FMU again

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -703,19 +703,20 @@ fn fmu_solver_flags(flags_json: &str) -> String {
         .join(" ")
 }
 
-/// Which solver libraries an FMU exported with these `--fmiFlags` can reach; the rest
-/// are linked as stubs. The flags are fixed at export, so this is the whole set the
-/// FMU will ever select from. `klu` comes along with any of the others: the shared
-/// SUNDIALS core they call into, and IDA's default linear solver.
+/// Which solver libraries an FMU exported with these `--fmiFlags` and this
+/// Co-Simulation method can reach; the rest are linked as stubs. Both are fixed
+/// at export, so this is the whole set the FMU will ever select from. `klu` comes
+/// along with any of the others: the shared SUNDIALS core they call into, and
+/// IDA's default linear solver.
 ///
 /// `cs` gates only the integrator: Model Exchange never integrates, but its
 /// initialisation and residuals run the same nonlinear and linear solvers.
-fn fmu_solver_libraries(flags_json: &str, cs: bool) -> Vec<&'static str> {
+fn fmu_solver_libraries(flags_json: &str, cs_method: &str, cs: bool) -> Vec<&'static str> {
     let flag = |name: &str| fmi_flag(flags_json, name).unwrap_or_default();
     let (nls, ls, lss) = (flag("nls"), flag("ls"), flag("lss"));
     let named = |v: &str| ls == v || lss == v;
     let mut wanted = Vec::new();
-    if cs && fmu_needs_sundials(&flag("s")) {
+    if cs && fmu_needs_sundials(cs_method) {
         wanted.push("sundials_driver");
     }
     if matches!(nls.as_str(), "kinsol" | "experimental-kinsol") {
@@ -3180,7 +3181,13 @@ fn cad_basename(uri: &str) -> &str {
 
 /// C's `FMI2CS_initializeSolverData`: `-s` from `_flags.json`, euler otherwise.
 /// The model's own method stays for the artifact's plain-simulation face.
-fn fmu_cs_method(simulation_flags_json: &str, kind: &str) -> String {
+///
+/// A DAE-mode model overrides to IDA (`resolve_solver_method`), so the export has
+/// to agree or the FMU steps with the one solver it did not link.
+fn fmu_cs_method(simulation_flags_json: &str, kind: &str, dae_mode: bool) -> String {
+    if kind != "ME" && dae_mode {
+        return "ida".to_string();
+    }
     match fmi_flag(simulation_flags_json, "s") {
         Some(s) => s,
         None if kind != "ME" => "euler".to_string(),
@@ -3272,7 +3279,7 @@ pub fn translateFmu(sim_code: SimCode::SimCode, fmu_type: ArcStr, simulation_fla
     sync_engine_threading()?;
     sim_runtime::start_runtime_compile();
     let kind = fmu_kind(&fmu_type);
-    let cs_method = fmu_cs_method(&simulation_flags_json, kind);
+    let cs_method = fmu_cs_method(&simulation_flags_json, kind, sim_code.daeModeData.is_some());
     let fmi_solver_flags = fmu_solver_flags(&simulation_flags_json);
     let prefix = sim_code.fileNamePrefix.to_string();
     let _ = openmodelica_wasi::fs::remove_file(&format!("{prefix}.wasm"));
@@ -3345,7 +3352,7 @@ fn emit_fmu(
 ) -> Result<()> {
     sync_engine_threading()?;
     sim_runtime::start_runtime_compile();
-    let cs_method = fmu_cs_method(&simulation_flags_json, kind);
+    let cs_method = fmu_cs_method(&simulation_flags_json, kind, sim_code.daeModeData.is_some());
     let fmi_solver_flags = fmu_solver_flags(&simulation_flags_json);
     // Emitting the model takes seconds; a host that compiles the native platforms
     // out of process can spend them loading its compiler.
@@ -3366,7 +3373,7 @@ fn emit_fmu(
         // Both adapters import every solver, real or stubbed; only the integrator is
         // Co-Simulation's alone.
         let solvers =
-            sundials_available().then(|| fmu_solver_libraries(&simulation_flags_json, cs));
+            sundials_available().then(|| fmu_solver_libraries(&simulation_flags_json, &cs_method, cs));
         // An unzipped export is for an OpenModelica importer: it holds the model
         // description and the model kernel and nothing else, and the host links
         // that kernel against an adapter it compiled once into
@@ -11264,12 +11271,13 @@ mod link_tests {
             (r#"{"lss":"lis"}"#, false, vec!["lis", "klu"]),
             (r#"{"s":"cvode"}"#, false, vec![]),
         ] {
-            assert_eq!(fmu_solver_libraries(json, cs), want, "{json} cs={cs}");
+            let method = fmu_cs_method(json, if cs { "CS" } else { "ME" }, false);
+            assert_eq!(fmu_solver_libraries(json, &method, cs), want, "{json} cs={cs}");
         }
         // Every name the mapping can produce must be a library that exists.
         let known: Vec<&str> = SOLVER_LIBRARIES.iter().map(|l| l.name).collect();
         let all = r#"{"s":"ida","nls":"kinsol","ls":"lis","lss":"umfpack"}"#;
-        for name in fmu_solver_libraries(all, true) {
+        for name in fmu_solver_libraries(all, "ida", true) {
             assert!(known.contains(&name), "{name} is not a solver library");
         }
     }
@@ -11294,7 +11302,7 @@ mod link_tests {
                 .chain(baked.split_whitespace().map(str::to_string))
                 .collect();
             let f = simflags::parse(&argv).expect(&baked);
-            let libs = fmu_solver_libraries(json, true);
+            let libs = fmu_solver_libraries(json, &fmu_cs_method(json, "CS", false), true);
             let cap = simflags::Capabilities {
                 klu: libs.contains(&"klu"),
                 kinsol: libs.contains(&"kinsol"),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -6559,7 +6559,15 @@ impl IdaState {
                 Progress::WorkQuota
             }
             crate::sundials::Stop::Failed(crate::sundials::IDA_RTFUNC_FAIL) => Progress::RootThrew,
-            crate::sundials::Stop::Failed(_) => Progress::Failed("CodegenWasmJit: IDA failed"),
+            crate::sundials::Stop::Failed(flag) => {
+                // C's last word before it gives up (`ida_solver.c`).
+                omclog::info(
+                    omclog::STDOUT,
+                    false,
+                    &format!("##IDA## {flag} error occurred at time = {}", format_g(*t, 15)),
+                );
+                Progress::Failed("CodegenWasmJit: IDA failed")
+            }
             other => {
                 self.work_retries = 0;
                 self.restarted = false;
@@ -7995,7 +8003,9 @@ impl CsDriver {
         let layout = &model.layout;
         let sim_data = self.core.sim_data;
         // A reinit or discrete change in the master's update needs a DASKR restart.
-        if self.resume_reinit {
+        // DAE mode needs the `IDACalcIC` with it, so it restarts in
+        // `integrate_chunked`, where the residual's callback context is live.
+        if self.resume_reinit && !layout.dae_mode() {
             if self.core.n_states > 0 {
                 e.call1("functionODE", sim_data)?;
                 self.core.read_states(e)?;
@@ -8108,6 +8118,14 @@ impl CsDriver {
         let mut ctx = self.core.res_ctx(e, layout);
         let _guard = ResCtxGuard;
         RES_CTX.store(&mut ctx as *mut ResCtx, Ordering::Relaxed);
+        // `step_to`'s restart for DAE mode, the pair `handle_zc_flips` runs for an
+        // event the driver resolves itself.
+        if self.resume_reinit {
+            self.core.read_states(e)?;
+            self.core.restart()?;
+            self.core.dae_restart(e, &mut ctx as *mut ResCtx)?;
+            self.resume_reinit = false;
+        }
         let mut did_step = false;
         loop {
             let target = match self.fixed_h {

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -4474,7 +4474,7 @@ algorithm
 
   try
     (success, cache, libs, _, _) := SimCodeMain.translateModel(SimCodeMain.TranslateModelKind.FMU(FMUType, fmuTargetName, isWasmFMU),
-                                            cache, inEnv, className, filenameprefix, true, false, true, SOME(simSettings));
+                                            cache, inEnv, className, filenameprefix, true, Flags.getConfigBool(Flags.DAE_MODE), true, SOME(simSettings));
     // A wasm translation wrote no FMU: it lowered the model kernel and kept it,
     // so force its JIT compile (and resolve its external "C") here, as
     // buildModel's compile phase does. The model is then ready to simulate and
@@ -4897,7 +4897,7 @@ algorithm
       success := true;
     else
       (success, cache, libs, _, _) := SimCodeMain.translateModel(SimCodeMain.TranslateModelKind.FMU(FMUType, fmuTargetName, false),
-                                              cache, inEnv, className, filenameprefix, true, false, true, SOME(simSettings));
+                                              cache, inEnv, className, filenameprefix, true, Flags.getConfigBool(Flags.DAE_MODE), true, SOME(simSettings));
     end if;
     true := success;
     outValue := Values.STRING((if not Testsuite.isRunning() then System.pwd() + Autoconf.pathDelimiter else "") + fmuTargetName + ".fmu");

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -1743,7 +1743,7 @@ algorithm
 
     if runBackend then
       if useDAEMode then
-        (cache, outLibs, outFileDir, resultValues) := translateModelCallBackendOBDAEMode(cache, env, dae, className, inFileNamePrefix, inSimSettingsOpt, args);
+        (cache, outLibs, outFileDir, resultValues) := translateModelCallBackendOBDAEMode(cache, env, dae, className, inFileNamePrefix, inSimSettingsOpt, args, kind);
       else
         (cache, outLibs, outFileDir, resultValues) := translateModelCallBackendOB(kind, cache, env, dae, className, inFileNamePrefix, inSimSettingsOpt, args);
       end if;
@@ -1966,6 +1966,7 @@ public function translateModelCallBackendOBDAEMode
   input String inFileNamePrefix;
   input Option<SimCode.SimulationSettings> inSimSettingsOpt;
   input Absyn.FunctionArgs args "labels for remove terms";
+  input TranslateModelKind kind = TranslateModelKind.NORMAL() "FMU() to generate an FMU instead of a simulation";
   output list<String> outLibs;
   output String outFileDir;
   output list<tuple<String, Values.Value>> resultValues;
@@ -1983,6 +1984,8 @@ algorithm
       BackendDAE.BackendDAE dlow, initDAE;
       Option<BackendDAE.BackendDAE> initDAE_lambda0_option;
       list<BackendDAE.Equation> removedInitialEquationLst;
+      Option<list<String>> strPreOptModules;
+      Boolean isFMI;
 
     case graph algorithm
       System.realtimeTick(ClockIndexes.RT_CLOCK_BACKEND);
@@ -2012,8 +2015,17 @@ algorithm
         ExecStat.execStat("Serialize dlow");
       end if;
 
+      // The alias variables FMI 2.0/3.0 report top-level outputs off. Not its
+      // counterpart introduceOutputRealDerivatives: that makes every Real output a
+      // state, which in DAE mode changes the residual system.
+      isFMI := match kind
+        case TranslateModelKind.FMU() then FMI.isFMIVersion20() or FMI.isFMIVersion30();
+        else false;
+      end match;
+      strPreOptModules := if isFMI then SOME("introduceOutputAliases"::BackendDAEUtil.getPreOptModulesString()) else NONE();
+
       //BackendDump.printBackendDAE(dlow);
-      (dlow, initDAE, initDAE_lambda0_option, removedInitialEquationLst) := DAEMode.getEqSystemDAEmode(dlow, inFileNamePrefix);
+      (dlow, initDAE, initDAE_lambda0_option, removedInitialEquationLst) := DAEMode.getEqSystemDAEmode(dlow, inFileNamePrefix, strPreOptModules=strPreOptModules);
       ExecStat.execStat("Backend");
 
       timeBackend := System.realtimeTock(ClockIndexes.RT_CLOCK_BACKEND);
@@ -2025,7 +2037,7 @@ algorithm
         ExecStat.execStat("Serialize solved system");
       end if;
 
-      (libs, file_dir, timeSimCode, timeTemplates) := generateModelCodeDAE(dlow, initDAE, initDAE_lambda0_option, removedInitialEquationLst, SymbolTable.getAbsyn(), className, inFileNamePrefix, inSimSettingsOpt, args);
+      (libs, file_dir, timeSimCode, timeTemplates) := generateModelCodeDAE(dlow, initDAE, initDAE_lambda0_option, removedInitialEquationLst, SymbolTable.getAbsyn(), className, inFileNamePrefix, inSimSettingsOpt, args, kind);
       timeSimCode := System.realtimeTock(ClockIndexes.RT_CLOCK_SIMCODE);
       timeTemplates := System.realtimeTock(ClockIndexes.RT_CLOCK_TEMPLATES);
 
@@ -2098,6 +2110,7 @@ protected function generateModelCodeDAE
   input String filenamePrefix;
   input Option<SimCode.SimulationSettings> simSettingsOpt;
   input Absyn.FunctionArgs args;
+  input TranslateModelKind kind = TranslateModelKind.NORMAL() "FMU() to generate an FMU instead of a simulation";
   output list<String> libs;
   output String fileDir;
   output Real timeSimCode;
@@ -2164,7 +2177,26 @@ protected
   list<SimCode.SimEqSystem> nominalValueEquations = {};      // --> updateBoundNominalValues
   list<SimCode.SimEqSystem> parameterEquations = {};         // --> updateBoundParameters
   list<SimCode.SimEqSystem> jacobianEquations = {};
+
+  Boolean isFMU = false, translateOnly = false;
+  String FMUVersion = "", FMUType = "", fmuTargetName = "", fullPathPrefix = "";
+  Option<SimCode.FmiModelStructure> modelStructure = NONE();
+  Option<SimCode.FmiSimulationFlags> fmiSimulationFlags = NONE();
 algorithm
+  () := match kind
+    case TranslateModelKind.FMU()
+      algorithm
+        isFMU := true;
+        FMUVersion := FMI.getFMIVersionString();
+        FMUType := kind.kind;
+        fmuTargetName := kind.targetName;
+        translateOnly := kind.translateOnly;
+        // Where the C target writes the generated sources.
+        fullPathPrefix := Util.hashFileNamePrefix(filenamePrefix) + ".fmutmp/sources/";
+      then ();
+    else ();
+  end match;
+
   numCheckpoints:=ErrorExt.getNumCheckpoints();
   try
     StackOverflow.clearStacktraceMessages();
@@ -2359,6 +2391,17 @@ algorithm
     /* This is a *much* better estimate than the guessed number of equations */
     modelInfo := SimCodeUtil.addNumEqns(modelInfo, uniqueEqIndex - listLength(jacobianEquations));
 
+    // No FMIDER jacobian: it is an ODE right-hand-side derivative, which a
+    // DAE-mode model has none of. The specification lets an importer assume a
+    // dependency on every known instead.
+    if isFMU then
+      if FMI.isFMIVersion20(FMUVersion) or FMI.isFMIVersion30(FMUVersion) then
+        (_, modelStructure, modelInfo, _, uniqueEqIndex, _) :=
+          SimCodeUtil.createFMIModelStructure({}, modelInfo, uniqueEqIndex, inInitDAE, inBackendDAE);
+      end if;
+      fmiSimulationFlags := SimCodeUtil.createFMISimulationFlags();
+    end if;
+
     // update hash table
     // mahge: This creates a new crefToSimVarHT discarding everything added upto here
     // The updated variable 'numEquations' (by SimCodeUtil.addNumEqns) is not even used in createCrefToSimVarHT :/
@@ -2410,17 +2453,17 @@ algorithm
       jacobianMatrices            = SymbolicJacs,
       simulationSettingsOpt       = simSettingsOpt,
       fileNamePrefix              = filenamePrefix,
-      fullPathPrefix              = "",
-      fmuTargetName               = "",
+      fullPathPrefix              = fullPathPrefix,
+      fmuTargetName               = fmuTargetName,
       hpcomData                   = HpcOmSimCode.emptyHpcomData,
-      valueReferences             = AvlTreeCRToInt.EMPTY(),
+      valueReferences             = if isFMU then SimCodeUtil.getValueReferenceMapping(modelInfo) else AvlTreeCRToInt.EMPTY(),
       varToArrayIndexMapping      = varToArrayIndexMapping,
       varToIndexMapping           = varToIndexMapping,
       crefToSimVarHT              = crefToSimVarHT,
       crefToClockIndexHT          = crefToClockIndexHT,
       backendMapping              = NONE(),
-      modelStructure              = NONE(),
-      fmiSimulationFlags          = NONE(),
+      modelStructure              = modelStructure,
+      fmiSimulationFlags          = fmiSimulationFlags,
       partitionData               = SimCode.emptyPartitionData,
       daeModeData                 = daeModeData,
       inlineEquations             = {},
@@ -2444,7 +2487,11 @@ algorithm
     end if;
 
     System.realtimeTick(ClockIndexes.RT_CLOCK_TEMPLATES);
-    callTargetTemplates(simCode, Config.simCodeTarget());
+    if isFMU then
+      callTargetTemplatesFMU(simCode, Config.simCodeTarget(), FMUVersion, FMUType, p, translateOnly);
+    else
+      callTargetTemplates(simCode, Config.simCodeTarget());
+    end if;
     timeTemplates := System.realtimeTock(ClockIndexes.RT_CLOCK_TEMPLATES);
     ExecStat.execStat("Templates");
     return;

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -10380,21 +10380,21 @@ algorithm
 end startValueIsConstOrDefault;
 
 protected function updateStartValue
-  "function which updates Start value of an expression
-   depending on the initial = EXACT or APPROX and causality = INPUT "
+  "FMI requires a literal start value for a variable that is initial=exact or
+   approx, or an input; those get the type default when the model's start is
+   missing or is an expression. Every other variable keeps its start expression:
+   it is the same field the code generators read `$START.x` from, and the FMI
+   templates render only a literal anyway."
   input BackendDAE.Var var;
   input output Option<DAE.Exp> startValue;
   input SimCodeVar.Initial initial_;
   input SimCodeVar.Causality causality;
 algorithm
-  // update start value for FMI 2.0 and 3.0
-  if Flags.getConfigBool(Flags.BUILDING_FMU) and (FMI.isFMIVersion20() or FMI.isFMIVersion30()) then
+  if Flags.getConfigBool(Flags.BUILDING_FMU) and (FMI.isFMIVersion20() or FMI.isFMIVersion30())
+     and (isInitialExactOrApprox(initial_) or isCausalityInput(causality)) then
     startValue := match startValue
-      case SOME(_) guard isInitialExactOrApprox(initial_) then startValue;
-      case NONE() guard isInitialExactOrApprox(initial_) then setDefaultStartValue(var.varType);
-      case SOME(_) guard isCausalityInput(causality) then startValueIsConstOrDefault(startValue, var.varType);
-      case NONE() guard isCausalityInput(causality) then setDefaultStartValue(var.varType);
-      else startValueIsConstOrDefault(startValue, var.varType);
+      case SOME(_) then startValueIsConstOrDefault(startValue, var.varType);
+      else setDefaultStartValue(var.varType);
     end match;
   end if;
 end updateStartValue;

--- a/testsuite/openmodelica/fmi/CoSimulation/3.0/Makefile
+++ b/testsuite/openmodelica/fmi/CoSimulation/3.0/Makefile
@@ -3,6 +3,7 @@ TEST = ../../../../rtest -v
 TESTFILES = \
 fmi3_cs_01.mos \
 fmi3_msl_clocked_drive.mos \
+fmi3_wasm_daemode.mos \
 fmi3_wasm_solver_absent.mos \
 fmi3_wasm_solver_libraries.mos \
 fmi3_wasm_solver_me.mos

--- a/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_daemode.mo
+++ b/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_daemode.mo
@@ -1,0 +1,16 @@
+model DaeModeWhenLoop "Nonlinear algebraic loop that a when-equation is part of"
+  Real x(start = 0, fixed = true);
+  Real y(start = 0) "solved from a nonlinear equation that reads the timer";
+  discrete Real tSwitch(start = 1e60, fixed = true) "when y last rose past the threshold";
+equation
+  der(x) = 1 - x;
+  y = 0.5 * sin(y) + x + (if tSwitch < 1e59 then 0.2 else 0.0);
+  when y > 0.5 then
+    tSwitch = time;
+  elsewhen y < 0.5 then
+    tSwitch = 1e60;
+  end when;
+  annotation(
+    __OpenModelica_commandLineOptions = "--daeMode",
+    experiment(StopTime = 5, Tolerance = 1e-6));
+end DaeModeWhenLoop;

--- a/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_daemode.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_daemode.mos
@@ -1,0 +1,82 @@
+// name: fmi3_wasm_daemode.mos
+// keywords: FMI 3.0 export wasm Co-Simulation daeMode
+// status: correct
+// suite: wasm
+// teardown_command: rm -rf DaeModeWhenLoop* daemode_*.mat diff_daemode* om-wasm-include-*
+//
+// A `--daeMode` model answers with residuals, not with state derivatives, so FMI
+// Model Exchange is refused and `me_cs` is downgraded to Co-Simulation, which
+// integrates the model itself. Doing that means running the DAE-mode backend:
+// the ODE backend cannot translate this model at all (the tearing pulls a
+// when-equation into the nonlinear loop), so an export that dropped --daeMode
+// would fail here the way Dynawo's models did. Co-Simulation then has to
+// integrate with IDA, the one method that serves a residual form, and the model
+// crosses its threshold once so the event the master drives is covered too:
+// resuming from it needs an IDACalcIC, without which IDA does not converge on
+// the step after the event.
+
+setCommandLineOptions("--simCodeTarget=wasm-jit"); getErrorString();
+loadFile("fmi3_wasm_daemode.mo"); getErrorString();
+
+// The reference: the same model simulated the ordinary way.
+simulate(DaeModeWhenLoop, fileNamePrefix="daemode_plain"); getErrorString();
+
+// Model Exchange has to answer fmi3GetContinuousStateDerivatives.
+buildModelFMU(DaeModeWhenLoop, fileNamePrefix="DaeModeWhenLoop", fmuType="me", version="3.0", platforms={"wasm"}); getErrorString();
+
+setCommandLineOptions("--fmuDirectory=true"); getErrorString();
+buildModelFMU(DaeModeWhenLoop, fileNamePrefix="DaeModeWhenLoop", fmuType="me_cs", version="3.0", platforms={"wasm"}); getErrorString();
+
+// The artifact's own simulation face, then its Co-Simulation one.
+simulate(DaeModeWhenLoop, simflags="-r=daemode_sim.mat", resimulateExecutable="DaeModeWhenLoop.fmu"); getErrorString();
+simulate(DaeModeWhenLoop, simflags="-s fmi3:cs -r=daemode_cs.mat", resimulateExecutable="DaeModeWhenLoop.fmu"); getErrorString();
+
+diffSimulationResults("daemode_sim.mat", "daemode_plain_res.mat", "diff_daemode_sim", 1e-6, 1e-6);
+diffSimulationResults("daemode_cs.mat", "daemode_plain_res.mat", "diff_daemode_cs", 1e-6, 1e-6);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "daemode_plain_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 5.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'daemode_plain', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_STDOUT        | warning | Internal Numerical Jacobians without coloring are currently not supported by IDA with KLU. Colored numerical Jacobian will be used.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// ""
+// "Error: DAE mode (--daeMode) is not supported for FMI Model Exchange export (fmuType=\"me\"), which requires the state derivatives a DAE-mode model does not have. Export a Co-Simulation FMU instead, or remove the --daeMode flag.
+// "
+// true
+// ""
+// "DaeModeWhenLoop.fmu"
+// "Warning: DAE mode (--daeMode) has no Model Exchange interface, which would require the state derivatives a DAE-mode model does not have. Exporting Co-Simulation only.
+// Notification: Building FMU for platform 'wasm' (1/1).
+// Notification: Finished FMU for platform 'wasm' (1/1).
+// "
+// record SimulationResult
+//     resultFile = "daemode_sim.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 5.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'DaeModeWhenLoop', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-r=daemode_sim.mat'",
+//     messages = "LOG_STDOUT        | warning | Internal Numerical Jacobians without coloring are currently not supported by IDA with KLU. Colored numerical Jacobian will be used.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// record SimulationResult
+//     resultFile = "daemode_cs.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 5.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'DaeModeWhenLoop', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s fmi3:cs -r=daemode_cs.mat'",
+//     messages = "LOG_STDOUT        | info    | wasm artifact loaded (model kernel linked against the cached adapter)
+// LOG_STDOUT        | info    | CoSimulation instantiated
+// LOG_STDOUT        | info    | CoSimulation run: 501 communication steps, 2 events, 1 early returns, 504 samples
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// (true, {})
+// (true, {})
+// endResult


### PR DESCRIPTION
The library testing's wasm-jit lane now exports every model with buildModelFMU(fmuType="me_cs", version="3.0", platforms={"wasm"}) and simulates that one artifact three ways, where it used to translate and simulate the model directly. Dynawo fell from 116 models simulating and 57 verified to 42 and 2. Four separate faults, none of them the export itself:

**FMU export ignored `--daeMode`.** `callTranslateModelFMU` and `callBuildModelFMU` passed `useDAEMode=false` to
`SimCodeMain.translateModel`, so #16464's "exporting Co-Simulation only" warning was printed while the ODE backend ran. Some 41 Dynawo examples ask for `--daeMode`, and 20 of the 21 models that died before templates were those. `translateModelCallBackendOBDAEMode` and `generateModelCodeDAE` now take a `TranslateModelKind`, build the FMI ModelStructure and the value references, and render through `callTargetTemplatesFMU`. They hand over no FMIDER jacobian: it is an ODE right-hand-side derivative, which a DAE-mode model has none of, so the dependencies are left out - the specification lets an importer assume a dependency on every known instead.

**The export overwrote the model's start expressions.** `SimCodeUtil.updateStartValue` replaced every non-literal start with the type default, because `modelDescription.xml` can only carry a literal. But `SimCodeVar.initialValue` is also the field the code generators read the start from. The C runtime survives it, `$START.x` being a runtime attribute that `updateBoundStartValues` assigns; wasm-jit compiles `$START.x` to the start expression, so Dynawo's `running(start = Running0)` became a hard `false`, every generator initialized switched off, the `if running then ... else 0` linear system went singular, and the run died on `0/0`. The coercion now runs only where FMI requires a literal start (initial=exact or approx, or an input); the templates render only literals anyway.

**A DAE-mode Co-Simulation FMU was exported around euler.** The driver overrides the method to IDA for a DAE-mode model, so the FMU linked trap stubs instead of SUNDIALS and `fmi3DoStep` reached one. `fmu_cs_method` takes `dae_mode`, and `fmu_solver_libraries` takes the method it resolved rather than re-reading `-s` from the flags.

**Co-Simulation skipped the IDACalcIC after a master-driven event.** omc instantiates a CS FMU in Event Mode, so the FMU reports the event and the master calls update-discrete-states; `CsDriver::step_to` then resumed with the ODE recipe. DAE mode needs `restart` + `dae_restart`, the pair `handle_zc_flips` already runs for an event the driver resolves itself, and without it IDA fails to converge on the step after the event (`IDA_CONV_FAIL`). It runs in `integrate_chunked`, where the residual's callback context is live.

A wasm-jit IDA failure now also prints C's "##IDA## <flag> error occurred at time = ..."; a bare "IDA failed" said nothing about which failure it was.

`fmi3_wasm_daemode.mos` covers the export and both faces of the artifact against a plain `--daeMode` simulation. Its model is one the ODE backend cannot translate at all (a when-equation torn into a nonlinear loop), so dropping `useDAEMode` breaks it, and it crosses its threshold once, which covers the event the master drives.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
