### PR TITLE
NSimJacobian: fix flat-offset loss for INIT-partition partial-slice seeds

### DIFF
--- a/OMCompiler/Compiler/NSimCode/NSimJacobian.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimJacobian.mo
@@ -744,9 +744,22 @@ public
         list<Subscript> rest_subs;
         Dimension d;
         list<Dimension> rest_dims;
-        Integer v;
+        Integer v, v3;
         list<tuple<Integer, Integer>> rest_pairs;
       case ({}, _) then {};
+      case ({Subscript.INDEX(index = Expression.INTEGER(v3))}, {}) then {(v3, 1)};
+        // InstNode.getType(node) can come back without array dims for a seed's own
+        // node (e.g. an INIT-partition per-element seed cref, whose leaf node's
+        // declared type resolves to a bare scalar even though it indexes an array
+        // -- see the ODE partition's equivalent cref, whose node keeps its proper
+        // Real[n] type, for the same conceptual variable). When this is the node's
+        // ONLY subscript, falling all the way through to `{}` (as the general
+        // multi-subscript case below still does) would silently drop this
+        // dimension's contribution to the flat offset entirely -- exactly the
+        // "sizeCols/size mismatch" class of bug this whole file exists to avoid.
+        // A dim_size of 1 is always safe here: this pair is the innermost/only
+        // one from this node, so nothing multiplies by it going outward, and
+        // (v3-1)*1 is exactly the correct offset contribution.
       case (_, {}) then {};
       case (s :: rest_subs, d :: rest_dims)
         algorithm

--- a/testsuite/simulation/modelica/NBackend/differentation/partialSliceSeedCollision.mos
+++ b/testsuite/simulation/modelica/NBackend/differentation/partialSliceSeedCollision.mos
@@ -14,11 +14,14 @@
 // each later add() silently overwrote the previous one -- only x[4]
 // survived, and the runtime reported "Analytic Jacobian of non-linear
 // system 0 is 3x1, but the system has 3 iteration variables", falling
