### PR TITLE
wasm FMU: simulate like simulate() does

### DIFF
--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -103,10 +103,10 @@ endif()
 if(NOT OM_OMC_WASM)
   omc_add_subdirectory(SimulationRuntime)
 endif()
-# The ANTLR Modelica parser (omparse) and the Examples are part of the C omc
-# toolchain only — the Rust omc port has its own parser and links neither. They
-# also pull in the C compiler runtime (omc::compiler::runtime), which the Rust
-# build deliberately does not build. Skip them in Rust mode.
+# The ANTLR Modelica parser (omparse) is part of the C omc toolchain only — the
+# Rust omc port has its own parser and does not link it. It also pulls in the C
+# compiler runtime (omc::compiler::runtime), which the Rust build deliberately
+# does not build. Skip it in Rust mode.
 if(NOT OM_OMC_ENABLE_RUST)
   omc_add_subdirectory(Parser)
 endif()
@@ -119,6 +119,7 @@ omc_add_subdirectory(Compiler)
 if(NOT OM_OMC_WASM AND NOT RUST_OMC_PREBUILT_CDYLIB)
   omc_add_subdirectory(SimulationRuntime/rust)
 endif()
-if(NOT OM_OMC_ENABLE_RUST)
+# share/doc/omc/testmodels: files only, installed by every native omc.
+if(NOT OM_OMC_WASM)
   omc_add_subdirectory(Examples)
 endif()

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -691,16 +691,37 @@ fn fmu_needs_sundials(method: &str) -> bool {
     matches!(method, "cvode" | "ida")
 }
 
-/// The nonlinear/linear solver selection to hard-code into an FMU's metadata. An
-/// importer has no channel to pass simulation flags, so `--fmiFlags` is consumed here
-/// and the FMU applies these when it instantiates. `-s` is not among them: it is the
-/// Co-Simulation integrator, and [`SimMeta::cs_method`] already carries it.
+/// The simulation flags to hard-code into an FMU's metadata: the export's
+/// `_flags.json` but `-s`, which [`SimMeta::cs_method`] carries. An importer has no
+/// channel to pass simulation flags, so the FMU applies these when it instantiates.
+/// `--fmiFlags` takes any name; like C's `parseFlags`, ignore what is not a flag.
 fn fmu_solver_flags(flags_json: &str) -> String {
-    ["nls", "nlsLS", "ls", "lss"]
-        .iter()
-        .filter_map(|f| fmi_flag(flags_json, f).map(|v| format!("-{f}={v}")))
+    fmi_flags(flags_json)
+        .into_iter()
+        .filter(|(name, _)| name != "s")
+        .map(|(name, value)| if value.is_empty() { format!("-{name}") } else { format!("-{name}={value}") })
+        .filter(|arg| simflags::parse(&["model".to_string(), arg.clone()]).is_ok())
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+/// Every `"name" : "value"` pair of a `_flags.json`, in file order.
+fn fmi_flags(json: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let mut rest = json;
+    while let Some(start) = rest.find('"') {
+        let Some(len) = rest[start + 1..].find('"') else { break };
+        let name = &rest[start + 1..start + 1 + len];
+        let after = rest[start + 1 + len + 1..].trim_start();
+        let Some(value_part) = after.strip_prefix(':').map(str::trim_start).and_then(|a| a.strip_prefix('"')) else {
+            rest = &rest[start + 1 + len + 1..];
+            continue;
+        };
+        let Some(vlen) = value_part.find('"') else { break };
+        out.push((name.to_string(), value_part[..vlen].to_string()));
+        rest = &value_part[vlen + 1..];
+    }
+    out
 }
 
 /// Which solver libraries an FMU exported with these `--fmiFlags` and this
@@ -2977,6 +2998,18 @@ fn announce_directional_derivatives(model_description: &str, model: &SimModel) -
     )
 }
 
