### PR TITLE
wasm-jit: four event-handling gaps against C

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -5342,8 +5342,8 @@ fn build_sim_model(
         out.extend(eqs);
         out
     };
-    let algebraic_eqs =
-        with_local_known(if has_when { all_eqs } else { flatten_eqs_ll(&sim_code.algebraicEquations) });
+    let alg_eqs_raw = if has_when { Vec::new() } else { flatten_eqs_ll(&sim_code.algebraicEquations) };
+    let algebraic_eqs = with_local_known(if has_when { all_eqs } else { alg_eqs_raw.clone() });
     let output_eqs = if has_when { flatten_eqs_ll(&sim_code.algebraicEquations) } else { Vec::new() };
     // pre := live regions, appended to the per-step (algebraic) function when the
     // model has `when`-equations (see `sim_save_pre_values`).
@@ -5571,11 +5571,11 @@ fn build_sim_model(
     // earlier ones). `parameterEquations` belongs to `functionUpdateBoundParameters`
     // alone — evaluated in both, an external object's constructor runs twice.
     let stateset_diag = stateset_diag_offsets(&sim_code.stateSets, &var_map)?;
-    let mut chunks: Vec<we::Function> = Vec::new();
+    let mut pool = ChunkPool::default();
     let mut splits: Vec<SplitFn> = Vec::new();
     let param_units: Vec<EqUnit> =
         param_bindings.iter().map(|(cref, exp)| EqUnit::Binding(cref, exp)).collect();
-    splits.push(build_split_fn("functionParameters", &param_units, 1, eqfn_type, &stateset_diag, &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
+    splits.push(build_split_fn("functionParameters", &param_units, 1, eqfn_type, &stateset_diag, &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut pool, false)?);
     // Seed `relationsPre := relations` at the end of init (the in-wasm `simulate`
     // path skips the host `run_initialization`).
     let init_save: Vec<(u32, u32, u32)> = if layout.n_rel > 0 {
@@ -5583,15 +5583,45 @@ fn build_sim_model(
     } else {
         Vec::new()
     };
-    splits.push(build_split_fn("functionInitialEquations", &eq_units(&initial_eqs), 1, eqfn_type, &[], &init_save, &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
-    // `--parmodauto`: one chunk per ODE equation, each a schedulable task.
+    splits.push(build_split_fn("functionInitialEquations", &eq_units(&initial_eqs), 1, eqfn_type, &[], &init_save, &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut pool, false)?);
+    // Three orders over one equation set, so where they agree on a run they call the
+    // same chunk. Not under `--parmodauto`, whose tasks *are* the ODE chunks.
+    let shared = match parmod_info.is_none() && !has_when {
+        true => eq_segments(&ode_task_eqs, &alg_eqs_raw, &all_eqs_for_dae),
+        false => None,
+    };
     let ode_split = splits.len();
-    if parmod_info.is_some() {
-        splits.push(build_split_fn("functionODE", &eq_units(&ode_task_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, true)?);
-    } else {
-        splits.push(build_split_fn("functionODE", &eq_units(&ode_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
-    }
-    splits.push(build_split_fn("functionAlgebraics", &eq_units(&algebraic_eqs), 1, eqfn_type, &[], &save_pre, &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
+    let dae_chunks = match shared {
+        Some(segs) => {
+            let (ode, alg, dae) = build_shared_eq_chunks(segs, &all_eqs_for_dae, &local_known_eqs, eqfn_type, &var_map, &eq_index, &by_name, &mut literals, &mut pool)?;
+            for chunks in [ode, alg] {
+                let slot = bodies.len();
+                bodies.push(empty_eqfn());
+                splits.push(SplitFn { slot, chunks, n_params: 1, pre_calls: Vec::new() });
+            }
+            Some(dae)
+        }
+        // `--parmodauto`: one chunk per ODE equation, each a schedulable task.
+        None => {
+            if parmod_info.is_some() {
+                splits.push(build_split_fn("functionODE", &eq_units(&ode_task_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut pool, true)?);
+            } else {
+                splits.push(build_split_fn("functionODE", &eq_units(&ode_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut pool, false)?);
+            }
+            // A `when`-model's `functionAlgebraics` is `functionDAE` plus
+            // `storePreValues`, so the pre-store gets a chunk of its own and the rest
+            // is shared. `save_pre` is empty otherwise.
+            let slot = bodies.len();
+            bodies.push(empty_eqfn());
+            let eqs = build_chunks("functionAlgebraics", &eq_units(&algebraic_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut pool, false)?;
+            let mut chunks = eqs.clone();
+            if !save_pre.is_empty() {
+                chunks.extend(build_chunks("storePreValues", &[], 1, eqfn_type, &[], &save_pre, &var_map, &eq_index, &by_name, &mut literals, &mut pool, false)?);
+            }
+            splits.push(SplitFn { slot, chunks, n_params: 1, pre_calls: Vec::new() });
+            has_when.then_some(eqs)
+        }
+    };
     // eq_base + 4, before `simulate` so the in-wasm integrator can call it.
     let all_reals: Vec<&SimCodeVar::SimVar> = states
         .iter()
@@ -5975,7 +6005,7 @@ fn build_sim_model(
     // first step; a stub for models that do not use `homotopy()`.
     let init_lambda0_idx = {
         let idx = import_base + bodies.len() as u32;
-        splits.push(build_split_fn("functionInitialEquations_lambda0", &eq_units(&lambda0_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
+        splits.push(build_split_fn("functionInitialEquations_lambda0", &eq_units(&lambda0_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut pool, false)?);
         idx
     };
     // Min/max variable-attribute (and equation) assertion checks: C's
@@ -5984,14 +6014,14 @@ fn build_sim_model(
     let has_asserts = !assert_eqs.is_empty();
     let check_asserts_idx = {
         let idx = import_base + bodies.len() as u32;
-        splits.push(build_split_fn("functionCheckAsserts", &eq_units(&assert_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
+        splits.push(build_split_fn("functionCheckAsserts", &eq_units(&assert_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut pool, false)?);
         idx
     };
     // C's `function_ZeroCrossingsEquations`: what the crossings read, which is
     // neither `functionODE` nor all of `functionAlgebraics`.
     let zc_equations_idx = {
         let idx = import_base + bodies.len() as u32;
-        splits.push(build_split_fn("functionZeroCrossingsEquations", &eq_units(&zc_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
+        splits.push(build_split_fn("functionZeroCrossingsEquations", &eq_units(&zc_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut pool, false)?);
         idx
     };
     // C's `functionAlgebraics` + `storePreValues`. Only a `has_when` model needs its
@@ -5999,7 +6029,7 @@ fn build_sim_model(
     let outputs_idx = {
         let idx = import_base + bodies.len() as u32;
         if has_when {
-            splits.push(build_split_fn("functionOutputs", &eq_units(&output_eqs), 1, eqfn_type, &[], &save_pre, &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
+            splits.push(build_split_fn("functionOutputs", &eq_units(&output_eqs), 1, eqfn_type, &[], &save_pre, &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut pool, false)?);
         } else {
             use we::Instruction as I;
             let mut f = we::Function::new([]);
@@ -6066,7 +6096,7 @@ fn build_sim_model(
     // perturbation IDAS made to a sensitivity parameter.
     let update_bound_params_idx = {
         let idx = import_base + bodies.len() as u32;
-        splits.push(build_split_fn("functionUpdateBoundParameters", &eq_units(&param_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
+        splits.push(build_split_fn("functionUpdateBoundParameters", &eq_units(&param_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut pool, false)?);
         idx
     };
     // The optimizer's per-real-variable attributes (C reads them out of the
@@ -6141,28 +6171,37 @@ fn build_sim_model(
     // which form the model is in.
     let dae_residuals_idx = {
         let idx = import_base + bodies.len() as u32;
-        splits.push(build_split_fn("evaluateDAEResiduals", &dae_units(&dae_eqs), 2, dae_fn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
+        splits.push(build_split_fn("evaluateDAEResiduals", &dae_units(&dae_eqs), 2, dae_fn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut pool, false)?);
         idx
     };
     // C's `symbolicInlineSystem`. Emitted (empty without `--symSolver`) either way,
     // so every module's entry points sit at the same indices.
     let sym_inline_idx = {
         let idx = import_base + bodies.len() as u32;
-        splits.push(build_split_fn("symbolicInlineSystem", &eq_units(&inline_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
+        splits.push(build_split_fn("symbolicInlineSystem", &eq_units(&inline_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut pool, false)?);
         idx
     };
 
     // C's `functionDAE`: `functionLocalKnownVars` + `allEquations` in the discrete
-    // context, which `-reconcile` re-solves the model with.
-    let recon_dae_idx = match recon.present {
-        false => None,
-        true => {
-            let idx = import_base + bodies.len() as u32;
-            let mut units = eq_units(&local_known_eqs);
-            units.extend(eq_units(&all_eqs_for_dae));
-            splits.push(build_split_fn("functionDAE", &units, 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
-            Some(idx)
+    // context, and the discrete pass wherever `functionAlgebraics` is not already the
+    // full list: the sorted order interleaves the two subsets, so `functionODE` then
+    // `functionAlgebraics` would read an algebraic variable one pass stale. Exported
+    // from every model, as `MODEL_FNS` promises the runtimes that import it by name.
+    let dae_entry_idx = {
+        let idx = import_base + bodies.len() as u32;
+        match dae_chunks {
+            Some(chunks) => {
+                let slot = bodies.len();
+                bodies.push(empty_eqfn());
+                splits.push(SplitFn { slot, chunks, n_params: 1, pre_calls: Vec::new() });
+            }
+            None => {
+                let mut units = eq_units(&local_known_eqs);
+                units.extend(eq_units(&all_eqs_for_dae));
+                splits.push(build_split_fn("functionDAE", &units, 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut pool, false)?);
+            }
         }
+        idx
     };
 
     // `parmodTask(sim_data, k)` `call_indirect`s task `k` out of the module's own table 1.
@@ -6170,7 +6209,7 @@ fn build_sim_model(
         false => None,
         true => {
             let lk_idx = import_base + bodies.len() as u32;
-            splits.push(build_split_fn("functionLocalKnownVars", &eq_units(&local_known_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut chunks, false)?);
+            splits.push(build_split_fn("functionLocalKnownVars", &eq_units(&local_known_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut pool, false)?);
             splits[ode_split].pre_calls.push(lk_idx);
             let task_idx = import_base + bodies.len() as u32;
             let mut f = we::Function::new([]);
@@ -6184,15 +6223,15 @@ fn build_sim_model(
     };
 
     // The chunks, after all fixed-index bodies; each entry point's placeholder
-    // becomes a thunk calling its own.
+    // becomes a thunk calling the ones it needs.
     let chunk_base = import_base + bodies.len() as u32;
-    bodies.extend(chunks);
+    let ChunkPool { fns: chunk_fns, meta: chunk_meta } = pool;
+    bodies.extend(chunk_fns);
     for s in &splits {
         bodies[s.slot] = s.thunk(chunk_base);
     }
     let parmod_tasks: Option<Vec<u32>> = parmod_fns.map(|_| {
-        let s = &splits[ode_split];
-        (0..s.count).map(|k| chunk_base + (s.first + k) as u32).collect()
+        splits[ode_split].chunks.iter().map(|c| chunk_base + *c as u32).collect()
     });
 
     // --- Function section (type index per body, in body order). ---
@@ -6263,17 +6302,13 @@ fn build_sim_model(
     functions.function(eqfn_type); // functionRemovedInitialEquations: (i32) -> ()
     functions.function(dae_fn_type); // evaluateDAEResiduals: (i32, i32) -> ()
     functions.function(eqfn_type); // symbolicInlineSystem: (i32) -> ()
-    if recon_dae_idx.is_some() {
-        functions.function(eqfn_type); // functionDAE: (i32) -> ()
-    }
+    functions.function(eqfn_type); // functionDAE: (i32) -> ()
     if parmod_fns.is_some() {
         functions.function(eqfn_type); // functionLocalKnownVars: (i32) -> ()
         functions.function(dae_fn_type); // parmodTask: (i32 SimData, i32 task) -> ()
     }
-    for s in &splits {
-        for _ in 0..s.count {
-            functions.function(s.ty);
-        }
+    for (ty, _) in &chunk_meta {
+        functions.function(*ty);
     }
 
     // --- Shared literals, closure thunks and the module `start`. Both come after
@@ -6380,6 +6415,7 @@ fn build_sim_model(
         ("functionRemovedInitialEquations", removed_init_idx),
         ("functionInitSynchronous", sync_idx.0),
         ("symbolicInlineSystem", sym_inline_idx),
+        ("functionDAE", dae_entry_idx),
         ("linearJacA", linz_jac_idx),
         ("linearJacB", linz_jac_idx + 1),
         ("linearJacC", linz_jac_idx + 2),
@@ -6450,9 +6486,7 @@ fn build_sim_model(
             exports.export(name, we::ExportKind::Func, base + k as u32);
         }
     }
-    if let Some(idx) = recon_dae_idx {
-        exports.export("functionDAE", we::ExportKind::Func, idx);
-    }
+    exports.export("functionDAE", we::ExportKind::Func, dae_entry_idx);
     let (sync_init, sync_update, sync_eqs) = sync_idx;
     exports.export("functionRemovedInitialEquations", we::ExportKind::Func, removed_init_idx);
     exports.export("functionInitSynchronous", we::ExportKind::Func, sync_init);
@@ -6531,9 +6565,7 @@ fn build_sim_model(
             names.push((base + k as u32, name.to_string()));
         }
     }
-    if let Some(idx) = recon_dae_idx {
-        names.push((idx, "functionDAE".to_string()));
-    }
+    names.push((dae_entry_idx, "functionDAE".to_string()));
     names.push((sync_init, "functionInitSynchronous".to_string()));
     names.push((sync_update, "functionUpdateSynchronous".to_string()));
     names.push((sync_eqs, "functionEquationsSynchronous".to_string()));
@@ -6543,10 +6575,8 @@ fn build_sim_model(
         names.push((lk_idx, "functionLocalKnownVars".to_string()));
         names.push((task_idx, "parmodTask".to_string()));
     }
-    for s in &splits {
-        for k in 0..s.count {
-            names.push((chunk_base + (s.first + k) as u32, format!("{}${k}", s.name)));
-        }
+    for (k, (_, name)) in chunk_meta.iter().enumerate() {
+        names.push((chunk_base + k as u32, name.clone()));
     }
     names.sort_by_key(|(idx, _)| *idx);
     let mut fn_names = we::NameMap::new();
@@ -7921,16 +7951,13 @@ fn chunk_instrs() -> usize {
 /// the end of module assembly: the entry point is reserved as a placeholder body
 /// and filled in with [`SplitFn::thunk`] there.
 struct SplitFn {
-    /// Entry-point name, which the chunks extend (`functionODE$3`).
-    name: &'static str,
     /// Body-list slot reserved for the entry point.
     slot: usize,
-    /// This entry point's chunks in the module's chunk list.
-    first: usize,
-    count: usize,
+    /// This entry point's chunks, by position in [`ChunkPool`]. Entry points that
+    /// evaluate the same equations share them (see [`eq_segments`]).
+    chunks: Vec<usize>,
     /// `(SimData*)`, plus DAE mode's `stage`.
     n_params: u32,
-    ty: u32,
     /// Entry points called (with the same arguments) ahead of the chunks.
     pre_calls: Vec<u32>,
 }
@@ -7939,24 +7966,43 @@ impl SplitFn {
     fn thunk(&self, chunk_base: u32) -> we::Function {
         use we::Instruction as I;
         let mut f = we::Function::new([]);
+        let mut call = |f: &mut we::Function, idx: u32| {
+            for p in 0..self.n_params {
+                f.instruction(&I::LocalGet(p));
+            }
+            f.instruction(&I::Call(idx));
+        };
         for c in &self.pre_calls {
-            for p in 0..self.n_params {
-                f.instruction(&I::LocalGet(p));
-            }
-            f.instruction(&I::Call(*c));
+            call(&mut f, *c);
         }
-        for k in 0..self.count {
-            for p in 0..self.n_params {
-                f.instruction(&I::LocalGet(p));
-            }
-            f.instruction(&I::Call(chunk_base + (self.first + k) as u32));
+        for c in &self.chunks {
+            call(&mut f, chunk_base + *c as u32);
         }
         f.instruction(&I::End);
         f
     }
 }
 
-/// Lower `units` into chunk functions appended to `chunks`, reserving a `bodies`
+/// The module's chunk functions, emitted after every fixed-index body. An entry
+/// point names them by pool position, and several may name the same one.
+#[derive(Default)]
+struct ChunkPool {
+    fns: Vec<we::Function>,
+    /// Per chunk, for the function and name sections.
+    meta: Vec<(u32, String)>,
+}
+
+impl ChunkPool {
+    fn len(&self) -> usize {
+        self.fns.len()
+    }
+    fn push(&mut self, f: we::Function, ty: u32, name: String) {
+        self.fns.push(f);
+        self.meta.push((ty, name));
+    }
+}
+
+/// Lower `units` into chunk functions appended to `pool`, reserving a `bodies`
 /// slot for the entry point that calls them. `stateset_diag` heads the first chunk
 /// and `save_pre` tails the last; with no units at all they get a chunk to
 /// themselves. Cuts only happen where no constant-store stretch is open, so
@@ -7974,18 +8020,40 @@ fn build_split_fn(
     by_name: &HashMap<String, FnInfo>,
     literals: &mut Literals,
     bodies: &mut Vec<we::Function>,
-    chunks: &mut Vec<we::Function>,
+    pool: &mut ChunkPool,
     per_unit: bool,
 ) -> Result<SplitFn> {
     let slot = bodies.len();
     bodies.push(empty_eqfn());
-    let first = chunks.len();
+    let chunks = build_chunks(
+        name, units, n_params, ty, stateset_diag, save_pre, var_map, eq_index, by_name, literals,
+        pool, per_unit,
+    )?;
+    Ok(SplitFn { slot, chunks, n_params, pre_calls: Vec::new() })
+}
+
+/// [`build_split_fn`] without an entry point of its own.
+#[allow(clippy::too_many_arguments)]
+fn build_chunks(
+    name: &str,
+    units: &[EqUnit],
+    n_params: u32,
+    ty: u32,
+    stateset_diag: &[u32],
+    save_pre: &[(u32, u32, u32)],
+    var_map: &SimVarMap,
+    eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
+    by_name: &HashMap<String, FnInfo>,
+    literals: &mut Literals,
+    pool: &mut ChunkPool,
+    per_unit: bool,
+) -> Result<Vec<usize>> {
+    let first = pool.len();
     let mut i = 0usize;
-    while i < units.len()
-        || (chunks.len() == first && !(stateset_diag.is_empty() && save_pre.is_empty()))
+    while i < units.len() || (pool.len() == first && !(stateset_diag.is_empty() && save_pre.is_empty()))
     {
         let mut ctx = FnCtx::new_sim_params(sim_ctx(var_map), by_name, &mut *literals, n_params);
-        if chunks.len() == first {
+        if pool.len() == first {
             ctx.emit_stateset_diag_init(stateset_diag)?;
         }
         let mut pending: BTreeMap<u32, Vec<u8>> = BTreeMap::new();
@@ -8005,9 +8073,114 @@ fn build_split_fn(
         if i == units.len() {
             ctx.sim_save_pre_values(save_pre)?;
         }
-        chunks.push(finish_fn(ctx));
+        pool.push(finish_fn(ctx), ty, format!("{name}${}", pool.len() - first));
     }
-    Ok(SplitFn { name, slot, first, count: chunks.len() - first, n_params, ty, pre_calls: Vec::new() })
+    Ok((first..pool.len()).collect())
+}
+
+/// A run of `allEquations` that is also a run of the `odeEquations` or
+/// `algebraicEquations` list holding it, so its chunks serve both entry points, the
+/// way C's `eqFunction_<n>` do.
+struct EqSegment {
+    ode: bool,
+    /// Where the run starts in its own list.
+    pos: usize,
+    /// Where it sits in `allEquations`.
+    span: core::ops::Range<usize>,
+    chunks: Vec<usize>,
+}
+
+/// The equation's own index, including the forms [`eq_index_of`] leaves at -1.
+fn eq_id_of(eq: &SimCode::SimEqSystem) -> i32 {
+    use SimCode::SimEqSystem as E;
+    match eq {
+        E::SES_ALIAS { index, .. } | E::SES_FOR_EQUATION { index, .. } => *index,
+        _ => eq_index_of(eq),
+    }
+}
+
+/// Cut `all` (C's `allEquations`) into runs shared with `ode`/`alg`; `None` unless
+/// the two tile it, which leaves the caller lowering a copy of its own.
+///
+/// The orders differ by more than the interleaving -- `algebraicEquations` ends with
+/// C's `removedEquations` reversed -- so that tail comes back one equation per run.
+fn eq_segments(
+    ode: &[Arc<SimCode::SimEqSystem>],
+    alg: &[Arc<SimCode::SimEqSystem>],
+    all: &[Arc<SimCode::SimEqSystem>],
+) -> Option<Vec<EqSegment>> {
+    if all.len() != ode.len() + alg.len() {
+        return None;
+    }
+    let mut own: HashMap<i32, (bool, usize)> = HashMap::new();
+    for (is_ode, eqs) in [(true, ode), (false, alg)] {
+        for (pos, e) in eqs.iter().enumerate() {
+            if own.insert(eq_id_of(e), (is_ode, pos)).is_some() {
+                return None;
+            }
+        }
+    }
+    let mut segs: Vec<EqSegment> = Vec::new();
+    for (i, e) in all.iter().enumerate() {
+        let &(is_ode, pos) = own.get(&eq_id_of(e))?;
+        match segs.last_mut() {
+            Some(s) if s.ode == is_ode && s.pos + s.span.len() == pos => s.span.end = i + 1,
+            _ => segs.push(EqSegment { ode: is_ode, pos, span: i..i + 1, chunks: Vec::new() }),
+        }
+    }
+    // An entry point calls its own segments in its list's order, so they must tile it.
+    for (is_ode, len) in [(true, ode.len()), (false, alg.len())] {
+        let mut runs: Vec<(usize, usize)> =
+            segs.iter().filter(|s| s.ode == is_ode).map(|s| (s.pos, s.span.len())).collect();
+        runs.sort_unstable();
+        let mut next = 0;
+        for (pos, n) in runs {
+            if pos != next {
+                return None;
+            }
+            next += n;
+        }
+        if next != len {
+            return None;
+        }
+    }
+    Some(segs)
+}
+
+/// Lower the segments once; the three entry points' chunk lists come back, each
+/// headed by `functionLocalKnownVars` as C's are.
+#[allow(clippy::too_many_arguments)]
+fn build_shared_eq_chunks(
+    mut segs: Vec<EqSegment>,
+    all: &[Arc<SimCode::SimEqSystem>],
+    local_known: &[Arc<SimCode::SimEqSystem>],
+    ty: u32,
+    var_map: &SimVarMap,
+    eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
+    by_name: &HashMap<String, FnInfo>,
+    literals: &mut Literals,
+    pool: &mut ChunkPool,
+) -> Result<(Vec<usize>, Vec<usize>, Vec<usize>)> {
+    let head = build_chunks(
+        "functionLocalKnownVars", &eq_units(local_known), 1, ty, &[], &[], var_map, eq_index,
+        by_name, literals, pool, false,
+    )?;
+    for seg in &mut segs {
+        let name = format!("eqFunction_{}", eq_id_of(&all[seg.span.start]));
+        seg.chunks = build_chunks(
+            &name, &eq_units(&all[seg.span.clone()]), 1, ty, &[], &[], var_map, eq_index, by_name,
+            literals, pool, false,
+        )?;
+    }
+    let call = |segs: &[&EqSegment]| -> Vec<usize> {
+        head.iter().copied().chain(segs.iter().flat_map(|s| s.chunks.iter().copied())).collect()
+    };
+    let own = |ode: bool| -> Vec<&EqSegment> {
+        let mut own: Vec<&EqSegment> = segs.iter().filter(|s| s.ode == ode).collect();
+        own.sort_by_key(|s| s.pos);
+        own
+    };
+    Ok((call(&own(true)), call(&own(false)), call(&segs.iter().collect::<Vec<_>>())))
 }
 
 /// Lower `units` into one function, for entry points whose size is bounded by the

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -4737,12 +4737,22 @@ fn emit_model_error(ctx: &mut FnCtx) -> Result<()> {
     emit_sim_data_or_zero(ctx);
     emit_initial_flag(ctx);
     ctx.emit(I::Call(rt_index("rt_assert_common")?));
+    let taken = ctx.alloc_temp(WTy::I32);
+    ctx.emit(I::LocalSet(taken));
+    ctx.emit(I::LocalGet(taken));
+    ctx.emit(I::I32Const(1));
+    ctx.emit(I::I32Eq);
     ctx.emit(I::If(we::BlockType::Empty));
     release_heap_locals(ctx)?;
     push_outputs(ctx);
     ctx.emit(I::Return);
     ctx.emit(I::End);
+    // 2 is C's `noThrowAsserts`: fall through and use the out-of-domain value.
+    ctx.emit(I::LocalGet(taken));
+    ctx.emit(I::I32Eqz);
+    ctx.emit(I::If(we::BlockType::Empty));
     emit_assert_unwind(ctx);
+    ctx.emit(I::End);
     Ok(())
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -167,14 +167,51 @@ pub extern "C" fn rt_nls_assert_failed(
     }
 }
 
+/// Arm C's `needToReThrow` where the `noThrowAsserts` window is open. The driver
+/// holding it is this module's or the host's, never both.
+fn note_no_throw_assert() -> bool {
+    if openmodelica_sim_meta::driver::note_no_throw_assert() {
+        return true;
+    }
+    #[cfg(all(target_arch = "wasm32", feature = "host_log", not(feature = "standalone")))]
+    {
+        #[link(wasm_import_module = "env")]
+        unsafe extern "C" {
+            fn rt_host_note_no_throw_assert() -> i32;
+        }
+        return unsafe { rt_host_note_no_throw_assert() } != 0;
+    }
+    #[cfg(not(all(target_arch = "wasm32", feature = "host_log", not(feature = "standalone"))))]
+    false
+}
+
 /// C's `assertCommonVar` (a math builtin's domain guard): `omc_assert_warning`
 /// heads the `LOG_ASSERT` block and `throwStreamPrintWithEquationIndexes` adds the
 /// message, both before `getBestJumpBuffer` picks the jump buffer — so a fatal
-/// violation reports exactly as a caught one does. Returns non-zero where a solver
-/// residual or the step catches it, so the caller returns instead of unwinding.
-/// `msg` is this call's to release.
+/// violation reports exactly as a caught one does. `msg` is this call's to release.
+///
+/// Returns 0 where the caller must unwind, 1 where a solver residual or the step
+/// catches it (the caller returns instead), and 2 inside `noThrowAsserts`, where C
+/// logs the violation and carries on with the out-of-domain value.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_assert_common(msg: i32, sim_data: i32, initial: i32) -> i32 {
+    if note_no_throw_assert() {
+        use openmodelica_sim_meta::TIME_OFF;
+        let time = if sim_data != 0 { unsafe { load_f64(sim_data as u32 + TIME_OFF) } } else { 0.0 };
+        crate::omclog::info(
+            crate::omclog::ASSERT,
+            false,
+            &alloc::format!(
+                "The following assertion has been violated {}at time {}",
+                if initial != 0 { "during initialization " } else { "" },
+                crate::omclog::f(time, 0, 6)
+            ),
+        );
+        if msg != 0 {
+            crate::rt_release(msg as u32);
+        }
+        return 2;
+    }
     let caught = nls::error_caught();
     if nls::throw_reports() {
         use openmodelica_sim_meta::TIME_OFF;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -58,6 +58,7 @@ unsafe extern "C" {
     fn initSample(sim_data: u32);
     fn callExternalObjectDestructors(sim_data: u32);
     fn symbolicInlineSystem(sim_data: u32);
+    fn functionDAE(sim_data: u32);
     fn linearJacA(sim_data: u32);
     fn linearJacB(sim_data: u32);
     fn linearJacC(sim_data: u32);
@@ -128,6 +129,7 @@ impl SimEngine for StandaloneEngine {
                 "initSample" => initSample(arg),
                 "callExternalObjectDestructors" => callExternalObjectDestructors(arg),
                 "symbolicInlineSystem" => symbolicInlineSystem(arg),
+                "functionDAE" => functionDAE(arg),
                 "linearJacA" => linearJacA(arg),
                 "linearJacB" => linearJacB(arg),
                 "linearJacC" => linearJacC(arg),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -119,6 +119,8 @@ unsafe extern "C" {
     fn callExternalObjectDestructors_guard(sim_data: u32) -> u32;
     #[link_name = "symbolicInlineSystem$guard"]
     fn symbolicInlineSystem_guard(sim_data: u32) -> u32;
+    #[link_name = "functionDAE$guard"]
+    fn functionDAE_guard(sim_data: u32) -> u32;
 }
 
 // ── Messages ─────────────────────────────────────────────────────────────────
@@ -403,6 +405,7 @@ impl SimEngine for Engine {
                 "functionInitSynchronous" => functionInitSynchronous_guard(arg),
                 "callExternalObjectDestructors" => callExternalObjectDestructors_guard(arg),
                 "symbolicInlineSystem" => symbolicInlineSystem_guard(arg),
+                "functionDAE" => functionDAE_guard(arg),
                 #[cfg(all(feature = "me", feature = "cs"))]
                 "linearJacA" => linearJacA_guard(arg),
                 #[cfg(all(feature = "me", feature = "cs"))]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_sim_meta/src/driver.rs
@@ -583,10 +583,9 @@ pub trait SimEngine {
     fn no_throw_div_zero_addr(&mut self) -> u32 {
         0
     }
-    /// Whether the model has its own discrete-pass entry point (C's generated
-    /// `functionDAE`, which evaluates `allEquations` with `discreteCall` raised).
-    /// A wasm-jit module has none -- there the pass is `functionAlgebraics` --
-    /// so the default keeps [`eval_discrete`]'s split.
+    /// Whether [`eval_discrete`] should call the model's own `functionDAE` (C's
+    /// generated one, `allEquations` with `discreteCall` raised). A wasm-jit module
+    /// always exports one, so there `has_when` decides instead.
     fn has_discrete_entry(&self) -> bool {
         false
     }
@@ -1950,6 +1949,7 @@ mod rethrow_store {
         std::thread_local! {
             static PENDING: RefCell<Option<AssertInfo>> = const { RefCell::new(None) };
             static EVENT: Cell<bool> = const { Cell::new(false) };
+            static NOTED: Cell<bool> = const { Cell::new(false) };
         }
         pub fn arm(info: AssertInfo) {
             PENDING.with(|p| {
@@ -1962,17 +1962,24 @@ mod rethrow_store {
         pub fn note_event() {
             EVENT.with(|ev| ev.set(true));
         }
-        pub fn take() -> (Option<AssertInfo>, bool) {
-            (PENDING.with(|p| p.borrow_mut().take()), EVENT.with(|ev| ev.replace(false)))
+        pub fn note() {
+            NOTED.with(|n| n.set(true));
+        }
+        pub fn take() -> (Option<AssertInfo>, bool, bool) {
+            (
+                PENDING.with(|p| p.borrow_mut().take()),
+                EVENT.with(|ev| ev.replace(false)),
+                NOTED.with(|n| n.replace(false)),
+            )
         }
     }
     #[cfg(not(feature = "std"))]
     mod imp {
         use super::AssertInfo;
         use core::cell::UnsafeCell;
-        struct Store(UnsafeCell<(Option<AssertInfo>, bool)>);
+        struct Store(UnsafeCell<(Option<AssertInfo>, bool, bool)>);
         unsafe impl Sync for Store {}
-        static PENDING: Store = Store(UnsafeCell::new((None, false)));
+        static PENDING: Store = Store(UnsafeCell::new((None, false, false)));
         pub fn arm(info: AssertInfo) {
             unsafe {
                 let st = &mut *PENDING.0.get();
@@ -1984,14 +1991,27 @@ mod rethrow_store {
         pub fn note_event() {
             unsafe { (*PENDING.0.get()).1 = true };
         }
-        pub fn take() -> (Option<AssertInfo>, bool) {
+        pub fn note() {
+            unsafe { (*PENDING.0.get()).2 = true };
+        }
+        pub fn take() -> (Option<AssertInfo>, bool, bool) {
             unsafe {
                 let st = &mut *PENDING.0.get();
-                (st.0.take(), core::mem::replace(&mut st.1, false))
+                (st.0.take(), core::mem::replace(&mut st.1, false), core::mem::replace(&mut st.2, false))
             }
         }
     }
-    pub use imp::{arm, note_event, take};
+    pub use imp::{arm, note, note_event, take};
+}
+
+/// C's `assertCommonVar` under `noThrowAsserts`: arm `needToReThrow` and report
+/// that the caller may carry on with the out-of-domain value instead of throwing.
+pub fn note_no_throw_assert() -> bool {
+    if !NO_THROW.load(Ordering::Relaxed) {
+        return false;
+    }
+    rethrow_store::note();
+    true
 }
 
 /// Enter C's `noThrowAsserts` phase: a failed `assert()` is recorded, not thrown.
@@ -2006,8 +2026,8 @@ fn close_assert_window(e: &mut dyn SimEngine, sim_data: u32) -> Result<()> {
     set_no_throw(false);
     drain_asserts(e, sim_data, omclog::INFO)?;
     let noted = e.take_noted_assert();
-    let (info, found_event) = rethrow_store::take();
-    if info.is_none() && !noted {
+    let (info, found_event, self_noted) = rethrow_store::take();
+    if info.is_none() && !noted && !self_noted {
         return Ok(());
     }
     if found_event {
@@ -2888,19 +2908,15 @@ fn eval_ode(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<
     e.call1("functionODE", sim_data)
 }
 
-/// One pass of C's `functionDAE`, which evaluates `allEquations` once. With
-/// `when`-equations `functionAlgebraics` *is* that list, so `functionODE` first
-/// would solve the algebraic loops a second time against the previous pass's
-/// discrete state -- a switch configuration C never solves for.
+/// One pass of C's `functionDAE`, which evaluates `allEquations` once. A
+/// `when`-model takes it through `functionAlgebraics`, which is that list plus
+/// `storePreValues`.
 fn eval_discrete(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
     if layout.dae_mode() {
         return e.call2(MODEL_FN_DAE, sim_data, eval_stage::DISCRETE);
     }
-    if e.has_discrete_entry() {
+    if e.has_discrete_entry() || !layout.has_when {
         return e.call1("functionDAE", sim_data);
-    }
-    if !layout.has_when {
-        e.call1("functionODE", sim_data)?;
     }
     e.call1("functionAlgebraics", sim_data)
 }
@@ -6557,7 +6573,7 @@ impl IdaState {
             return Err("CodegenWasmJit: IDA setup failed");
         }
         if self.setup.dae.is_some() {
-            dae_calc_ic(ida, t)?;
+            dae_calc_ic(ida, t, self.rtol)?;
             y.copy_from_slice(ida.y());
             yp.copy_from_slice(ida.yp());
             self.setup.dae_store(e, sim_data, y, yp)?;
@@ -7114,28 +7130,38 @@ impl SolverCore {
         }
     }
 
-    /// The `IDACalcIC` half of C's `ida_event_update`, run after `restart` has
-    /// re-initialized IDA at the post-event state: consistent algebraic unknowns and
-    /// derivatives, pushed back into `SimData`. `ctx` must be the live callback
-    /// context — `IDACalcIC` evaluates the residual.
+    /// C's `ida_event_update`, which DAE mode installs as `functionDAE`: residuals in
+    /// the discrete context, re-initialize at what they leave behind, `IDACalcIC` for
+    /// the algebraic unknowns and derivatives, answer back into `SimData`. `ctx` must
+    /// be the live callback context — `IDACalcIC` evaluates the residual.
     fn dae_restart(&mut self, e: &mut (dyn SimEngine + 'static), ctx: *mut ResCtx) -> Result<()> {
-        if !self.dae {
-            return Ok(());
-        }
         let _ = ctx; // DAE mode needs SUNDIALS, so without it there is nothing to do
+        e.call2(MODEL_FN_DAE, self.sim_data, eval_stage::DISCRETE)?;
+        self.read_states(e)?;
+        self.restart()?;
         #[cfg(sundials)]
-        if let Solver::Ida(s) = &mut self.solver {
-            let Some(ida) = s.ida.as_mut() else { return Ok(()) };
+        if let Solver::Ida(s) = &mut self.solver
+            && let Some(ida) = s.ida.as_mut()
+        {
             if !ida.set_user_data(ctx as *mut core::ffi::c_void) {
                 return Err("CodegenWasmJit: IDA setup failed");
             }
-            dae_calc_ic(ida, self.t)?;
+            dae_calc_ic(ida, self.t, self.tol)?;
             self.y.copy_from_slice(ida.y());
             self.yp.copy_from_slice(ida.yp());
-            self.write_states(e)?;
-            e.call2(MODEL_FN_DAE, self.sim_data, eval_stage::DISCRETE)?;
         }
+        e.call2(MODEL_FN_DAE, self.sim_data, eval_stage::DISCRETE)?;
+        self.write_states(e)?;
         Ok(())
+    }
+
+    /// C's `didEventStep`: drop the step history at the post-event state, which in
+    /// DAE mode means the whole of `dae_restart`.
+    fn event_restart(&mut self, e: &mut (dyn SimEngine + 'static), ctx: *mut ResCtx) -> Result<()> {
+        match self.dae {
+            true => self.dae_restart(e, ctx),
+            false => self.restart(),
+        }
     }
 
     /// The `IDACalcIC` C's initialization performs before the first output row —
@@ -7234,8 +7260,11 @@ impl SolverCore {
     fn restart(&mut self) -> Result<()> {
         match &mut self.solver {
             Solver::Daskr(d) => {
-                d.past.fold(&d.iwork);
-                d.info[0] = 0; // INFO(1)=0
+                // C's `dasslAvoidEventRestart`: `-noRestart` keeps the BDF history.
+                if !crate::simflags::with_flags(|f| f.no_restart) {
+                    d.past.fold(&d.iwork);
+                    d.info[0] = 0; // INFO(1)=0
+                }
             }
             #[cfg(sundials)]
             Solver::Cvode(c) => {
@@ -7265,13 +7294,6 @@ impl SolverCore {
         Ok(())
     }
 
-    /// A time event changes discrete state the derivative may depend on, so a
-    /// solver that carries its own step history has to re-initialize. gbode and the
-    /// sym solvers always do, as C's `didEventStep` is set for time events too.
-    fn restart_after_time_event(&self) -> bool {
-        matches!(self.solver, Solver::Gbode(_) | Solver::Sym(_))
-    }
-
     /// Recompute `yp` after an event, as C's `updateContinuousSystem` does: a
     /// `reinit` otherwise leaves the next step on the pre-event derivative.
     fn refresh_yp(&mut self, e: &mut (dyn SimEngine + 'static)) -> Result<()> {
@@ -7287,14 +7309,14 @@ impl SolverCore {
 
     /// Latch `(y, yp)` from `SimData` — after initialization, or after anything
     /// that moved a state behind DASKR's back. In DAE mode the algebraic unknowns
-    /// follow the states in `y` (C's `getAlgebraicDAEVars`); their `y'` entries stay
-    /// zero, as C's `calloc`'d `statesDer` leaves them.
+    /// follow the states in `y` (C's `getAlgebraicDAEVars`); only the states' `y'`
+    /// moves, as C's `statesDer` keeps what the last `IDAGetConsistentIC` left there.
     fn read_states(&mut self, e: &mut (dyn SimEngine + 'static)) -> Result<()> {
         self.read_y(e)?;
-        self.yp = (0..self.n_states)
-            .map(|i| read_f64(e, self.ders_base + (i as u32) * 8))
-            .collect::<Result<_>>()?;
         self.yp.resize(self.n_unknowns, 0.0);
+        for i in 0..self.n_states {
+            self.yp[i] = read_f64(e, self.ders_base + (i as u32) * 8)?;
+        }
         Ok(())
     }
 
@@ -7631,8 +7653,7 @@ impl SolverCore {
         // No `functionODE`: `event_update` left the derivative slots consistent, and
         // C restarts DASKR on the `YPRIME` in its ring buffer.
         self.read_states(e)?;
-        self.restart()?;
-        self.dae_restart(e, ctx)?;
+        self.event_restart(e, ctx)?;
         Ok(false)
     }
 
@@ -7659,7 +7680,6 @@ impl SolverCore {
         let layout = &model.layout;
         let sim_data = self.sim_data;
         let n_states = self.n_states;
-        let ders_base = self.ders_base;
         let span = model.stop_time - model.start_time;
         let eps = reached_eps(tout, span);
         let step_eps = small_step_eps(span);
@@ -7832,8 +7852,7 @@ impl SolverCore {
                     // Re-read states (a reinit may have jumped one) and restart DASKR
                     // at troot (INFO(1)=0); see `handle_zc_flips` for the `functionODE`.
                     self.read_states(e)?;
-                    self.restart()?;
-                    self.dae_restart(e, ctx)?;
+                    self.event_restart(e, ctx)?;
                     if tout - troot < GRID_SKIP_EPS {
                         grid_covered = true;
                     }
@@ -7886,13 +7905,9 @@ impl SolverCore {
                     return Ok(Step::Terminated);
                 }
                 self.read_y(e)?;
-                // A sample may change discrete state the derivative depends on;
-                // recompute yp and restart so the integrator continues consistently.
+                // C sets `didEventStep` for a time event too.
                 self.refresh_yp(e)?;
-                if layout.n_zc > 0 || self.dae || self.restart_after_time_event() {
-                    self.restart()?;
-                    self.dae_restart(e, ctx)?;
-                }
+                self.event_restart(e, ctx)?;
                 if tout - te < GRID_SKIP_EPS {
                     grid_covered = true;
                 }
@@ -7914,8 +7929,7 @@ impl SolverCore {
                     store_operators(e, sim_data, layout)?;
                     self.read_y(e)?;
                     self.refresh_yp(e)?;
-                    self.restart()?;
-                    self.dae_restart(e, ctx)?;
+                    self.event_restart(e, ctx)?;
                     if tout - target < GRID_SKIP_EPS {
                         grid_covered = true;
                     }
@@ -8269,8 +8283,7 @@ impl CsDriver {
                     self.core.refresh_yp(e)?;
                 }
             }
-            self.core.restart()?;
-            self.core.dae_restart(e, &mut ctx as *mut ResCtx)?;
+            self.core.event_restart(e, &mut ctx as *mut ResCtx)?;
         }
         let mut did_step = false;
         loop {
@@ -9237,8 +9250,9 @@ struct DaeSolve {
 }
 
 #[cfg(sundials)]
-fn dae_calc_ic(ida: &mut crate::sundials::Ida, t: f64) -> Result<()> {
-    match ida.calc_ic_at(t) {
+fn dae_calc_ic(ida: &mut crate::sundials::Ida, t: f64, tol: f64) -> Result<()> {
+    omclog::info(omclog::SOLVER, false, &format!("##IDA## do event update at {}", format_g(t, 15)));
+    match ida.calc_ic_at(t, tol) {
         true => Ok(()),
         false => Err("CodegenWasmJit: IDA could not find consistent initial conditions (IDACalcIC)"),
     }
@@ -9652,6 +9666,7 @@ unsafe extern "C" fn ida_jac(
         },
         None => unsafe { core::slice::from_raw_parts_mut(crate::sundials::dense_data(j), n * n) },
     };
+    vals.fill(0.0); // C's `SUNMatZero`: the widened diagonal has no difference to carry
     ctx.jac_gp.resize(n, 0.0);
     ctx.nje += 1;
     // C's `jacColoredSymbolicalSparse` / `jacColoredSymbolicalDense`. IDA's residual
@@ -9664,9 +9679,12 @@ unsafe extern "C" fn ida_jac(
                     None => col * n + row,
                 }] = v;
             })?;
-            // -cj·∂F/∂y' = -cj·I, which the column equations do not carry.
-            for col in 0..n {
-                vals[pattern.map_or(col * n + col, |p| p.diag[col])] -= cj;
+            // -cj·∂F/∂y' = -cj·I, which the column equations do not carry. C adds it
+            // for an ODE only; a DAE pattern is not widened and has no diagonal slot.
+            if dae.is_none() {
+                for col in 0..n {
+                    vals[pattern.map_or(col * n + col, |p| p.diag[col])] -= cj;
+                }
             }
             Ok(())
         })();

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/sundials.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/sundials.rs
@@ -483,6 +483,7 @@ unsafe extern "C" {
     fn IDAGetCurrentStep(mem: *mut c_void, hcur: *mut f64) -> c_int;
 
     fn IDAGetNumSteps(mem: *mut c_void, n: *mut c_long) -> c_int;
+    fn IDAGetNumNonlinSolvIters(mem: *mut c_void, n: *mut c_long) -> c_int;
     fn IDAGetNumResEvals(mem: *mut c_void, n: *mut c_long) -> c_int;
     fn IDAGetNumJacEvals(mem: *mut c_void, n: *mut c_long) -> c_int;
     fn IDAGetNumErrTestFails(mem: *mut c_void, n: *mut c_long) -> c_int;
@@ -701,6 +702,11 @@ impl Ida {
         }
     }
 
+    /// C's `IDAflagIsSuccess`: a root return counts, a warning does not.
+    fn flag_is_success(flag: c_int) -> bool {
+        matches!(flag, IDA_SUCCESS | IDA_TSTOP_RETURN | IDA_ROOT_RETURN)
+    }
+
     /// The step IDA would take first; `IDACalcIC` needs a nonzero one.
     pub fn actual_init_step(&self) -> f64 {
         let mut h = 0.0;
@@ -718,36 +724,65 @@ impl Ida {
     }
 
     /// `IDACalcIC(IDA_YA_YDP_INIT)`: solve for the algebraic unknowns and every
-    /// derivative, `tout1` giving the direction. Raised iteration limits as in
-    /// `ida_event_update`; `line_search` off is C's retry.
-    pub fn calc_ic(&mut self, tout1: f64, line_search: bool) -> bool {
+    /// derivative, `tout1` giving the direction, with `ida_event_update`'s raised
+    /// iteration limits.
+    fn calc_ic(&mut self, tout1: f64) -> c_int {
         unsafe {
             let lim = (2 * self.n * 10) as c_int;
             IDASetMaxNumStepsIC(self.mem, lim);
             IDASetMaxNumJacsIC(self.mem, lim);
             IDASetMaxNumItersIC(self.mem, lim);
-            IDASetLineSearchOffIC(self.mem, !line_search as c_int);
-            IDACalcIC(self.mem, IDA_YA_YDP_INIT, tout1) == IDA_SUCCESS
+            IDACalcIC(self.mem, IDA_YA_YDP_INIT, tout1)
         }
     }
 
-    /// Read what [`calc_ic`](Ida::calc_ic) settled on back into `y`/`yp`.
+    fn nonlin_iters(&self) -> c_long {
+        let mut n = 0;
+        unsafe { IDAGetNumNonlinSolvIters(self.mem, &mut n) };
+        n
+    }
+
+    fn log_calc_ic(&self, flag: c_int) {
+        crate::omclog::info(
+            crate::omclog::SOLVER,
+            false,
+            &alloc::format!("##IDA## IDACalcIC run status {flag}.\nIterations : {}\n", self.nonlin_iters()),
+        );
+    }
+
+    /// Read what `IDACalcIC` settled on back into `y`/`yp`.
     pub fn consistent_ic(&mut self) -> bool {
         unsafe { IDAGetConsistentIC(self.mem, self.y, self.yp) == IDA_SUCCESS }
     }
 
     /// C's `ida_event_update`: `IDACalcIC` over the algebraic unknowns and every
     /// derivative at `t`, directed by the step IDA would take next (floored, so a
-    /// zero step still gives a direction), retried with the line search off, and
-    /// the result read back into `y`/`yp`. The initial step goes back to automatic
-    /// afterwards, as C leaves it.
-    pub fn calc_ic_at(&mut self, t: f64) -> bool {
+    /// zero step still gives a direction), retried at `t + tol` with the line search
+    /// off — which C leaves off for the rest of the run — and read back into `y`/`yp`.
+    pub fn calc_ic_at(&mut self, t: f64, tol: f64) -> bool {
         let mut h = self.actual_init_step();
         if h < f64::EPSILON {
             h = f64::EPSILON;
             self.set_init_step(h);
+            crate::omclog::info(
+                crate::omclog::SOLVER,
+                false,
+                &alloc::format!("##IDA## corrected step-size at {}", crate::omclog::g(h, 0, 15)),
+            );
         }
-        let ok = (self.calc_ic(t + h, true) || self.calc_ic(t + h, false)) && self.consistent_ic();
+        let mut flag = self.calc_ic(t + h);
+        self.log_calc_ic(flag);
+        if !Self::flag_is_success(flag) {
+            crate::omclog::info(
+                crate::omclog::SOLVER,
+                false,
+                "##IDA## first event iteration failed. Start next try without line search!",
+            );
+            unsafe { IDASetLineSearchOffIC(self.mem, 1) };
+            flag = self.calc_ic(t + tol);
+            self.log_calc_ic(flag);
+        }
+        let ok = Self::flag_is_success(flag) && self.consistent_ic();
         self.set_init_step(0.0);
         ok
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/sundials_ode.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_solvers/src/sundials_ode.rs
@@ -589,7 +589,7 @@ impl IdaDae {
         if !ida.set_user_data(&mut ctx as *mut DaeCtx as *mut c_void) {
             return Err("ida: the context could not be bound");
         }
-        let ok = ida.calc_ic_at(t);
+        let ok = ida.calc_ic_at(t, self.tolerance);
         if let Some(e) = ctx.failed {
             return Err(e);
         }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/host.rs
@@ -537,6 +537,7 @@ pub fn add_host_builtins<T: 'static>(linker: &mut wasmtime::Linker<T>) -> Result
     wt(linker.func_wrap("env", "rt_host_init_done", || openmodelica_sim_meta::driver::signal_init_done()))?;
     wt(linker.func_wrap("env", "rt_host_set_no_throw", |v: i32| set_no_throw_asserts(v != 0)))?;
     wt(linker.func_wrap("env", "rt_host_runtime_error", || openmodelica_sim_meta::driver::note_runtime_error_flag()))?;
+    wt(linker.func_wrap("env", "rt_host_note_no_throw_assert", || -> i32 { openmodelica_sim_meta::driver::note_no_throw_assert() as i32 }))?;
     // The external "C" libraries are the host's, so C's `RHSFinalFlag` is too.
     wt(linker.func_wrap("env", "rt_host_rhs_final", |v: i32| openmodelica_util::dynload::set_rhs_final_flag(v != 0)))?;
     // The model's violations land here even when the driver runs in-wasm; hand
@@ -774,6 +775,7 @@ pub fn add_host_builtins(store: &mut wasmer::Store, imports: &mut wasmer::Import
     imports.define("env", "rt_host_init_done", Function::new_typed(store, || openmodelica_sim_meta::driver::signal_init_done()));
     imports.define("env", "rt_host_set_no_throw", Function::new_typed(store, |v: i32| set_no_throw_asserts(v != 0)));
     imports.define("env", "rt_host_runtime_error", Function::new_typed(store, || openmodelica_sim_meta::driver::note_runtime_error_flag()));
+    imports.define("env", "rt_host_note_no_throw_assert", Function::new_typed(store, || -> i32 { openmodelica_sim_meta::driver::note_no_throw_assert() as i32 }));
     // The wasmer host has no external-library loader, so the flag has nowhere to go.
     imports.define("env", "rt_host_rhs_final", Function::new_typed(store, |_v: i32| {}));
     // See the wasmtime counterpart.


### PR DESCRIPTION
Found by running the 238 locally installed models from the wasm-jit regression overview twice with the same omc, once with `--simCodeTarget=wasm-jit` and once with `--simCodeTarget=C`, and diffing the two result files.

## The integrator was not restarted after a time event

C's `perform_simulation` sets `didEventStep` for every event, time events included, and every integrator reacts to it: DASSL cold-starts (`INFO(1) = 0`), CVODE and IDA re-initialize. The driver only did that for a sample event when the model had zero crossings, was in DAE mode, or ran on gbode/symSolver, so a purely sampled model kept DASKR's BDF history across the event and took its next step on the pre-event derivative:

```modelica
model M
  Boolean b(start = true, fixed = true);
  Real u;
  Real y(start = 0, fixed = true);
equation
  when sample(0.125, 0.25) then
    b = not pre(b);
  end when;
  u = if b then 1.0 else -1.0;
  der(y) = u;
end M;
```

`y` kept rising for one step past the event where C turns it around. The same shape is what made every `Buildings.Controls.OBC.CDL` PID validation model fail verification: their setpoint is a `CDL` pulse and the integrator ran on the stale sign. `...CDL.Reals.Validation.PID` is now equal to the C target on all 218 result variables.

`-noRestart` is honoured for DASKR the way C's `dasslAvoidEventRestart` is, so the flag still keeps both the history and its statistics.

## The discrete pass is C's `functionDAE`

C's `functionDAE` evaluates `allEquations` -- one list, sorted, with the ODE and algebraic equations interleaved. wasm-jit only exported it under `-reconcile`, so `eval_discrete` approximated it as `functionODE` then `functionAlgebraics` for a model without `when`-equations. An ODE equation that reads a variable an algebraic equation assigns earlier in `allEquations` then saw the value one pass stale.

`Chemical.Obsolete.Examples.AcidBase.AcidBaseBufferTest` died on it right after `### END INITIALIZATION ###`:

    $cse4 = ...stateOfMatter.molarMassOfBaseMolecule(...)   // eq 109
    buffer.nFreeBuffer = (-buffer.solution.mj) / $cse4      // eq 126

109 is in `functionAlgebraics`, 126 in `functionODE`, so the division ran against a `$cse4` still at zero and threw where C divides by 0.018.

The DAE entry is now emitted whenever `functionAlgebraics` is not already the full list, and `eval_discrete` calls it. All three AcidBase examples simulate and are equal to the C target on every result variable.

It shares its equations rather than lowering them again, the way C shares its `eqFunction_<n>` between the three: `allEquations` is cut into runs that are also runs of the `odeEquations`/`algebraicEquations` list holding them, and each entry point calls the permutation of its own runs that puts its list back in order. The three orders differ by more than the interleaving -- `algebraicEquations` ends with `removedEquations` reversed -- so that tail comes back as one chunk per equation; a model whose two lists are not a partition of `allEquations` falls back to a `functionDAE` copy of its own.

On ScalableTestSuite's `CocurrentHeatExchangerEquations_N_1280` that is 729 kB less code (8.9%) and 57 fewer functions, and the JIT compiles the module in 0.26 s rather than 0.32 s (best of five). Simulation time is unchanged, there and on `HeatExchangerSimulation`, whose finer interleaving trades 184 kB of code for 419 more functions.

## `noThrowAsserts` covers math-domain errors

C's `assertCommonVar` -- the guard every math builtin emits for sqrt/log/log10/asin/acos/nthRoot -- gates on
`simulationInfo->noThrowAsserts` exactly as a user `assert()` does: inside the window it logs the violation at info level, arms `needToReThrow` and carries on with the out-of-domain value, so the event search can reach the crossing that makes the argument valid again.

wasm-jit suppressed only user asserts, so a `sqrt(-1e-8)` a hair before an event trapped the run. `rt_assert_common` now asks for the window -- this module's driver first (the in-wasm session, an FMU, the standalone), then the host's over `env.rt_host_note_no_throw_assert` -- and returns a third code for it, which the emitted code answers by falling through to the builtin, as C does. `close_assert_window` settles the armed re-throw with the assertions it already collects.

`OpenHydraulics.DevelopmentTests.DirectionalValveTest` now finishes with the same LOG_ASSERT trace as the C runtime instead of dying in a bare `unreachable`; its results match C on every variable but four volume-derivative signals.

## IDA's event update as `ida_solver.c` writes it

`dae_restart` was the `IDACalcIC` half of `ida_event_update` only, run after the caller had already re-initialized IDA. C's version evaluates the residuals in the discrete context *first*, takes `y`/`y'` from what they leave behind, re-initializes there, and only then solves the algebraic unknowns; its tail evaluates the residuals once more before pushing IDA's answer into the model. It now does the same, and is the whole of the post-event restart in DAE mode.

`read_states` rebuilt `yp` from scratch, so the algebraic unknowns' `y'` went back to zero at every event. C copies `nStates` entries into `statesDer` and leaves the rest at what the last `IDAGetConsistentIC` put there.

`ida_jac` never zeroed the matrix. In DAE mode every stored slot is written from the sparsity, but an ODE model's widened diagonal (`IdaPattern::diag`) has no difference quotient to carry, so `-= cj` landed on uninitialised memory. C opens with `SUNMatZero`. The symbolic arm applied that `-cj` diagonal in DAE mode too, where the pattern is not widened and `diag` is empty -- C runs `_omc_SUNMatScaleIAdd_Sparse` only for an ODE.

`IDACalcIC` now reports as C does: the event-update time, the corrected step size, the run status with its iteration count, and the line-search-off retry -- at `t + tolerance`, and left off for the rest of the run, as C leaves it.

Also drops an unused local the `CsDriver` step loop left behind.

Verified against the C target: the `--daeMode` testsuite package (testDAE.p1..p9, DrumBoiler, scaling, DAE10), CauerLowPassSC and CoupledClutches under `-s=ida` (`diffSimulationResults` clean), the three AcidBase examples, and DirectionalValveTest.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
