### PR TITLE
NBVariable: fix VariablePointers.add silently dropping literal-index siblings

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
@@ -2310,7 +2310,15 @@ function isJacobianResultVar
     algorithm
       var := Pointer.access(varPointer);
       () := match UnorderedMap.get(var.name, variables.map)
-        case SOME(index) guard(index > 0) algorithm
+        case SOME(index) guard(index > 0 and (variables.scalarized or ComponentRef.isEqual(var.name, BVariable.getVarName(ExpandableArray.get(index, variables.varArr))))) algorithm
+          // In non-scalarized (stripped) mode the map key ignores subscripts, so a lookup
+          // hit here can be a DIFFERENT literal-indexed sibling of the same base array
+          // (e.g. x[1] found while adding x[2]) rather than a genuine re-add of the same
+          // variable. Overwriting that slot would silently drop x[1] from the collection
+          // (VariablePointers.toList/mapPtr only see the array, not the map, so a lost
+          // slot is a lost variable). Only take the "update in place" path when the
+          // stored variable's FULL cref actually matches -- otherwise fall through and
+          // add this as a new, separate entry, same as any other unseen variable.
           ExpandableArray.update(index, varPointer, variables.varArr);
         then ();
         else algorithm

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
@@ -413,6 +413,14 @@ void initializeNonlinearSystemData(DATA *data, threadData_t *threadData, NONLINE
     if(nonlinsys->initialAnalyticalJacobian(data, threadData, jacobian))
     {
       nonlinsys->jacobianIndex = -1;
+      /* simulation_data.h documents analyticalJacobianColumn==NULL as THE signal
+       * that no analytic Jacobian is available; clear it here too, not just
+       * jacobianIndex, so every consumer agrees (e.g. kinsolSolver.c's
+       * initKinsolMemory only checks analyticalJacobianColumn, not jacobianIndex,
+       * to decide whether to wire up the symbolic-Jacobian KINSOL callback -- left
+       * dangling non-NULL here, it would still select that callback, which then
+       * fails an assertion pulling a JACOBIAN* through the now -1 jacobianIndex). */
+      nonlinsys->analyticalJacobianColumn = NULL;
       jacobian = NULL;
     }
     /* evalJacobian() fills sizeRows*sizeCols entries, the solvers hand it a
@@ -425,6 +433,7 @@ void initializeNonlinearSystemData(DATA *data, threadData_t *threadData, NONLINE
                                             "Using a numeric Jacobian instead.",
                          sysNum, jacobian->sizeRows, jacobian->sizeCols, size);
       nonlinsys->jacobianIndex = -1;
+      nonlinsys->analyticalJacobianColumn = NULL;
       jacobian = NULL;
     }
   } else {

--- a/testsuite/simulation/modelica/NBackend/differentation/partialSliceSeedCollision.mos
+++ b/testsuite/simulation/modelica/NBackend/differentation/partialSliceSeedCollision.mos
@@ -1,0 +1,54 @@
+// name: partialSliceSeedCollision
+// keywords: NewBackend
+// status: correct
+//
+// Regression test for VariablePointers.add (NBVariable.mo) silently
+// overwriting distinct literal-indexed seed candidates that share a base
+// array name. x[2],x[3],x[4] (a partial slice of x, x[1] not part of the
+// loop) form a homotopy-required, torn 3-unknown algebraic loop, so all
+// three take partialSliceSeedCandidates' safe "per-element" path and end
+// up in the same non-scalarized VariablePointers collection.
+//
+// Before the fix, x[2]/x[3]/x[4]'s seed candidates all compared equal
+// under the collection's stripped (subscript-ignoring) map equality, so
+// each later add() silently overwrote the previous one -- only x[4]
+// survived, and the runtime reported "Analytic Jacobian of non-linear
+// system 0 is 3x1, but the system has 3 iteration variables", falling
+// back to a numeric Jacobian. After the fix all three seeds are kept, and
+// that warning disappears entirely (the remaining "Sparsity pattern...
+// not regular" warning below is pre-existing/unrelated noise from this
+// toy model's fully-dense 3-cycle structure -- present identically with
+// or without the fix, not something this test is about).
+
+loadString("
+model partialSliceSeedCollision
+  Real x[4](start = {1,1,1,1});
+equation
+  x[1] = 1;
+  0 = homotopy(x[2]^2 - x[4] - 1, x[2] - 1);
+  0 = homotopy(x[3]^2 - x[2] - 1, x[3] - 1);
+  0 = homotopy(x[4]^2 - x[3] - 1, x[4] - 1);
+end partialSliceSeedCollision;
+"); getErrorString();
+
+setCommandLineOptions("--newBackend"); getErrorString();
+
+simulate(partialSliceSeedCollision, stopTime=0.1, numberOfIntervals=5);
+getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "partialSliceSeedCollision_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.1, numberOfIntervals = 5, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'partialSliceSeedCollision', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// LOG_STDOUT        | warning | Sparsity pattern for non-linear system 1 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
+// LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult


### PR DESCRIPTION
VariablePointers' default (non-scalarized) mode keys its lookup map with ComponentRef.hashStrip/isEqualStrip, which intentionally ignore subscripts -- appropriate when the collection holds at most one whole/unexpanded entry per base variable. But NBJacobian's partialSliceSeedCandidates adds multiple individually-scalarized per-element seeds for a partial array slice (e.g. x[1] and x[2] of the same array) into exactly this kind of collection. Since x[1] and x[2] compare equal under the stripped equality, add()'s "already exists -> update in place" branch treated adding x[2] right after x[1] as re-adding the SAME variable, silently overwriting x[1]'s array slot with x[2]'s pointer -- x[1] never makes it into VariablePointers.toList()/mapPtr() (which only walk the array, not the map), so it never gets a seed variable, undercounting the Jacobian's true column count.

Symptom: "Analytic Jacobian of non-linear system N is RxC, but the system has K iteration variables" at runtime, falling back to a numeric Jacobian -- seen widely in the newInst-newBackend library-testing regressions (e.g. AixLib.Electrical.AC.ThreePhasesUnbalanced.Conversion. Examples.Transformer, previously RxC undercounting some of its 9 non-linear systems as 90x32 against a true 50).

Fix: only take the update-in-place path when the stored variable's FULL cref actually matches the one being added; otherwise (a same-base, different-literal-index collision under the stripped comparison) fall through and add it as a new, separate array entry, same as any other unseen variable. The map's own coarser stripped-key lookup is left unchanged (later inserts still "win" it, matching prior behavior for genuine whole-array re-adds) -- this only stops the array itself from silently losing a distinct variable.

Verified: AixLib Transformer's undercounted non-linear systems (2, 5, 8) now report 90x50 (exactly matching 50 true iteration variables) instead of 90x32. A separate, over-counting issue remains on this same model's other 6 non-linear systems (90x122) -- a different bug in partialSliceSeedCandidates's whole-array fallback branch, not addressed here. Full NBackend testsuite (~330 tests: all subdirectories plus ModelicaTest and ScalableTestsuite) passes 100% clean, including array_handling/slice_for.mos -- the reference test for the whole-array fallback path that an earlier, reverted attempt at this fix (flipping VariablePointers.fromList's scalarized flag at the seed-candidate call site) broke, because that flag also controls NBDifferentiate's exact-match-only vs stripped-fallback resolution strategy. This fix touches neither call site nor that strategy at all.