+/// The runtime's `-lv` streams as log categories of an FMI 3.0 export, so an
+/// importer can ask the FMU for the trace `simulate()` would print.
+fn declare_log_streams(model_description: &str) -> String {
+    let end = model_description.find("</LogCategories>").filter(|_| fmi_version() == "3.0");
+    let Some(end) = end else { return model_description.to_string() };
+    let categories: String = omclog::STREAM_NAME[1..]
+        .iter()
+        .map(|s| format!("      <Category name=\"{s}\" />\n"))
+        .collect();
+    format!("{}{categories}    {}", &model_description[..end], &model_description[end..])
+}
+
 /// The FMI version being exported, `"3.0"` unless `buildModelFMU` asked otherwise.
 fn fmi_version() -> String {
     let v = openmodelica_util::Flags::getConfigString(openmodelica_util::Flags::FMI_VERSION.clone())
@@ -3201,20 +3234,34 @@ fn cad_basename(uri: &str) -> &str {
     uri.rsplit(['/', '\\']).next().unwrap_or(uri)
 }
 
-/// C's `FMI2CS_initializeSolverData`: `-s` from `_flags.json`, euler otherwise.
-/// The model's own method stays for the artifact's plain-simulation face.
-///
-/// A DAE-mode model overrides to IDA (`resolve_solver_method`), so the export has
-/// to agree or the FMU steps with the one solver it did not link.
-fn fmu_cs_method(simulation_flags_json: &str, kind: &str, dae_mode: bool) -> String {
-    if kind != "ME" && dae_mode {
+/// The integrator a Co-Simulation FMU embeds: `-s` from the export's `_flags.json`,
+/// else the model's own method, with DASKR for one this build cannot step with. A
+/// `--daeMode` model integrates with IDA. Empty for Model Exchange.
+fn fmu_cs_method(simulation_flags_json: &str, kind: &str, sim_code: &SimCode::SimCode) -> String {
+    let own = sim_code.simulationSettingsOpt.as_ref().map(|s| s.method.to_string()).unwrap_or_default();
+    cs_method_from(simulation_flags_json, kind, sim_code.daeModeData.is_some(), &own)
+}
+
+fn cs_method_from(simulation_flags_json: &str, kind: &str, dae_mode: bool, own: &str) -> String {
+    if kind == "ME" {
+        return String::new();
+    }
+    if dae_mode {
         return "ida".to_string();
     }
-    match fmi_flag(simulation_flags_json, "s") {
-        Some(s) => s,
-        None if kind != "ME" => "euler".to_string(),
-        None => String::new(),
+    if let Some(s) = fmi_flag(simulation_flags_json, "s") {
+        return s;
     }
+    let own = if own.is_empty() { "dassl".to_string() } else { own.to_string() };
+    if fmu_cs_solvers().contains(&own.as_str()) {
+        return own;
+    }
+    let _ = openmodelica_util::Error::addCompilerNotification(ArcStr::from(format!(
+        "A Co-Simulation wasm FMU cannot integrate with method=\"{own}\"; it integrates with dassl. \
+         Available: {}.",
+        fmu_cs_solvers().join(", ")
+    )));
+    "dassl".to_string()
 }
 
 /// Lower the model kernel a wasm FMU is built around, and check that this omc and
@@ -3301,7 +3348,7 @@ pub fn translateFmu(sim_code: SimCode::SimCode, fmu_type: ArcStr, simulation_fla
     sync_engine_threading()?;
     sim_runtime::start_runtime_compile();
     let kind = fmu_kind(&fmu_type);
-    let cs_method = fmu_cs_method(&simulation_flags_json, kind, sim_code.daeModeData.is_some());
+    let cs_method = fmu_cs_method(&simulation_flags_json, kind, &sim_code);
     let fmi_solver_flags = fmu_solver_flags(&simulation_flags_json);
     let prefix = sim_code.fileNamePrefix.to_string();
     let _ = openmodelica_wasi::fs::remove_file(&format!("{prefix}.wasm"));
@@ -3379,7 +3426,7 @@ fn emit_fmu(
 ) -> Result<()> {
     sync_engine_threading()?;
     sim_runtime::start_runtime_compile();
-    let cs_method = fmu_cs_method(&simulation_flags_json, kind, sim_code.daeModeData.is_some());
+    let cs_method = fmu_cs_method(&simulation_flags_json, kind, &sim_code);
     let fmi_solver_flags = fmu_solver_flags(&simulation_flags_json);
     // Emitting the model takes seconds; a host that compiles the native platforms
     // out of process can spend them loading its compiler.
@@ -3429,7 +3476,10 @@ fn emit_fmu(
         // an importer resolves `binaries/<platform>/<modelIdentifier>`.
         let model_id = model_name_prefix(&sim_code);
         let mut entries = vec![
-            ("modelDescription.xml".to_string(), announce_directional_derivatives(&model_description, &model).into_bytes()),
+            (
+                "modelDescription.xml".to_string(),
+                declare_log_streams(&announce_directional_derivatives(&model_description, &model)).into_bytes(),
+            ),
         ];
         if !ls_dae_manifest.is_empty() {
             entries.push((LS_DAE_MANIFEST.to_string(), ls_dae_manifest.as_bytes().to_vec()));
@@ -11173,7 +11223,7 @@ mod link_tests {
             (r#"{"lss":"lis"}"#, false, vec!["lis", "klu"]),
             (r#"{"s":"cvode"}"#, false, vec![]),
         ] {
-            let method = fmu_cs_method(json, if cs { "CS" } else { "ME" }, false);
+            let method = cs_method_from(json, if cs { "CS" } else { "ME" }, false, "dassl");
             assert_eq!(fmu_solver_libraries(json, &method, cs), want, "{json} cs={cs}");
         }
         // Every name the mapping can produce must be a library that exists.
@@ -11204,7 +11254,7 @@ mod link_tests {
                 .chain(baked.split_whitespace().map(str::to_string))
                 .collect();
             let f = simflags::parse(&argv).expect(&baked);
-            let libs = fmu_solver_libraries(json, &fmu_cs_method(json, "CS", false), true);
+            let libs = fmu_solver_libraries(json, &cs_method_from(json, "CS", false, "dassl"), true);
             let cap = simflags::Capabilities {
                 klu: libs.contains(&"klu"),
                 kinsol: libs.contains(&"kinsol"),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/artifact.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/artifact.rs
@@ -627,6 +627,7 @@ fn run_fmi(
     // `-lv=LOG_STATS` asks the *runtime* for a block, not the FMU for a trace of
     // every event, so it alone leaves the FMI logger off.
     opts.logging_on = flags.has_log("LOG_EVENTS") || flags.has_log("LOG_NLS") || flags.has_log("LOG_DSS");
+    opts.log_streams = flags.log.clone();
     opts.alarm = flags.alarm;
     // A run wedged inside one call into wasm never reaches the master's deadline;
     // the epoch alarm interrupts that (`OMC_WASM_HARD_ALARM`).

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/dylink_fmi.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/dylink_fmi.rs
@@ -325,6 +325,15 @@ impl Fmi3 for DylinkInstance {
         status("fmi3ExitInitializationMode", raw)
     }
 
+    fn set_debug_logging(&mut self, logging_on: bool, categories: &[&str]) -> Result<()> {
+        let (p, n) = self.write_str(&categories.join("\n"))?;
+        let raw = self
+            .fmu
+            .call("om_fmi3SetDebugLogging", &[Val::I32(logging_on as i32), Val::I32(p as i32), Val::I32(n as i32)])
+            .map_err(|e| err("fmi3SetDebugLogging", e))?;
+        status("fmi3SetDebugLogging", raw)
+    }
+
     fn enter_event_mode(&mut self) -> Result<()> {
         let raw = self.fmu.call("om_fmi3EnterEventMode", &[]).map_err(|e| err("fmi3EnterEventMode", e))?;
         status("fmi3EnterEventMode", raw)

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/capi.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/capi.rs
@@ -168,6 +168,14 @@ pub extern "C" fn om_fmi3ExitInitializationMode() -> i32 {
     with(|i| status(GuestModelExchangeInstance::exit_initialization_mode(i, )), ERROR)
 }
 
+/// `categories` is one buffer of newline-separated names.
+#[unsafe(no_mangle)]
+pub extern "C" fn om_fmi3SetDebugLogging(logging_on: i32, categories: u32, categories_len: u32) -> i32 {
+    let categories: Vec<String> =
+        read_str(categories, categories_len).lines().filter(|c| !c.is_empty()).map(String::from).collect();
+    with(|i| status(GuestModelExchangeInstance::set_debug_logging(i, logging_on != 0, categories)), ERROR)
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn om_fmi3EnterEventMode() -> i32 {
     with(|i| status(GuestModelExchangeInstance::enter_event_mode(i, )), ERROR)

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -765,10 +765,9 @@ pub struct Instance {
 
 /// Allocate and zero the model's `SimData` and build the instance state. Shared by
 /// both worlds' instantiate.
-/// The nonlinear/linear solver selection the export hard-coded into the metadata.
-/// An importer has no channel to pass simulation flags, so this is the only one there
-/// is; the export linked exactly the libraries these reach, so a rejection here means
-/// the two disagree and the instance must not come up quietly using another solver.
+/// The simulation flags the export hard-coded into the metadata. The export linked
+/// exactly the libraries these reach, so a rejection here means the two disagree and
+/// the instance must not come up quietly using another solver.
 fn apply_baked_solver_flags(flags: &str) -> Option<()> {
     if flags.is_empty() {
         return Some(());
@@ -790,6 +789,10 @@ fn apply_baked_solver_flags(flags: &str) -> Option<()> {
         })
         .ok()?;
     openmodelica_codegen_wasm_jit_runtime::apply_sim_flags(&parsed);
+    simflags::print_notices(&parsed);
+    let streams = parsed.log_mask & !omclog::ALWAYS_ON;
+    simflags::set_flags(parsed);
+    omclog::set_mask(omclog::FMU_STREAMS | streams);
     Some(())
 }
 
@@ -851,19 +854,34 @@ macro_rules! shared_instance_methods {
     () => {
 
     /// C's `omcSetDebugLogging`: every category off, then the named ones follow
-    /// `logging_on`. An unknown name is reported unfiltered, as in C.
+    /// `logging_on`; an unknown name is reported unfiltered, as in C. A category
+    /// named like a runtime stream (`LOG_EVENTS`; the export declares them all)
+    /// switches that stream instead.
     fn set_debug_logging(&self, logging_on: bool, categories: Vec<String>) -> Status {
         let mut cats = 0u32;
         let mut unknown: Vec<String> = Vec::new();
+        let mut streams: Vec<String> = Vec::new();
+        let mut fmi_categories = false;
         for c in categories {
             match CATEGORIES.iter().position(|n| *n == c) {
-                Some(i) if logging_on => cats |= 1 << i,
-                Some(_) => {}
+                Some(i) => {
+                    fmi_categories = true;
+                    if logging_on {
+                        cats |= 1 << i;
+                    }
+                }
+                None if omclog::STREAM_NAME.contains(&c.as_str()) => streams.push(c),
                 None => unknown.push(c),
             }
         }
-        // The `FILTERED_LOG` filter only: C leaves the `-lv` streams alone here.
-        logger().cats = cats;
+        if fmi_categories || streams.is_empty() {
+            logger().cats = cats;
+        }
+        if let Ok(m) = omclog::mask_from_streams(&streams) {
+            let m = m & !omclog::ALWAYS_ON;
+            let cur = omclog::mask();
+            omclog::set_mask(if logging_on { cur | m } else { cur & !m });
+        }
         for c in unknown {
             log_raw(
                 Status::Warning,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/api.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/api.rs
@@ -86,6 +86,10 @@ pub trait Fmi3 {
         start_time: f64,
         stop_time: Option<f64>,
     ) -> Result<()>;
+    /// `fmi3SetDebugLogging`. A backend without it logs what it was instantiated with.
+    fn set_debug_logging(&mut self, _logging_on: bool, _categories: &[&str]) -> Result<()> {
+        Ok(())
+    }
     fn exit_initialization_mode(&mut self) -> Result<()>;
     fn enter_event_mode(&mut self) -> Result<()>;
     fn update_discrete_states(&mut self) -> Result<DiscreteStates>;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/common.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/common.rs
@@ -2,7 +2,7 @@
 
 use crate::api::{DiscreteStates, Fmi3};
 use crate::{Error, Options, Result};
-use openmodelica_fmi::VarType;
+use openmodelica_fmi::{ModelDescription, VarType};
 
 /// C's `MAX_EVENT_ITER`: an event iteration that does not settle is a model
 /// error, not something to spin on.
@@ -59,9 +59,23 @@ impl Inputs {
 /// lets a parameter be set.
 pub fn initialize(
     inst: &mut dyn Fmi3,
+    md: &ModelDescription,
     inputs: &mut Inputs,
     opts: &Options<'_>,
 ) -> Result<()> {
+    // Without the full trace, still ask for the status categories: the message
+    // behind an error status is the only account of what failed.
+    let declared = |name: &str| md.log_categories.iter().any(|c| c.name == name);
+    let mut categories: Vec<&str> = Vec::new();
+    if !opts.logging_on {
+        categories.extend(
+            md.log_categories.iter().map(|c| c.name.as_str()).filter(|c| c.starts_with("logStatus")),
+        );
+    }
+    categories.extend(opts.log_streams.iter().map(String::as_str).filter(|s| declared(s)));
+    if !categories.is_empty() {
+        inst.set_debug_logging(true, &categories)?;
+    }
     inst.enter_initialization_mode(opts.tolerance, opts.start_time, Some(opts.stop_time))?;
     for p in &opts.parameters {
         inst.set_numeric(p.ty.wire(), &[p.value_reference], &[p.value])?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/component.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/component.rs
@@ -451,6 +451,15 @@ impl Fmi3 for WasmInstance {
         ))
     }
 
+    fn set_debug_logging(&mut self, logging_on: bool, categories: &[&str]) -> Result<()> {
+        let categories: Vec<String> = categories.iter().map(|c| c.to_string()).collect();
+        common!(self, |store, g, h| check(
+            "fmi3SetDebugLogging",
+            g.call_set_debug_logging(store, h, logging_on, &categories)
+                .map_err(|e| trap("fmi3SetDebugLogging", e))?
+        ))
+    }
+
     fn enter_event_mode(&mut self) -> Result<()> {
         common!(self, |store, g, h| check(
             "fmi3EnterEventMode",

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/cs.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/cs.rs
@@ -54,7 +54,7 @@ pub fn simulate(
 
     let mut inputs = Inputs::new(opts);
     let mut rec = Recorder::new(md, opts.keep);
-    initialize(as_common(inst), &mut inputs, opts)?;
+    initialize(as_common(inst), md, &mut inputs, opts)?;
 
     let mut terminated_at = None;
     let (mut steps, mut events, mut early_returns) = (0, 0, 0);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/ffi.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/ffi.rs
@@ -67,6 +67,7 @@ struct Vtable {
     enter_initialization_mode: unsafe extern "C" fn(Instance, bool, f64, f64, bool, f64) -> i32,
     exit_initialization_mode: unsafe extern "C" fn(Instance) -> i32,
     enter_event_mode: unsafe extern "C" fn(Instance) -> i32,
+    set_debug_logging: Option<unsafe extern "C" fn(Instance, bool, usize, *const *const c_char) -> i32>,
     update_discrete_states: unsafe extern "C" fn(
         Instance,
         *mut bool,
@@ -175,6 +176,7 @@ impl Library {
             enter_initialization_mode: required!(lib, "fmi3EnterInitializationMode"),
             exit_initialization_mode: required!(lib, "fmi3ExitInitializationMode"),
             enter_event_mode: required!(lib, "fmi3EnterEventMode"),
+            set_debug_logging: optional!(lib, "fmi3SetDebugLogging"),
             update_discrete_states: required!(lib, "fmi3UpdateDiscreteStates"),
             terminate: required!(lib, "fmi3Terminate"),
             get_float32: required!(lib, "fmi3GetFloat32"),
@@ -447,6 +449,13 @@ impl Fmi3 for FmuInstance<'_> {
     fn exit_initialization_mode(&mut self) -> Result<()> {
         let f = self.v().exit_initialization_mode;
         check("fmi3ExitInitializationMode", unsafe { f(self.handle) })
+    }
+
+    fn set_debug_logging(&mut self, logging_on: bool, categories: &[&str]) -> Result<()> {
+        let Some(f) = self.v().set_debug_logging else { return Ok(()) };
+        let owned: Vec<CString> = categories.iter().map(|c| CString::new(*c).unwrap_or_default()).collect();
+        let ptrs: Vec<*const c_char> = owned.iter().map(|c| c.as_ptr()).collect();
+        check("fmi3SetDebugLogging", unsafe { f(self.handle, logging_on, ptrs.len(), ptrs.as_ptr()) })
     }
 
     fn enter_event_mode(&mut self) -> Result<()> {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/lib.rs
@@ -178,6 +178,8 @@ pub struct Options<'a> {
     pub solver: Solver,
     /// Ask the FMU to log; its messages reach [`api::Fmi3::take_log`].
     pub logging_on: bool,
+    /// The run's `-lv` streams, asked of an FMU that declares them as log categories.
+    pub log_streams: Vec<String>,
     /// Drive the FMU's Event Mode (Co-Simulation), when it has one.
     pub event_mode: bool,
     /// Ask an FMU that offers them for the Jacobian's columns instead of
@@ -223,6 +225,7 @@ impl Options<'_> {
             tolerance: e.tolerance,
             solver: Solver::default(),
             logging_on: false,
+            log_streams: Vec::new(),
             event_mode: true,
             directional_derivatives: true,
             dae: None,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/me.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/me.rs
@@ -565,7 +565,7 @@ pub fn simulate(
     }
     {
         let common: &mut dyn Fmi3 = inst;
-        initialize(common, &mut inputs, opts)?;
+        initialize(common, md, &mut inputs, opts)?;
     }
     // Exiting Initialization Mode leaves a Model Exchange FMU in Event Mode.
     let mut info = {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/record.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/record.rs
@@ -5,7 +5,8 @@
 //! group. Parameters and constants are read once, after initialization, and go
 //! into the `.mat`'s time-invariant half — the same layout a simulated
 //! OpenModelica model writes, so OMPlot and `omc-diff` read an FMU run
-//! unchanged.
+//! unchanged. An alias (an FMI 3.0 `<Alias>` child, or an FMI 1.0 `alias`
+//! variable) shares its variable's column.
 
 use crate::api::Fmi3;
 use crate::{Error, Result};
@@ -13,6 +14,7 @@ use openmodelica_fmi::{
     Alias, Causality, Dimension, ModelDescription, VarType, Variability, Variable,
 };
 use openmodelica_mat_writer as mat;
+use std::collections::HashMap;
 
 pub struct Column {
     pub name: String,
@@ -45,6 +47,8 @@ pub struct Recorder {
     param_groups: Vec<Group>,
     /// Aliases: `(name, description, column of the variable it aliases, negated)`.
     aliases: Vec<(String, String, usize, bool)>,
+    /// Aliases of parameters: `(name, description, index into `parameters`, negated)`.
+    param_aliases: Vec<(String, String, usize, bool)>,
     scratch: Vec<f64>,
 }
 
@@ -61,6 +65,46 @@ fn is_recorded(v: &Variable) -> bool {
 /// A variable that keeps one value for the whole run.
 fn is_parameter(v: &Variable) -> bool {
     v.ty.is_numeric() && v.alias == Alias::NoAlias && v.causality != Causality::Independent && !is_recorded(v)
+}
+
+/// The FMI 1.0 alias variables by the value reference they share.
+fn fmi1_aliases(md: &ModelDescription) -> HashMap<u32, Vec<&Variable>> {
+    let mut map: HashMap<u32, Vec<&Variable>> = HashMap::new();
+    for a in md.variables.iter().filter(|a| a.alias != Alias::NoAlias) {
+        map.entry(a.value_reference).or_default().push(a);
+    }
+    map
+}
+
+/// `(name, description, negated)` for the names of `v` and its aliases the filter
+/// keeps; the first names the column (the variable's own, else a non-negated
+/// alias), the rest alias it. `None` when the filter keeps none.
+fn names_kept<'a>(
+    v: &'a Variable,
+    fmi1: &HashMap<u32, Vec<&'a Variable>>,
+    keep: &dyn Fn(&str) -> bool,
+) -> Option<Vec<(&'a str, &'a str, bool)>> {
+    let mut names: Vec<(&str, &str, bool)> = Vec::new();
+    if keep(&v.name) {
+        names.push((&v.name, v.description.as_deref().unwrap_or_default(), false));
+    }
+    names.extend(
+        v.aliases
+            .iter()
+            .filter(|a| keep(&a.name))
+            .map(|a| (a.name.as_str(), a.description.as_deref().unwrap_or_default(), false)),
+    );
+    names.extend(
+        fmi1.get(&v.value_reference)
+            .into_iter()
+            .flatten()
+            .filter(|a| a.ty == v.ty && keep(&a.name))
+            .map(|a| (a.name.as_str(), a.description.as_deref().unwrap_or_default(), a.alias == Alias::NegatedAlias)),
+    );
+    // A negated alias cannot name the column: it would carry the wrong sign.
+    let column = names.iter().position(|(_, _, negated)| !negated)?;
+    names.swap(0, column);
+    Some(names)
 }
 
 fn group_by_type(vars: &[(&Variable, usize, usize)]) -> Vec<Group> {
@@ -124,26 +168,40 @@ fn element_names(name: &str, dimensions: &[usize]) -> Vec<String> {
 impl Recorder {
     pub fn new(md: &ModelDescription, keep: Option<&dyn Fn(&str) -> bool>) -> Recorder {
         // Dropped here, not at write time: the sampling is the cost.
-        let wanted = |v: &Variable| is_recorded(v) && keep.is_none_or(|k| k(&v.name));
+        let keep = |name: &str| keep.is_none_or(|k| k(name));
         let states: Vec<u32> = md.continuous_states();
         let mut columns = Vec::new();
         let mut recorded = Vec::new();
-        for v in md.variables.iter().filter(|v| wanted(v)) {
+        let mut aliases = Vec::new();
+        let fmi1 = fmi1_aliases(md);
+        for v in md.variables.iter().filter(|v| is_recorded(v)) {
+            let Some(names) = names_kept(v, &fmi1, &keep) else { continue };
+            let (name, description, _) = names[0];
+            let extents = extents(md, v);
             let first = columns.len() + 1; // column 0 is time
-            for name in element_names(&v.name, &extents(md, v)) {
+            for element in element_names(name, &extents) {
                 columns.push(Column {
-                    name,
-                    description: v.description.clone().unwrap_or_default(),
+                    name: element,
+                    description: description.to_string(),
                     unit: v.unit.clone(),
                     causality: v.causality,
                     is_state: states.contains(&v.value_reference),
                 });
             }
+            for (alias, description, negated) in &names[1..] {
+                for (k, element) in element_names(alias, &extents).into_iter().enumerate() {
+                    aliases.push((element, description.to_string(), first + k, *negated));
+                }
+            }
             recorded.push((v, first, columns.len() + 1 - first));
         }
         let mut parameters = Vec::new();
+        let mut param_aliases = Vec::new();
         let mut params = Vec::new();
         for v in md.variables.iter().filter(|v| is_parameter(v)) {
+            let Some(names) = names_kept(v, &fmi1, &keep) else { continue };
+            let (name, description, _) = names[0];
+            let extents = extents(md, v);
             let first = parameters.len();
             let starts = match &v.start {
                 Some(openmodelica_fmi::Start::Reals(r)) => r.clone(),
@@ -153,34 +211,16 @@ impl Recorder {
                 }
                 _ => Vec::new(),
             };
-            for (k, name) in element_names(&v.name, &extents(md, v)).into_iter().enumerate() {
-                parameters.push((
-                    name,
-                    v.description.clone().unwrap_or_default(),
-                    starts.get(k).copied().unwrap_or(0.0),
-                ));
+            for (k, element) in element_names(name, &extents).into_iter().enumerate() {
+                parameters.push((element, description.to_string(), starts.get(k).copied().unwrap_or(0.0)));
+            }
+            for (alias, description, negated) in &names[1..] {
+                for (k, element) in element_names(alias, &extents).into_iter().enumerate() {
+                    param_aliases.push((element, description.to_string(), first + k, *negated));
+                }
             }
             params.push((v, first, parameters.len() - first));
         }
-        // FMI 1.0 aliases: the same value reference under another name, so they
-        // share the column rather than being sampled again.
-        let aliases = md
-            .variables
-            .iter()
-            .filter(|v| v.alias != Alias::NoAlias && v.ty.is_numeric())
-            .filter_map(|v| {
-                let col = recorded
-                    .iter()
-                    .find(|(base, ..)| base.value_reference == v.value_reference)
-                    .map(|(_, c, _)| *c)?;
-                Some((
-                    v.name.clone(),
-                    v.description.clone().unwrap_or_default(),
-                    col,
-                    v.alias == Alias::NegatedAlias,
-                ))
-            })
-            .collect();
         let n_values = columns.len();
         Recorder {
             groups: group_by_type(&recorded),
@@ -189,6 +229,7 @@ impl Recorder {
             rows: Vec::new(),
             parameters,
             aliases,
+            param_aliases,
             scratch: vec![0.0; n_values.max(1)],
         }
     }
@@ -288,14 +329,23 @@ impl Recorder {
                 },
             });
         }
-        for (name, description, _) in &self.parameters {
+        let mut params: Vec<f64> = Vec::with_capacity(self.parameters.len() + self.param_aliases.len());
+        for (name, description, value) in &self.parameters {
             signals.push(mat::MatVar {
                 name,
                 comment: description,
                 kind: mat::MatKind::Param { negate: mat::Neg::None },
             });
+            params.push(*value);
         }
-        let params: Vec<f64> = self.parameters.iter().map(|(_, _, v)| *v).collect();
+        for (name, description, index, negated) in &self.param_aliases {
+            signals.push(mat::MatVar {
+                name,
+                comment: description,
+                kind: mat::MatKind::Param { negate: if *negated { mat::Neg::Arith } else { mat::Neg::None } },
+            });
+            params.push(self.parameters[*index].2);
+        }
         mat::write_mat4(
             &signals,
             start_time,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -7768,6 +7768,7 @@ impl SolverCore {
                         event_step = true;
                         self.note_chatter(model, flips[0])?;
                         if defers(self.t) {
+                            log_state_event(self.t, &flips, model);
                             return Ok(Step::Event { time: self.t });
                         }
                         if self.handle_zc_flips(e, model, ctx, sync, rows.as_deref_mut(), &flips)? {
@@ -7781,15 +7782,13 @@ impl SolverCore {
                 // crossing, so the root itself is the event.
                 if rooted {
                     let troot = self.t;
-                    if defers(troot) {
-                        write_time(e, sim_data, troot)?;
-                        return Ok(Step::Event { time: troot });
-                    }
-                    self.state_events += 1;
                     event_step = true;
                     let roots = self.roots_nonzero();
                     log_state_event(troot, &roots, model);
-                    self.note_chatter(model, roots.first().copied().unwrap_or(0))?;
+                    if !defers(troot) {
+                        self.state_events += 1;
+                        self.note_chatter(model, roots.first().copied().unwrap_or(0))?;
+                    }
                     if let Some((t_l, y_l)) = self.event_left() {
                         store_operators_left(e, sim_data, layout, self.states_base, t_l, &y_l)?;
                         // C restores `time_right`/`states_right`.
@@ -7807,6 +7806,10 @@ impl SolverCore {
                         capture_pre(e, r, sim_data, layout, troot)?;
                     }
                     let _ = save_zero_crossings(e, sim_data, layout)?;
+                    if defers(troot) {
+                        write_time(e, sim_data, troot)?;
+                        return Ok(Step::Event { time: troot });
+                    }
                     event_update(e, sim_data, layout, None, troot)?;
                     save_zero_crossings_after_event(e, sim_data, layout)?;
                     if let Some(r) = rows.as_deref_mut() {
@@ -7855,11 +7858,6 @@ impl SolverCore {
             if te <= target + SAMPLE_EPS {
                 *did_step = true;
                 event_step = true;
-                if defers(te) {
-                    self.t = te;
-                    write_time(e, sim_data, te)?;
-                    return Ok(Step::Event { time: te });
-                }
                 log_time_event(e, te, samp, model);
                 if let Some(r) = rows.as_deref_mut()
                     && !no_event_emit()
@@ -7868,6 +7866,11 @@ impl SolverCore {
                 }
                 store_operators_at(e, sim_data, layout, te)?;
                 let _ = save_zero_crossings(e, sim_data, layout)?;
+                if defers(te) {
+                    self.t = te;
+                    write_time(e, sim_data, te)?;
+                    return Ok(Step::Event { time: te });
+                }
                 fire_time_event(e, samp, sim_data, layout, te)?;
                 e.clean_nls_history(te);
                 self.time_events += 1;
@@ -7959,9 +7962,19 @@ pub struct CsDriver {
     /// The step `euler`/`rungekutta` take (the model's own output step); `None` for a
     /// variable-step method, which is handed the whole interval.
     fixed_h: Option<f64>,
-    /// A `do_event_update` ran since the last step, so `step_to` must re-read
-    /// states and restart DASKR.
-    resume_reinit: bool,
+    /// The event the master's `update-discrete-states` resolved since the last
+    /// step; the next step restarts the integrator for it.
+    resume: Option<MasterEvent>,
+    /// The zero-crossing values at the last accepted point, for the no-states walk.
+    zc0: Vec<f64>,
+}
+
+/// What the master's Event Mode resolved; the integrator resumes as
+/// [`SolverCore::integrate_to`] does after the same event.
+#[derive(Clone, Copy)]
+enum MasterEvent {
+    State,
+    Time,
 }
 
 /// Which events the FMU reports to the master instead of resolving itself: C's
@@ -8054,7 +8067,11 @@ impl CsDriver {
         }
         let h = model.step_size();
         let fixed_h = fixed_kind(method).map(|_| if h > 0.0 { h } else { f64::INFINITY });
-        Ok(CsDriver { core, samp, sync, pivots, fixed_h, resume_reinit: false })
+        let mut zc0 = vec![0.0f64; layout.n_zc as usize];
+        if core.n_states == 0 && layout.n_zc > 0 {
+            read_zero_crossings(e, sim_data, layout, &mut zc0)?;
+        }
+        Ok(CsDriver { core, samp, sync, pivots, fixed_h, resume: None, zc0 })
     }
 
     /// The time reached so far (FMI's `last-successful-time`).
@@ -8074,43 +8091,77 @@ impl CsDriver {
     ) -> Result<CsStep> {
         let layout = &model.layout;
         let sim_data = self.core.sim_data;
-        // A reinit or discrete change in the master's update needs a DASKR restart.
-        // DAE mode needs the `IDACalcIC` with it, so it restarts in
-        // `integrate_chunked`, where the residual's callback context is live.
-        if self.resume_reinit && !layout.dae_mode() {
-            if self.core.n_states > 0 {
-                e.call1("functionODE", sim_data)?;
-                self.core.read_states(e)?;
-                self.core.restart()?;
-            }
-            self.resume_reinit = false;
-        }
-        // No continuous states: only the samples move the model along.
+        // No continuous states: samples, and zero crossings on `time` bracketed and
+        // bisected between the communication points as `EventsDriver` does.
         if self.core.n_states == 0 {
-            let eps = t_target.abs().max(1.0) * 1e-10;
+            self.resume = None;
+            let eps = reached_eps(t_target, model.stop_time - model.start_time);
             let defers = |t: f64| match defer {
                 CsDefer::None => false,
                 CsDefer::AtTarget => t >= t_target - eps,
                 CsDefer::Any => true,
             };
-            while self.samp.next_time() <= t_target + eps {
+            let mut scratch = vec![0.0f64; layout.n_zc as usize];
+            loop {
+                rotate_old_real(e, sim_data, layout)?;
                 let te = self.samp.next_time();
-                if defers(te) {
-                    self.core.t = te;
-                    write_time(e, sim_data, te)?;
-                    return Ok(CsStep::Event { time: te });
+                let subtarget = if te >= self.core.t && te <= t_target + SAMPLE_EPS { te } else { t_target };
+                let mut troot = None;
+                if layout.n_zc > 0 && subtarget - self.core.t > eps {
+                    update_zero_crossings(e, sim_data, layout, subtarget, &mut scratch, false)?;
+                    if zc_crossed(&self.zc0, &scratch) {
+                        troot = Some(locate_zc_root(e, sim_data, layout, self.core.t, subtarget, &self.zc0, &scratch)?);
+                    }
                 }
-                write_i32(e, sim_data + layout.rel_fresh_off, 1)?;
-                event_update(e, sim_data, layout, Some(&mut self.samp), te)?;
-                self.core.time_events += 1;
-                if terminated(e, sim_data, layout)? {
-                    self.core.t = te;
-                    return Ok(CsStep::Terminated);
+                if let Some((tleft, tr)) = troot {
+                    store_operators_left(e, sim_data, layout, sim_data + REAL_OFF, tleft, &[])?;
+                    // The bisection left `SimData` at its last trial point.
+                    update_zero_crossings(e, sim_data, layout, tr, &mut scratch, false)?;
+                    self.core.t = tr;
+                    log_state_event(tr, &zc_crossed_idx(&self.zc0, &scratch), model);
+                    if defers(tr) {
+                        write_time(e, sim_data, tr)?;
+                        return Ok(CsStep::Event { time: tr });
+                    }
+                    event_update(e, sim_data, layout, None, tr)?;
+                    self.core.state_events += 1;
+                    if terminated(e, sim_data, layout)? {
+                        return Ok(CsStep::Terminated);
+                    }
+                    self.after_walk_event(e, layout)?;
+                    continue;
                 }
+                if te <= subtarget + SAMPLE_EPS {
+                    self.core.t = te;
+                    log_time_event(e, te, &self.samp, model);
+                    if defers(te) {
+                        write_time(e, sim_data, te)?;
+                        return Ok(CsStep::Event { time: te });
+                    }
+                    store_operators_at(e, sim_data, layout, te)?;
+                    fire_time_event(e, &mut self.samp, sim_data, layout, te)?;
+                    e.clean_nls_history(te);
+                    self.core.time_events += 1;
+                    if terminated(e, sim_data, layout)? {
+                        return Ok(CsStep::Terminated);
+                    }
+                    self.after_walk_event(e, layout)?;
+                    continue;
+                }
+                break;
             }
             self.core.t = t_target;
+            write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
             write_time(e, sim_data, t_target)?;
             e.call1_if_present("functionAlgebraics", sim_data)?;
+            if terminated(e, sim_data, layout)? {
+                return Ok(CsStep::Terminated);
+            }
+            store_operators(e, sim_data, layout)?;
+            if layout.n_zc > 0 {
+                read_zero_crossings(e, sim_data, layout, &mut self.zc0)?;
+                save_zc_pre(e, sim_data, layout)?;
+            }
             return Ok(CsStep::Reached);
         }
 
@@ -8140,9 +8191,21 @@ impl CsDriver {
         Ok(CsStep::Reached)
     }
 
-    /// The master's `update-discrete-states` at the event `step_to` stopped on.
-    /// Fires any sample through the driver's own schedule so it stays in step with
-    /// the integrator, and flags a DASKR restart for the next step.
+    /// After an event the no-states walk resolved itself.
+    fn after_walk_event(&mut self, e: &mut (dyn SimEngine + 'static), layout: &SimLayout) -> Result<()> {
+        let sim_data = self.core.sim_data;
+        store_operators(e, sim_data, layout)?;
+        if layout.n_zc > 0 {
+            read_zero_crossings(e, sim_data, layout, &mut self.zc0)?;
+            save_zc_pre(e, sim_data, layout)?;
+        }
+        omclog::close(omclog::EVENTS);
+        Ok(())
+    }
+
+    /// The master's `update-discrete-states` at the event `step_to` stopped on: the
+    /// discrete update and bookkeeping [`integrate_to`](SolverCore::integrate_to)
+    /// runs for an event it resolves itself, the restart left to the next step.
     pub fn do_event_update(
         &mut self,
         e: &mut (dyn SimEngine + 'static),
@@ -8150,14 +8213,21 @@ impl CsDriver {
         time: f64,
     ) -> Result<EventUpdate> {
         let layout = &model.layout;
-        let eps = time.abs().max(1.0) * 1e-10;
-        if self.samp.next_time() <= time + eps {
+        let sim_data = self.core.sim_data;
+        let time_event = self.samp.next_time() <= time + SAMPLE_EPS;
+        if time_event {
             self.core.time_events += 1;
         } else {
             self.core.state_events += 1;
         }
-        let up = event_update(e, self.core.sim_data, layout, Some(&mut self.samp), time)?;
-        self.resume_reinit = true;
+        let up = event_update(e, sim_data, layout, Some(&mut self.samp), time)?;
+        save_zero_crossings_after_event(e, sim_data, layout)?;
+        store_operators(e, sim_data, layout)?;
+        if self.core.n_states == 0 && layout.n_zc > 0 {
+            read_zero_crossings(e, sim_data, layout, &mut self.zc0)?;
+        }
+        omclog::close(omclog::EVENTS);
+        self.resume = Some(if time_event { MasterEvent::Time } else { MasterEvent::State });
         Ok(up)
     }
 
@@ -8190,13 +8260,17 @@ impl CsDriver {
         let mut ctx = self.core.res_ctx(e, layout);
         let _guard = ResCtxGuard;
         RES_CTX.store(&mut ctx as *mut ResCtx, Ordering::Relaxed);
-        // `step_to`'s restart for DAE mode, the pair `handle_zc_flips` runs for an
-        // event the driver resolves itself.
-        if self.resume_reinit {
-            self.core.read_states(e)?;
+        // Here, where the residual context the `IDACalcIC` needs is live.
+        if let Some(event) = self.resume.take() {
+            match event {
+                MasterEvent::State => self.core.read_states(e)?,
+                MasterEvent::Time => {
+                    self.core.read_y(e)?;
+                    self.core.refresh_yp(e)?;
+                }
+            }
             self.core.restart()?;
             self.core.dae_restart(e, &mut ctx as *mut ResCtx)?;
-            self.resume_reinit = false;
         }
         let mut did_step = false;
         loop {

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -4693,6 +4693,72 @@ algorithm
   FlagsUtil.setConfigStringList(Flags.FMI_FLAGS, {"s:" + method});
 end fmuMethodToSimulationFlag;
 
+protected function fmuAnnotationSimulationFlags
+  "A wasm FMU runs the model with the flags simulate() would: the class's
+   __OpenModelica_simulationFlags go into --fmiFlags, whose `_flags.json` the FMU
+   applies when it instantiates. A flag already named wins. A C FMU reads only a
+   few flags and warns about the rest, so it keeps to what --fmiFlags said."
+  input Absyn.Path className;
+  input Boolean isWasmFMU;
+protected
+  list<String> fmiFlags, names = {}, folded = {};
+  list<Absyn.ElementArg> args;
+  Option<Absyn.Modification> mod;
+  String name;
+algorithm
+  if not isWasmFMU or Flags.getConfigBool(Flags.IGNORE_SIMULATION_FLAGS_ANNOTATION) then
+    return;
+  end if;
+  fmiFlags := Flags.getConfigStringList(Flags.FMI_FLAGS);
+  if listLength(fmiFlags) == 1 and stringEq(listHead(fmiFlags), "default") then
+    fmiFlags := {};
+  end if;
+  // `none` and a `*.json` path are whole-value settings, not a list to extend.
+  for f in fmiFlags loop
+    if not stringEq(f, "default") and not (listLength(Util.stringSplitAtChar(f, ":")) == 2) then
+      return;
+    end if;
+    names := listHead(Util.stringSplitAtChar(f, ":")) :: names;
+  end for;
+  loadProgram(className);
+  mod := ProgramUtil.getNamedAnnotationExp(className, SymbolTable.getAbsyn(),
+    Absyn.IDENT("__OpenModelica_simulationFlags"), SOME(NONE()), Util.id);
+  args := match mod
+    case SOME(Absyn.CLASSMOD(elementArgLst = args)) then args;
+    else {};
+  end match;
+  for arg in args loop
+    name := AbsynUtil.pathString(AbsynUtil.elementArgName(arg));
+    if not listMember(name, names) then
+      folded := (name + ":" + fmuSimulationFlagValue(arg)) :: folded;
+    end if;
+  end for;
+  if not listEmpty(folded) then
+    FlagsUtil.setConfigStringList(Flags.FMI_FLAGS, listAppend(fmiFlags, listReverse(folded)));
+  end if;
+end fmuAnnotationSimulationFlags;
+
+protected function fmuSimulationFlagValue
+  "One __OpenModelica_simulationFlags entry as a `_flags.json` value; empty for a
+   flag that takes none."
+  input Absyn.ElementArg arg;
+  output String value;
+algorithm
+  value := match arg
+    local
+      Absyn.Exp exp;
+    case Absyn.ElementArg.MODIFICATION(modification =
+        SOME(Absyn.Modification.CLASSMOD(eqMod = Absyn.EqMod.EQMOD(exp = exp))))
+      then
+        match exp
+          case Absyn.STRING("()") then "";
+          case Absyn.STRING() then exp.value;
+          else Dump.printExpStr(exp);
+        end match;
+    else "";
+  end match;
+end fmuSimulationFlagValue;
+
 protected function reportFMUPlatformsBuilt
   "The platform progress the C export reports around each platform's compile.
    A wasm FMU is already linked by the time `translateModel` returns, so the pair
@@ -4762,6 +4828,7 @@ algorithm
     // not — without __OpenModelica_commandLineOptions `flags` aliases the store.
     fmiFlags := Flags.getConfigStringList(Flags.FMI_FLAGS);
     fmuMethodToSimulationFlag(method, isWasmFMUExport(FMUVersion, platforms));
+    fmuAnnotationSimulationFlags(className, isWasmFMUExport(FMUVersion, platforms));
 
     try
       (cache, outValue) := callBuildModelFMU(inCache,inEnv,className,FMUVersion,inFMUType,inFileNamePrefix,addDummy,platforms,inSimSettings);

--- a/OMCompiler/Examples/CMakeLists.txt
+++ b/OMCompiler/Examples/CMakeLists.txt
@@ -1,12 +1,4 @@
-
-# get all files in directory dir
-FILE(GLOB ALL_C *.c)
-FILE(GLOB ALL_H *.h)
-FILE(GLOB ALL_MO *.mo)
-FILE(GLOB ALL_MOS *.mos)
-FILE(GLOB ALL_ONB *.onb)
-FILE(GLOB ALL_PY *.py)
-
-SET(DOCS ${ALL_C} ${ALL_H} ${ALL_MO} ${ALL_MOS} ${ALL_ONB} ${ALL_PY})
-# TODO: Add this install to some User's Guide target
-INSTALL(FILES ${DOCS} DESTINATION "share/doc/omc/testmodels")
+# Every file here but this one, as the autotools build's `cp -p Examples/*.*`.
+file(GLOB DOCS LIST_DIRECTORIES false "*.*")
+list(FILTER DOCS EXCLUDE REGEX "/CMakeLists\\.txt$")
+install(FILES ${DOCS} DESTINATION "share/doc/omc/testmodels")

--- a/testsuite/omsimulator/DualMassOscillator_cs.mos
+++ b/testsuite/omsimulator/DualMassOscillator_cs.mos
@@ -4,8 +4,8 @@
 
 loadFile("DualMassOscillator.mo"); getErrorString();
 
-buildModelFMU(DualMassOscillator.System1, version="2.0", fmuType="cs", fileNamePrefix="DualMassOscillator.System1", platforms={"static"}); getErrorString();
-buildModelFMU(DualMassOscillator.System2, version="2.0", fmuType="cs", fileNamePrefix="DualMassOscillator.System2", platforms={"static"}); getErrorString();
+buildModelFMU(DualMassOscillator.System1, version="2.0", fmuType="cs", fileNamePrefix="DualMassOscillator.System1", platforms={"static"}, method="euler"); getErrorString();
+buildModelFMU(DualMassOscillator.System2, version="2.0", fmuType="cs", fileNamePrefix="DualMassOscillator.System2", platforms={"static"}, method="euler"); getErrorString();
 
 writeFile("DualMassOscillator_cs.py", "
 from OMSimulator import SSP, Settings, CRef

--- a/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_daemode.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_daemode.mos
@@ -65,7 +65,7 @@ diffSimulationResults("daemode_cs.mat", "daemode_plain_res.mat", "diff_daemode_c
 //     simulationOptions = "startTime = 0.0, stopTime = 5.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'DaeModeWhenLoop', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s fmi3:cs -r=daemode_cs.mat'",
 //     messages = "LOG_STDOUT        | info    | wasm artifact loaded (model kernel linked against the cached adapter)
 // LOG_STDOUT        | info    | CoSimulation instantiated
-// LOG_STDOUT        | info    | CoSimulation run: 501 communication steps, 2 events, 1 early returns, 504 samples
+// LOG_STDOUT        | info    | CoSimulation run: 501 communication steps, 1 events, 1 early returns, 503 samples
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;


### PR DESCRIPTION
The library testing's `master-wasm-jit-cs` lane verified 5471 models where the plain simulation verified 10035, and simulated ~2900 fewer. Six independent causes, all in how the Co-Simulation face of a wasm artifact differs from `simulate()`:

* The CS FMU integrated with explicit Euler at the communication step (C's `FMI2CS_initializeSolverData` default, adopted for `omsimulator/DualMassOscillator_cs.mos`). It now embeds the model's own method, `-s` in `_flags.json` overriding, with DASKR for one this build cannot step with. The omsimulator test says `method="euler"`, which keeps the C FMU's answer and makes the wasm one agree.
* A master-driven event skipped the driver's bookkeeping around the discrete update (`save_zero_crossings*`, `store_operators*`) and resumed with a `functionODE`. Every event was found twice. The deferred paths now run the same prologue, `do_event_update` the epilogue, and the resume mirrors the self-resolved paths.
* Without continuous states the CS driver only fired samples; a zero crossing on `time` was never located. It walks and bisects like `EventsDriver` does.
* The result file dropped FMI 3.0 `<Alias>` names (the recorder knew FMI 1.0's `alias=` only); aliases share their variable's column, a filter keeping only an alias still samples the variable.
* The FMU's error text never reached the log: the importer asks for the `logStatus*` categories (`Fmi3::set_debug_logging`, all backends), and passes the run's `-lv` streams, which the wasm export declares as log categories and the FMU maps onto its runtime mask.
* The FMU ignored `__OpenModelica_simulationFlags` (`-mei=30` in ScalableTestSuite's BreakerNetwork). `buildModelFMU` folds the annotation into `--fmiFlags` for a wasm export, and the FMU applies every entry of `_flags.json`, not only the solver selection.

Also: `share/doc/omc/testmodels` (dygraph-combined.js, which the library testing's diff pages load) is installed by the Rust omc too, and with every file type.

Assisted-by: Claude Fable 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
