### PR TITLE
wasm FMU: DAE-mode Model Exchange via fmi-ls-dae

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -240,6 +240,7 @@ openmodelica_fmi/examples/fmuinfo.rs
 openmodelica_fmi/src/description.rs
 openmodelica_fmi/src/figures.rs
 openmodelica_fmi/src/lib.rs
+openmodelica_fmi/src/lsdae.rs
 openmodelica_fmi/src/lswasm.rs
 openmodelica_fmi/src/parse/mod.rs
 openmodelica_fmi/src/parse/v1.rs

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -2637,7 +2637,10 @@ fn link_err(e: impl core::fmt::Debug) -> &'static str {
 /// The value references are `getFMI3ValueReference`'s, the ones `CodegenFMU3`
 /// writes into `modelDescription.xml`. Variables with no slot are skipped; the
 /// adapter reports an unresolvable vr as an error.
-fn build_fmi_vrs(sim_code: &SimCode::SimCode, map: &SimVarMap, layout: &SimLayout) -> Result<Vec<FmiVr>> {
+/// Also the fmi-ls-dae `EnableDAE` value reference, 0 for a model without a DAE
+/// formulation. The synthetic variables follow `CodegenFMU3`: time, then the event
+/// indicators, then (`--daeMode`) the DAE-mode switch and the residuals.
+fn build_fmi_vrs(sim_code: &SimCode::SimCode, map: &SimVarMap, layout: &SimLayout) -> Result<(Vec<FmiVr>, u32)> {
     use openmodelica_backend::SimCodeUtil;
     let vars = &sim_code.modelInfo.vars;
     let all = lst(&vars.stateVars)
@@ -2726,9 +2729,25 @@ fn build_fmi_vrs(sim_code: &SimCode::SimCode, map: &SimVarMap, layout: &SimLayou
             der_off: 0,
         });
     }
+    let mut dae_enable_vr = 0;
+    if let Some(d) = &sim_code.daeModeData {
+        dae_enable_vr = time_vr + 1 + layout.n_zc;
+        for sv in lst(&d.residualVars) {
+            let i = u32::try_from(sv.index).map_err(|_| "CodegenWasmJit: DAE mode residual has no index")?;
+            out.push(FmiVr {
+                vr: dae_enable_vr + 1 + i,
+                off: layout.dae_res_off + i * 8,
+                wty: WTy::F64,
+                negate: Neg::None,
+                start_off: 0,
+                is_string: false,
+                der_off: 0,
+            });
+        }
+    }
     out.sort_by_key(|e| e.vr);
     out.dedup_by_key(|e| e.vr);
-    Ok(out)
+    Ok((out, dae_enable_vr))
 }
 
 /// CRC-32 (IEEE) for the ZIP entries.
@@ -2899,11 +2918,12 @@ pub fn emitMeFmu(
     fmu_path: ArcStr,
     _guid: ArcStr,
     model_description: ArcStr,
+    ls_dae_manifest: ArcStr,
     documentation_dir: ArcStr,
     terminals_dir: ArcStr,
     simulation_flags_json: ArcStr,
 ) -> Result<()> {
-    emit_fmu(sim_code, fmu_path, model_description, documentation_dir, terminals_dir, simulation_flags_json, FMI3_ME_ADAPTER, "ME")
+    emit_fmu(sim_code, fmu_path, model_description, ls_dae_manifest, documentation_dir, terminals_dir, simulation_flags_json, FMI3_ME_ADAPTER, "ME")
 }
 
 /// Co-Simulation: the FMU integrates itself, so the adapter embeds the driver.
@@ -2917,11 +2937,12 @@ pub fn emitCsFmu(
     fmu_path: ArcStr,
     _guid: ArcStr,
     model_description: ArcStr,
+    ls_dae_manifest: ArcStr,
     documentation_dir: ArcStr,
     terminals_dir: ArcStr,
     simulation_flags_json: ArcStr,
 ) -> Result<()> {
-    emit_fmu(sim_code, fmu_path, model_description, documentation_dir, terminals_dir, simulation_flags_json, FMI3_MECS_ADAPTER, "CS")
+    emit_fmu(sim_code, fmu_path, model_description, ls_dae_manifest, documentation_dir, terminals_dir, simulation_flags_json, FMI3_MECS_ADAPTER, "CS")
 }
 
 /// me_cs: one component exporting both interfaces (the wasm equivalent of a
@@ -2931,11 +2952,12 @@ pub fn emitMeCsFmu(
     fmu_path: ArcStr,
     _guid: ArcStr,
     model_description: ArcStr,
+    ls_dae_manifest: ArcStr,
     documentation_dir: ArcStr,
     terminals_dir: ArcStr,
     simulation_flags_json: ArcStr,
 ) -> Result<()> {
-    emit_fmu(sim_code, fmu_path, model_description, documentation_dir, terminals_dir, simulation_flags_json, FMI3_MECS_ADAPTER, "me_cs")
+    emit_fmu(sim_code, fmu_path, model_description, ls_dae_manifest, documentation_dir, terminals_dir, simulation_flags_json, FMI3_MECS_ADAPTER, "me_cs")
 }
 
 /// Say that the FMU answers `fmi3GetDirectionalDerivative` when the model was
@@ -3340,10 +3362,15 @@ fn fmu_kind(fmu_type: &str) -> &'static str {
 
 /// `adapter` is `(plain, with-SUNDIALS)`; the second is picked for a method that needs
 /// CVODE/IDA and is empty for Model Exchange.
