### PR TITLE
Backend and SimCode performance

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAE.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAE.mo
@@ -648,7 +648,7 @@ uniontype EventInfo
   record EVENT_INFO
     list<TimeEvent> timeEvents    "stores all information related to time events";
     ZeroCrossingSet zeroCrossings "list of zero crossing conditions";
-    DoubleEnded.MutableList<ZeroCrossing> relations "list of zero crossing function as before";
+    ZeroCrossingSet relations "list of zero crossing function as before";
     ZeroCrossingSet samples       "[deprecated] list of sample as before, only used by cpp runtime (TODO: REMOVE ME)";
     Integer numberMathEvents      "stores the number of math function that trigger events e.g. floor, ceil, integer, ...";
   end EVENT_INFO;

--- a/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
@@ -63,7 +63,6 @@ import Config;
 import ClassInf;
 import DAEDump;
 import DAEUtil;
-import DoubleEnded;
 import Debug;
 import ElementSource;
 import Error;

--- a/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
@@ -158,7 +158,7 @@ algorithm
     eqnarr := BackendEquation.listEquation(eqns);
     reqnarr := BackendEquation.listEquation(reqns);
     ieqnarr := BackendEquation.listEquation(ieqns);
-    einfo := BackendDAE.EVENT_INFO(timeEvents, ZeroCrossings.new(), DoubleEnded.fromList({}), ZeroCrossings.new(), 0);
+    einfo := BackendDAE.EVENT_INFO(timeEvents, ZeroCrossings.new(), ZeroCrossings.new(), ZeroCrossings.new(), 0);
     symjacs := {(NONE(), ({}, {}, ({}, {}), -1), {}, ({}, {}, ({}, {}), -1)),
                 (NONE(), ({}, {}, ({}, {}), -1), {}, ({}, {}, ({}, {}), -1)),
                 (NONE(), ({}, {}, ({}, {}), -1), {}, ({}, {}, ({}, {}), -1)),

--- a/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -381,7 +381,7 @@ protected function traverseEventInfoExps<T>
 algorithm
   arg := DoubleEnded.mapFoldNoCopy(eventInfo.zeroCrossings.zc, function traverseZeroCrossingExps(func=func), arg);
   arg := DoubleEnded.mapFoldNoCopy(eventInfo.samples.zc, function traverseZeroCrossingExps(func=func), arg);
-  arg := DoubleEnded.mapFoldNoCopy(eventInfo.relations, function traverseZeroCrossingExps(func=func), arg);
+  arg := DoubleEnded.mapFoldNoCopy(eventInfo.relations.zc, function traverseZeroCrossingExps(func=func), arg);
 end traverseEventInfoExps;
 
 protected function traverseZeroCrossingExps<T>

--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -1301,61 +1301,69 @@ algorithm
   outIntegerArray := markStateEquationsWork(eqns,m,ass1,arr);
 end markStateEquations;
 
-public function markZeroCrossingEquations "function: markStateEquations
-  This function goes through all equations and marks the ones that
-  calculates a state, or is needed in order to calculate a state,
-  with a non-zero value in the array passed as argument.
-  This is done by traversing the directed graph of nodes where
-  a node is an equation/solved variable and following the edges in the
-  backward direction.
-  inputs: (daeLow: BackendDAE,
-             marks: int array,
-    adjacencyMatrix: AdjacencyMatrix,
-    adjacencyMatrixT: AdjacencyMatrixT,
-    assignments1: int vector,
-    assignments2: int vector)
-  outputs: marks: int array"
+public function zeroCrossingVarIndices
+  "For every equation system, the indices of its variables that occur in a zero
+   crossing relation. All systems are resolved against one combined variable set
+   in a single pass; looking each zero crossing up in every system is quadratic."
+  input BackendDAE.EqSystems systs;
+  input list<BackendDAE.ZeroCrossing> zeroCross;
+  output array<AvlSetInt.Tree> trees;
+protected
+  Integer nsys = listLength(systs), total = 0, gidx = 0, s = 0, n;
+  BackendDAE.Variables allVars;
+  array<Integer> sysOf, locOf "combined index -> system / index within that system";
+  AvlSetInt.Tree tree;
+algorithm
+  trees := arrayCreate(intMax(nsys, 1), AvlSetInt.new());
+  for syst in systs loop
+    total := total + BackendVariable.varsSize(syst.orderedVars);
+  end for;
+  if total == 0 then
+    return;
+  end if;
+
+  allVars := BackendVariable.emptyVarsSized(total);
+  sysOf := arrayCreate(total, 0);
+  locOf := arrayCreate(total, 0);
+  for syst in systs loop
+    s := s + 1;
+    n := BackendVariable.varsSize(syst.orderedVars);
+    for i in 1:n loop
+      allVars := BackendVariable.addNewVar(BackendVariable.getVarAt(syst.orderedVars, i), allVars);
+      gidx := gidx + 1;
+      arrayUpdate(sysOf, gidx, s);
+      arrayUpdate(locOf, gidx, i);
+    end for;
+  end for;
+
+  tree := AvlSetInt.new();
+  for zc in zeroCross loop
+    tree := BackendEquation.expressionVarsIndexes(zc.relation_, tree,
+              function BackendEquation.checkEquationsVarsExpTopDown(vars=allVars));
+  end for;
+
+  for gi in AvlSetInt.listKeys(tree) loop
+    s := arrayGet(sysOf, gi);
+    arrayUpdate(trees, s, AvlSetInt.add(arrayGet(trees, s), arrayGet(locOf, gi)));
+  end for;
+end zeroCrossingVarIndices;
+
+public function markZeroCrossingEquations
+  "Marks the equations needed to evaluate this system's zero crossings by
+  following the adjacency graph backwards from the variables they use."
   input BackendDAE.EqSystem syst;
-  input list<BackendDAE.ZeroCrossing> inZeroCross;
+  input AvlSetInt.Tree zcVars "this system's variables occurring in a zero crossing, see zeroCrossingVarIndices";
   input array<Integer> arr;
   input array<Integer> ass1;
   output array<Integer> outIntegerArray;
 protected
-  list<Integer> varindx_lst,eqns;
+  list<Integer> eqns;
   BackendDAE.AdjacencyMatrix m;
-  BackendDAE.Variables v;
-  AvlSetInt.Tree tree;
-  CheckEquationsVarsExpTopDownFunc func;
-  partial function CheckEquationsVarsExpTopDownFunc
-    input output DAE.Exp exp;
-    output Boolean cont;
-    input output AvlSetInt.Tree tree;
-  end CheckEquationsVarsExpTopDownFunc;
 algorithm
-  BackendDAE.EQSYSTEM(orderedVars = v,m=SOME(m)) := syst;
-  tree := AvlSetInt.new();
-  func := function BackendEquation.checkEquationsVarsExpTopDown(vars=v);
-  for zc in inZeroCross loop
-    tree := varsCollector(zc.relation_, tree, func);
-  end for;
-  varindx_lst := AvlSetInt.listKeys(tree);
-  eqns := list(arrayGet(ass1,i) for i guard arrayGet(ass1,i)>0 in varindx_lst);
+  BackendDAE.EQSYSTEM(m=SOME(m)) := syst;
+  eqns := list(arrayGet(ass1,i) for i guard arrayGet(ass1,i)>0 in AvlSetInt.listKeys(zcVars));
   outIntegerArray := markStateEquationsWork(eqns,m,ass1,arr);
 end markZeroCrossingEquations;
-
-protected function varsCollector
-  input DAE.Exp exp;
-  input output AvlSetInt.Tree tree;
-  input CheckEquationsVarsExpTopDownFunc func;
-
-  partial function CheckEquationsVarsExpTopDownFunc
-    input output DAE.Exp exp;
-    output Boolean cont;
-    input output AvlSetInt.Tree tree;
-  end CheckEquationsVarsExpTopDownFunc;
-algorithm
-  tree := BackendEquation.expressionVarsIndexes(exp, tree, func);
-end varsCollector;
 
 protected function markStateEquationsWork
   "Helper function to mark_state_equation
@@ -1485,15 +1493,19 @@ protected
   BackendDAE.AdjacencyMatrix adjMatrix, adjMatrixT;
 
   list<BackendDAE.ZeroCrossing> zeroCrossings;
+  array<AvlSetInt.Tree> zcVars;
+  Integer sysIdx = 0;
 
   constant Boolean debug = false;
 algorithm
 
   // get zeroCrossings
   zeroCrossings := ZeroCrossings.toList(inBackendDAE.shared.eventInfo.zeroCrossings);
+  zcVars := zeroCrossingVarIndices(inBackendDAE.eqs, zeroCrossings);
 
   // walk once through all comps and get of dependends of dynamic, algebraic, zeroCrossings,
   for eqSystem in inBackendDAE.eqs loop
+    sysIdx := sysIdx + 1;
     if debug then
       BackendDump.printEqSystem(eqSystem);
     end if;
@@ -1521,7 +1533,7 @@ algorithm
       eqns := setMarkedEqnsEvalStage(eqns, markedEqns, BackendEquation.setEvalStageDynamic);
 
       markedEqns := arrayCreate(BackendEquation.getNumberOfEquations(eqns), 0);
-      markedEqns := markZeroCrossingEquations(eqSystem, zeroCrossings, markedEqns, assigndVar);
+      markedEqns := markZeroCrossingEquations(eqSystem, arrayGet(zcVars, sysIdx), markedEqns, assigndVar);
       eqns := setMarkedEqnsEvalStage(eqns, markedEqns, BackendEquation.setEvalStageZeroCross);
 
       markedEqns := arrayCreate(BackendEquation.getNumberOfEquations(eqns), 0);

--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -83,7 +83,6 @@ import DAEMode;
 import DAEUtil;
 import DataReconciliation;
 import Debug;
-import DoubleEnded;
 import Differentiate;
 import DumpGraphML;
 import DynamicOptimization;

--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -611,7 +611,7 @@ protected
 algorithm
   outNumZeroCrossings := ZeroCrossings.length(eventInfo.zeroCrossings);
   outNumTimeEvents := listLength(eventInfo.timeEvents);
-  outNumRelations := DoubleEnded.length(eventInfo.relations);
+  outNumRelations := ZeroCrossings.count(eventInfo.relations);
   outNumMathEventFunctions := eventInfo.numberMathEvents;
 end numberOfZeroCrossings;
 
@@ -9640,7 +9640,7 @@ end collapseRemovedEqs1;
 public function emptyEventInfo
   output BackendDAE.EventInfo info;
 algorithm
-  info := BackendDAE.EVENT_INFO({}, ZeroCrossings.new(), DoubleEnded.fromList({}), ZeroCrossings.new(), 0);
+  info := BackendDAE.EVENT_INFO({}, ZeroCrossings.new(), ZeroCrossings.new(), ZeroCrossings.new(), 0);
 end emptyEventInfo;
 
 public function getSubClock

--- a/OMCompiler/Compiler/BackEnd/BackendDump.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDump.mo
@@ -69,7 +69,6 @@ import DAEDump;
 import DAEDumpTypes;
 import DAEUtil;
 import Debug;
-import DoubleEnded;
 import DumpHTML;
 import ElementSource;
 import Error;

--- a/OMCompiler/Compiler/BackEnd/BackendDump.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDump.mo
@@ -268,7 +268,7 @@ algorithm
   dumpEquationArray(inShared.removedEqs, "Simple Shared Equations");
   dumpEquationArray(inShared.initialEqs, "Initial Equations");
   dumpZeroCrossingList(ZeroCrossings.toList(inShared.eventInfo.zeroCrossings), "Zero Crossings");
-  dumpZeroCrossingList(DoubleEnded.toListNoCopyNoClear(inShared.eventInfo.relations), "Relations");
+  dumpZeroCrossingList(ZeroCrossings.toList(inShared.eventInfo.relations), "Relations");
   if stringEqual(Config.simCodeTarget(), "Cpp") then
     dumpZeroCrossingList(ZeroCrossings.toList(inShared.eventInfo.samples), "Samples");
   else

--- a/OMCompiler/Compiler/BackEnd/BackendInline.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendInline.mo
@@ -863,11 +863,11 @@ algorithm
   () := matchcontinue inEventInfo
     local
       BackendDAE.ZeroCrossingSet zclst;
-      DoubleEnded.MutableList<BackendDAE.ZeroCrossing> relations;
+      BackendDAE.ZeroCrossingSet relations;
 
     case BackendDAE.EVENT_INFO(zeroCrossings=zclst, relations=relations) algorithm
       inlineZeroCrossings(zclst.zc, fns);
-      inlineZeroCrossings(relations, fns);
+      inlineZeroCrossings(relations.zc, fns);
     then ();
 
     else

--- a/OMCompiler/Compiler/BackEnd/BackendVarTransform.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVarTransform.mo
@@ -2358,7 +2358,7 @@ protected
   Integer numberMathEvents;
   list<BackendDAE.TimeEvent> timeEvents;
   BackendDAE.ZeroCrossingSet zeroCrossingLst, sampleLst;
-  DoubleEnded.MutableList<BackendDAE.ZeroCrossing> relationsLst;
+  BackendDAE.ZeroCrossingSet relationsLst;
   protected partial function Func
     input output BackendDAE.ZeroCrossing zc;
     input Option<FuncTypeExp_ExpToBoolean> inFuncTypeExpExpToBooleanOption;
@@ -2370,7 +2370,7 @@ algorithm
   zc := function replaceZeroCrossing(inVariableReplacements=inVariableReplacements);
   DoubleEnded.mapNoCopy_1(zeroCrossingLst.zc, zc, inFuncTypeExpExpToBooleanOption);
   DoubleEnded.mapNoCopy_1(sampleLst.zc, zc, inFuncTypeExpExpToBooleanOption);
-  DoubleEnded.mapNoCopy_1(relationsLst, zc, inFuncTypeExpExpToBooleanOption);
+  DoubleEnded.mapNoCopy_1(relationsLst.zc, zc, inFuncTypeExpExpToBooleanOption);
   eInfoOut := BackendDAE.EVENT_INFO(timeEvents,zeroCrossingLst,relationsLst,sampleLst,numberMathEvents);
 end replaceEventInfo;
 

--- a/OMCompiler/Compiler/BackEnd/FindZeroCrossings.mo
+++ b/OMCompiler/Compiler/BackEnd/FindZeroCrossings.mo
@@ -71,8 +71,8 @@ import MetaModelica.Dangerous.listReverseInPlace;
 import ExpressionBasics;
 import Config;
 
-type ZCArgType  = tuple<tuple<BackendDAE.ZeroCrossingSet, DoubleEnded.MutableList<BackendDAE.ZeroCrossing>, BackendDAE.ZeroCrossingSet, Integer>, tuple<Integer, BackendDAE.Variables, BackendDAE.Variables>, Option<list<BackendDAE.SimIterator>>>;
-type ForArgType = tuple<DAE.Exp, list<DAE.Exp>, DAE.Exp, tuple<BackendDAE.ZeroCrossingSet, DoubleEnded.MutableList<BackendDAE.ZeroCrossing>, BackendDAE.ZeroCrossingSet, Integer>, tuple<Integer, BackendDAE.Variables, BackendDAE.Variables>>;
+type ZCArgType  = tuple<tuple<BackendDAE.ZeroCrossingSet, BackendDAE.ZeroCrossingSet, BackendDAE.ZeroCrossingSet, Integer>, tuple<Integer, BackendDAE.Variables, BackendDAE.Variables>, Option<list<BackendDAE.SimIterator>>>;
+type ForArgType = tuple<DAE.Exp, list<DAE.Exp>, DAE.Exp, tuple<BackendDAE.ZeroCrossingSet, BackendDAE.ZeroCrossingSet, BackendDAE.ZeroCrossingSet, Integer>, tuple<Integer, BackendDAE.Variables, BackendDAE.Variables>>;
 // =============================================================================
 // section for preOptModule >>encapsulateWhenConditions<<
 //
@@ -580,7 +580,7 @@ algorithm
       list<BackendDAE.Equation> eqs_lst, eqs_lst1;
       list<BackendDAE.TimeEvent> timeEvents;
       BackendDAE.ZeroCrossingSet zero_crossings, sampleLst;
-      DoubleEnded.MutableList<BackendDAE.ZeroCrossing> relations;
+      BackendDAE.ZeroCrossingSet relations;
       Integer countMathFunctions;
       Option<String> solver;
     //No zero crossing for clocked discrete partitions;
@@ -600,7 +600,7 @@ algorithm
         eqs_lst1 := listReverse(eqs_lst1);
         eqns1 := BackendEquation.listEquation(eqs_lst1);
         if Flags.isSet(Flags.RELIDX) then
-          print("findZeroCrossings1 number of relations: " + intString(DoubleEnded.length(relations)) + "\n");
+          print("findZeroCrossings1 number of relations: " + intString(ZeroCrossings.count(relations)) + "\n");
           print("findZeroCrossings1 sample index: " + intString(ZeroCrossings.length(sampleLst)) + "\n");
         end if;
         // replace zerocrossing expressions also in jacobian matrices
@@ -624,19 +624,19 @@ protected function findZeroCrossings2
   input Integer inEqnCount;
   input Integer inNumberOfMathFunctions;
   input BackendDAE.ZeroCrossingSet inZeroCrossingLst;
-  input DoubleEnded.MutableList<BackendDAE.ZeroCrossing> inRelationsLst;
+  input BackendDAE.ZeroCrossingSet inRelationsLst;
   input BackendDAE.ZeroCrossingSet inSamplesLst;
   input list<BackendDAE.Equation> inEquationLstAccum;
   output BackendDAE.ZeroCrossingSet outZeroCrossingLst;
   output list<BackendDAE.Equation> outEquationLst;
   output Integer outNumberOfMathFunctions;
-  output DoubleEnded.MutableList<BackendDAE.ZeroCrossing> outRelationsLst;
+  output BackendDAE.ZeroCrossingSet outRelationsLst;
   output BackendDAE.ZeroCrossingSet outSamplesLst;
 algorithm
   (outZeroCrossingLst, outEquationLst, outNumberOfMathFunctions, outRelationsLst, outSamplesLst) := match inEquationLst2
     local
       BackendDAE.ZeroCrossingSet zcs1, res, res1, sampleLst;
-      DoubleEnded.MutableList<BackendDAE.ZeroCrossing> relationsLst;
+      BackendDAE.ZeroCrossingSet relationsLst;
       Integer size, eq_count, countMathFunctions;
       BackendDAE.Equation e;
       list<BackendDAE.Equation> xs, eq_reslst, eqnsAccum;
@@ -726,7 +726,7 @@ end findZeroCrossings2;
 protected function findZeroCrossingsWhenEqns
   input BackendDAE.WhenEquation inWhenEqn;
   input BackendDAE.ZeroCrossingSet inZeroCrossings;
-  input DoubleEnded.MutableList<BackendDAE.ZeroCrossing> inrelationsinZC;
+  input BackendDAE.ZeroCrossingSet inrelationsinZC;
   input BackendDAE.ZeroCrossingSet inSamplesLst;
   input Integer incountMathFunctions;
   input Integer counteq;
@@ -736,7 +736,7 @@ protected function findZeroCrossingsWhenEqns
   output BackendDAE.WhenEquation oWhenEqn;
   output Integer outCountMathFunctions;
   output BackendDAE.ZeroCrossingSet outZeroCrossings;
-  output DoubleEnded.MutableList<BackendDAE.ZeroCrossing> outrelationsinZC;
+  output BackendDAE.ZeroCrossingSet outrelationsinZC;
   output BackendDAE.ZeroCrossingSet outSamplesLst;
 algorithm
   (oWhenEqn, outCountMathFunctions, outZeroCrossings, outrelationsinZC, outSamplesLst) := match inWhenEqn
@@ -744,7 +744,7 @@ algorithm
       DAE.Exp cond;
       BackendDAE.WhenEquation we;
       BackendDAE.ZeroCrossingSet zc, samples;
-      DoubleEnded.MutableList<BackendDAE.ZeroCrossing> relations;
+      BackendDAE.ZeroCrossingSet relations;
       Integer countMathFunctions;
       list<BackendDAE.WhenOperator> whenStmtLst;
       Option<BackendDAE.WhenEquation> oweelse;
@@ -768,7 +768,7 @@ end findZeroCrossingsWhenEqns;
 protected function findZeroCrossingsIfEqns
   input BackendDAE.Equation inIfEqn;
   input BackendDAE.ZeroCrossingSet inZeroCrossings;
-  input DoubleEnded.MutableList<BackendDAE.ZeroCrossing> inrelationsinZC;
+  input BackendDAE.ZeroCrossingSet inrelationsinZC;
   input BackendDAE.ZeroCrossingSet inSamplesLst;
   input Integer incountMathFunctions;
   input Integer counteq;
@@ -778,7 +778,7 @@ protected function findZeroCrossingsIfEqns
   output BackendDAE.Equation outIfEqn;
   output Integer outCountMathFunctions;
   output BackendDAE.ZeroCrossingSet outZeroCrossings;
-  output DoubleEnded.MutableList<BackendDAE.ZeroCrossing> outrelationsinZC;
+  output BackendDAE.ZeroCrossingSet outrelationsinZC;
   output BackendDAE.ZeroCrossingSet outSamplesLst;
 algorithm
   (outIfEqn, outCountMathFunctions, outZeroCrossings, outrelationsinZC, outSamplesLst) := match inIfEqn
@@ -789,7 +789,7 @@ algorithm
       list<BackendDAE.Equation> eqnstrue, elseeqns;
       list<list<BackendDAE.Equation>> eqnsTrueLst, resteqns;
       BackendDAE.ZeroCrossingSet zc, samples;
-      DoubleEnded.MutableList<BackendDAE.ZeroCrossing> relations;
+      BackendDAE.ZeroCrossingSet relations;
       Integer countMathFunctions;
       DAE.ElementSource source_;
       BackendDAE.EquationAttributes eqAttr;
@@ -814,7 +814,7 @@ end findZeroCrossingsIfEqns;
 protected function findZeroCrossingsinJacobians
   input BackendDAE.StrongComponents inStrongComponents;
   input BackendDAE.ZeroCrossingSet zeroCrossingLst;
-  input DoubleEnded.MutableList<BackendDAE.ZeroCrossing> relationsLst;
+  input BackendDAE.ZeroCrossingSet relationsLst;
   input BackendDAE.ZeroCrossingSet samplesLst;
   input BackendDAE.Variables allVariables;
   input BackendDAE.Variables globalKnownVars;
@@ -859,7 +859,7 @@ end findZeroCrossingsinJacobians;
 protected function replaceZCExpinFullJacobian
   input BackendDAE.FullJacobian fullJac;
   input BackendDAE.ZeroCrossingSet zeroCrossingLst;
-  input DoubleEnded.MutableList<BackendDAE.ZeroCrossing> relationsLst;
+  input BackendDAE.ZeroCrossingSet relationsLst;
   input BackendDAE.ZeroCrossingSet samplesLst;
   input BackendDAE.Variables allVariables;
   input BackendDAE.Variables globalKnownVars;
@@ -885,7 +885,7 @@ end replaceZCExpinFullJacobian;
 protected function replaceZCExpinSymJacobian
   input BackendDAE.SymbolicJacobian symJac;
   input BackendDAE.ZeroCrossingSet zeroCrossingLst;
-  input DoubleEnded.MutableList<BackendDAE.ZeroCrossing> relationsLst;
+  input BackendDAE.ZeroCrossingSet relationsLst;
   input BackendDAE.ZeroCrossingSet samplesLst;
   input BackendDAE.Variables allVariables;
   input BackendDAE.Variables globalKnownVars;
@@ -904,7 +904,7 @@ end replaceZCExpinSymJacobian;
 protected function replaceZeroCrossingsJacBackend
   input BackendDAE.BackendDAE inBackendDAE;
   input BackendDAE.ZeroCrossingSet zeroCrossingLst;
-  input DoubleEnded.MutableList<BackendDAE.ZeroCrossing> relationsLst;
+  input BackendDAE.ZeroCrossingSet relationsLst;
   input BackendDAE.ZeroCrossingSet samplesLst;
   input BackendDAE.Variables allVariables;
   input BackendDAE.Variables globalKnownVars;
@@ -939,7 +939,7 @@ end replaceZeroCrossingsJacBackend;
 protected function findZeroCrossings3
   input DAE.Exp e;
   input BackendDAE.ZeroCrossingSet inZeroCrossings;
-  input DoubleEnded.MutableList<BackendDAE.ZeroCrossing> inrelationsinZC;
+  input BackendDAE.ZeroCrossingSet inrelationsinZC;
   input BackendDAE.ZeroCrossingSet inSamplesLst;
   input Integer incountMathFunctions;
   input Integer counteq;
@@ -949,7 +949,7 @@ protected function findZeroCrossings3
   output DAE.Exp eres;
   output Integer outCountMathFunctions;
   output BackendDAE.ZeroCrossingSet outZeroCrossings;
-  output DoubleEnded.MutableList<BackendDAE.ZeroCrossing> outrelationsinZC;
+  output BackendDAE.ZeroCrossingSet outrelationsinZC;
   output BackendDAE.ZeroCrossingSet outSamplesLst;
 algorithm
   if Flags.isSet(Flags.RELIDX) then
@@ -983,7 +983,7 @@ algorithm
       DAE.Exp index, delay, delayMax, in0, in1, x, dir, initPnts, initVals;
       BackendDAE.Variables vars, globalKnownVars;
       BackendDAE.ZeroCrossingSet zeroCrossings, samples;
-      DoubleEnded.MutableList<BackendDAE.ZeroCrossing> relations;
+      BackendDAE.ZeroCrossingSet relations;
       DAE.Operator op;
       Integer eq_count, itmp, numMathFunctions, oldNumRelations;
       BackendDAE.ZeroCrossing zc;
@@ -1027,12 +1027,12 @@ algorithm
         (delay, ((_, relations, samples, numMathFunctions), tp1, iters))                 := Expression.traverseExpTopDown(delay, collectZC, ((ZeroCrossings.new(), relations, samples, numMathFunctions), tp1, iters));
 
         // create zero crossing function
-        eres1 := DAE.CALL(Absyn.IDENT("delayZeroCrossing"), {index, DAE.ICONST(DoubleEnded.length(relations)), delay}, attr);
-        e_1 := DAE.RELATION(eres1, DAE.GREATER(DAE.T_REAL_DEFAULT) ,DAE.RCONST(0.0), DoubleEnded.length(relations), NONE());
+        eres1 := DAE.CALL(Absyn.IDENT("delayZeroCrossing"), {index, DAE.ICONST(ZeroCrossings.count(relations)), delay}, attr);
+        e_1 := DAE.RELATION(eres1, DAE.GREATER(DAE.T_REAL_DEFAULT) ,DAE.RCONST(0.0), ZeroCrossings.count(relations), NONE());
         zc := createZeroCrossing(eres1, {eq_count}, iters);
-        (eres, relations) := zcIndexRelation(e_1, relations, DoubleEnded.length(relations), zc);
+        (eres, relations, _) := zcIndex(e_1, relations, ZeroCrossings.count(relations), zc);
         zc := createZeroCrossing(eres, {eq_count}, iters);
-        (DAE.RELATION(index=itmp), zeroCrossings, _) := zcIndex(eres, zeroCrossings, DoubleEnded.length(relations), zc);
+        (DAE.RELATION(index=itmp), zeroCrossings, _) := zcIndex(eres, zeroCrossings, ZeroCrossings.count(relations), zc);
 
         if Flags.isSet(Flags.RELIDX) then
           print("collectZC result zc: " + ExpressionBasics.printExpStr(eres) + " index: " + intString(itmp) + "\n");
@@ -1050,12 +1050,12 @@ algorithm
         (dir, ((_, relations, samples, numMathFunctions), tp1 as (eq_count, _, _), iters)) := Expression.traverseExpTopDown(dir, collectZC, ((ZeroCrossings.new(), relations, samples, numMathFunctions), tp1, iters));
 
         // create zero crossing function
-        eres1 := DAE.CALL(Absyn.IDENT("spatialDistributionZeroCrossing"), {index, DAE.ICONST(DoubleEnded.length(relations)), x, dir}, attr);
-        e_1 := DAE.RELATION(eres1, DAE.GREATER(DAE.T_REAL_DEFAULT) ,DAE.RCONST(0.0), DoubleEnded.length(relations), NONE());
+        eres1 := DAE.CALL(Absyn.IDENT("spatialDistributionZeroCrossing"), {index, DAE.ICONST(ZeroCrossings.count(relations)), x, dir}, attr);
+        e_1 := DAE.RELATION(eres1, DAE.GREATER(DAE.T_REAL_DEFAULT) ,DAE.RCONST(0.0), ZeroCrossings.count(relations), NONE());
         zc := createZeroCrossing(eres1, {eq_count}, iters);
-        (eres, relations) := zcIndexRelation(e_1, relations, DoubleEnded.length(relations), zc);
+        (eres, relations, _) := zcIndex(e_1, relations, ZeroCrossings.count(relations), zc);
         zc := createZeroCrossing(eres, {eq_count}, iters);
-        (DAE.RELATION(index=itmp), zeroCrossings, _) := zcIndex(eres, zeroCrossings, DoubleEnded.length(relations), zc);
+        (DAE.RELATION(index=itmp), zeroCrossings, _) := zcIndex(eres, zeroCrossings, ZeroCrossings.count(relations), zc);
 
         if Flags.isSet(Flags.RELIDX) then
           print("collectZC result zc: " + ExpressionBasics.printExpStr(eres) + " index: " + intString(itmp) + "\n");
@@ -1068,7 +1068,7 @@ algorithm
       guard not BackendDAEUtil.hasExpContinuousParts(e1, vars, globalKnownVars)
       algorithm
       if Flags.isSet(Flags.RELIDX) then
-        print("discrete LUNARY: " + intString(DoubleEnded.length(relations)) + "\n");
+        print("discrete LUNARY: " + intString(ZeroCrossings.count(relations)) + "\n");
       end if;
       //fcall(Flags.RELIDX, BackendDump.debugExpStr, (inExp, "\n"));
     then (inExp, true, inTpl);
@@ -1077,7 +1077,7 @@ algorithm
       guard not (BackendDAEUtil.hasExpContinuousParts(e1, vars, globalKnownVars) or BackendDAEUtil.hasExpContinuousParts(e2, vars, globalKnownVars))
       algorithm
       if Flags.isSet(Flags.RELIDX) then
-        print("discrete LBINARY: " + intString(DoubleEnded.length(relations)) + "\n");
+        print("discrete LBINARY: " + intString(ZeroCrossings.count(relations)) + "\n");
       end if;
       //fcall(Flags.RELIDX, BackendDump.debugExpStr, (inExp, "\n"));
     then (inExp, true, inTpl);
@@ -1085,7 +1085,7 @@ algorithm
     // coditions that are zerocrossings.
     case (DAE.LUNARY(exp=e1, operator=op), ((zeroCrossings, relations, _, _), _, iters), _) algorithm
       if Flags.isSet(Flags.RELIDX) then
-        print("continues LUNARY: " + intString(DoubleEnded.length(relations)) + "\n");
+        print("continues LUNARY: " + intString(ZeroCrossings.count(relations)) + "\n");
       end if;
       (e1, tpl as (_, (eq_count, _, _), _)) := Expression.traverseExpTopDown(e1, collectZC, inTpl);
       e_1 := DAE.LUNARY(op, e1);
@@ -1101,13 +1101,13 @@ algorithm
 
     case (DAE.LBINARY(exp1=e1, operator=op, exp2=e2), ((zeroCrossings, relations, samples, numMathFunctions), tp1, iters), _) algorithm
       if Flags.isSet(Flags.RELIDX) then
-        print("continues LBINARY: " + String(DoubleEnded.length(relations)) + "\n");
+        print("continues LBINARY: " + String(ZeroCrossings.count(relations)) + "\n");
         BackendDump.debugExpStr(inExp, "\n");
       end if;
-      oldNumRelations := DoubleEnded.length(relations);
+      oldNumRelations := ZeroCrossings.count(relations);
       (e_1, ((_, relations, samples, numMathFunctions), tp1, iters)) := Expression.traverseExpTopDown(e1, collectZC, ((ZeroCrossings.new(), relations, samples, numMathFunctions), tp1, iters));
       (e_2, ((_, relations, samples, numMathFunctions), tp1 as (eq_count, _, _), iters)) := Expression.traverseExpTopDown(e2, collectZC, ((ZeroCrossings.new(), relations, samples, numMathFunctions), tp1, iters));
-      if intGt(DoubleEnded.length(relations), oldNumRelations) then
+      if intGt(ZeroCrossings.count(relations), oldNumRelations) then
         e_1 := DAE.LBINARY(e_1, op, e_2);
         zc := createZeroCrossing(e_1, {eq_count}, iters);
         empty := not ZeroCrossings.contains(zeroCrossings, zc);
@@ -1129,7 +1129,7 @@ algorithm
       guard not (BackendDAEUtil.hasExpContinuousParts(e1, vars, globalKnownVars) or BackendDAEUtil.hasExpContinuousParts(e2, vars, globalKnownVars))
       algorithm
       if Flags.isSet(Flags.RELIDX) then
-        print("discrete RELATION: " + intString(DoubleEnded.length(relations)) + "\n");
+        print("discrete RELATION: " + intString(ZeroCrossings.count(relations)) + "\n");
       end if;
     then (inExp, true, inTpl);
 
@@ -1138,13 +1138,13 @@ algorithm
       guard Flags.isSet(Flags.EVENTS)
       algorithm
       if Flags.isSet(Flags.RELIDX) then
-        print("start collectZC (2): " + ExpressionBasics.printExpStr(inExp) + " numRelations: " +intString(DoubleEnded.length(relations)) + "\n");
+        print("start collectZC (2): " + ExpressionBasics.printExpStr(inExp) + " numRelations: " +intString(ZeroCrossings.count(relations)) + "\n");
       end if;
-      e_1 := DAE.RELATION(e1, op, e2, DoubleEnded.length(relations), NONE());
+      e_1 := DAE.RELATION(e1, op, e2, ZeroCrossings.count(relations), NONE());
       zc := createZeroCrossing(e_1, {eq_count}, iters);
-      (eres, relations) := zcIndexRelation(e_1, relations, DoubleEnded.length(relations), zc);
+      (eres, relations, _) := zcIndex(e_1, relations, ZeroCrossings.count(relations), zc);
       zc := createZeroCrossing(eres, {eq_count}, iters);
-      (DAE.RELATION(index=itmp), zeroCrossings, _) := zcIndex(eres, zeroCrossings, DoubleEnded.length(relations), zc);
+      (DAE.RELATION(index=itmp), zeroCrossings, _) := zcIndex(eres, zeroCrossings, ZeroCrossings.count(relations), zc);
       if Flags.isSet(Flags.RELIDX) then
         print("collectZC result zc: " + ExpressionBasics.printExpStr(eres) + " index: " + intString(itmp) + "\n");
       end if;
@@ -1276,7 +1276,7 @@ algorithm
       list<DAE.Exp> inExpLst, explst;
       BackendDAE.Variables vars, globalKnownVars;
       BackendDAE.ZeroCrossingSet zeroCrossings, samples;
-      DoubleEnded.MutableList<BackendDAE.ZeroCrossing> relations;
+      BackendDAE.ZeroCrossingSet relations;
       list<BackendDAE.ZeroCrossing> zcLstNew, zc_lst;
       DAE.Operator op;
       Integer alg_indx, itmp, numMathFunctions, oldNumRelations;
@@ -1290,7 +1290,7 @@ algorithm
       list<DAE.Exp> le;
       tuple<Integer, BackendDAE.Variables, BackendDAE.Variables> tp1;
       ForArgType tpl;
-      tuple<BackendDAE.ZeroCrossingSet, DoubleEnded.MutableList<BackendDAE.ZeroCrossing>, BackendDAE.ZeroCrossingSet, Integer> tp2;
+      tuple<BackendDAE.ZeroCrossingSet, BackendDAE.ZeroCrossingSet, BackendDAE.ZeroCrossingSet, Integer> tp2;
 
     case (DAE.CALL(path=Absyn.IDENT(name="noEvent")), _)
     then (inExp, false, inTpl);
@@ -1316,11 +1316,11 @@ algorithm
       guard Expression.expContains(inExp, iterator)
       algorithm
       if Flags.isSet(Flags.RELIDX) then
-        print("continues LUNARY with Iterator: " + intString(DoubleEnded.length(relations)) + "\n");
+        print("continues LUNARY with Iterator: " + intString(ZeroCrossings.count(relations)) + "\n");
       end if;
       (e1, tpl as (iterator, inExpLst, _, (_, relations, _, _), (alg_indx, _, _))) := Expression.traverseExpTopDown(e1, collectZCAlgsFor, inTpl);
       e_1 := DAE.LUNARY(op, e1);
-      (explst,_) := replaceIteratorWithStaticValues(e_1, iterator, inExpLst, DoubleEnded.length(relations));
+      (explst,_) := replaceIteratorWithStaticValues(e_1, iterator, inExpLst, ZeroCrossings.count(relations));
       zc_lst := createZeroCrossings(explst, {alg_indx});
       ZeroCrossings.add_list(zeroCrossings, zc_lst);
       if Flags.isSet(Flags.RELIDX) then
@@ -1332,7 +1332,7 @@ algorithm
     // coditions that are zerocrossings.
     case (DAE.LUNARY(exp=e1, operator=op), (_, _, _, (zeroCrossings, relations, _, _), _)) algorithm
       if Flags.isSet(Flags.RELIDX) then
-        print("continues LUNARY: " + intString(DoubleEnded.length(relations)) + "\n");
+        print("continues LUNARY: " + intString(ZeroCrossings.count(relations)) + "\n");
       end if;
       (e1, tpl as (_, _, _, _, (alg_indx, _, _))) := Expression.traverseExpTopDown(e1, collectZCAlgsFor, inTpl);
       e_1 := DAE.LUNARY(op, e1);
@@ -1351,16 +1351,16 @@ algorithm
     case (DAE.LBINARY(exp1=e1, operator=op, exp2=e2), (iterator, inExpLst, range, (zeroCrossings, relations, samples, numMathFunctions), tp1))
       algorithm
       if Flags.isSet(Flags.RELIDX) then
-        print("continues LBINARY: " + intString(DoubleEnded.length(relations)) + "\n");
+        print("continues LBINARY: " + intString(ZeroCrossings.count(relations)) + "\n");
         BackendDump.debugExpStr(inExp, "\n");
       end if;
-      oldNumRelations := DoubleEnded.length(relations);
+      oldNumRelations := ZeroCrossings.count(relations);
       (e_1, (_, inExpLst, range, tp2, tp1)) := Expression.traverseExpTopDown(e1, collectZCAlgsFor, (iterator, inExpLst, range, (ZeroCrossings.new(), relations, samples, numMathFunctions), tp1));
       (e_2, (_, inExpLst, range, (_, relations, samples, numMathFunctions), tp1 as (alg_indx, _, _))) := Expression.traverseExpTopDown(e2, collectZCAlgsFor, (iterator, inExpLst, range, tp2, tp1));
-      if intGt(DoubleEnded.length(relations), oldNumRelations) then
+      if intGt(ZeroCrossings.count(relations), oldNumRelations) then
         e_1 := DAE.LBINARY(e_1, op, e_2);
         if Expression.expContains(e1, iterator) or Expression.expContains(e2, iterator) then
-          (explst,_) := replaceIteratorWithStaticValues(e_1, iterator, inExpLst, DoubleEnded.length(relations));
+          (explst,_) := replaceIteratorWithStaticValues(e_1, iterator, inExpLst, ZeroCrossings.count(relations));
           zc_lst := createZeroCrossings(explst, {alg_indx});
           ZeroCrossings.add_list(zeroCrossings, zc_lst);
           if Flags.isSet(Flags.RELIDX) then
@@ -1394,20 +1394,20 @@ algorithm
       guard if Flags.isSet(Flags.EVENTS) then (if Expression.expContains(e1, iterator) then true else Expression.expContains(e2, iterator)) else false
       algorithm
       if Flags.isSet(Flags.RELIDX) then
-        print(" number of relations: " + intString(DoubleEnded.length(relations)) + "\n");
+        print(" number of relations: " + intString(ZeroCrossings.count(relations)) + "\n");
       end if;
       stepvalue := Util.getOptionOrDefault(stepvalueopt, DAE.ICONST(1));
       istart := BackendDAEUtil.expInt(startvalue, globalKnownVars);
       istep := BackendDAEUtil.expInt(stepvalue, globalKnownVars);
-      eres := DAE.RELATION(e1, op, e2, DoubleEnded.length(relations), SOME((iterator, istart, istep)));
-      (explst, itmp) := replaceIteratorWithStaticValues(inExp, iterator, inExpLst, DoubleEnded.length(relations));
+      eres := DAE.RELATION(e1, op, e2, ZeroCrossings.count(relations), SOME((iterator, istart, istep)));
+      (explst, itmp) := replaceIteratorWithStaticValues(inExp, iterator, inExpLst, ZeroCrossings.count(relations));
       if Flags.isSet(Flags.RELIDX) then
         print(" number of new zc (1): " + intString(listLength(explst)) + "\n");
       end if;
       zcLstNew := createZeroCrossings(explst, {alg_indx});
-      DoubleEnded.push_list_back(relations, zcLstNew);
+      ZeroCrossings.push_list(relations, zcLstNew);
       if Flags.isSet(Flags.RELIDX) then
-        print(" number of new zc (2): " + intString(DoubleEnded.length(relations)) + "\n");
+        print(" number of new zc (2): " + intString(ZeroCrossings.count(relations)) + "\n");
       end if;
       itmp := listLength(zcLstNew);
       if Flags.isSet(Flags.RELIDX) then
@@ -1415,7 +1415,7 @@ algorithm
       end if;
       ZeroCrossings.add_list(zeroCrossings, zcLstNew);
       if Flags.isSet(Flags.RELIDX) then
-        print("collectZCAlgsFor result zc: " + ExpressionBasics.printExpStr(eres)+ " index:" + intString(DoubleEnded.length(relations)) + "\n");
+        print("collectZCAlgsFor result zc: " + ExpressionBasics.printExpStr(eres)+ " index:" + intString(ZeroCrossings.count(relations)) + "\n");
       end if;
     then (eres, true, (iterator, inExpLst, range, (zeroCrossings, relations, samples, numMathFunctions), tp1));
 
@@ -1423,12 +1423,12 @@ algorithm
     case (DAE.RELATION(exp1=e1, operator=op, exp2=e2), (iterator, inExpLst, range, (zeroCrossings, relations, samples, numMathFunctions), tp1 as (alg_indx, _, _)))
       guard Flags.isSet(Flags.EVENTS) // and (not Expression.expContains(e1, iterator) or Expression.expContains(e2, iterator))
       algorithm
-      eres := DAE.RELATION(e1, op, e2, DoubleEnded.length(relations), NONE());
+      eres := DAE.RELATION(e1, op, e2, ZeroCrossings.count(relations), NONE());
       zc := createZeroCrossing(eres, {alg_indx}, NONE());
-      DoubleEnded.push_back(relations, zc);
+      ZeroCrossings.push(relations, zc);
       ZeroCrossings.add(zeroCrossings, zc);
       if Flags.isSet(Flags.RELIDX) then
-        print("collectZCAlgsFor result zc: " + ExpressionBasics.printExpStr(eres)+ " index:" + intString(DoubleEnded.length(relations)) + "\n");
+        print("collectZCAlgsFor result zc: " + ExpressionBasics.printExpStr(eres)+ " index:" + intString(ZeroCrossings.count(relations)) + "\n");
       end if;
     then (eres, true, (iterator, inExpLst, range, (zeroCrossings, relations, samples, numMathFunctions), tp1));
 
@@ -1621,45 +1621,6 @@ algorithm
     then fail();
   end match;
 end zcIndex;
-
-protected function zcIndexRelation
-  input output DAE.Exp relation;
-  input output DoubleEnded.MutableList<BackendDAE.ZeroCrossing> zeroCrossings;
-  input output Integer index;
-  input BackendDAE.ZeroCrossing zc;
-protected
-  list<BackendDAE.ZeroCrossing> duplicate;
-algorithm
-  duplicate := List.select1(DoubleEnded.toListNoCopyNoClear(zeroCrossings), ZeroCrossings.equals, zc);
-  (relation, index) := match (relation, duplicate)
-    local
-      DAE.Exp rel;
-
-    case (DAE.RELATION(), {})
-      algorithm
-        DoubleEnded.push_back(zeroCrossings, zc);
-      then (relation, index+1);
-
-    // math function with one argument and index
-    case (DAE.CALL(expLst={_, _}), {})
-      algorithm
-        DoubleEnded.push_back(zeroCrossings, zc);
-      then (relation, index+1);
-
-    // math function with two arguments and index
-    case (DAE.CALL(expLst={_, _, _}), {})
-      algorithm
-        DoubleEnded.push_back(zeroCrossings, zc);
-      then (relation, index+2);
-
-    case (_, BackendDAE.ZERO_CROSSING(relation_=rel)::_)
-      then (rel, index);
-
-    else algorithm
-      Error.addInternalError(getInstanceName() + " failed for: " + ExpressionBasics.printExpStr(relation), sourceInfo());
-    then fail();
-  end match;
-end zcIndexRelation;
 
 protected function mergeZeroCrossings "
   Takes a list of zero crossings and if more than one have identical
@@ -1900,7 +1861,7 @@ algorithm
   (outStatements, outTpl) := match (inExplst, inExtraArg)
     local
       list<DAE.Statement> statementLst;
-      tuple<BackendDAE.ZeroCrossingSet, DoubleEnded.MutableList<BackendDAE.ZeroCrossing>, BackendDAE.ZeroCrossingSet, Integer> tpl2;
+      tuple<BackendDAE.ZeroCrossingSet, BackendDAE.ZeroCrossingSet, BackendDAE.ZeroCrossingSet, Integer> tpl2;
       tuple<Integer, BackendDAE.Variables, BackendDAE.Variables> tpl3;
       ForArgType extraArg;
 

--- a/OMCompiler/Compiler/BackEnd/Initialization.mo
+++ b/OMCompiler/Compiler/BackEnd/Initialization.mo
@@ -1334,9 +1334,14 @@ algorithm
 
     if not (listEmpty(redundantEqns) and listEmpty(unfixedVars)) then
       // 6. use subroutine resolveOverAndUnderconstraints for unmatched variables and equations
-      (me, _, _, _) := BackendDAEUtil.getAdjacencyMatrixEnhancedScalar(outEqSystem, inShared, false);
-      consistencyCheck(redundantEqns, outEqSystem.orderedEqs, outEqSystem.orderedVars, inShared, 0, m, me, var_to_eqn, eqn_to_var, scal_to_arr);
-      redundantEqns := List.unique(list(scal_to_arr[i] for i in redundantEqns));
+      if not listEmpty(redundantEqns) then
+        // The enhanced adjacency matrix is consulted for the redundant equations
+        // only, and building it differentiates and simplifies every equation
+        // with respect to every variable it contains.
+        (me, _, _, _) := BackendDAEUtil.getAdjacencyMatrixEnhancedScalar(outEqSystem, inShared, false);
+        consistencyCheck(redundantEqns, outEqSystem.orderedEqs, outEqSystem.orderedVars, inShared, 0, m, me, var_to_eqn, eqn_to_var, scal_to_arr);
+        redundantEqns := List.unique(list(scal_to_arr[i] for i in redundantEqns));
+      end if;
       outEqSystem := resolveOverAndUnderconstraints(outEqSystem, initVars, unfixedVars, redundantEqns, dumpVars, removedEqns);
       (outEqSystem, m, mT, _, scal_to_arr) := BackendDAEUtil.getAdjacencyMatrixScalar(outEqSystem, BackendDAE.SOLVABLE(), SOME(funcs), true);
       nVars := BackendVariable.varsSize(outEqSystem.orderedVars);
@@ -1373,8 +1378,10 @@ algorithm
 
         if not (listEmpty(redundantEqns) and listEmpty(unfixedVars)) then
           // 7.2 use subroutine resolveOverAndUnderconstraints for unmatched variables and equations
-          (me, _, _, _) := BackendDAEUtil.getAdjacencyMatrixEnhancedScalar(outEqSystem, inShared, false);
-          consistencyCheck(redundantEqns, outEqSystem.orderedEqs, outEqSystem.orderedVars, inShared, 0, m, me, var_to_eqn, eqn_to_var, scal_to_arr);
+          if not listEmpty(redundantEqns) then
+            (me, _, _, _) := BackendDAEUtil.getAdjacencyMatrixEnhancedScalar(outEqSystem, inShared, false);
+            consistencyCheck(redundantEqns, outEqSystem.orderedEqs, outEqSystem.orderedVars, inShared, 0, m, me, var_to_eqn, eqn_to_var, scal_to_arr);
+          end if;
           outEqSystem := resolveOverAndUnderconstraints(outEqSystem, initVars, unfixedVars, redundantEqns, dumpVars, removedEqns);
           (outEqSystem, m, mT, _, scal_to_arr) := BackendDAEUtil.getAdjacencyMatrixScalar(outEqSystem, BackendDAE.SOLVABLE(), SOME(funcs), true);
         end if;

--- a/OMCompiler/Compiler/BackEnd/ZeroCrossings.mo
+++ b/OMCompiler/Compiler/BackEnd/ZeroCrossings.mo
@@ -122,6 +122,33 @@ algorithm
   end for;
 end add_list;
 
+function push "Appends without checking for duplicates; the lookup tree keeps the first occurrence."
+  input ZeroCrossingSet zc_set;
+  input ZeroCrossing zc;
+protected
+  list<ZeroCrossing> addedCell;
+algorithm
+  DoubleEnded.push_back(zc_set.zc, zc);
+  addedCell := DoubleEnded.currentBackCell(zc_set.zc);
+  arrayUpdate(zc_set.tree, 1, ZeroCrossingTree.add(arrayGet(zc_set.tree, 1), zc, addedCell, ZeroCrossingTree.addConflictKeep));
+end push;
+
+function push_list
+  input ZeroCrossingSet zc_set;
+  input list<ZeroCrossing> zc_lst;
+algorithm
+  for zc in zc_lst loop
+    push(zc_set, zc);
+  end for;
+end push_list;
+
+function count "Number of stored zero crossings; unlike length() this does not expand iterators."
+  input ZeroCrossingSet zc_set;
+  output Integer i;
+algorithm
+  i := DoubleEnded.length(zc_set.zc);
+end count;
+
 function toList
   input ZeroCrossingSet zc;
   output list<ZeroCrossing> lst = {};

--- a/OMCompiler/Compiler/FrontEnd/ComponentReferenceBasics.mo
+++ b/OMCompiler/Compiler/FrontEnd/ComponentReferenceBasics.mo
@@ -908,36 +908,20 @@ end match;
 end hashComponentRef;
 
 protected function hashSubscripts "help function, hashing subscripts making sure [1,2] and [2,1] doesn't match to the same number"
+  // TODO: Currently, the types of component references are wrong, they consider the subscripts but they should not.
+  // For example, given Real a[10,10];  the component reference 'a[1,2]' should have type Real[10,10] but it has type Real,
+  // so the dimensions of tp cannot be used as the per-subscript factor yet.
   input DAE.Type tp;
   input list<DAE.Subscript> subs;
-  output Integer hash;
+  output Integer hash = 0;
+protected
+  Integer factor = 1;
 algorithm
-  hash := match subs
-  case {} then 0;
-  // TODO: Currently, the types of component references are wrong, they consider the subscripts but they should not.
-  // For example, given Real a[10,10];  the component reference 'a[1,2]' should have type Real[10,10] but it has type Real.
-  else hashSubscripts2(List.fill(1,listLength(subs)),/*DAEUtil.expTypeArrayDimensions(tp),*/subs,1);
-  end match;
+  for s in subs loop
+    hash := hash + hashSubscript(s)*factor;
+    factor := factor*1000/* *dim */;
+  end for;
 end hashSubscripts;
-
-protected function hashSubscripts2 "help function"
-  input list<Integer> dims;
-  input list<DAE.Subscript> subs;
-  input Integer factor;
-  output Integer hash;
-algorithm
-  hash := match(dims, subs)
-  local
-    DAE.Subscript s;
-    list<Integer> rest_dims;
-    list<DAE.Subscript> rest_subs;
-
-    case({}, {}) then 0;
-    case(_::rest_dims, s::rest_subs)
-    // TODO: change to using dimensions once cref types has been fixed.
-    then hashSubscript(s)*factor + hashSubscripts2(rest_dims,rest_subs,factor*1000/* *i1 */);
-  end match;
-end hashSubscripts2;
 
 protected function hashSubscript "help function"
   input DAE.Subscript sub;

--- a/OMCompiler/Compiler/FrontEnd/ExpressionSimplify.mo
+++ b/OMCompiler/Compiler/FrontEnd/ExpressionSimplify.mo
@@ -5036,16 +5036,16 @@ algorithm
 
     // a >= b
     case(DAE.GREATEREQ(), _, _)
-      then simplifyRelation2(origExp,inOperator2, inExp3,inExp4, index,optionExpisASUB,Expression.isPositiveOrZero);
+      then simplifyRelation2(origExp,inOperator2, inExp3,inExp4);
      // a > b
     case(DAE.GREATER(), _, _)
-      then simplifyRelation2(origExp,inOperator2, inExp3,inExp4, index,optionExpisASUB,Expression.isPositiveOrZero);
+      then simplifyRelation2(origExp,inOperator2, inExp3,inExp4);
     // a <= b
     case(DAE.LESSEQ(), _, _)
-      then simplifyRelation2(origExp,inOperator2, inExp4,inExp3, index,optionExpisASUB,Expression.isPositiveOrZero);
+      then simplifyRelation2(origExp,inOperator2, inExp4,inExp3);
     // a < b
     case(DAE.LESS(), _, _)
-      then simplifyRelation2(origExp,inOperator2, inExp4,inExp3, index,optionExpisASUB,Expression.isPositiveOrZero);
+      then simplifyRelation2(origExp,inOperator2, inExp4,inExp3);
 
     else origExp;
 
@@ -5058,38 +5058,17 @@ protected function simplifyRelation2
   input Operator inOp;
   input DAE.Exp lhs "Note: already simplified";
   input DAE.Exp rhs "Note: aldready simplified";
-  input Integer index;
-  input Option<tuple<DAE.Exp,Integer,Integer>> optionExpisASUB;
-  input Fun isPositive;
   output DAE.Exp oExp;
-
-  partial function Fun
-    input DAE.Exp x;
-    output Boolean positive;
-  end Fun;
-
-protected
-  Boolean b;
 algorithm
-  oExp := Expression.expSub(lhs, rhs);
-  (oExp,b) := simplify(oExp);
-  if Expression.isGreatereqOrLesseq(inOp) and isPositive(oExp) then
-    oExp := DAE.BCONST(true);
-/*
-  elseif b and not (Expression.isConstValue(rhs) or Expression.isConstValue(lhs)) then
-    tp := Expression.typeof(oExp);
-    oExp := if Expression.isLesseqOrLess(inOp) then
-                 DAE.RELATION(Expression.makeConstZero(tp), inOp, oExp, index,optionExpisASUB)
-            else DAE.RELATION(oExp, inOp,Expression.makeConstZero(tp),index,optionExpisASUB);
-*/
+  (oExp, _) := simplify(Expression.expSub(lhs, rhs));
+  if Expression.isGreatereqOrLesseq(inOp) then
+    // lhs >= rhs holds when lhs - rhs is known to be >= 0.
+    oExp := if Expression.isPositiveOrZero(oExp) then DAE.BCONST(true) else origExp;
   else
-    if Expression.isGreatereqOrLesseq(inOp) then
-      oExp := origExp;
-    else
-      oExp := Expression.negate(oExp);
-      (oExp,_) := simplify(oExp);
-      oExp := if isPositive(oExp) then DAE.BCONST(false) else origExp;
-    end if;
+    // lhs > rhs is false when lhs - rhs is known to be <= 0. isNegativeOrZero
+    // is the structural dual of isPositiveOrZero, so it answers here what
+    // negating the difference and simplifying it a second time used to.
+    oExp := if Expression.isNegativeOrZero(oExp) then DAE.BCONST(false) else origExp;
   end if;
 end simplifyRelation2;
 

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/list/mod.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/list/mod.rs
@@ -36,9 +36,32 @@ impl<T: Clone> Drop for List<T> {
         if matches!(&**tail, List::Nil) {
             return;
         }
-        // One shared Nil per unlink walk; replacing a tail with a clone of
-        // it is just a refcount increment.
-        let nil: Arc<List<T>> = Arc::new(List::Nil);
+        // A shared tail is not ours to unlink, and dropping our reference to
+        // it only decrements its refcount, so there is nothing to do.
+        if Arc::strong_count(tail) != 1 || Arc::weak_count(tail) != 0 {
+            return;
+        }
+        // The hole left by each detached tail has to be filled with *some*
+        // `Arc<List<T>>`. Take the list's own terminating Nil rather than
+        // allocating one — a list drop is one of the compiler's most frequent
+        // operations, and `Arc::new(List::Nil)` made every one of them
+        // allocate. The scan only walks the uniquely-owned prefix, i.e. the
+        // nodes the unlink loop below is about to touch anyway; a shared
+        // suffix stops it, and then there is no reachable Nil to borrow.
+        let nil: Arc<List<T>> = {
+            let mut p: &Arc<List<T>> = tail;
+            loop {
+                match &**p {
+                    List::Nil => break p.clone(),
+                    List::Cons { tail: next, .. } => {
+                        if Arc::strong_count(next) != 1 || Arc::weak_count(next) != 0 {
+                            break Arc::new(List::Nil);
+                        }
+                        p = next;
+                    }
+                }
+            }
+        };
         let mut cur = std::mem::replace(tail, nil.clone());
         loop {
             match Arc::get_mut(&mut cur) {
@@ -304,6 +327,29 @@ mod tests {
     use arcstr::{literal, ArcStr};
     mod list_function_tests {
         use super::*;
+
+        /// A long list must be released iteratively (see `impl Drop`), and the
+        /// unlink walk must leave a shared suffix intact.
+        #[test]
+        fn test_drop_long_list_is_iterative() {
+            let mut l: Arc<List<i32>> = nil();
+            for i in 0..500_000 {
+                l = cons(i, l);
+            }
+            drop(l);
+
+            let mut shared: Arc<List<i32>> = nil();
+            for i in 0..200_000 {
+                shared = cons(i, shared);
+            }
+            let mut prefixed = shared.clone();
+            for i in 0..200_000 {
+                prefixed = cons(i, prefixed);
+            }
+            drop(prefixed);
+            assert_eq!(shared.len(), 200_000);
+            drop(shared);
+        }
 
         #[test]
         fn test_list_append() {

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
@@ -19990,22 +19990,26 @@ impl<'a> UseBeforeDef<'a> {
             }
             E::Cons { head, tail, .. } => { self.walk_exp(head, assigned); self.walk_exp(tail, assigned); }
             E::Tuple(v) | E::Array { elems: v, .. } => for x in v { self.walk_exp(x, assigned); },
-            E::Match { input, cases, .. } => {
+            E::Match { kind, input, cases, .. } => {
                 self.walk_exp(input, assigned);
                 for c in cases {
                     if let Some(g) = &c.guard { self.walk_exp(g, assigned); }
                     for (_, _, def, _) in &c.locals {
                         if let Some(d) = def { self.walk_exp(d, assigned); }
                     }
-                    // A tracked variable assigned inside an arm is threaded out
-                    // of the arm's closure (see "matchcontinue output writeback"
-                    // / "match binds outer local writeback"): the closure
-                    // prologue seeds `let mut v = v.clone();` from the *outer*
-                    // value, an implicit read of `v` before the arm runs. So any
-                    // outer var the arm writes must already be initialised.
-                    let mut arm_writes = HashSet::new();
-                    stmts_assigned_var_names(&c.stmts, &mut arm_writes);
-                    for v in &arm_writes { self.read(v, assigned); }
+                    // A matchcontinue arm is an IIFE, and a tracked variable it
+                    // assigns is threaded out of that closure: the prologue seeds
+                    // `let mut v = v.clone();` from the *outer* value (see
+                    // `init_from_outer`), an implicit read of `v` before the arm
+                    // runs, so `v` must already hold something. A plain `match`
+                    // lowers to a Rust `match` whose arms assign the outer
+                    // binding directly — no seeding read, so an arm write there
+                    // does not force the implicit default.
+                    if matches!(kind, MatchKind::MatchContinue) {
+                        let mut arm_writes = HashSet::new();
+                        stmts_assigned_var_names(&c.stmts, &mut arm_writes);
+                        for v in &arm_writes { self.read(v, assigned); }
+                    }
                     // Arm bodies run conditionally: collect their reads against a
                     // throwaway copy of `assigned` and discard any assignments
                     // they make (they are never definite for the whole match).

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -88,7 +88,6 @@ import Config;
 import DAEMode;
 import DAEUtil;
 import Debug;
-import DoubleEnded;
 import Error;
 import ErrorExt;
 import ExecStat;

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -2152,7 +2152,7 @@ protected
   list<DAE.ComponentRef> discreteModelVars;
   list<BackendDAE.TimeEvent> timeEvents;
   BackendDAE.ZeroCrossingSet zeroCrossingsSet, sampleZCSet;
-  DoubleEnded.MutableList<BackendDAE.ZeroCrossing> de_relations;
+  BackendDAE.ZeroCrossingSet de_relations;
   list<BackendDAE.ZeroCrossing> zeroCrossings, sampleZC, relations;
 
   BackendDAE.Variables daeVars, resVars, algStateVars, auxVars;
@@ -2226,7 +2226,7 @@ algorithm
     timeEvents := inBackendDAE.shared.eventInfo.timeEvents;
     (zeroCrossings,relations,sampleZC) := match inBackendDAE.shared.eventInfo
       case BackendDAE.EVENT_INFO(zeroCrossings=zeroCrossingsSet, relations=de_relations, samples=sampleZCSet)
-      then (ZeroCrossings.toList(zeroCrossingsSet), DoubleEnded.toListNoCopyNoClear(de_relations), ZeroCrossings.toList(sampleZCSet));
+      then (ZeroCrossings.toList(zeroCrossingsSet), ZeroCrossings.toList(de_relations), ZeroCrossings.toList(sampleZCSet));
     end match;
 
     // initialization stuff

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -15475,7 +15475,8 @@ protected
 algorithm
   ocode := getGlobalRoot(Global.optionSimCode);
   code := match ocode
-    case SOME(code) then code;
+    local SimCode.SimCode c;
+    case SOME(c) then c;
     else algorithm Error.addInternalError("Tried to generate code that requires the SimCode structure, but this is not set (function context?)", sourceInfo()); then fail();
   end match;
 end getSimCode;
@@ -15614,17 +15615,17 @@ public function codegenExpSanityCheck "Handle some things that Susan cannot hand
 "
   input output DAE.Exp e;
   input SimCodeFunction.Context context;
-protected
-  list<SimCodeVar.SimVar> vars;
-  SimCode.SimCode simCode;
-  Integer index;
-  list<DAE.ComponentRef> crf_lst;
 algorithm
   if SimCodeFunctionUtil.inFunctionContext(context) then
     return;
   end if;
 
   e := match e
+    local
+      list<SimCodeVar.SimVar> vars;
+      SimCode.SimCode simCode;
+      Integer index;
+      list<DAE.ComponentRef> crf_lst;
     case DAE.CREF(ty=DAE.T_ARRAY())
       algorithm
         simCode := getSimCode();

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -265,7 +265,7 @@ protected
   //list<BackendDAE.Equation> paramAsserts, remEqLst;
   list<BackendDAE.TimeEvent> timeEvents;
   BackendDAE.ZeroCrossingSet zeroCrossingsSet, sampleZCSet;
-  DoubleEnded.MutableList<BackendDAE.ZeroCrossing> de_relations;
+  BackendDAE.ZeroCrossingSet de_relations;
   list<BackendDAE.ZeroCrossing> zeroCrossings, sampleZC, relations;
   list<DAE.ClassAttributes> classAttributes;
   list<DAE.ComponentRef> discreteModelVars, iterationVarsLst1, iterationVarsLst2;
@@ -388,7 +388,7 @@ algorithm
     timeEvents := eventInfo.timeEvents;
     (zeroCrossings,relations,sampleZC) := match eventInfo
       case BackendDAE.EVENT_INFO(zeroCrossings=zeroCrossingsSet, relations=de_relations, samples=sampleZCSet)
-      then (ZeroCrossings.toList(zeroCrossingsSet), DoubleEnded.toListNoCopyNoClear(de_relations), ZeroCrossings.toList(sampleZCSet));
+      then (ZeroCrossings.toList(zeroCrossingsSet), ZeroCrossings.toList(de_relations), ZeroCrossings.toList(sampleZCSet));
     end match;
     if ifcpp then
       zeroCrossings := listAppend(relations, sampleZC);

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -75,6 +75,7 @@ protected
 import AbsynUtil;
 import Array;
 import Autoconf;
+import AvlSetInt;
 import AvlSetString;
 import AvlTreeCRToInt;
 import BackendDAEOptimize;
@@ -1536,7 +1537,7 @@ tuple<Integer /*uniqueEqIndex*/,
       list<tuple<Integer,Integer>> /*eqBackendSimCodeMapping*/,
       SimCode.BackendMapping  /*backendSimCodeMapping*/,
       Integer  /*sccOffset*/>;
-protected type CreateEquationsForSystemsArg = tuple<BackendDAE.Shared, list<BackendDAE.ZeroCrossing>, Boolean>;
+protected type CreateEquationsForSystemsArg = tuple<BackendDAE.Shared, Boolean>;
 
 protected function createEquationsForSystems "Some kind of comments would be very helpful!"
   input BackendDAE.EqSystems inSysts;
@@ -1561,11 +1562,17 @@ protected function createEquationsForSystems "Some kind of comments would be ver
 protected
   CreateEquationsForSystemsFold foldArg;
   CreateEquationsForSystemsArg arg;
+  array<AvlSetInt.Tree> zcVars;
+  Integer sysIdx = 0;
 algorithm
   try
-    arg := (shared, inAllZeroCrossings, createAlgebraicEquations);
+    arg := (shared, createAlgebraicEquations);
+    zcVars := BackendDAEUtil.zeroCrossingVarIndices(inSysts, inAllZeroCrossings);
     foldArg := (iuniqueEqIndex, {}, {}, {}, {}, itempvars, {}, {}, iBackendMapping, iSccOffset);
-    foldArg := List.fold1(inSysts, createEquationsForSystems1, arg, foldArg);
+    for syst in inSysts loop
+      sysIdx := sysIdx + 1;
+      foldArg := createEquationsForSystems1(syst, arrayGet(zcVars, sysIdx), arg, foldArg);
+    end for;
     (ouniqueEqIndex, oodeEquations, oalgebraicEquations, oallEquations, oequationsForZeroCrossings, otempvars,
     oeqSccMapping, oeqBackendSimCodeMapping, obackendMapping, oSccOffset) := foldArg;
     oequationsForZeroCrossings := Dangerous.listReverseInPlace(oequationsForZeroCrossings);
@@ -1578,6 +1585,7 @@ end createEquationsForSystems;
 
 protected function createEquationsForSystems1
   input BackendDAE.EqSystem inSyst;
+  input AvlSetInt.Tree zcVars "this system's variables occurring in a zero crossing";
   input CreateEquationsForSystemsArg inArg;
   input CreateEquationsForSystemsFold inFold;
   output CreateEquationsForSystemsFold outFold;
@@ -1596,7 +1604,6 @@ algorithm
       AvlTreePathFunction.Tree funcs;
       list<tuple<Integer,Integer>> eqSccMapping, eqBackendSimCodeMapping;
       SimCode.BackendMapping backendMapping;
-      list<BackendDAE.ZeroCrossing> zeroCrossings;
       BackendDAE.Shared shared;
       Boolean createAlgebraicEquations;
     case BackendDAE.MATCHING(ass1=ass1, comps=comps)
@@ -1605,7 +1612,7 @@ algorithm
           BackendDump.dumpEqSystemBLTmatrixHTML(inSyst);
         end if;
 
-        (shared, zeroCrossings, createAlgebraicEquations) := inArg;
+        (shared, createAlgebraicEquations) := inArg;
         (uniqueEqIndex, odeEquations, algebraicEquations, allEquations, equationsForZeroCrossings, tempvars,
          eqSccMapping, eqBackendSimCodeMapping, backendMapping, sccOffset) := inFold;
 
@@ -1615,7 +1622,7 @@ algorithm
         stateeqnsmark := arrayCreate(BackendDAEUtil.equationArraySizeDAE(syst), 0);
         zceqnsmarks := arrayCreate(BackendDAEUtil.equationArraySizeDAE(syst), 0);
         stateeqnsmark := BackendDAEUtil.markStateEquations(syst, stateeqnsmark, ass1);
-        zceqnsmarks := BackendDAEUtil.markZeroCrossingEquations(syst, zeroCrossings, zceqnsmarks, ass1);
+        zceqnsmarks := BackendDAEUtil.markZeroCrossingEquations(syst, zcVars, zceqnsmarks, ass1);
 
         (odeEquations1, algebraicEquations1, allEquations1, equationsForZeroCrossings1, uniqueEqIndex,
          tempvars, eqSccMapping, eqBackendSimCodeMapping, backendMapping) :=


### PR DESCRIPTION
Claude worked on these 8 commits:

Corpus totals from omdb master (19 800 models): backend 23.9 ks, simcode 2.9 ks. The heavy tails were ClaRa (4.6 ks), Buildings, and ScalableTestSuite. I worked the three worst models in those.

```
┌────────────────────────────────────────────────────────────┬─────────────────────────────────┬────────────────────────────────────┐
│                                                            │             before              │               after                │
├────────────────────────────────────────────────────────────┼─────────────────────────────────┼────────────────────────────────────┤
│ ClaRa TestMillBox_1 — analyzeInitialSystem                 │ 236.7 s (+224.8 s lambda0)      │ 2.3 s (+1.6 s)                     │
├────────────────────────────────────────────────────────────┼─────────────────────────────────┼────────────────────────────────────┤
│ ClaRa TestMillBox_1 — whole translation                    │ 9m26s                           │ 1m18s                              │
├────────────────────────────────────────────────────────────┼─────────────────────────────────┼────────────────────────────────────┤
│ ClaRa TestAerosolVolume — translation                      │ 200 s                           │ 43 s                               │
├────────────────────────────────────────────────────────────┼─────────────────────────────────┼────────────────────────────────────┤
│ ManyEvents_N_4000 (Rust omc)                               │ 2m12s                           │ 32.5 s                             │
├────────────────────────────────────────────────────────────┼─────────────────────────────────┼────────────────────────────────────┤
│ ManyEvents_N_4000 — findZeroCrossings / simcode (C omc)    │ 13.7 s / 27.0 s                 │ 0.37 s / 0.12 s                    │
├────────────────────────────────────────────────────────────┼─────────────────────────────────┼────────────────────────────────────┤
│ DistributionSystemModelica_N_20_M_20 (Rust omc, callgrind) │ 35.81 G Ir, 106.0 M allocations │ 32.88 G (−8.2 %), 83.7 M (−21.0 %) │
└────────────────────────────────────────────────────────────┴─────────────────────────────────┴────────────────────────────────────┘
```
The eight fixes

Four are algorithmic and help the C compiler equally, four are Rust-port work.

1. EVENT_INFO.relations was a bare list while its two siblings were tree-indexed sets, so zcIndexRelation did a List.select1 over the whole list per relation. Making it a ZeroCrossingSet made that function identical to zcIndex, so it's gone.
2. markZeroCrossingEquations ran once per equation system with the full ZC list — 1000 partitions × 1000 crossings, each miss going through getVar's three fallbacks including expandCref. New zeroCrossingVarIndices resolves all systems in one pass.
3. hashSubscripts built List.fill(1, listLength(subs)) on every cref hash purely to have something to recurse over; the dims were never used. 1.2 % of all instructions and 5.75 M of 106 M allocations.
4. List's Drop allocated a Nil to fill the hole in each detached tail — an allocation per list drop. It now borrows the list's own terminating Nil.
5. simplifyRelation2 ran the full simplifier twice for strict </>: isNegativeOrZero is the structural dual and answers the same question on the already-simplified difference.
6. mmtorust forced an implicit Default::default() on any local a match arm writes. That's only needed for a matchcontinue arm (an IIFE seeded from the outer value); a plain match assigns the outer binding directly. Default::default() cost dropped from 1149 M to 338 M instructions.
7. SimCodeUtil locals scoped to the arm that uses them (getSimCode's pattern variable was shadowing its own output).
8. The big one: balanceInitialSystem built the enhanced adjacency matrix — differentiating and simplifying every equation against every variable — whenever the initial system was unbalanced, but its only consumer returns immediately when there are no redundant equations. Merely under-determined systems, the common case, paid for it and threw it away.

Verification

Each change: bootstrapped C build (the MetaModelica type-check), byte-comparison of generated C, and testsuite subsets. In total 415 cases across events, initialization, equations, synchronous, algorithms, others, asserts, nonlinear/linear systems, flattening and the debug dumps. Generated code is identical (GUID/timestamp only) on ManyEvents_N_1000, DistributionSystemModelica_N_20_M_20, MultiBody DoublePendulum, ClaRa TestAerosolVolume, and a model written to fold relations through both simplifyRelation2 paths.