-// back to a numeric Jacobian. After the fix all three seeds are kept, and
-// that warning disappears entirely (the remaining "Sparsity pattern...
-// not regular" warning below is pre-existing/unrelated noise from this
-// toy model's fully-dense 3-cycle structure -- present identically with
-// or without the fix, not something this test is about).
+// back to a numeric Jacobian. After the fix all three seeds are kept.
+//
+// Also incidentally covers a second, separate fix (NSimJacobian.mo's
+// crefFlatOffset/virtual-SimVar offset computation for partial-slice
+// seeds): before that fix, this model additionally emitted "Sparsity
+// pattern ... is not regular" for both non-linear systems, from the same
+// class of lost-array-dimension bug manifesting in the sparsity pattern
+// rather than the seed count. Both warnings are gone after both fixes.
 
 loadString("
 model partialSliceSeedCollision
@@ -44,9 +47,7 @@ getErrorString();
 // record SimulationResult
 //     resultFile = "partialSliceSeedCollision_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 0.1, numberOfIntervals = 5, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'partialSliceSeedCollision', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_STDOUT        | warning | Sparsity pattern for non-linear system 0 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
-// LOG_STDOUT        | warning | Sparsity pattern for non-linear system 1 is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.
-// LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/NBackend/initialization/initPartialSliceOffset.mos
+++ b/testsuite/simulation/modelica/NBackend/initialization/initPartialSliceOffset.mos
@@ -1,0 +1,63 @@
+// name: initPartialSliceOffset
+// keywords: NewBackend
+// status: correct
+//
+// Regression test for NSimJacobian.mo's crefFlatOffset/virtual-SimVar
+// offset computation losing a partial-slice seed's array dimension in the
+// INITIALIZATION partition specifically. x[1] is a plain state with its
+// own trivial initial equation; x[2]/x[3] are excluded from x[1]'s
+// initial equation but form a genuinely coupled 2x2 linear system via
+// their own "der(x[2])=der(x[3])=0" steady-state initial equations,
+// so NBackend must invert that system for x[2]/x[3] at init time even
+// though no inversion is needed during ODE integration (each der(x[i])
+// is already explicit there).
+//
+// Before the fix, InstNode.getType on the init-partition seed cref's
+// leaf node resolved to a bare scalar Real instead of x's true Real[3]
+// array type (unlike the ODE partition's equivalent cref, which kept the
+// correct type for the same conceptual variable) -- crefFlatOffset then
+// silently computed a flat offset of 0 for x[2]/x[3] alike instead of a
+// distinguishing 0/1, corrupting the 2x2 Jacobian into a matrix with an
+// entirely empty first column ("Matrix U" showing "-0" in both rows) and
+// failing "system is singular for U[2,2]". After the fix the flat offset
+// falls back to the raw subscript (still exactly correct for this single-
+// subscript case) whenever the declared-dimension lookup comes back
+// empty, and the system solves normally.
+
+loadString("
+model initPartialSliceOffset
+  parameter Real a = -2, b = 3;
+  Real x[3](start = {1, 0.5, 0.5});
+equation
+  der(x[1]) = -x[1];
+  der(x[2]) = a*x[2] - b*x[3];
+  der(x[3]) = b*x[2] + a*x[3];
+initial equation
+  x[1] = 1;
+  der(x[2]) = 0;
+  der(x[3]) = 0;
+end initPartialSliceOffset;
+"); getErrorString();
+
+setCommandLineOptions("--newBackend"); getErrorString();
+
+simulate(initPartialSliceOffset, stopTime=0.1, numberOfIntervals=5, simflags="-lv=LOG_LS,LOG_STDOUT");
+getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "initPartialSliceOffset_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.1, numberOfIntervals = 5, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initPartialSliceOffset', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_LS,LOG_STDOUT'",
+//     messages = "LOG_LS            | info    | initialize linear system solvers
+// |                 | |       | | 1 linear systems
+// LOG_LS            | info    | Start solving Linear System 5 (size 2) at time 0 with Lapack Solver
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult


### PR DESCRIPTION
crefFlatOffset (used to compute a partial-slice seed's virtual SimVar index for base-cref lookups, e.g. resolving $SEED.x[$i1]/$SEED.x[2] against a torn loop's own x[2]/x[3] seeds) derives each cref node's array dimension via InstNode.getType(cref.node). For an INITIALIZATION- partition seed cref, that lookup can come back as a bare scalar type instead of the variable's true array type -- confirmed via instrumentation that the SAME conceptual variable's ODE-partition seed cref keeps the correct Real[n] type, only the INIT-partition one loses it. With no declared dimension, collectNodeSubDimPairsOuterFirst silently dropped the subscript's contribution entirely, so crefFlatOffset returned 0 for every element of the slice instead of a distinguishing offset -- e.g. x[2] and x[3] of a torn 2x2 loop both computing offset 0, so their column-sparsity-pattern entries for the SAME residual collided instead of landing in separate columns. The resulting Jacobian silently had an entirely empty first column, and the runtime's direct linear solve reported "system is singular" (Matrix U's first column showing "-0" in every row) even though the underlying 2x2 system is genuinely non-singular.

Root-caused precisely via Modelica.Blocks.Examples.Filter (newInst- newBackend library-testing regression): its Bessel/Butterworth/ChebyshevI sub-filters each solve a torn 2-unknown steady-state initial-equation system (der(x[i])=0) for two states drawn from a larger x[1:nx] array, exactly this failure shape. Traced the exact wrong value with targeted print() instrumentation at each stage (virtual SimVar creation, InstNode.getType's returned dimensions) rather than guessing.

Fix: when a cref node's only subscript is a single literal INDEX and its declared-dimension lookup comes back empty, fall back to treating that subscript's own dimension as size 1 -- always correct for the innermost/ only pair from a node (nothing multiplies by it going outward), and exactly the "true offset != correction" case InstNode.getType is failing to answer. Multi-subscript nodes with a genuinely empty dimension lookup are unaffected (behavior there is unchanged from before this fix).

Verified: Modelica.Blocks.Examples.Filter and Modelica.Electrical.Analog. Examples.OpAmps.Integrator (both previously hard failures in the newInst-newBackend regressions) now simulate cleanly; numeric results for Filter's Bessel/Butterworth/ChebyshevI cross-check against the old backend. Full NBackend testsuite (~330 tests) passes clean, including an incidental second improvement: partialSliceSeedCollision.mos (added two commits ago) no longer emits its "Sparsity pattern ... not regular" warnings either -- same root cause, different manifestation. Added a new minimal, self-contained regression test
(initialization/initPartialSliceOffset.mos) verified to reproduce the exact "Matrix U" singular-first-column failure without this fix and solve cleanly with it.

This is a narrow, single mechanism within the broader "still broken" bucket from the newInst-newBackend regression triage -- most of that bucket's other failures (diode/thyristor event-iteration chatter, getNominalFromScalarIdx out-of-bounds, mechanical-system Damper/ AllComponents failures) are separate, unfixed root causes, confirmed via a 23-model sweep of the previously-identified still-broken MSL library models (2 fixed by this change, 21 unaffected).