+/// `openmodelica_fmi::lsdae::MANIFEST_PATH`, which the web build does not link.
+const LS_DAE_MANIFEST: &str = "extra/org.fmi-standard.fmi-ls-dae/fmi-ls-manifest.xml";
+
+#[allow(clippy::too_many_arguments)]
 fn emit_fmu(
     sim_code: SimCode::SimCode,
     fmu_path: ArcStr,
     model_description: ArcStr,
+    ls_dae_manifest: ArcStr,
     documentation_dir: ArcStr,
     terminals_dir: ArcStr,
     simulation_flags_json: ArcStr,
@@ -3404,6 +3431,9 @@ fn emit_fmu(
         let mut entries = vec![
             ("modelDescription.xml".to_string(), announce_directional_derivatives(&model_description, &model).into_bytes()),
         ];
+        if !ls_dae_manifest.is_empty() {
+            entries.push((LS_DAE_MANIFEST.to_string(), ls_dae_manifest.as_bytes().to_vec()));
+        }
         if !bare {
             add_directory(&mut entries, &documentation_dir, "documentation");
             add_directory(&mut entries, &terminals_dir, "terminalsAndIcons");
@@ -5559,7 +5589,8 @@ fn build_sim_model(
     // driver / standalone) and kept on the `SimModel` (for the host driver).
     // Only the FMU export needs the vr table; a plain simulation would just carry
     // it around unused.
-    let fmi_vrs = if fmi_vrs { build_fmi_vrs(sim_code, &var_map, &layout)? } else { Vec::new() };
+    let (fmi_vrs, fmi_dae_enable_vr) =
+        if fmi_vrs { build_fmi_vrs(sim_code, &var_map, &layout)? } else { (Vec::new(), 0) };
     // C labels its `-lv=LOG_NLS` unknowns from the `_info.json` `defines` array,
     // which `SerializeModelInfo` writes from these same `crefs`.
     // C diagnoses (`newtonDiagnostics`) the systems of `initialEquations_lambda0`,
@@ -5716,7 +5747,7 @@ fn build_sim_model(
     let meta = build_sim_meta(
         &layout, &result_vars, settings, cs_method, fmi_solver_flags, &model_name,
         &sim_code.fileNamePrefix, jac_a.clone(), &state_sets,
-        fmi_vrs, zc_descriptions(&zero_crossings), rel_descriptions(&sim_code.relations),
+        fmi_vrs, fmi_dae_enable_vr, zc_descriptions(&zero_crossings), rel_descriptions(&sim_code.relations),
         param_vars(vars)?, attr_log_entries(sim_code)?,
         removed_init_residuals(sim_code).iter().map(|e| dump_exp(e)).collect(),
         nls_warnings.clone(),
@@ -7126,6 +7157,7 @@ fn build_sim_meta(
     jac_a: Option<JacAInfo>,
     state_sets: &[StateSetInfo],
     fmi_vrs: Vec<FmiVr>,
+    fmi_dae_enable_vr: u32,
     zc_desc: Vec<String>,
     rel_desc: Vec<String>,
     params: openmodelica_sim_meta::ParamVars,
@@ -7162,6 +7194,7 @@ fn build_sim_meta(
         jac_a,
         state_sets: state_sets.to_vec(),
         fmi_vrs,
+        fmi_dae_enable_vr,
         zc_desc,
         rel_desc,
         params,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/artifact.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/artifact.rs
@@ -9,7 +9,7 @@
 //! | `-s` | what runs |
 //! | --- | --- |
 //! | absent, or an ordinary solver | the artifact's own simulation runtime, in wasm |
-//! | `fmi3:me[:solver]` | Model Exchange, this process integrating (DASKR by default) |
+//! | `fmi3:me[:solver]` | Model Exchange, this process integrating (DASKR by default; with `-daeMode`, IDA over the FMU's fmi-ls-dae residuals) |
 //! | `fmi3:cs` | Co-Simulation, the artifact integrating itself |
 //!
 //! The export takes one of two forms. `--fmuDirectory` writes the model kernel
@@ -65,7 +65,8 @@ fn recall(path: &Path) -> Option<Arc<WasmArtifact>> {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Face {
     Simulation,
-    ModelExchange(Solver),
+    /// The integrator named after `fmi3:me:`; `None` leaves the choice to the mode.
+    ModelExchange(Option<Solver>),
     CoSimulation,
 }
 
@@ -116,9 +117,10 @@ fn parse_face(v: &str) -> std::result::Result<Face, String> {
     match kind {
         "me" => {
             let s = match solver {
+                "" => None,
                 // DASKR is the BDF integrator behind `-s=dassl`; both names reach it.
-                "" | "daskr" | "dassl" => Solver::Dassl,
-                name => Solver::parse(name).ok_or_else(|| unknown("solver", name))?,
+                "daskr" | "dassl" => Some(Solver::Dassl),
+                name => Some(Solver::parse(name).ok_or_else(|| unknown("solver", name))?),
             };
             Ok(Face::ModelExchange(s))
         }
@@ -440,7 +442,23 @@ pub fn run(
     let out = result_path(&flags, result_file);
     let res = match face {
         Face::Simulation => run_simulation(&loaded, &flags, &out, simflags, &mut log),
-        Face::ModelExchange(solver) => run_fmi(&loaded, &flags, &out, Some(solver), &mut log),
+        Face::ModelExchange(solver) => {
+            let solver = match (solver, flags.dae_mode) {
+                (None, false) => Solver::Dassl,
+                (None, true) | (Some(Solver::Ida), true) => Solver::Ida,
+                (Some(s), false) => s,
+                (Some(s), true) => {
+                    return (
+                        Err(format!(
+                            "wasm artifact: -daeMode integrates with IDA; `-s fmi3:me:{}` cannot serve a residual form",
+                            s.as_str()
+                        )),
+                        log,
+                    )
+                }
+            };
+            run_fmi(&loaded, &flags, &out, Some(solver), &mut log)
+        }
         Face::CoSimulation => run_fmi(&loaded, &flags, &out, None, &mut log),
     };
     (res, log)
@@ -615,6 +633,19 @@ fn run_fmi(
     openmodelica_wasm_jit::sim_runtime::set_alarm(flags.alarm);
     if let Some(s) = me_solver {
         opts.solver = s;
+        if flags.dae_mode {
+            opts.dae = Some(match fmu.ls_dae_manifest() {
+                Some(Ok(m)) => m,
+                Some(Err(e)) => return Err(format!("wasm artifact: fmi-ls-dae manifest: {e}")),
+                None => {
+                    return Err(
+                        "wasm artifact: -daeMode asks for fmi-ls-dae, which this FMU does not declare \
+                         (export the model with --daeMode)"
+                            .to_string(),
+                    )
+                }
+            });
+        }
     }
     // C's `doOverride`, as far as FMI reaches: a parameter is settable in
     // Initialization Mode and nothing else is.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/dylink_fmi.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/dylink_fmi.rs
@@ -358,6 +358,16 @@ impl Fmi3 for DylinkInstance {
         status("fmi3Terminate", raw)
     }
 
+    fn enter_configuration_mode(&mut self) -> Result<()> {
+        let raw = self.fmu.call("om_fmi3EnterConfigurationMode", &[]).map_err(|e| err("fmi3EnterConfigurationMode", e))?;
+        status("fmi3EnterConfigurationMode", raw)
+    }
+
+    fn exit_configuration_mode(&mut self) -> Result<()> {
+        let raw = self.fmu.call("om_fmi3ExitConfigurationMode", &[]).map_err(|e| err("fmi3ExitConfigurationMode", e))?;
+        status("fmi3ExitConfigurationMode", raw)
+    }
+
     fn get_numeric(&mut self, ty: VarType, vrs: &[u32], values: &mut [f64]) -> Result<()> {
         let (call, width) = numeric_call(ty.wire(), true)
             .ok_or_else(|| Error::Unsupported(format!("reading a {} as a number", ty.as_str())))?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod description;
 pub mod figures;
+pub mod lsdae;
 #[cfg(feature = "component")]
 pub mod lswasm;
 mod parse;
@@ -243,6 +244,14 @@ impl Fmu {
     pub fn ls_wasm_manifest(&self) -> Option<lswasm::Manifest> {
         let xml = self.read(lswasm::MANIFEST_PATH)?;
         lswasm::Manifest::parse(&String::from_utf8_lossy(&xml)).ok()
+    }
+
+    /// The fmi-ls-dae manifest, when the FMU has a DAE formulation. A manifest
+    /// that is there but unreadable is an error: the importer was asked for DAE
+    /// mode and must not fall back to ODE mode quietly.
+    pub fn ls_dae_manifest(&self) -> Option<Result<lsdae::Manifest>> {
+        let xml = self.read(lsdae::MANIFEST_PATH)?;
+        Some(lsdae::Manifest::parse(&String::from_utf8_lossy(&xml)))
     }
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/lsdae.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/lsdae.rs
@@ -1,0 +1,98 @@
+//! The fmi-ls-dae layered standard: the manifest that turns a Model Exchange FMU
+//! into a DAE one — the structural parameter that enables the mode, the algebraic
+//! variables the importer then solves for beside the states, and the residuals it
+//! drives to zero, with a `<ModelStructure>` that replaces the model description's.
+
+use crate::description::{DependenciesKind, Unknown};
+use crate::parse::{child, children, list_attr, u32_attr};
+use crate::{Error, Result};
+
+pub const MANIFEST_PATH: &str = "extra/org.fmi-standard.fmi-ls-dae/fmi-ls-manifest.xml";
+pub const LS_NAME: &str = "org.fmi-standard.fmi-ls-dae";
+
+/// One `<Formulation>`: a residual variable, and how many times the constraint
+/// it came from was differentiated to get it.
+#[derive(Clone, Debug)]
+pub struct Formulation {
+    pub value_reference: u32,
+    pub index: Option<u32>,
+    /// `None`: depends on every known.
+    pub dependencies: Option<Vec<u32>>,
+    pub dependencies_kind: Vec<DependenciesKind>,
+}
+
+/// A `<Residual>`: one constraint, in one or more differentiated forms.
+#[derive(Clone, Debug)]
+pub struct Residual {
+    pub formulations: Vec<Formulation>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Manifest {
+    pub version: String,
+    /// The Boolean structural parameter set to `true` in Configuration Mode.
+    pub enable_vr: u32,
+    /// The algebraic unknowns, in the order the residual Jacobian's columns follow the states.
+    pub algebraic_variables: Vec<u32>,
+    pub residuals: Vec<Residual>,
+    /// The `<ModelStructure>` overriding the model description's; each list is
+    /// empty when the manifest leaves it out.
+    pub outputs: Vec<Unknown>,
+    pub continuous_state_derivatives: Vec<Unknown>,
+    pub initial_unknowns: Vec<Unknown>,
+    pub event_indicators: Vec<Unknown>,
+}
+
+impl Manifest {
+    pub fn parse(xml: &str) -> Result<Manifest> {
+        let doc = roxmltree::Document::parse(xml).map_err(|e| Error::Xml(e.to_string()))?;
+        let root = doc.root_element();
+        if root.tag_name().name() != "fmi-ls-dae" {
+            return Err(Error::Xml(format!("root element is <{}>, not <fmi-ls-dae>", root.tag_name().name())));
+        }
+        let enable = child(root, "EnableDAE").ok_or_else(|| Error::Xml("<fmi-ls-dae> has no <EnableDAE>".into()))?;
+        let enable_vr = u32_attr(enable, "valueReference")
+            .ok_or_else(|| Error::Xml("<EnableDAE> has no valueReference".into()))?;
+        let algebraic_variables = child(root, "AlgebraicVariables")
+            .map(|a| children(a, "AlgebraicVariable").filter_map(|v| u32_attr(v, "valueReference")).collect())
+            .unwrap_or_default();
+        let ms = child(root, "ModelStructure");
+        let residuals = ms
+            .map(|ms| {
+                children(ms, "Residual")
+                    .map(|r| Residual {
+                        formulations: children(r, "Formulation")
+                            .filter_map(|f| {
+                                Some(Formulation {
+                                    value_reference: u32_attr(f, "valueReference")?,
+                                    index: u32_attr(f, "index"),
+                                    dependencies: list_attr(f, "dependencies"),
+                                    dependencies_kind: crate::parse::dependencies_kind(f),
+                                })
+                            })
+                            .collect(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let unknowns = |tag| ms.map(|ms| crate::parse::unknowns3(ms, tag)).unwrap_or_default();
+        Ok(Manifest {
+            version: root.attribute(("http://fmi-standard.org/fmi-ls-manifest", "fmi-ls-version"))
+                .or_else(|| root.attribute("fmi-ls-version"))
+                .unwrap_or_default()
+                .to_string(),
+            enable_vr,
+            algebraic_variables,
+            residuals,
+            outputs: unknowns("Output"),
+            continuous_state_derivatives: unknowns("ContinuousStateDerivative"),
+            initial_unknowns: unknowns("InitialUnknown"),
+            event_indicators: unknowns("EventIndicator"),
+        })
+    }
+
+    /// The residual variables in row order, every formulation of every residual.
+    pub fn residual_vrs(&self) -> Vec<u32> {
+        self.residuals.iter().flat_map(|r| r.formulations.iter().map(|f| f.value_reference)).collect()
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/parse/mod.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/parse/mod.rs
@@ -9,6 +9,7 @@ mod v2;
 mod v3;
 
 use crate::description::*;
+pub(crate) use v3::unknowns as unknowns3;
 use crate::{Error, Result};
 use roxmltree::{Document, Node};
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/parse/v3.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/parse/v3.rs
@@ -214,7 +214,7 @@ fn clock_info(n: Node) -> ClockInfo {
     }
 }
 
-fn unknowns(ms: Node, tag: &'static str) -> Vec<Unknown> {
+pub(crate) fn unknowns(ms: Node, tag: &'static str) -> Vec<Unknown> {
     children(ms, tag)
         .filter_map(|u| {
             Some(Unknown {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/capi.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/capi.rs
@@ -179,6 +179,16 @@ pub extern "C" fn om_fmi3EnterContinuousTimeMode() -> i32 {
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3EnterConfigurationMode() -> i32 {
+    with(|i| status(GuestModelExchangeInstance::enter_configuration_mode(i)), ERROR)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3ExitConfigurationMode() -> i32 {
+    with(|i| status(GuestModelExchangeInstance::exit_configuration_mode(i)), ERROR)
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn om_fmi3EnterStepMode() -> i32 {
     with(|i| status(GuestCoSimulationInstance::enter_step_mode(i)), ERROR)
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -27,8 +27,8 @@ use alloc::vec::Vec;
 use core::cell::RefCell;
 
 use openmodelica_sim_meta::driver::{
-    self, event_update, run_initialization, set_param_overrides, set_zc_tolerance, Samples,
-    SimEngine,
+    self, dae_solve_explicit, eval_stage, event_update, run_initialization, set_param_overrides,
+    set_zc_tolerance, Samples, SimEngine,
 };
 #[cfg(feature = "cs")]
 use openmodelica_sim_meta::driver::{CsDefer, CsDriver, CsStep};
@@ -526,6 +526,12 @@ struct MeState {
     defer: openmodelica_sim_meta::driver::CsDefer,
     vrs: Vrs,
     mode: Mode,
+    /// fmi-ls-dae: the `EnableDAE` structural parameter's value reference (0 when
+    /// the model has no DAE formulation), whether it is set, and whether the
+    /// importer is in Configuration Mode, the only place it may be set.
+    dae_enable_vr: u32,
+    dae_mode: bool,
+    configuring: bool,
     /// C's `_need_update`, consumed by `update_if_needed`.
     need_update: bool,
     /// Every set made before Initialization Mode is left, applied by
@@ -589,10 +595,34 @@ impl MeState {
     }
 
     /// `functionOutputs`, not `functionAlgebraics`: a getter runs no discrete update.
+    ///
+    /// A `--daeMode` model has neither: its continuous equations are the residual
+    /// `F(t, x, x', z) = 0`. In DAE mode the importer has set `x'` and `z` and reads
+    /// `F` back; in ODE mode the model owes it `x'` and `z`, solved for here.
     fn eval(&self) -> driver::Result<()> {
         let mut e = Engine;
+        if self.layout.dae_mode() {
+            if !self.dae_mode {
+                let dae = self.meta.dae.as_ref().ok_or("fmi3: DAE-mode model without DAE metadata")?;
+                dae_solve_explicit(&mut e, self.sim_data, &self.layout, dae)?;
+            }
+            return e.call2(
+                driver::MODEL_FN_DAE,
+                self.sim_data,
+                eval_stage::DYNAMIC | eval_stage::ALGEBRAIC,
+            );
+        }
         e.call1("functionODE", self.sim_data)?;
         e.call1("functionOutputs", self.sim_data)
+    }
+
+    /// `functionODE` for the derivatives and the event indicators: a `--daeMode`
+    /// model has no such partial evaluation, so it evaluates whole.
+    fn eval_ode(&mut self) -> driver::Result<()> {
+        if self.layout.dae_mode() {
+            return self.update_if_needed();
+        }
+        Engine.call1("functionODE", self.sim_data)
     }
 
     /// The state a value reference reads, when it is one of the continuous
@@ -778,6 +808,7 @@ fn new_state() -> Option<MeState> {
     unsafe {
         core::ptr::write_bytes(sim_data as *mut u8, 0, layout.total as usize);
     }
+    let dae_enable_vr = meta.fmi_dae_enable_vr;
     let st = MeState {
         sim_data,
         layout,
@@ -788,6 +819,9 @@ fn new_state() -> Option<MeState> {
         #[cfg(feature = "cs")]
         defer: CsDefer::None,
         mode: Mode::Instantiated,
+        dae_enable_vr,
+        dae_mode: false,
+        configuring: false,
         need_update: true,
         init_overrides: Vec::new(),
         init_start_overrides: Vec::new(),
@@ -977,6 +1011,8 @@ macro_rules! shared_instance_methods {
             core::ptr::write_bytes(st.sim_data as *mut u8, 0, st.layout.total as usize);
         }
         st.mode = Mode::Instantiated;
+        st.dae_mode = false;
+        st.configuring = false;
         st.need_update = true;
         st.init_overrides.clear();
         st.init_start_overrides.clear();
@@ -991,11 +1027,23 @@ macro_rules! shared_instance_methods {
         Status::Ok
     }
 
+    /// The one structural parameter is `fixed`: Configuration Mode is open from
+    /// Instantiated only, not the Reconfiguration Mode a `tunable` one would allow.
     fn enter_configuration_mode(&self) -> Status {
-        Status::Error
+        let mut st = self.st.borrow_mut();
+        if st.mode != Mode::Instantiated || st.configuring {
+            return err_status("fmi3EnterConfigurationMode: only allowed in the Instantiated state");
+        }
+        st.configuring = true;
+        Status::Ok
     }
     fn exit_configuration_mode(&self) -> Status {
-        Status::Error
+        let mut st = self.st.borrow_mut();
+        if !st.configuring {
+            return err_status("fmi3ExitConfigurationMode: not in Configuration Mode");
+        }
+        st.configuring = false;
+        Status::Ok
     }
 
     // ── Getters ───────────────────────────────────────────────────────────────
@@ -1086,6 +1134,10 @@ macro_rules! shared_instance_methods {
         }
         let mut out = Vec::with_capacity(vrs.len());
         for vr in vrs {
+            if vr == st.dae_enable_vr && vr != 0 {
+                out.push(st.dae_mode);
+                continue;
+            }
             match st.vrs.resolve(vr) {
                 Some(e) if e.wty == WTy::I32 && !e.is_string => {
                     out.push(e.negate.apply_i32(st.read_i32(e.off)) != 0)
@@ -1218,6 +1270,16 @@ macro_rules! shared_instance_methods {
         }
         let mut st = self.st.borrow_mut();
         for (vr, v) in vrs.into_iter().zip(values) {
+            if vr == st.dae_enable_vr && vr != 0 {
+                if !st.configuring {
+                    return err_status("fmi-ls-dae: the DAE-mode parameter can only be set in Configuration Mode");
+                }
+                if v && !st.layout.dae_mode() {
+                    return err_status("fmi-ls-dae: this FMU has no DAE formulation");
+                }
+                st.dae_mode = v;
+                continue;
+            }
             match st.vrs.resolve(vr) {
                 Some(e) if e.wty == WTy::I32 && e.negate == Neg::None && !e.is_string => {
                     let iv = if v { 1 } else { 0 };
@@ -1424,12 +1486,14 @@ impl GuestModelExchangeInstance for Instance {
     }
 
     /// C's `internalGetDerivatives`, which leaves `_need_update` set for the next
-    /// getter.
+    /// getter. In DAE mode the derivatives are the importer's own, set as knowns
+    /// of the residuals; in ODE mode a `--daeMode` model solves for them.
     fn get_continuous_state_derivatives(&self) -> Result<Vec<f64>, Status> {
-        let st = self.st.borrow();
-        let mut e = Engine;
-        if st.need_update && e.call1("functionODE", st.sim_data).is_err() {
-            return Err(Status::Error);
+        let mut st = self.st.borrow_mut();
+        if st.need_update && (!st.dae_mode || st.mode == Mode::Init) {
+            if let Err(err) = st.eval_ode() {
+                return Err(err_status(err));
+            }
         }
         let n = st.layout.n_states;
         let base = REAL_OFF + n * 8;
@@ -1439,7 +1503,9 @@ impl GuestModelExchangeInstance for Instance {
         let mut st = self.st.borrow_mut();
         let mut e = Engine;
         if st.need_update {
-            e.call1("functionODE", st.sim_data).map_err(|_| Status::Error)?;
+            if let Err(err) = st.eval_ode() {
+                return Err(err_status(err));
+            }
             st.need_update = false;
         }
         if st.layout.n_zc == 0 {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/api.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/api.rs
@@ -91,6 +91,16 @@ pub trait Fmi3 {
     fn update_discrete_states(&mut self) -> Result<DiscreteStates>;
     fn terminate(&mut self) -> Result<()>;
 
+    /// `fmi3EnterConfigurationMode`/`fmi3ExitConfigurationMode`, the only place a
+    /// structural parameter may be set. An FMU without structural parameters
+    /// need not offer them.
+    fn enter_configuration_mode(&mut self) -> Result<()> {
+        Err(Error::Unsupported("fmi3EnterConfigurationMode".into()))
+    }
+    fn exit_configuration_mode(&mut self) -> Result<()> {
+        Err(Error::Unsupported("fmi3ExitConfigurationMode".into()))
+    }
+
     /// Read numeric variables as `f64`, whatever their declared type: the
     /// masters plot and record in `f64`, and the `.mat` holds nothing else.
     /// `ty` selects the `fmi3Get*` to call.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/component.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/component.rs
@@ -480,6 +480,20 @@ impl Fmi3 for WasmInstance {
         ))
     }
 
+    fn enter_configuration_mode(&mut self) -> Result<()> {
+        common!(self, |store, g, h| check(
+            "fmi3EnterConfigurationMode",
+            g.call_enter_configuration_mode(store, h).map_err(|e| trap("fmi3EnterConfigurationMode", e))?
+        ))
+    }
+
+    fn exit_configuration_mode(&mut self) -> Result<()> {
+        common!(self, |store, g, h| check(
+            "fmi3ExitConfigurationMode",
+            g.call_exit_configuration_mode(store, h).map_err(|e| trap("fmi3ExitConfigurationMode", e))?
+        ))
+    }
+
     fn get_numeric(&mut self, ty: VarType, vrs: &[u32], values: &mut [f64]) -> Result<()> {
         match ty.wire() {
             VarType::Float64 => {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/ffi.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/ffi.rs
@@ -102,6 +102,8 @@ struct Vtable {
     set_boolean: SetT<bool>,
     get_string: GetT<*const c_char>,
     set_string: SetT<*const c_char>,
+    enter_configuration_mode: Option<unsafe extern "C" fn(Instance) -> i32>,
+    exit_configuration_mode: Option<unsafe extern "C" fn(Instance) -> i32>,
 
     // Model Exchange
     enter_continuous_time_mode: Option<unsafe extern "C" fn(Instance) -> i32>,
@@ -199,6 +201,8 @@ impl Library {
             set_boolean: required!(lib, "fmi3SetBoolean"),
             get_string: required!(lib, "fmi3GetString"),
             set_string: required!(lib, "fmi3SetString"),
+            enter_configuration_mode: optional!(lib, "fmi3EnterConfigurationMode"),
+            exit_configuration_mode: optional!(lib, "fmi3ExitConfigurationMode"),
             enter_continuous_time_mode: optional!(lib, "fmi3EnterContinuousTimeMode"),
             set_time: optional!(lib, "fmi3SetTime"),
             set_continuous_states: optional!(lib, "fmi3SetContinuousStates"),
@@ -469,6 +473,20 @@ impl Fmi3 for FmuInstance<'_> {
     fn terminate(&mut self) -> Result<()> {
         let f = self.v().terminate;
         check("fmi3Terminate", unsafe { f(self.handle) })
+    }
+
+    fn enter_configuration_mode(&mut self) -> Result<()> {
+        let Some(f) = self.v().enter_configuration_mode else {
+            return missing("fmi3EnterConfigurationMode");
+        };
+        check("fmi3EnterConfigurationMode", unsafe { f(self.handle) })
+    }
+
+    fn exit_configuration_mode(&mut self) -> Result<()> {
+        let Some(f) = self.v().exit_configuration_mode else {
+            return missing("fmi3ExitConfigurationMode");
+        };
+        check("fmi3ExitConfigurationMode", unsafe { f(self.handle) })
     }
 
     fn get_numeric(&mut self, ty: VarType, vrs: &[u32], values: &mut [f64]) -> Result<()> {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/lib.rs
@@ -183,6 +183,10 @@ pub struct Options<'a> {
     /// Ask an FMU that offers them for the Jacobian's columns instead of
     /// differencing them (Model Exchange). Off compares the two.
     pub directional_derivatives: bool,
+    /// Run a Model Exchange FMU in fmi-ls-dae's DAE mode: the master solves the
+    /// residuals it declares, over the states and the algebraic variables, with
+    /// IDA. The manifest names them; `None` is the ordinary ODE mode.
+    pub dae: Option<openmodelica_fmi::lsdae::Manifest>,
     pub parameters: Vec<Parameter>,
     pub inputs: Vec<Input>,
     /// Called at each output point with the samples so far, for a host that
@@ -221,6 +225,7 @@ impl Options<'_> {
             logging_on: false,
             event_mode: true,
             directional_derivatives: true,
+            dae: None,
             parameters: Vec::new(),
             inputs: Vec::new(),
             progress: None,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/me.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/me.rs
@@ -8,19 +8,26 @@
 //! the solver locating a sign change in the event indicators, the FMU asking
 //! for Event Mode after a completed step, and the time events
 //! `fmi3UpdateDiscreteStates` announces.
+//!
+//! An FMU with an fmi-ls-dae manifest can instead be run in DAE mode
+//! ([`Options::dae`]): the master sets the states, their derivatives and the
+//! algebraic variables, reads the residuals back, and IDA drives them to zero over
+//! `y = [states | algebraic variables]` — with `IDACalcIC` making the point
+//! consistent at the start and after every event, as a `--daeMode` model's own
+//! runtime does.
 
 use crate::api::{Fmi3, Fmi3ModelExchange};
 use crate::common::{Inputs, event_iteration, initialize};
 use crate::record::Recorder;
 use crate::{Deadline, Error, Options, Result, Solver};
-use openmodelica_fmi::ModelDescription;
+use openmodelica_fmi::{ModelDescription, VarType};
 use openmodelica_solvers::dassl::{Dassl, DasslStep};
 use openmodelica_solvers::events::StepEnd;
 use openmodelica_solvers::fixedstep::{FixedKind, FixedStep};
 use openmodelica_solvers::gbode::{GbStep, Gbode};
 #[cfg(sundials)]
-use openmodelica_solvers::sundials_ode::{CvodeOde, IdaOde, SunStep};
-use openmodelica_solvers::Ode;
+use openmodelica_solvers::sundials_ode::{CvodeOde, IdaDae, IdaOde, SunStep};
+use openmodelica_solvers::{Dae, Ode};
 
 pub struct Run {
     pub recorder: Recorder,
@@ -39,8 +46,20 @@ pub struct Run {
     pub event_times: Vec<f64>,
 }
 
+/// The value references DAE mode works through, out of the fmi-ls-dae manifest.
+struct DaeVrs {
+    nx: usize,
+    /// The algebraic variables, which follow the states in `y`.
+    alg_vrs: Vec<u32>,
+    /// The state derivatives, set as knowns of the residuals.
+    der_vrs: Vec<u32>,
+    /// The residuals, one per row of `F`.
+    res_vrs: Vec<u32>,
+}
+
 /// The FMU as an ODE: set the time and the states, then read the derivatives or
-/// the event indicators back.
+/// the event indicators back. In DAE mode the derivatives and the algebraic
+/// variables are set too, and the residuals are what is read.
 struct FmuOde<'a> {
     inst: &'a mut dyn Fmi3ModelExchange,
     inputs: &'a mut Inputs,
@@ -60,8 +79,10 @@ struct FmuOde<'a> {
     /// The point the FMU is standing at, so the same one is not set twice: an
     /// FMU treats every `fmi3SetContinuousStates` as a move and throws away what
     /// it cached for the old point — including its Jacobian, which a colour-by-
-    /// colour assembly would then pay for again per colour.
-    committed: Option<(f64, Vec<f64>)>,
+    /// colour assembly would then pay for again per colour. The derivatives are
+    /// part of the point in DAE mode only.
+    committed: Option<(f64, Vec<f64>, Vec<f64>)>,
+    dae: Option<DaeVrs>,
     /// What the FMU actually said, behind the static message the solvers carry.
     failure: Option<Error>,
     /// `-alarm`, polled here rather than only at the output points: a solver that
@@ -76,16 +97,61 @@ impl FmuOde<'_> {
     /// Put `(t, y)` into the FMU, with the inputs of that time. Setting the
     /// point it already holds is skipped.
     fn commit(&mut self, t: f64, y: &[f64]) -> Result<()> {
-        if self.committed.as_ref().is_some_and(|(ct, cy)| *ct == t && cy == y) {
+        self.commit_point(t, y, &[])
+    }
+
+    /// [`commit`](Self::commit), with the derivatives too in DAE mode: the
+    /// residuals are a function of `(t, y, y')`.
+    fn commit_point(&mut self, t: f64, y: &[f64], yp: &[f64]) -> Result<()> {
+        let Some(dae) = self.dae.as_ref() else {
+            if self.committed.as_ref().is_some_and(|(ct, cy, _)| *ct == t && cy == y) {
+                return Ok(());
+            }
+            self.inst.set_time(t)?;
+            self.inst.set_continuous_states(y)?;
+            if self.inputs.is_time_varying() {
+                let inst: &mut dyn Fmi3 = self.inst;
+                self.inputs.apply(inst, self.opts, t)?;
+            }
+            self.committed = Some((t, y.to_vec(), Vec::new()));
+            return Ok(());
+        };
+        let nx = dae.nx;
+        let ders = &yp[..nx.min(yp.len())];
+        if self.committed.as_ref().is_some_and(|(ct, cy, cp)| *ct == t && cy == y && cp == ders) {
             return Ok(());
         }
         self.inst.set_time(t)?;
-        self.inst.set_continuous_states(y)?;
+        self.inst.set_continuous_states(&y[..nx])?;
+        if !dae.alg_vrs.is_empty() {
+            let inst: &mut dyn Fmi3 = self.inst;
+            inst.set_numeric(VarType::Float64, &dae.alg_vrs, &y[nx..])?;
+        }
+        if ders.len() == nx && nx > 0 {
+            let inst: &mut dyn Fmi3 = self.inst;
+            inst.set_numeric(VarType::Float64, &dae.der_vrs, ders)?;
+        }
         if self.inputs.is_time_varying() {
             let inst: &mut dyn Fmi3 = self.inst;
             self.inputs.apply(inst, self.opts, t)?;
         }
-        self.committed = Some((t, y.to_vec()));
+        self.committed = Some((t, y.to_vec(), ders.to_vec()));
+        Ok(())
+    }
+
+    /// DAE mode: the point the FMU holds — states, algebraic variables, state
+    /// derivatives — after the FMU moved it (initialization, an event).
+    fn read_dae_point(&mut self, y: &mut [f64], yp: &mut [f64]) -> Result<()> {
+        let Some(dae) = self.dae.as_ref() else { return Ok(()) };
+        let nx = dae.nx;
+        if nx > 0 {
+            self.inst.get_continuous_states(&mut y[..nx])?;
+            self.inst.get_continuous_state_derivatives(&mut yp[..nx])?;
+        }
+        if !dae.alg_vrs.is_empty() {
+            let inst: &mut dyn Fmi3 = self.inst;
+            inst.get_numeric(VarType::Float64, &dae.alg_vrs, &mut y[nx..])?;
+        }
         Ok(())
     }
 
@@ -173,6 +239,75 @@ impl Ode for FmuOde<'_> {
     }
 }
 
+impl Dae for FmuOde<'_> {
+    fn residual(&mut self, t: f64, y: &[f64], yp: &[f64], res: &mut [f64]) -> openmodelica_solvers::Result<()> {
+        if self.past_deadline() {
+            return Err(self.note(Error::Alarm));
+        }
+        self.commit_point(t, y, yp).map_err(|e| self.note(e))?;
+        let Some(d) = self.dae.as_ref() else { return Ok(()) };
+        let inst: &mut dyn Fmi3 = self.inst;
+        let r = inst.get_numeric(VarType::Float64, &d.res_vrs, res);
+        r.map_err(|e| self.note(e))
+    }
+
+    fn eval_zc(&mut self, t: f64, y: &[f64], yp: &[f64], zc: &mut [f64]) -> openmodelica_solvers::Result<()> {
+        if zc.is_empty() {
+            return Ok(());
+        }
+        if self.past_deadline() {
+            return Err(self.note(Error::Alarm));
+        }
+        self.commit_point(t, y, yp).map_err(|e| self.note(e))?;
+        self.inst.get_event_indicators(zc).map_err(|e| self.note(e))
+    }
+
+    fn nominals(&self) -> &[f64] {
+        &self.nominals
+    }
+
+    fn note_call(&mut self) {
+        self.calls += 1;
+    }
+}
+
+/// The value references DAE mode needs, checked against the model description:
+/// a manifest naming a variable the FMU does not have is a broken FMU, not a
+/// broken run.
+fn dae_vrs(md: &ModelDescription, m: &openmodelica_fmi::lsdae::Manifest, nx: usize) -> Result<DaeVrs> {
+    let float64 = |vr: u32, what: &str| -> Result<u32> {
+        match md.variable_by_vr(vr) {
+            Some(v) if v.ty == VarType::Float64 => Ok(vr),
+            _ => Err(Error::Unsupported(format!(
+                "fmi-ls-dae: {what} value reference {vr} is not a Float64 variable of the FMU"
+            ))),
+        }
+    };
+    let der_vrs: Vec<u32> = md
+        .model_structure
+        .continuous_state_derivatives
+        .iter()
+        .map(|u| u.value_reference)
+        .collect();
+    if der_vrs.len() != nx {
+        return Err(Error::Unsupported(format!(
+            "fmi-ls-dae: the FMU has {nx} continuous states but <ModelStructure> lists {} derivatives",
+            der_vrs.len()
+        )));
+    }
+    let alg_vrs = m.algebraic_variables.iter().map(|&vr| float64(vr, "algebraic variable")).collect::<Result<Vec<_>>>()?;
+    let res_vrs = m.residual_vrs().into_iter().map(|vr| float64(vr, "residual")).collect::<Result<Vec<_>>>()?;
+    if res_vrs.len() != nx + alg_vrs.len() {
+        return Err(Error::Unsupported(format!(
+            "fmi-ls-dae: {} residuals for {} states and {} algebraic variables; only a square system can be integrated",
+            res_vrs.len(),
+            nx,
+            alg_vrs.len()
+        )));
+    }
+    Ok(DaeVrs { nx, alg_vrs, der_vrs, res_vrs })
+}
+
 /// The ODE Jacobian's sparsity as `<ModelStructure>` gives it: for each state
 /// derivative, the `dependencies` that are themselves states. An FMU that lists
 /// no dependencies for an entry is saying "everything", which is a dense column
@@ -233,9 +368,13 @@ enum Integrator {
     Cvode(Box<CvodeOde>),
     #[cfg(sundials)]
     Ida(Box<IdaOde>),
+    /// DAE mode: IDA over the residuals, `y` carrying the algebraic variables too.
+    #[cfg(sundials)]
+    IdaDae(Box<IdaDae>),
 }
 
 impl Integrator {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         solver: Solver,
         nx: usize,
@@ -244,7 +383,20 @@ impl Integrator {
         nominals: &[f64],
         jac_colors: usize,
         directional: bool,
+        n_alg: Option<usize>,
     ) -> Result<Integrator> {
+        if let Some(n_alg) = n_alg {
+            if solver != Solver::Ida {
+                return Err(Error::Unsupported(format!(
+                    "integrating in DAE mode with `{}`: only IDA takes a residual form",
+                    solver.as_str()
+                )));
+            }
+            #[cfg(sundials)]
+            return Ok(Integrator::IdaDae(Box::new(IdaDae::new(nx, n_alg, nz, tolerance, nominals))));
+            #[cfg(not(sundials))]
+            return Err(Error::Unsupported("`ida`: this build has no SUNDIALS".to_string()));
+        }
         // With no continuous states there is nothing to integrate and nothing
         // for gbode's Newton matrix to factor: every solver degenerates to
         // stepping from event to event, which the fixed-step one already does.
@@ -292,8 +444,22 @@ impl Integrator {
             Integrator::Cvode(cv) => cv.set_nominals(nominals),
             #[cfg(sundials)]
             Integrator::Ida(ida) => ida.set_nominals(nominals),
+            #[cfg(sundials)]
+            Integrator::IdaDae(ida) => ida.set_nominals(nominals),
             _ => {}
         }
+    }
+
+    /// DAE mode: make `(y, y')` consistent at `t` (`IDACalcIC`), so the point
+    /// reported next is one the residuals hold at. Nothing for an ODE.
+    fn make_consistent(&mut self, ode: &mut FmuOde, t: f64, y: &mut [f64], yp: &mut [f64]) -> Result<()> {
+        #[cfg(sundials)]
+        if let Integrator::IdaDae(ida) = self {
+            ida.make_consistent(ode, t, y, yp).map_err(|e| ode.failure.take().unwrap_or(Error::Solver(e)))?;
+        }
+        #[cfg(not(sundials))]
+        let _ = (ode, t, y, yp);
+        Ok(())
     }
 
     /// Integrate toward `target`, stopping at `limit` (the next time event) or
@@ -330,6 +496,11 @@ impl Integrator {
                 SunStep::Root(te) => Ok(Some(te)),
                 SunStep::Reached => Ok(None),
             },
+            #[cfg(sundials)]
+            Integrator::IdaDae(ida) => match ida.step(ode, target.min(limit), t, y, yp)? {
+                SunStep::Root(te) => Ok(Some(te)),
+                SunStep::Reached => Ok(None),
+            },
         }
     }
 
@@ -343,6 +514,8 @@ impl Integrator {
             Integrator::Cvode(cv) => cv.restart(),
             #[cfg(sundials)]
             Integrator::Ida(ida) => ida.restart(),
+            #[cfg(sundials)]
+            Integrator::IdaDae(ida) => ida.restart(),
         }
     }
 
@@ -356,6 +529,8 @@ impl Integrator {
             Integrator::Cvode(cv) => cv.counters().jac_evals,
             #[cfg(sundials)]
             Integrator::Ida(ida) => ida.counters().jac_evals,
+            #[cfg(sundials)]
+            Integrator::IdaDae(ida) => ida.counters().jac_evals,
         }
     }
 
@@ -368,6 +543,8 @@ impl Integrator {
             Integrator::Cvode(cv) => cv.counters().steps,
             #[cfg(sundials)]
             Integrator::Ida(ida) => ida.counters().steps,
+            #[cfg(sundials)]
+            Integrator::IdaDae(ida) => ida.counters().steps,
         }
     }
 }
@@ -380,6 +557,12 @@ pub fn simulate(
 ) -> Result<Run> {
     let mut inputs = Inputs::new(opts);
     let mut rec = Recorder::new(md, opts.keep);
+    if let Some(m) = &opts.dae {
+        let common: &mut dyn Fmi3 = inst;
+        common.enter_configuration_mode()?;
+        common.set_numeric(VarType::Boolean, &[m.enable_vr], &[1.0])?;
+        common.exit_configuration_mode()?;
+    }
     {
         let common: &mut dyn Fmi3 = inst;
         initialize(common, &mut inputs, opts)?;
@@ -403,18 +586,22 @@ pub fn simulate(
         .get_number_of_event_indicators()
         .unwrap_or(md.number_of_event_indicators as usize);
 
-    let mut x = vec![0.0; nx];
-    // Where the fixed-step solvers leave the derivatives of the step they took.
-    let mut xp = vec![0.0; nx];
-    inst.get_continuous_states(&mut x)?;
+    let dae = opts.dae.as_ref().map(|m| dae_vrs(md, m, nx)).transpose()?;
+    let n_alg = dae.as_ref().map(|d| d.alg_vrs.len());
+    let ny = nx + n_alg.unwrap_or(0);
+    let mut x = vec![0.0; ny];
+    // Where the fixed-step solvers and IDA in DAE mode leave the derivatives.
+    let mut xp = vec![0.0; ny];
+    inst.get_continuous_states(&mut x[..nx])?;
     let mut nominals = vec![1.0; nx];
     if inst.get_nominals_of_continuous_states(&mut nominals).is_err() {
         nominals.fill(1.0);
     }
-    {
-        let common: &mut dyn Fmi3 = inst;
-        rec.snapshot_parameters(common)?;
-        rec.sample(common, opts.start_time)?;
+    if let Some(d) = &dae {
+        for &vr in &d.alg_vrs {
+            let nom = md.variable_by_vr(vr).and_then(|v| v.nominal).map(f64::abs).filter(|n| *n > 0.0);
+            nominals.push(nom.unwrap_or(1.0));
+        }
     }
 
     let states = md.continuous_states();
@@ -428,6 +615,7 @@ pub fn simulate(
         .map(|u| u.value_reference)
         .collect();
     let directional = opts.directional_derivatives
+        && dae.is_none()
         && md
             .interface(openmodelica_fmi::InterfaceKind::ModelExchange)
             .is_some_and(|i| i.provides_directional_derivatives)
@@ -436,7 +624,7 @@ pub fn simulate(
 
     let tolerance = opts.tolerance.unwrap_or(1e-6);
     let mut integrator =
-        Integrator::new(opts.solver, nx, nz, tolerance, &nominals, colors.len(), directional)?;
+        Integrator::new(opts.solver, nx, nz, tolerance, &nominals, colors.len(), directional, n_alg)?;
     integrator.set_experiment(opts);
     integrator.set_nominals(&nominals);
 
@@ -455,11 +643,22 @@ pub fn simulate(
         directional,
         calls: 0,
         committed: None,
+        dae,
         failure: None,
         deadline: Deadline::arm(opts),
         polls: 0,
     };
     let mut t = opts.start_time;
+    if ode.dae.is_some() {
+        ode.read_dae_point(&mut x, &mut xp)?;
+        integrator.make_consistent(&mut ode, t, &mut x, &mut xp)?;
+        ode.commit_point(t, &x, &xp)?;
+    }
+    {
+        let common: &mut dyn Fmi3 = ode.inst;
+        rec.snapshot_parameters(common)?;
+        rec.sample(common, t)?;
+    }
     let mut next_event = info.next_event_time.unwrap_or(f64::INFINITY);
     let (mut state_events, mut time_events) = (0u64, 0u64);
     let mut event_times = Vec::new();
@@ -479,7 +678,7 @@ pub fn simulate(
             // C's `completedIntegratorStep`: the FMU may want Event Mode for a
             // reason the indicators do not show.
             if needs_completed_step {
-                ode.commit(t, &x)?;
+                ode.commit_point(t, &x, &xp)?;
                 let done = ode.inst.completed_integrator_step(true)?;
                 if done.terminate {
                     terminated_at = Some(t);
@@ -499,17 +698,19 @@ pub fn simulate(
             let Some(te) = event_at else { continue };
             t = te;
             event_times.push(te);
-            ode.commit(t, &x)?;
+            ode.commit_point(t, &x, &xp)?;
             ode.forget_point();
             {
                 let common: &mut dyn Fmi3 = ode.inst;
                 rec.sample(common, t)?;
                 common.enter_event_mode()?;
                 info = event_iteration(common)?;
-                rec.sample(common, t)?;
+                if ode.dae.is_none() {
+                    rec.sample(common, t)?;
+                }
             }
             if info.states_changed && nx > 0 {
-                ode.inst.get_continuous_states(&mut x)?;
+                ode.inst.get_continuous_states(&mut x[..nx])?;
             }
             if info.nominals_changed && nx > 0 {
                 let mut n = vec![1.0; nx];
@@ -522,13 +723,21 @@ pub fn simulate(
             ode.inst.enter_continuous_time_mode()?;
             ode.forget_point();
             integrator.restart();
+            if ode.dae.is_some() {
+                // C's `ida_event_update`, before the row after the event.
+                ode.read_dae_point(&mut x, &mut xp)?;
+                integrator.make_consistent(&mut ode, t, &mut x, &mut xp)?;
+                ode.commit_point(t, &x, &xp)?;
+                let common: &mut dyn Fmi3 = ode.inst;
+                rec.sample(common, t)?;
+            }
             if info.terminate {
                 terminated_at = Some(t);
                 break 'grid;
             }
         }
         // The grid point itself: the solver interpolated the states onto it.
-        ode.commit(target, &x)?;
+        ode.commit_point(target, &x, &xp)?;
         t = target;
         let common: &mut dyn Fmi3 = ode.inst;
         rec.sample(common, t)?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -22,7 +22,7 @@ use crate::simflags::JacobianMethod;
 use crate::simflags::{CvodeIter, CvodeLmm};
 use crate::sync::SYNC_EPS;
 use crate::{
-    JacAInfo, Layout as SimLayout, MetaKind as ResultKind, REAL_OFF, SimMeta, SolveStats, StateSetInfo,
+    DaeInfo, JacAInfo, Layout as SimLayout, MetaKind as ResultKind, REAL_OFF, SimMeta, SolveStats, StateSetInfo,
     TIME_OFF,
     WTy,
 };
@@ -9090,25 +9090,12 @@ struct DaeSolve {
     id: Vec<f64>,
 }
 
-/// `IDACalcIC` over the algebraic unknowns and every derivative, directed by the
-/// step IDA would take next (floored, so a zero step still gives a direction). A
-/// failed first attempt is retried with the line search off, as C does.
 #[cfg(sundials)]
 fn dae_calc_ic(ida: &mut crate::sundials::Ida, t: f64) -> Result<()> {
-    let mut h = ida.actual_init_step();
-    if h < f64::EPSILON {
-        h = f64::EPSILON;
-        ida.set_init_step(h);
+    match ida.calc_ic_at(t) {
+        true => Ok(()),
+        false => Err("CodegenWasmJit: IDA could not find consistent initial conditions (IDACalcIC)"),
     }
-    if !ida.calc_ic(t + h, true) && !ida.calc_ic(t + h, false) {
-        return Err("CodegenWasmJit: IDA could not find consistent initial conditions (IDACalcIC)");
-    }
-    if !ida.consistent_ic() {
-        return Err("CodegenWasmJit: IDAGetConsistentIC failed");
-    }
-    // C resets the initial step to automatic afterwards.
-    ida.set_init_step(0.0);
-    Ok(())
 }
 
 /// `-idaLS`, defaulting to KLU as `ida_solver.c` does. Without states there is
@@ -10036,4 +10023,188 @@ impl GuessStepper {
         write_time(e, self.core.sim_data, self.core.t)?;
         eval_continuous(e, self.core.sim_data, layout)
     }
+}
+
+// ── A `--daeMode` model evaluated as an explicit ODE ─────────────────────────
+
+/// Solve `F(t, x, x', z) = 0` for the derivatives and the algebraic unknowns at
+/// the time and states `SimData` holds — what an FMU exported from a `--daeMode`
+/// model owes an importer that runs it as an ordinary ODE FMU. A damped Newton
+/// iteration over `evaluateDAEResiduals`, started from the values the slots hold
+/// (the previous point, or the initial system's), with a differenced Jacobian: a
+/// colour at a time where the residual sparsity is known, a `der(x)` column taking
+/// its state's pattern since DAE-mode differentiation folds `der(x)` into `x`.
+pub fn dae_solve_explicit(
+    e: &mut dyn SimEngine,
+    sim_data: u32,
+    layout: &SimLayout,
+    dae: &DaeInfo,
+) -> Result<()> {
+    const MAX_ITER: usize = 100;
+    const RTOL: f64 = 1e-10;
+    let n = layout.n_dae_res as usize;
+    let ns = layout.n_states as usize;
+    if n == 0 {
+        return Ok(());
+    }
+    if dae.alg_offs.len() + ns != n {
+        return Err("CodegenWasmJit: DAE-mode metadata disagrees with the layout");
+    }
+    let offs: Vec<u32> = (0..ns)
+        .map(|i| REAL_OFF + ((ns + i) as u32) * 8)
+        .chain(dae.alg_offs.iter().copied())
+        .collect();
+    let mut scale = vec![1.0; n];
+    for k in 0..dae.alg_offs.len() {
+        let nom = read_f64(e, sim_data + layout.dae_alg_nom_off + (k as u32) * 8)?.abs();
+        if nom > 0.0 && nom.is_finite() {
+            scale[ns + k] = nom;
+        }
+    }
+    let mut u: Vec<f64> = offs.iter().map(|&o| read_f64(e, sim_data + o)).collect::<Result<_>>()?;
+    let res_base = sim_data + layout.dae_res_off;
+    let mut residual = |e: &mut dyn SimEngine, u: &[f64], out: &mut [f64]| -> Result<()> {
+        for (&o, &v) in offs.iter().zip(u) {
+            write_f64(e, sim_data + o, v)?;
+        }
+        e.call2(MODEL_FN_DAE, sim_data, eval_stage::DYNAMIC)?;
+        read_f64s(e, res_base, out)
+    };
+    let pattern = dae.sparsity.as_ref().filter(|p| p.n as usize == n && p.rows_by_col.len() == n);
+    let mut f0 = vec![0.0; n];
+    let mut f1 = vec![0.0; n];
+    let mut jac = vec![0.0; n * n];
+    let mut delta = vec![0.0; n];
+    let mut trial = vec![0.0; n];
+    residual(e, &u, &mut f0)?;
+    let norm = |f: &[f64]| f.iter().fold(0.0f64, |m, v| m.max(v.abs()));
+    let mut fnorm = norm(&f0);
+    for _ in 0..MAX_ITER {
+        if !fnorm.is_finite() {
+            return Err(DAE_EXPLICIT_FAILED);
+        }
+        if fnorm == 0.0 {
+            break;
+        }
+        jac.iter_mut().for_each(|v| *v = 0.0);
+        let step = |j: usize, u: &[f64]| libm::sqrt(f64::EPSILON) * u[j].abs().max(scale[j]);
+        let mut column = |e: &mut dyn SimEngine, cols: &[usize], jac: &mut [f64], u: &mut [f64]| -> Result<()> {
+            let saved: Vec<f64> = cols.iter().map(|&j| u[j]).collect();
+            for &j in cols {
+                u[j] += step(j, u);
+            }
+            residual(e, u, &mut f1)?;
+            for (&j, &old) in cols.iter().zip(&saved) {
+                let h = u[j] - old;
+                u[j] = old;
+                let rows: Vec<usize> = match pattern {
+                    Some(p) => p.rows_by_col[j].iter().map(|&r| r as usize).collect(),
+                    None => (0..n).collect(),
+                };
+                for r in rows {
+                    jac[r * n + j] = (f1[r] - f0[r]) / h;
+                }
+            }
+            Ok(())
+        };
+        match pattern {
+            Some(p) => {
+                for color in &p.colors {
+                    let cols: Vec<usize> = color.iter().map(|&c| c as usize).collect();
+                    column(e, &cols, &mut jac, &mut u)?;
+                }
+            }
+            None => {
+                for j in 0..n {
+                    column(e, &[j], &mut jac, &mut u)?;
+                }
+            }
+        }
+        for i in 0..n {
+            delta[i] = -f0[i];
+        }
+        if !lu_solve(&mut jac, &mut delta, n) {
+            return Err(DAE_EXPLICIT_FAILED);
+        }
+        let mut lambda = 1.0;
+        let mut accepted = false;
+        for _ in 0..8 {
+            for i in 0..n {
+                trial[i] = u[i] + lambda * delta[i];
+            }
+            residual(e, &trial, &mut f1)?;
+            let fn1 = norm(&f1);
+            if fn1.is_finite() && fn1 < fnorm * (1.0 - 1e-4 * lambda) {
+                accepted = true;
+                break;
+            }
+            lambda *= 0.5;
+        }
+        if !accepted {
+            lambda = 1.0;
+            for i in 0..n {
+                trial[i] = u[i] + delta[i];
+            }
+            residual(e, &trial, &mut f1)?;
+        }
+        let converged =
+            (0..n).all(|i| (lambda * delta[i]).abs() <= RTOL * u[i].abs().max(scale[i]));
+        u.copy_from_slice(&trial);
+        core::mem::swap(&mut f0, &mut f1);
+        fnorm = norm(&f0);
+        if converged && fnorm.is_finite() {
+            return Ok(());
+        }
+    }
+    if fnorm == 0.0 {
+        return Ok(());
+    }
+    Err(DAE_EXPLICIT_FAILED)
+}
+
+const DAE_EXPLICIT_FAILED: &str =
+    "CodegenWasmJit: the derivatives of the DAE-mode model could not be solved for (the Newton iteration over the residual did not converge)";
+
+/// Gaussian elimination with partial pivoting on the row-major `a`, `b` becoming
+/// the solution. `false` on a singular matrix.
+fn lu_solve(a: &mut [f64], b: &mut [f64], n: usize) -> bool {
+    for k in 0..n {
+        let mut p = k;
+        let mut best = a[k * n + k].abs();
+        for i in k + 1..n {
+            let v = a[i * n + k].abs();
+            if v > best {
+                best = v;
+                p = i;
+            }
+        }
+        if !(best > 0.0) || !best.is_finite() {
+            return false;
+        }
+        if p != k {
+            for j in 0..n {
+                a.swap(k * n + j, p * n + j);
+            }
+            b.swap(k, p);
+        }
+        let pivot = a[k * n + k];
+        for i in k + 1..n {
+            let f = a[i * n + k] / pivot;
+            if f == 0.0 {
+                continue;
+            }
+            for j in k..n {
+                a[i * n + j] -= f * a[k * n + j];
+            }
+            b[i] -= f * b[k];
+        }
+    }
+    for k in (0..n).rev() {
+        let mut s = b[k];
+        for j in k + 1..n {
+            s -= a[k * n + j] * b[j];
+        }
+        b[k] = s / a[k * n + k];
+    }
+    true
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/lib.rs
@@ -1044,6 +1044,9 @@ pub struct SimMeta {
     /// FMI value reference -> `SimData` slot, sorted by `vr`. Only filled for the
     /// FMU export; empty for a plain simulation.
     pub fmi_vrs: Vec<FmiVr>,
+    /// fmi-ls-dae's `EnableDAE` structural parameter, the value reference that
+    /// switches a `--daeMode` FMU into DAE mode; 0 for an FMU without one.
+    pub fmi_dae_enable_vr: u32,
     /// Per-zero-crossing description (Modelica source of the relation, e.g.
     /// `x > 0.0`), 1:1 with the layout's zero-crossings — the driver names the
     /// culprit crossing in the chattering message. Empty ⇒ descriptions absent.
@@ -1577,6 +1580,7 @@ pub fn encode(m: &SimMeta) -> Vec<u8> {
         o.push(v.is_string as u8);
         put_u32(&mut o, v.der_off);
     }
+    put_u32(&mut o, m.fmi_dae_enable_vr);
     put_u32(&mut o, m.zc_desc.len() as u32);
     for d in &m.zc_desc {
         put_str(&mut o, d);
@@ -2064,6 +2068,7 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
         let der_off = r.u32()?;
         fmi_vrs.push(FmiVr { vr, off, wty, negate, start_off, is_string, der_off });
     }
+    let fmi_dae_enable_vr = r.u32()?;
     let ndesc = r.u32()? as usize;
     let mut zc_desc = Vec::with_capacity(ndesc);
     for _ in 0..ndesc {
@@ -2344,7 +2349,7 @@ pub fn decode(bytes: &[u8]) -> Result<SimMeta, &'static str> {
     Ok(SimMeta {
         layout, start_time, stop_time, n_intervals, method, cs_method, fmi_solver_flags, tolerance,
         output_format, prefix,
-        model_name, vars, jac_a, state_sets, fmi_vrs, zc_desc, rel_desc, params, attr_log,
+        model_name, vars, jac_a, state_sets, fmi_vrs, fmi_dae_enable_vr, zc_desc, rel_desc, params, attr_log,
         removed_init_desc, nls_warnings, sample_index, soti, sens_params, nls_vars, n_lin_systems, dae, clocks, lin, opt, inputs, recon, prof,
         parmod,
     })
@@ -2407,6 +2412,7 @@ mod tests {
                 FmiVr { vr: 0, off: 8, wty: WTy::F64, negate: Neg::None, start_off: 96, is_string: false, der_off: 0 },
                 FmiVr { vr: 7, off: 64, wty: WTy::I32, negate: Neg::Arith, start_off: 0, is_string: true, der_off: 0 },
             ],
+            fmi_dae_enable_vr: 9,
             zc_desc: vec!["x > 0.0".to_string(), "y < 1.0".to_string()],
             rel_desc: vec!["x > 0.0".to_string(), "y < 1.0".to_string()],
             params: ParamVars {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_simulation_runtime/src/meta.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_simulation_runtime/src/meta.rs
@@ -302,6 +302,7 @@ pub fn build(data: *mut DATA, xml: &InitXml, layout: &Layout, prefix: &str) -> S
         jac_a: jac_a_info(data, layout),
         state_sets: crate::stateset::describe(data, layout),
         fmi_vrs: Vec::new(),
+        fmi_dae_enable_vr: 0,
         zc_desc,
         rel_desc,
         sample_index: (0..md.nSamples).map(|i| unsafe { (*md.samplesInfo.add(i as usize)).index as i32 }).collect(),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/lib.rs
@@ -120,6 +120,24 @@ pub trait Ode {
     fn note_call(&mut self) {}
 }
 
+/// A model in residual form, `F(t, y, y') = 0` over `y = [states | algebraic
+/// unknowns]`, which only IDA integrates. `y'` carries a derivative per component,
+/// the algebraic ones being whatever IDA holds there.
+pub trait Dae {
+    /// `res := F(t, y, y')`.
+    fn residual(&mut self, t: f64, y: &[f64], yp: &[f64], res: &mut [f64]) -> Result<()>;
+
+    /// The zero-crossing functions at `(t, y, y')`.
+    fn eval_zc(&mut self, t: f64, y: &[f64], yp: &[f64], zc: &mut [f64]) -> Result<()>;
+
+    /// One nominal per component of `y`; empty means "one".
+    fn nominals(&self) -> &[f64] {
+        &[]
+    }
+
+    fn note_call(&mut self) {}
+}
+
 /// C's `bisection` iteration bound (`events.c`, `gbode_events.c`): `-mbi` when it
 /// is set to a positive value, else what halving the bracket down to `ttol` takes.
 pub fn bisection_iterations(width: f64, ttol: f64) -> i64 {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/sundials.rs
@@ -736,6 +736,22 @@ impl Ida {
         unsafe { IDAGetConsistentIC(self.mem, self.y, self.yp) == IDA_SUCCESS }
     }
 
+    /// C's `ida_event_update`: `IDACalcIC` over the algebraic unknowns and every
+    /// derivative at `t`, directed by the step IDA would take next (floored, so a
+    /// zero step still gives a direction), retried with the line search off, and
+    /// the result read back into `y`/`yp`. The initial step goes back to automatic
+    /// afterwards, as C leaves it.
+    pub fn calc_ic_at(&mut self, t: f64) -> bool {
+        let mut h = self.actual_init_step();
+        if h < f64::EPSILON {
+            h = f64::EPSILON;
+            self.set_init_step(h);
+        }
+        let ok = (self.calc_ic(t + h, true) || self.calc_ic(t + h, false)) && self.consistent_ic();
+        self.set_init_step(0.0);
+        ok
+    }
+
     /// Start forward sensitivity analysis over `p0`, the differentiated
     /// parameters' current values, in `ida_solver_initial`'s configuration:
     /// sensitivities from zero, IDAS's own forward difference quotients.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/sundials_ode.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/sundials_ode.rs
@@ -14,7 +14,7 @@ use core::ffi::{c_int, c_void};
 use crate::sundials::{
     self, Counters, Cvode, Ida, IdaLs, IdaOptions, NVector, Stop, nv_data,
 };
-use crate::{Ode, Result};
+use crate::{Dae, Ode, Result};
 
 /// How far one step got.
 pub enum SunStep {
@@ -393,5 +393,209 @@ fn ida_failure(flag: c_int) -> &'static str {
         -10 => "ida: the residual function failed repeatedly",
         sundials::IDA_RTFUNC_FAIL => "ida: the zero-crossing functions failed",
         _ => "ida: the integrator failed",
+    }
+}
+
+// ── IDA over a residual form ─────────────────────────────────────────────────
+
+struct DaeCtx<'a> {
+    dae: &'a mut dyn Dae,
+    n: usize,
+    n_zc: usize,
+    failed: Option<&'static str>,
+}
+
+unsafe extern "C" fn dae_res(t: f64, yy: NVector, yp: NVector, rr: NVector, user: *mut c_void) -> c_int {
+    let c = unsafe { &mut *(user as *mut DaeCtx) };
+    let n = c.n;
+    let (y, yp, r) = unsafe {
+        (
+            core::slice::from_raw_parts(nv_data(yy), n),
+            core::slice::from_raw_parts(nv_data(yp), n),
+            core::slice::from_raw_parts_mut(nv_data(rr), n),
+        )
+    };
+    c.dae.note_call();
+    match c.dae.residual(t, y, yp, r) {
+        Ok(()) => 0,
+        Err(e) => {
+            c.failed = Some(e);
+            -1
+        }
+    }
+}
+
+unsafe extern "C" fn dae_roots(t: f64, yy: NVector, yp: NVector, gout: *mut f64, user: *mut c_void) -> c_int {
+    let c = unsafe { &mut *(user as *mut DaeCtx) };
+    let (n, n_zc) = (c.n, c.n_zc);
+    let (y, yp, g) = unsafe {
+        (
+            core::slice::from_raw_parts(nv_data(yy), n),
+            core::slice::from_raw_parts(nv_data(yp), n),
+            core::slice::from_raw_parts_mut(gout, n_zc),
+        )
+    };
+    match c.dae.eval_zc(t, y, yp, g) {
+        Ok(()) => 0,
+        Err(e) => {
+            c.failed = Some(e);
+            -1
+        }
+    }
+}
+
+/// IDA over a [`Dae`]: `y = [states | algebraic unknowns]`, `IDASetId` telling the
+/// two apart, and `IDACalcIC` making `(y, y')` consistent wherever the integration
+/// (re)starts — at the first step and after every event, as `ida_event_update`
+/// does for a `--daeMode` model.
+pub struct IdaDae {
+    ida: Option<Ida>,
+    n_states: usize,
+    n: usize,
+    n_zc: usize,
+    tolerance: f64,
+    nominals: Vec<f64>,
+    pending: Pending,
+    past: Counters,
+}
+
+impl IdaDae {
+    pub fn new(n_states: usize, n_alg: usize, n_zc: usize, tolerance: f64, nominals: &[f64]) -> IdaDae {
+        IdaDae {
+            ida: None,
+            n_states,
+            n: n_states + n_alg,
+            n_zc,
+            tolerance,
+            nominals: nominals.to_vec(),
+            pending: Pending::Rebuild,
+            past: Counters::default(),
+        }
+    }
+
+    pub fn restart(&mut self) {
+        if self.pending == Pending::None {
+            self.pending = Pending::Reinit;
+        }
+    }
+
+    pub fn set_nominals(&mut self, nominals: &[f64]) {
+        if self.nominals != nominals {
+            self.nominals = nominals.to_vec();
+            self.pending = Pending::Rebuild;
+        }
+    }
+
+    pub fn counters(&self) -> Counters {
+        match self.ida.as_ref() {
+            Some(ida) => add(self.past, ida.counters()),
+            None => self.past,
+        }
+    }
+
+    /// Integrate toward `target`; `y` and `yp` hold the point reached, a root
+    /// included.
+    pub fn step(
+        &mut self,
+        dae: &mut dyn Dae,
+        target: f64,
+        t: &mut f64,
+        y: &mut [f64],
+        yp: &mut [f64],
+    ) -> Result<SunStep> {
+        if y.is_empty() {
+            *t = target;
+            return Ok(SunStep::Reached);
+        }
+        self.prepare(dae, *t, y, yp)?;
+        let (n, n_zc) = (self.n, self.n_zc);
+        let ida = self.ida.as_mut().expect("prepare built it");
+        let mut ctx = DaeCtx { dae, n, n_zc, failed: None };
+        if !ida.set_user_data(&mut ctx as *mut DaeCtx as *mut c_void) {
+            return Err("ida: the context could not be bound");
+        }
+        let mut retries = 0;
+        let stop = loop {
+            match ida.step(t, target, false) {
+                Stop::Failed(sundials::IDA_TOO_MUCH_WORK) if retries < WORK_RETRIES => retries += 1,
+                other => break other,
+            }
+        };
+        if let Some(e) = ctx.failed {
+            return Err(e);
+        }
+        y.copy_from_slice(ida.y());
+        yp.copy_from_slice(ida.yp());
+        match stop {
+            Stop::Reached | Stop::Stepped => Ok(SunStep::Reached),
+            Stop::Root => Ok(SunStep::Root(*t)),
+            Stop::Failed(flag) => Err(ida_failure(flag)),
+        }
+    }
+
+    /// Make `(y, y')` consistent at `t` now — `IDACalcIC` over the algebraic
+    /// unknowns and the derivatives — rather than at the next step, so the caller
+    /// can report the consistent point.
+    pub fn make_consistent(&mut self, dae: &mut dyn Dae, t: f64, y: &mut [f64], yp: &mut [f64]) -> Result<()> {
+        if y.is_empty() {
+            return Ok(());
+        }
+        if self.pending == Pending::None {
+            self.pending = Pending::Reinit;
+        }
+        self.prepare(dae, t, y, yp)?;
+        let ida = self.ida.as_ref().expect("prepare built it");
+        y.copy_from_slice(ida.y());
+        yp.copy_from_slice(ida.yp());
+        Ok(())
+    }
+
+    fn prepare(&mut self, dae: &mut dyn Dae, t: f64, y: &[f64], yp: &[f64]) -> Result<()> {
+        let pending = core::mem::replace(&mut self.pending, Pending::None);
+        if pending == Pending::None {
+            return Ok(());
+        }
+        if pending == Pending::Rebuild {
+            if let Some(ida) = self.ida.take() {
+                self.past = add(self.past, ida.counters());
+            }
+            let atol = abs_tolerances(self.tolerance, self.n, &self.nominals);
+            let root = (self.n_zc > 0).then_some(dae_roots as sundials::IdaRootFn);
+            let opts = IdaOptions {
+                max_order: crate::simflags::with_flags(|f| f.max_order),
+                ..IdaOptions::default()
+            };
+            let mut ida = Ida::new(
+                t, y, yp, self.tolerance, &atol, self.n_zc, dae_res, root, IdaLs::Dense, 0, None, &opts,
+            )
+            .ok_or("ida: the integrator could not be created")?;
+            let mut id = vec![1.0; self.n_states];
+            id.resize(self.n, 0.0);
+            if !ida.set_id(&id, crate::simflags::with_flags(|f| f.ida_no_suppress_alg)) {
+                return Err("ida: IDASetId failed");
+            }
+            self.ida = Some(ida);
+        }
+        let ida = self.ida.as_mut().expect("built above");
+        if pending == Pending::Reinit {
+            ida.y_mut().copy_from_slice(y);
+            ida.yp_mut().copy_from_slice(yp);
+            if !ida.reinit(t) {
+                return Err("ida: the integrator could not be restarted");
+            }
+        }
+        let (n, n_zc) = (self.n, self.n_zc);
+        let mut ctx = DaeCtx { dae, n, n_zc, failed: None };
+        if !ida.set_user_data(&mut ctx as *mut DaeCtx as *mut c_void) {
+            return Err("ida: the context could not be bound");
+        }
+        let ok = ida.calc_ic_at(t);
+        if let Some(e) = ctx.failed {
+            return Err(e);
+        }
+        if !ok {
+            return Err("ida: no consistent initial conditions were found (IDACalcIC)");
+        }
+        Ok(())
     }
 }

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -4433,24 +4433,15 @@ algorithm
     Error.addMessage(Error.FMU_EXPORT_NOT_SUPPORTED_CPP, {FMUType});
     FMUType := "me";
   end if;
-  if Flags.getConfigBool(Flags.DAE_MODE) then
-    // Model Exchange has to answer with state derivatives, which a DAE-mode model
-    // has none of. Co-Simulation integrates the model itself, and of the two
-    // runtimes that do so only the wasm one handles the residual form.
-    if isWasmFMU and FMUType == "me_cs" then
-      Error.addMessage(Error.FMU_EXPORT_DAE_MODE_ME_DROPPED, {});
-      FMUType := "cs";
-    elseif FMI.isFMIMEType(FMUType) then
-      success := false;
-      outValue := Values.STRING("");
+  if Flags.getConfigBool(Flags.DAE_MODE) and not isWasmFMU then
+    success := false;
+    outValue := Values.STRING("");
+    if FMI.isFMIMEType(FMUType) then
       Error.addMessage(Error.FMU_EXPORT_DAE_MODE_ME, {FMUType});
-      return;
-    elseif not isWasmFMU then
-      success := false;
-      outValue := Values.STRING("");
+    else
       Error.addMessage(Error.FMU_EXPORT_DAE_MODE_C_CS, {});
-      return;
     end if;
+    return;
   end if;
 
   // NOTE: The FMUs use fileNamePrefix for the internal name when it would be expected to be fileNamePrefix that decides the .fmu filename
@@ -4845,21 +4836,14 @@ algorithm
     Error.addMessage(Error.FMU_EXPORT_NOT_SUPPORTED_CPP, {FMUType});
     FMUType := "me";
   end if;
-  if Flags.getConfigBool(Flags.DAE_MODE) then
-    // As in callTranslateModelFMU, which has to make the same choice: the
-    // `fmuTranslationFor` lookup below is keyed on the interface.
-    if isWasmFMU and FMUType == "me_cs" then
-      Error.addMessage(Error.FMU_EXPORT_DAE_MODE_ME_DROPPED, {});
-      FMUType := "cs";
-    elseif FMI.isFMIMEType(FMUType) then
-      outValue := Values.STRING("");
+  if Flags.getConfigBool(Flags.DAE_MODE) and not isWasmFMU then
+    outValue := Values.STRING("");
+    if FMI.isFMIMEType(FMUType) then
       Error.addMessage(Error.FMU_EXPORT_DAE_MODE_ME, {FMUType});
-      return;
-    elseif not isWasmFMU then
-      outValue := Values.STRING("");
+    else
       Error.addMessage(Error.FMU_EXPORT_DAE_MODE_C_CS, {});
-      return;
     end if;
+    return;
   end if;
 
   // NOTE: The FMUs use fileNamePrefix for the internal name when it would be expected to be fileNamePrefix that decides the .fmu filename

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -976,6 +976,7 @@ public function emitWasmFMU
   input Absyn.Program program;
 protected
   String guid, modelDescriptionStr, simulationFlagsJson;
+  String lsDaeManifestStr = "";
   String fmutmp = "", terminalsDir = "", documentationDir = "";
   list<SimCode.FmiTerminal> terminals;
   // `--fmuDirectory`: an export for an OpenModelica importer, which reads the
@@ -1005,6 +1006,11 @@ algorithm
     modelDescriptionStr := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + Tpl.textString(
       CodegenFMU3.fmiModelDescription(Tpl.emptyTxt, simCode, guid, FMUType, {}));
     ExecStat.execStat("FMU modelDescription.xml");
+    if isSome(simCode.daeModeData) and FMI.isFMIMEType(FMUType) then
+      lsDaeManifestStr := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + Tpl.textString(
+        CodegenFMU3.fmiLsDaeManifest(Tpl.emptyTxt, simCode));
+      ExecStat.execStat("FMU fmi-ls-manifest.xml");
+    end if;
     // terminalsAndIcons/ by the C target's route: SimCode writes the XML, then the
     // OMGraphics renderer adds the <GraphicalRepresentation> and the icons beside it.
     if not bareExport then
@@ -1029,11 +1035,11 @@ algorithm
   end if;
   simulationFlagsJson := wasmFMUSimulationFlagsJson(simCode);
   if FMI.isFMIMEType(FMUType) and FMI.isFMICSType(FMUType) then
-    CodegenWasmJit.emitMeCsFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, documentationDir, terminalsDir, simulationFlagsJson);
+    CodegenWasmJit.emitMeCsFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, lsDaeManifestStr, documentationDir, terminalsDir, simulationFlagsJson);
   elseif FMI.isFMICSType(FMUType) then
-    CodegenWasmJit.emitCsFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, documentationDir, terminalsDir, simulationFlagsJson);
+    CodegenWasmJit.emitCsFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, lsDaeManifestStr, documentationDir, terminalsDir, simulationFlagsJson);
   else
-    CodegenWasmJit.emitMeFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, documentationDir, terminalsDir, simulationFlagsJson);
+    CodegenWasmJit.emitMeFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, lsDaeManifestStr, documentationDir, terminalsDir, simulationFlagsJson);
   end if;
   setGlobalRoot(Global.optionSimCode, NONE());
 end emitWasmFMU;

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -2378,6 +2378,9 @@ algorithm
     (algebraicStateVars, _) :=  BackendVariable.traverseBackendDAEVars(algStateVars, SimCodeUtil.traversingdlowvarToSimvar, ({}, BackendVariable.emptyVars()));
 
     algebraicStateVars := SimCodeUtil.sortSimVarsAndWriteIndex(algebraicStateVars, crefToSimVarHT);
+    if isFMU then
+      modelInfo := SimCodeUtil.exportDaeAlgebraicStates(modelInfo, algebraicStateVars);
+    end if;
 
     // only create sparsity pattern for dae mode data even if it is created with --generateDynamicJacobian=symbolic
     // the A matrix will be used symbolically

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -14998,6 +14998,33 @@ algorithm
   outValueReference := String(numReal + numInteger + numBoolean + numString + numExtObj + numClock);
 end getFMI3TimeValueReference;
 
+public function exportDaeAlgebraicStates
+  "fmi-ls-dae: the algebraic states are unknowns the importer sets, so they are in
+   the model description whatever --fmiFilter hides, as the states are."
+  input output SimCode.ModelInfo modelInfo;
+  input list<SimCodeVar.SimVar> algebraicStateVars;
+protected
+  HashSet.HashSet crefs = HashSet.emptyHashSet();
+  SimCodeVar.SimVars vars;
+algorithm
+  for v in algebraicStateVars loop
+    crefs := BaseHashSet.add(v.name, crefs);
+  end for;
+  vars := modelInfo.vars;
+  vars.algVars := list(exportIfAlgebraicState(v, crefs) for v in vars.algVars);
+  modelInfo.vars := vars;
+end exportDaeAlgebraicStates;
+
+protected function exportIfAlgebraicState
+  input output SimCodeVar.SimVar v;
+  input HashSet.HashSet crefs;
+algorithm
+  if isNone(v.exportVar) and BaseHashSet.has(v.name, crefs) then
+    v.exportVar := SOME(if Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_BLACKBOX
+                        then ComponentReference.getConcealedCref() else v.name);
+  end if;
+end exportIfAlgebraicState;
+
 public function getFMI3DaeModeValueReference
   "fmi-ls-dae: the value reference of the structural parameter that switches a
    --daeMode FMU into DAE mode, the first one past the event indicators. The

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -14998,6 +14998,76 @@ algorithm
   outValueReference := String(numReal + numInteger + numBoolean + numString + numExtObj + numClock);
 end getFMI3TimeValueReference;
 
+public function getFMI3DaeModeValueReference
+  "fmi-ls-dae: the value reference of the structural parameter that switches a
+   --daeMode FMU into DAE mode, the first one past the event indicators. The
+   residuals follow it (getFMI3DaeResidualValueReference); the wasm emitter
+   (CodegenWasmJit.build_fmi_vrs) assigns the same numbers."
+  input SimCode.SimCode simCode;
+  output String vr;
+algorithm
+  vr := String(stringInt(getFMI3TimeValueReference(simCode)) + simCode.modelInfo.varInfo.numZeroCrossings + 1);
+end getFMI3DaeModeValueReference;
+
+public function getFMI3DaeResidualValueReference
+  input SimCodeVar.SimVar residualVar "one of daeModeData.residualVars";
+  input SimCode.SimCode simCode;
+  output String vr;
+algorithm
+  vr := String(stringInt(getFMI3DaeModeValueReference(simCode)) + 1 + residualVar.index);
+end getFMI3DaeResidualValueReference;
+
+public function getFMI3DaeResidualDependencyAttributes
+  "fmi-ls-dae: the dependencies and dependenciesKind attributes of the residual at
+   0-based row `index` of the DAE-mode Jacobian, read off its transposed sparsity.
+   A state column stands for the state and its derivative both, since DAE-mode
+   differentiation folds der(x) into x ($cj * x.Seed); the other columns are the
+   algebraic variables. Empty without a pattern, which the standard reads as a
+   dependency on every known."
+  input SimCode.SimCode simCode;
+  input Integer index;
+  output String attributes = "";
+protected
+  SimCode.DaeModeData dmd;
+  SimCode.JacobianMatrix jm;
+  list<Integer> cols = {};
+  Integer numStates, row = 0;
+  list<Integer> colsOfRow;
+  SimCodeVar.SimVar sv;
+  String stateVR;
+  list<String> acc = {};
+algorithm
+  if isNone(simCode.daeModeData) then
+    return;
+  end if;
+  SOME(dmd) := simCode.daeModeData;
+  if isNone(dmd.sparsityPattern) then
+    return;
+  end if;
+  SOME(jm) := dmd.sparsityPattern;
+  for entry in jm.sparsityT loop
+    (_, colsOfRow) := entry;
+    if row == index then
+      cols := colsOfRow;
+    end if;
+    row := row + 1;
+  end for;
+  numStates := numScalarElems(simCode.modelInfo.vars.stateVars);
+  for c in cols loop
+    if c < numStates then
+      sv := listGet(simCode.modelInfo.vars.stateVars, c + 1);
+      stateVR := getFMI3ValueReference(sv, simCode);
+      acc := String(stringInt(stateVR) + numStates) :: stateVR :: acc;
+    else
+      sv := listGet(dmd.algebraicVars, c - numStates + 1);
+      acc := getFMI3ValueReference(sv, simCode) :: acc;
+    end if;
+  end for;
+  acc := listReverse(acc);
+  attributes := " dependencies=\"" + stringDelimitList(acc, " ") + "\" dependenciesKind=\""
+    + stringDelimitList(list("dependent" for s in acc), " ") + "\"";
+end getFMI3DaeResidualDependencyAttributes;
+
 public function getLocalValueReference
  "returns the local value reference of current OMSIFuncton of a variable for
   direct memory access considering aliases and array storage order."

--- a/OMCompiler/Compiler/Template/CodegenFMU3.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU3.tpl
@@ -494,9 +494,81 @@ case MODELINFO(vars=SIMVARS(stateVars=stateVars)) then
     <%vars.extObjVars |> var => Variable3(var, simCode, numScalarStates) ;separator="\n"%>
     <%SimCodeUtil.getFMI3Clocks(simCode) |> clk => Clock3(clk, FMUType) ;separator="\n"%>
     <%EventIndicatorVariables3(simCode)%>
+    <%if isFMIMEType(FMUType) then DaeModeVariables3(simCode)%>
   </ModelVariables>
   >>
 end fmiModelVariables3;
+
+template DaeModeVariables3(SimCode simCode)
+ "fmi-ls-dae, for a Model Exchange FMU of a --daeMode model: the structural
+  parameter that switches it into DAE mode (false: an ordinary ODE FMU), and one
+  Float64 per residual of the DAE formulation. Their value references follow the
+  event indicators; the manifest (fmiLsDaeManifest) names them."
+::=
+match simCode
+case SIMCODE(daeModeData=SOME(dmd as DAEMODEDATA(__))) then
+  <<
+  <Boolean name="_D_daeMode" valueReference="<%SimCodeUtil.getFMI3DaeModeValueReference(simCode)%>" causality="structuralParameter" variability="fixed" start="false" description="Set to true to enable DAE mode as defined by FMI-LS-DAE."/>
+  <%dmd.residualVars |> var => DaeResidualVariable3(var, simCode) ;separator="\n"%>
+  >>
+end DaeModeVariables3;
+
+template DaeResidualVariable3(SimVar simVar, SimCode simCode)
+::=
+match simVar
+case SIMVAR(__) then
+  let nm = Util.escapeModelicaStringToXmlString(System.stringReplace(crefStrNoUnderscore(name),"$", "_D_"))
+  '<Float64 name="<%nm%>" valueReference="<%SimCodeUtil.getFMI3DaeResidualValueReference(simVar, simCode)%>" causality="local" variability="continuous" initial="calculated" description="DAE-mode residual <%index%>"/>'
+end DaeResidualVariable3;
+
+template fmiLsDaeManifest(SimCode simCode)
+ "fmi-ls-dae's manifest (extra/org.fmi-standard.fmi-ls-dae/fmi-ls-manifest.xml)
+  for a --daeMode Model Exchange FMU: the switch, the algebraic variables the
+  importer solves for beside the states, and a ModelStructure that restates the
+  model description's and adds the residuals — the fully implicit form
+  F(der(x), x, z, t) = 0, so no ContinuousStateDerivative entries."
+::=
+match simCode
+case SIMCODE(daeModeData=SOME(dmd as DAEMODEDATA(__)), modelStructure=modelStructure) then
+  let _ = SimCodeUtil.cacheFMI3ValueReferences(simCode)
+  let structure = match modelStructure
+    case SOME(fmistruct as FMIMODELSTRUCTURE(__)) then
+      <<
+      <%ModelStructureOutputs3(simCode, fmistruct.fmiOutputs)%>
+      <%ModelStructureInitialUnknowns3(simCode, fmistruct.fmiInitialUnknowns)%>
+      >>
+    else ''
+  let indicators = EventIndicators3(simCode)
+  let residuals = (dmd.residualVars |> var hasindex i0 => DaeResidual3(simCode, var, i0) ;separator="\n")
+  let _ = SimCodeUtil.clearFMI3ValueReferences()
+  <<
+  <fmi-ls-dae
+    xmlns="http://fmi-standard.org/fmi-ls-manifest"
+    xmlns:fmi-ls="http://fmi-standard.org/fmi-ls-manifest"
+    fmi-ls:fmi-ls-name="org.fmi-standard.fmi-ls-dae"
+    fmi-ls:fmi-ls-version="0.1.0"
+    fmi-ls:fmi-ls-description="Layered standard for DAE support in FMI.">
+    <EnableDAE valueReference="<%SimCodeUtil.getFMI3DaeModeValueReference(simCode)%>"/>
+    <AlgebraicVariables>
+      <%dmd.algebraicVars |> var => '<AlgebraicVariable valueReference="<%SimCodeUtil.getFMI3ValueReference(var, simCode)%>"/>' ;separator="\n"%>
+    </AlgebraicVariables>
+    <ModelStructure>
+      <%structure%>
+      <%indicators%>
+      <%residuals%>
+    </ModelStructure>
+  </fmi-ls-dae>
+  >>
+end fmiLsDaeManifest;
+
+template DaeResidual3(SimCode simCode, SimVar residualVar, Integer row)
+::=
+  <<
+  <Residual>
+    <Formulation valueReference="<%SimCodeUtil.getFMI3DaeResidualValueReference(residualVar, simCode)%>"<%SimCodeUtil.getFMI3DaeResidualDependencyAttributes(simCode, row)%>/>
+  </Residual>
+  >>
+end DaeResidual3;
 
 template EventIndicatorVariables3(SimCode simCode)
  "FMI 3.0 requires event indicators to be exposed as Float64 variables that are

--- a/OMCompiler/Compiler/Template/CodegenWasmJit.mo
+++ b/OMCompiler/Compiler/Template/CodegenWasmJit.mo
@@ -128,6 +128,7 @@ function emitMeFmu
   input String fmuPath;
   input String guid;
   input String modelDescription;
+  input String lsDaeManifest "fmi-ls-dae's manifest for a --daeMode model, empty for none";
   input String documentationDir "directory shipped as documentation/ (index.html and the images it references); empty for none";
   input String terminalsDir "directory shipped as terminalsAndIcons/ (the XML and the rendered icons); empty for none";
   input String simulationFlagsJson "--fmiFlags as CodegenFMU renders it, empty when there are none";
@@ -144,6 +145,7 @@ function emitCsFmu
   input String fmuPath;
   input String guid;
   input String modelDescription;
+  input String lsDaeManifest "fmi-ls-dae's manifest for a --daeMode model, empty for none";
   input String documentationDir "directory shipped as documentation/ (index.html and the images it references); empty for none";
   input String terminalsDir "directory shipped as terminalsAndIcons/ (the XML and the rendered icons); empty for none";
   input String simulationFlagsJson "--fmiFlags as CodegenFMU renders it, empty when there are none";
@@ -160,6 +162,7 @@ function emitMeCsFmu
   input String fmuPath;
   input String guid;
   input String modelDescription;
+  input String lsDaeManifest "fmi-ls-dae's manifest for a --daeMode model, empty for none";
   input String documentationDir "directory shipped as documentation/ (index.html and the images it references); empty for none";
   input String terminalsDir "directory shipped as terminalsAndIcons/ (the XML and the rendered icons); empty for none";
   input String simulationFlagsJson "--fmiFlags as CodegenFMU renders it, empty when there are none";

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -1535,6 +1535,23 @@ package SimCodeUtil
     output String outValueReference;
   end getFMI3TimeValueReference;
 
+  function getFMI3DaeModeValueReference
+    input SimCode.SimCode simCode;
+    output String vr;
+  end getFMI3DaeModeValueReference;
+
+  function getFMI3DaeResidualValueReference
+    input SimCodeVar.SimVar residualVar;
+    input SimCode.SimCode simCode;
+    output String vr;
+  end getFMI3DaeResidualValueReference;
+
+  function getFMI3DaeResidualDependencyAttributes
+    input SimCode.SimCode simCode;
+    input Integer index;
+    output String attributes;
+  end getFMI3DaeResidualDependencyAttributes;
+
   function getLocalValueReference
     input SimCodeVar.SimVar inSimVar;
     input SimCode.SimCode inSimCode;

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -1342,11 +1342,9 @@ public constant ErrorTypes.Message DUPLICATE_VARIABLE_ERROR = ErrorTypes.MESSAGE
 public constant ErrorTypes.Message ENCRYPTION_NOT_SUPPORTED = ErrorTypes.MESSAGE(7026, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   "File not Found: %s. Compile OpenModelica with Encryption support.");
 public constant ErrorTypes.Message FMU_EXPORT_DAE_MODE_ME = ErrorTypes.MESSAGE(7027, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
-  "DAE mode (--daeMode) is not supported for FMI Model Exchange export (fmuType=\"%s\"), which requires the state derivatives a DAE-mode model does not have. Export a Co-Simulation FMU instead, or remove the --daeMode flag.");
+  "DAE mode (--daeMode) is not supported by the C simulation runtime, so it cannot build a Model Exchange FMU (fmuType=\"%s\") from it. Export with platforms={\"wasm\"}, whose runtime serves the residual form (as fmi-ls-dae for Model Exchange), or remove the --daeMode flag.");
 public constant ErrorTypes.Message USER_CANCELLED = ErrorTypes.MESSAGE(7028, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   "Operation cancelled by user.");
-public constant ErrorTypes.Message FMU_EXPORT_DAE_MODE_ME_DROPPED = ErrorTypes.MESSAGE(7031, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
-  "DAE mode (--daeMode) has no Model Exchange interface, which would require the state derivatives a DAE-mode model does not have. Exporting Co-Simulation only.");
 public constant ErrorTypes.Message FMU_EXPORT_DAE_MODE_C_CS = ErrorTypes.MESSAGE(7030, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   "DAE mode (--daeMode) is not supported by the C simulation runtime, so it cannot build a Co-Simulation FMU either. Export with platforms={\"wasm\"}, whose runtime does support it, or remove the --daeMode flag.");
 public constant ErrorTypes.Message FMU_EXPORT_WASM_FMI1 = ErrorTypes.MESSAGE(7029, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),

--- a/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_daemode.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_daemode.mos
@@ -4,25 +4,22 @@
 // suite: wasm
 // teardown_command: rm -rf DaeModeWhenLoop* daemode_*.mat diff_daemode* om-wasm-include-*
 //
-// A `--daeMode` model answers with residuals, not with state derivatives, so FMI
-// Model Exchange is refused and `me_cs` is downgraded to Co-Simulation, which
-// integrates the model itself. Doing that means running the DAE-mode backend:
-// the ODE backend cannot translate this model at all (the tearing pulls a
-// when-equation into the nonlinear loop), so an export that dropped --daeMode
-// would fail here the way Dynawo's models did. Co-Simulation then has to
-// integrate with IDA, the one method that serves a residual form, and the model
-// crosses its threshold once so the event the master drives is covered too:
-// resuming from it needs an IDACalcIC, without which IDA does not converge on
-// the step after the event.
+// A `--daeMode` model answers with residuals, not with state derivatives, so its
+// Co-Simulation FMU integrates the model itself. Doing that means running the
+// DAE-mode backend: the ODE backend cannot translate this model at all (the
+// tearing pulls a when-equation into the nonlinear loop), so an export that
+// dropped --daeMode would fail here the way Dynawo's models did. Co-Simulation
+// then has to integrate with IDA, the one method that serves a residual form, and
+// the model crosses its threshold once so the event the master drives is covered
+// too: resuming from it needs an IDACalcIC, without which IDA does not converge
+// on the step after the event. (Model Exchange serves the same model through
+// fmi-ls-dae; see ModelExchange/3.0/fmi3_wasm_daemode_me.mos.)
 
 setCommandLineOptions("--simCodeTarget=wasm-jit"); getErrorString();
 loadFile("fmi3_wasm_daemode.mo"); getErrorString();
 
 // The reference: the same model simulated the ordinary way.
 simulate(DaeModeWhenLoop, fileNamePrefix="daemode_plain"); getErrorString();
-
-// Model Exchange has to answer fmi3GetContinuousStateDerivatives.
-buildModelFMU(DaeModeWhenLoop, fileNamePrefix="DaeModeWhenLoop", fmuType="me", version="3.0", platforms={"wasm"}); getErrorString();
 
 setCommandLineOptions("--fmuDirectory=true"); getErrorString();
 buildModelFMU(DaeModeWhenLoop, fileNamePrefix="DaeModeWhenLoop", fmuType="me_cs", version="3.0", platforms={"wasm"}); getErrorString();
@@ -48,14 +45,10 @@ diffSimulationResults("daemode_cs.mat", "daemode_plain_res.mat", "diff_daemode_c
 // "
 // end SimulationResult;
 // ""
-// ""
-// "Error: DAE mode (--daeMode) is not supported for FMI Model Exchange export (fmuType=\"me\"), which requires the state derivatives a DAE-mode model does not have. Export a Co-Simulation FMU instead, or remove the --daeMode flag.
-// "
 // true
 // ""
 // "DaeModeWhenLoop.fmu"
-// "Warning: DAE mode (--daeMode) has no Model Exchange interface, which would require the state derivatives a DAE-mode model does not have. Exporting Co-Simulation only.
-// Notification: Building FMU for platform 'wasm' (1/1).
+// "Notification: Building FMU for platform 'wasm' (1/1).
 // Notification: Finished FMU for platform 'wasm' (1/1).
 // "
 // record SimulationResult

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/Makefile
@@ -25,6 +25,7 @@ fmi3_terminals_alias_nb.mos \
 fmi3_terminals_alias.mos \
 fmi3_terminals.mos \
 fmi3_types.mos \
+fmi3_wasm_daemode_me.mos \
 fmi3_wasm_native_record.mos \
 fmi3_wasm_output_record.mos
 

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_wasm_daemode_me.mo
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_wasm_daemode_me.mo
@@ -1,0 +1,18 @@
+model DaeModeMe "Index-1 DAE: an algebraic loop, a nonlinear algebraic variable, a state event"
+  Real x(start = 1, fixed = true);
+  Real y "in a linear loop with z";
+  Real z(nominal = 0.1);
+  Real w "nonlinear in z";
+  discrete Real bump(start = 0, fixed = true);
+equation
+  der(x) = y - bump;
+  y + 2*z = x;
+  y - 3*z = 2*x;
+  w = x*z + z^2;
+  when x > 1.5 then
+    bump = 0.5;
+  end when;
+  annotation(
+    __OpenModelica_commandLineOptions = "--daeMode",
+    experiment(StopTime = 1, Tolerance = 1e-6));
+end DaeModeMe;

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_wasm_daemode_me.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_wasm_daemode_me.mos
@@ -1,0 +1,134 @@
+// name: fmi3_wasm_daemode_me.mos
+// keywords: FMI 3.0 export wasm Model Exchange daeMode fmi-ls-dae
+// status: correct
+// suite: wasm
+// teardown_command: rm -rf DaeModeMe* plain_res.mat me_*.mat diff_me_* om-wasm-include-*
+//
+// A `--daeMode` model as a Model Exchange FMU, through fmi-ls-dae: the FMU is an
+// ordinary ODE FMU until the importer sets the structural parameter the manifest
+// names, and a DAE FMU after — the importer sets the states, their derivatives
+// and the algebraic variables, and reads the residuals back.
+//
+// Three runs of the same export against the model's own simulation: the
+// zipped component in DAE mode (omc integrating the residuals with IDA), and
+// the linked artifact in both modes — in ODE mode the FMU has to solve for the
+// derivatives and the algebraic variables itself, which a DAE-mode model does
+// not have equations for.
+
+setCommandLineOptions("--simCodeTarget=wasm-jit"); getErrorString();
+loadFile("fmi3_wasm_daemode_me.mo"); getErrorString();
+
+simulate(DaeModeMe, fileNamePrefix="plain"); getErrorString();
+
+buildModelFMU(DaeModeMe, fileNamePrefix="DaeModeMe", fmuType="me_cs", version="3.0", platforms={"wasm"}); getErrorString();
+simulate(DaeModeMe, simflags="-s fmi3:me -daeMode -r=me_dae_zip.mat", resimulateExecutable="DaeModeMe.fmu"); getErrorString();
+diffSimulationResults("me_dae_zip.mat", "plain_res.mat", "diff_me_dae_zip", 1e-4, 1e-4);
+
+setCommandLineOptions("--fmuDirectory=true"); getErrorString();
+buildModelFMU(DaeModeMe, fileNamePrefix="DaeModeMeDir", fmuType="me_cs", version="3.0", platforms={"wasm"}); getErrorString();
+readFile("DaeModeMeDir.fmu/extra/org.fmi-standard.fmi-ls-dae/fmi-ls-manifest.xml"); getErrorString();
+regexBool(readFile("DaeModeMeDir.fmu/modelDescription.xml"), "<Boolean name=\"_D_daeMode\" valueReference=\"[0-9]+\" causality=\"structuralParameter\" variability=\"fixed\" start=\"false\"");
+
+simulate(DaeModeMe, simflags="-s fmi3:me -r=me_ode.mat", resimulateExecutable="DaeModeMeDir.fmu"); getErrorString();
+simulate(DaeModeMe, simflags="-s fmi3:me -daeMode -r=me_dae.mat", resimulateExecutable="DaeModeMeDir.fmu"); getErrorString();
+diffSimulationResults("me_ode.mat", "plain_res.mat", "diff_me_ode", 1e-4, 1e-4);
+diffSimulationResults("me_dae.mat", "plain_res.mat", "diff_me_dae", 1e-4, 1e-4);
+
+// DAE mode is IDA's alone.
+simulate(DaeModeMe, simflags="-s fmi3:me:dassl -daeMode", resimulateExecutable="DaeModeMeDir.fmu"); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "plain_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'plain', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_STDOUT        | warning | Internal Numerical Jacobians without coloring are currently not supported by IDA with KLU. Colored numerical Jacobian will be used.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// "DaeModeMe.fmu"
+// "Notification: Building FMU for platform 'wasm' (1/1).
+// Notification: Finished FMU for platform 'wasm' (1/1).
+// "
+// record SimulationResult
+//     resultFile = "me_dae_zip.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'DaeModeMe', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s fmi3:me -daeMode -r=me_dae_zip.mat'",
+//     messages = "LOG_STDOUT        | info    | wasm artifact loaded (compiled from the component)
+// LOG_STDOUT        | info    | ModelExchange instantiated
+// LOG_STDOUT        | info    | ModelExchange run: 67 steps, 190 evaluations, 34 Jacobians, 1 state events, 0 time events, 503 samples
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// (true, {})
+// true
+// ""
+// "DaeModeMeDir.fmu"
+// "Notification: Building FMU for platform 'wasm' (1/1).
+// Notification: Finished FMU for platform 'wasm' (1/1).
+// "
+// "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+// <fmi-ls-dae
+//   xmlns=\"http://fmi-standard.org/fmi-ls-manifest\"
+//   xmlns:fmi-ls=\"http://fmi-standard.org/fmi-ls-manifest\"
+//   fmi-ls:fmi-ls-name=\"org.fmi-standard.fmi-ls-dae\"
+//   fmi-ls:fmi-ls-version=\"0.1.0\"
+//   fmi-ls:fmi-ls-description=\"Layered standard for DAE support in FMI.\">
+//   <EnableDAE valueReference=\"9\"/>
+//   <AlgebraicVariables>
+//     <AlgebraicVariable valueReference=\"3\"/>
+//     <AlgebraicVariable valueReference=\"4\"/>
+//   </AlgebraicVariables>
+//   <ModelStructure>
+//     <InitialUnknown valueReference=\"1\"/>
+//     <EventIndicator valueReference=\"8\"/>
+//     <Residual>
+//       <Formulation valueReference=\"10\" dependencies=\"0 1 3 4\" dependenciesKind=\"dependent dependent dependent dependent\"/>
+//     </Residual>
+//     <Residual>
+//       <Formulation valueReference=\"11\" dependencies=\"0 1 3 4\" dependenciesKind=\"dependent dependent dependent dependent\"/>
+//     </Residual>
+//     <Residual>
+//       <Formulation valueReference=\"12\" dependencies=\"0 1 3\" dependenciesKind=\"dependent dependent dependent\"/>
+//     </Residual>
+//   </ModelStructure>
+// </fmi-ls-dae>"
+// ""
+// true
+// record SimulationResult
+//     resultFile = "me_ode.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'DaeModeMe', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s fmi3:me -r=me_ode.mat'",
+//     messages = "LOG_STDOUT        | info    | wasm artifact loaded (model kernel linked against the cached adapter)
+// LOG_STDOUT        | info    | ModelExchange instantiated
+// LOG_STDOUT        | info    | ModelExchange run: 43 steps, 145 evaluations, 33 Jacobians, 1 state events, 0 time events, 503 samples
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// record SimulationResult
+//     resultFile = "me_dae.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'DaeModeMe', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s fmi3:me -daeMode -r=me_dae.mat'",
+//     messages = "LOG_STDOUT        | info    | wasm artifact loaded (model kernel linked against the cached adapter)
+// LOG_STDOUT        | info    | ModelExchange instantiated
+// LOG_STDOUT        | info    | ModelExchange run: 67 steps, 190 evaluations, 34 Jacobians, 1 state events, 0 time events, 503 samples
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// (true, {})
+// (true, {})
+// record SimulationResult
+//     resultFile = "",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'DaeModeMe', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s fmi3:me:dassl -daeMode'",
+//     messages = "Simulation execution failed for model: DaeModeMe
+// LOG_STDOUT        | info    | wasm artifact loaded (model kernel linked against the cached adapter)
+// LOG_ERROR         | error   | wasm artifact: -daeMode integrates with IDA; `-s fmi3:me:dassl` cannot serve a residual form
+// "
+// end SimulationResult;
+// ""
+// endResult


### PR DESCRIPTION
A `--daeMode` model can now be exported as a Model Exchange (or me_cs) wasm FMU. It is an ordinary ODE FMU until the importer sets the structural parameter fmi-ls-dae names, and a DAE FMU after:

* `modelDescription.xml` gets `_D_daeMode` (Boolean, `causality="structuralParameter"`, `variability="fixed"`) and one local Float64 per DAE residual, with value references after the event indicators. `SimMeta.fmi_dae_enable_vr` carries the switch to the adapter.
* `extra/org.fmi-standard.fmi-ls-dae/fmi-ls-manifest.xml` names the switch, the algebraic variables and the residuals; the residual dependencies come from the DAE Jacobian's transposed sparsity, a state column standing for `x` and `der(x)` both since DAE-mode differentiation folds `der(x)` into `x`.
* Adapter: Configuration Mode and the switch. In DAE mode `evaluateDAEResiduals` runs over the importer's `x`, `der(x)` and `z`. In ODE mode the model owes `der(x)` and `z`: `dae_solve_explicit`, a damped Newton over the residual with a colored differenced Jacobian (dense LU, so meant for small models).
* Import: `-s fmi3:me -daeMode` on a wasm artifact parses the manifest, enables the mode, and integrates `[x | z]` with `IdaDae` (`IDASetId`, `IDACalcIC` at the start and after every event, the consistent point written back before the row after an event). IDA is the only choice; `-daeMode` alone selects it. The `Fmi3` trait gained `enter/exit_configuration_mode` for the component, ffi and dylink backends.

The C target keeps refusing `--daeMode` FMUs; the wasm me_cs downgrade to Co-Simulation and its warning are gone.

Assisted-by: Claude Fable 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
