### PR TITLE
Fix three gaps in the library testing results

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -7885,6 +7885,7 @@ algorithm
     then (listReverse(acc),ishared,listReverse(acc1),iCausalized);
 
     case syst::systs algorithm
+      Error.checkCancel();
       (syst,shared,arg,causalized) := causalizeDAEWork(syst,ishared,inMatchingOptions,matchingAlgorithm,stateDeselection,iCausalized);
       (systs,shared,args,causalized) := mapCausalizeDAE(systs,shared,inMatchingOptions,matchingAlgorithm,stateDeselection,syst::acc,arg::acc1,causalized);
     then (systs,shared,args,causalized);
@@ -7941,6 +7942,8 @@ algorithm
     then (syst, shared,SOME(arg), true);
 
     case (_, (_,mAmethodstr), (_,str1,_,_)) algorithm
+      // A cancel unwinds through here; do not blame the module for it.
+      Error.checkCancel();
       str := "Transformation Module " + mAmethodstr + " index Reduction Method " + str1 + " failed!";
       if not isInitializationDAE(ishared) then
         Error.addMessage(Error.INTERNAL_ERROR, {str});
@@ -7971,7 +7974,9 @@ protected function mapSortEqnsDAE "Run Tarjan's Algorithm."
 algorithm
   outSystem := list(match syst
     case BackendDAE.EQSYSTEM(matching=BackendDAE.MATCHING(comps=_::_)) then syst;
-    else sortEqnsDAEWork(syst, inShared);
+    else algorithm
+      Error.checkCancel();
+    then sortEqnsDAEWork(syst, inShared);
   end match for syst in inSystem);
 end mapSortEqnsDAE;
 

--- a/OMCompiler/Compiler/BackEnd/IndexReduction.mo
+++ b/OMCompiler/Compiler/BackEnd/IndexReduction.mo
@@ -111,6 +111,7 @@ protected
   Integer size, newsize;
   list<list<Integer>> eqns_1, unassignedStates, unassignedEqns;
 algorithm
+  Error.checkCancel();
   if listEmpty(inEqns) then
     Error.addMessage(Error.INTERNAL_ERROR, {"- IndexReduction.pantelidesIndexReduction called with empty list of equations!"});
     if Flags.isSet(Flags.OPT_DAE_DUMP) then

--- a/OMCompiler/Compiler/BackEnd/Matching.mo
+++ b/OMCompiler/Compiler/BackEnd/Matching.mo
@@ -5602,6 +5602,7 @@ protected function matchingExternal
   output BackendDAE.Shared oshared;
   output BackendDAE.StructurallySingularSystemHandlerArg outArg;
 algorithm
+  Error.checkCancel();
   (outAss1,outAss2,osyst,oshared,outArg):=
   match (meqns,internalCall,isyst,inMatchingOptions)
     local
@@ -5786,6 +5787,7 @@ algorithm
   for var in artificialStates loop
     unique_flag := false;
     for eqn in equations loop
+      Error.checkCancel();
       try
         residuals := BackendEquation.equationToScalarResidualForm(eqn, shared.functionTree);
         for res in residuals loop
@@ -5884,6 +5886,7 @@ algorithm
   end for;
   idx := 1;
   for eq in BackendEquation.equationList(eqs) loop
+    Error.checkCancel();
     //print("Check equation "+BackendDump.equationString(eq)+"\n");
     isDiscrete := BackendEquation.isWhenEquationOrDiscreteAlgorithm(eq,vars);
     if isDiscrete then
@@ -5934,6 +5937,7 @@ algorithm
   functionTree := shared.functionTree;
   idx := 1;
   for eq in BackendEquation.equationList(eqs) loop
+    Error.checkCancel();
     (hasNoDerAnno,noDerInputs) := BackendDAEUtil.isFuncCallWithNoDerAnnotation(eq,functionTree);
     if hasNoDerAnno then
       (_,varIdxs) := BackendVariable.getVarLst(noDerInputs,vars);
@@ -6220,6 +6224,7 @@ algorithm
     case e::rest
       guard not intGt(colummarks[e],0)
       algorithm
+        Error.checkCancel();
         // row is not visited
         // if it is a multi dim equation take all scalare equations
         e1 := mapIncRowEqn[e];

--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -1925,6 +1925,7 @@ external "builtin" annotation(Library = {"omcruntime"});
 annotation(__OpenModelica_Impure=true,Documentation(info="<html>
 <p>Like <a href=\"http://linux.die.net/man/2/alarm\">alarm(2)</a>.</p>
 <p>Note that OpenModelica also sends SIGALRM to the process group when the alarm is triggered (in order to kill running simulations).</p>
+<p>The first signal asks the running command to stop, so that omc survives to report what it completed; a second one a tenth of the time later (at least 5 and at most 60 seconds) terminates omc if the command has no cancellation point to stop at. Re-arming or clearing the alarm withdraws the request.</p>
 </html>"));
 end alarm;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -2181,6 +2181,7 @@ external "builtin" annotation(Library = {"omcruntime"});
 annotation(__OpenModelica_Impure=true, Documentation(info="<html>
 <p>Like <a href=\"http://linux.die.net/man/2/alarm\">alarm(2)</a>.</p>
 <p>Note that OpenModelica also sends SIGALRM to the process group when the alarm is triggered (in order to kill running simulations).</p>
+<p>The first signal asks the running command to stop, so that omc survives to report what it completed; a second one a tenth of the time later (at least 5 and at most 60 seconds) terminates omc if the command has no cancellation point to stop at. Re-arming or clearing the alarm withdraws the request.</p>
 </html>"));
 end alarm;
 

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/external_c_calls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/external_c_calls.rs
@@ -490,6 +490,7 @@ fn registry() -> &'static BTreeMap<&'static str, Fallibility> {
         m.insert("System_getVariableValue", Fallible);         // throws on lookup failure
         m.insert("System_getuid", Infallible);
         m.insert("System_isCancelled", Infallible);           // pure read of the cancel flag
+        m.insert("System_alarmExpired", Infallible);          // pure read of the alarm flag
         m.insert("System_reportProgress", Infallible);        // one-way progress store
         m.insert("System_reportProgressMessage", Infallible); // one-way progress store
         m.insert("System_initGarbageCollector", Infallible);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -694,15 +694,37 @@ fn fmu_needs_sundials(method: &str) -> bool {
 /// The simulation flags to hard-code into an FMU's metadata: the export's
 /// `_flags.json` but `-s`, which [`SimMeta::cs_method`] carries. An importer has no
 /// channel to pass simulation flags, so the FMU applies these when it instantiates.
-/// `--fmiFlags` takes any name; like C's `parseFlags`, ignore what is not a flag.
+/// `--fmiFlags` takes any name; like C's `parseFlags`, ignore what this FMU cannot
+/// honour — `createFMISimulationFlags` has already warned about the name.
 fn fmu_solver_flags(flags_json: &str) -> String {
     fmi_flags(flags_json)
         .into_iter()
         .filter(|(name, _)| name != "s")
+        .filter(|(name, value)| fmu_accepts_flag(name, value))
         .map(|(name, value)| if value.is_empty() { format!("-{name}") } else { format!("-{name}={value}") })
-        .filter(|arg| simflags::parse(&["model".to_string(), arg.clone()]).is_ok())
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+/// `CodegenWasmJit.fmuAcceptsFlag`: whether a wasm FMU can honour `-name=value`
+/// (an empty value for a flag that takes none). One it cannot is better dropped
+/// where it comes from than baked into `_flags.json`, where it would only
+/// surface at the importer's `instantiate`.
+pub fn fmuAcceptsFlag(name: ArcStr, value: ArcStr) -> bool {
+    fmu_accepts_flag(name.as_str(), value.as_str())
+}
+
+fn fmu_accepts_flag(name: &str, value: &str) -> bool {
+    if name == "s" {
+        // Baked into the component rather than parsed at instantiation, so only
+        // what it linked can serve it.
+        return fmu_cs_solvers().contains(&value);
+    }
+    let arg = if value.is_empty() { format!("-{name}") } else { format!("-{name}={value}") };
+    match simflags::parse(&["model".to_string(), arg]) {
+        Ok(f) => simflags::check(&f, fmu_capabilities()).is_ok(),
+        Err(_) => false,
+    }
 }
 
 /// Every `"name" : "value"` pair of a `_flags.json`, in file order.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
@@ -1487,22 +1487,16 @@ pub fn realtimeTick(clockIndex: i32) -> Result<()> {
 }
 
 pub fn realtimeTock(clockIndex: i32) -> Result<metamodelica::Real> {
-    // The C runtime's `rt_tock(ix)` never fails: a clock that was never
-    // started has a zeroed `tick_tp[ix]` and the call returns "now minus
-    // zero" — a large, meaningless duration. Callers do tock without tick
-    // (e.g. `Tpl.textFileConvertLines` reads RT_CLOCK_BUILD_MODEL purely
-    // for optional perf logging), so failing here is wrong. Return the
-    // slot's accumulated time instead (0.0 for a never-started clock),
-    // which is harmless for the logging-only consumers and avoids the C
-    // version's garbage value.
-    let nanos = with(|s| -> u128 {
+    // Callers tock without tick, so this must not fail. -1 is what
+    // `System_realtimeTock` answers for a clock whose `rt_ncall` is zero.
+    let nanos = with(|s| -> Option<u128> {
         let slot = rt_slot_mut(s, clockIndex);
-        match slot.tick {
-            Some(start) => openmodelica_wasi::monotonic_nanos().saturating_sub(start) as u128,
-            None => slot.accumulated_ns,
-        }
+        slot.tick.map(|start| openmodelica_wasi::monotonic_nanos().saturating_sub(start) as u128)
     });
-    Ok(metamodelica::OrderedFloat(nanos as f64 / 1.0e9))
+    Ok(metamodelica::OrderedFloat(match nanos {
+        Some(n) => n as f64 / 1.0e9,
+        None => -1.0,
+    }))
 }
 
 pub fn realtimeClear(clockIndex: i32) -> Result<()> {
@@ -1510,6 +1504,8 @@ pub fn realtimeClear(clockIndex: i32) -> Result<()> {
         let slot = rt_slot_mut(s, clockIndex);
         slot.accumulated_ns = 0;
         slot.ntick = 0;
+        // C's `rt_clear` zeroes `rt_clock_ncall`; same effect.
+        slot.tick = None;
     });
     Ok(())
 }
@@ -2394,6 +2390,23 @@ pub fn isCancelled() -> bool {
     metamodelica::cancel::check_cancel()
 }
 
+/// Seconds to unwind in before the process is killed outright: a tenth of the
+/// deadline, bounded. OpenModelicaLibraryTesting/shared.py mirrors the formula,
+/// because the harness has to outwait it.
+#[cfg(unix)]
+const ALARM_GRACE_MIN: u32 = 5;
+#[cfg(unix)]
+const ALARM_GRACE_MAX: u32 = 60;
+#[cfg(unix)]
+static ALARM_GRACE: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(ALARM_GRACE_MIN);
+
+/// Tracks that the alarm, rather than a host, asked for the cancellation.
+static ALARM_EXPIRED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+pub fn alarmExpired() -> bool {
+    ALARM_EXPIRED.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 pub fn reportProgress(permille: i32, phase: i32) {
     metamodelica::cancel::report_progress(permille, phase);
 }
@@ -2468,22 +2481,36 @@ pub fn stat(filename: ArcStr) -> (bool, metamodelica::Real, metamodelica::Real, 
     }
 }
 
-/// Mirrors `SystemImpl__alarm`: schedule a SIGALRM `seconds` from now and, on
-/// the first call, install a handler that broadcasts SIGALRM to the whole
-/// process group (so child processes die too) and then restores the default
-/// disposition. Used by `--alarm=N` to force-terminate omc after a timeout.
-/// Returns the number of seconds remaining on the previously scheduled alarm.
+/// Mirrors `SystemImpl__alarm`: at `seconds` the running command is asked to
+/// unwind through the shared cancellation flag, so omc survives to report the
+/// phases it completed, and the signal goes to the process group to take any
+/// child simulation with it; [`ALARM_GRACE`] seconds later the process is killed
+/// outright. Returns the seconds left on the previous alarm, which re-arming
+/// withdraws along with its cancellation request.
 #[cfg(unix)]
 pub fn alarm(seconds: i32) -> i32 {
     use std::sync::atomic::{AtomicBool, Ordering};
     static HANDLER_INSTALLED: AtomicBool = AtomicBool::new(false);
 
-    extern "C" fn alarm_handler(signo: core::ffi::c_int) {
+    extern "C" fn alarm_handler(
+        signo: core::ffi::c_int,
+        si: *mut libc::siginfo_t,
+        _ctx: *mut core::ffi::c_void,
+    ) {
+        use std::sync::atomic::Ordering::{Relaxed, SeqCst};
         unsafe {
-            // Forward the alarm to every process in our group, then reset
-            // SIGALRM to its default action so the signal terminates us.
-            libc::kill(-libc::getpid(), signo);
+            // Our own group broadcast coming back, not a second deadline.
+            if !si.is_null() && (*si).si_code == libc::SI_USER && (*si).si_pid() == libc::getpid() {
+                return;
+            }
+            if !ALARM_EXPIRED.swap(true, SeqCst) {
+                metamodelica::cancel::request_cancel();
+                libc::kill(-libc::getpid(), signo);
+                libc::alarm(ALARM_GRACE.load(Relaxed));
+                return;
+            }
             libc::signal(libc::SIGALRM, libc::SIG_DFL);
+            libc::raise(signo);
         }
     }
 
@@ -2492,7 +2519,20 @@ pub fn alarm(seconds: i32) -> i32 {
             .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
             .is_ok()
         {
-            libc::signal(libc::SIGALRM, alarm_handler as *const () as libc::sighandler_t);
+            let mut sa: libc::sigaction = core::mem::zeroed();
+            sa.sa_sigaction = alarm_handler as *const () as libc::sighandler_t;
+            sa.sa_flags = libc::SA_SIGINFO;
+            libc::sigemptyset(&mut sa.sa_mask);
+            libc::sigaction(libc::SIGALRM, &sa, core::ptr::null_mut());
+        }
+        if ALARM_EXPIRED.swap(false, Ordering::SeqCst) {
+            metamodelica::cancel::clear_cancel();
+        }
+        if seconds > 0 {
+            ALARM_GRACE.store(
+                (seconds as u32 / 10).clamp(ALARM_GRACE_MIN, ALARM_GRACE_MAX),
+                Ordering::Relaxed,
+            );
         }
         libc::alarm(seconds as core::ffi::c_uint) as i32
     }

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -4696,15 +4696,17 @@ end fmuMethodToSimulationFlag;
 protected function fmuAnnotationSimulationFlags
   "A wasm FMU runs the model with the flags simulate() would: the class's
    __OpenModelica_simulationFlags go into --fmiFlags, whose `_flags.json` the FMU
-   applies when it instantiates. A flag already named wins. A C FMU reads only a
-   few flags and warns about the rest, so it keeps to what --fmiFlags said."
+   applies when it instantiates. A flag already named wins, and one the FMU cannot
+   honour is left out rather than baked in to fail at the importer's first
+   instantiate. A C FMU reads only a few flags and warns about the rest, so it
+   keeps to what --fmiFlags said."
   input Absyn.Path className;
   input Boolean isWasmFMU;
 protected
   list<String> fmiFlags, names = {}, folded = {};
   list<Absyn.ElementArg> args;
   Option<Absyn.Modification> mod;
-  String name;
+  String name, value;
 algorithm
   if not isWasmFMU or Flags.getConfigBool(Flags.IGNORE_SIMULATION_FLAGS_ANNOTATION) then
     return;
@@ -4729,8 +4731,14 @@ algorithm
   end match;
   for arg in args loop
     name := AbsynUtil.pathString(AbsynUtil.elementArgName(arg));
+    value := fmuSimulationFlagValue(arg);
     if not listMember(name, names) then
-      folded := (name + ":" + fmuSimulationFlagValue(arg)) :: folded;
+      if CodegenWasmJit.fmuAcceptsFlag(name, value) then
+        folded := (name + ":" + value) :: folded;
+      else
+        Error.addCompilerNotification("Leaving the __OpenModelica_simulationFlags entry " + name
+          + "=\"" + value + "\" out of the FMU: it cannot honour it.");
+      end if;
     end if;
   end for;
   if not listEmpty(folded) then

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -1668,8 +1668,11 @@ protected
   String flatString = "", NFFlatString = "";
 
 algorithm
+  // BUILD_MODEL starts only once the translation is through, so clear it too:
+  // a failing translation would otherwise read an earlier command's tick.
   List.map_0({ClockIndexes.RT_CLOCK_FRONTEND,ClockIndexes.RT_CLOCK_BACKEND,
-              ClockIndexes.RT_CLOCK_SIMCODE,ClockIndexes.RT_CLOCK_TEMPLATES},System.realtimeClear);
+              ClockIndexes.RT_CLOCK_SIMCODE,ClockIndexes.RT_CLOCK_TEMPLATES,
+              ClockIndexes.RT_CLOCK_BUILD_MODEL},System.realtimeClear);
   FlagsUtil.setConfigBool(Flags.BUILDING_MODEL, true);
 
   outLibs := {};

--- a/OMCompiler/Compiler/Template/CodegenWasmJit.mo
+++ b/OMCompiler/Compiler/Template/CodegenWasmJit.mo
@@ -193,5 +193,17 @@ algorithm
   methods := {};
 end fmuCsSolvers;
 
+function fmuAcceptsFlag
+  " Whether a wasm FMU can honour the simulation flag `-name=value` (an empty
+    value for a flag that takes none). One it cannot is dropped rather than baked
+    into `resources/<prefix>_flags.json`, where it would only surface at the
+    importer's first instantiate. False without the Rust export. Implemented in Rust. "
+  input String name;
+  input String value;
+  output Boolean accepted;
+algorithm
+  accepted := false;
+end fmuAcceptsFlag;
+
 annotation(__OpenModelica_Interface="codegen_wasm_jit");
 end CodegenWasmJit;

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -1347,6 +1347,8 @@ public constant ErrorTypes.Message USER_CANCELLED = ErrorTypes.MESSAGE(7028, Err
   "Operation cancelled by user.");
 public constant ErrorTypes.Message FMU_EXPORT_DAE_MODE_C_CS = ErrorTypes.MESSAGE(7030, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   "DAE mode (--daeMode) is not supported by the C simulation runtime, so it cannot build a Co-Simulation FMU either. Export with platforms={\"wasm\"}, whose runtime does support it, or remove the --daeMode flag.");
+public constant ErrorTypes.Message ALARM_EXPIRED = ErrorTypes.MESSAGE(7031, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
+  "Operation aborted: the time limit set by the alarm ran out.");
 public constant ErrorTypes.Message FMU_EXPORT_WASM_FMI1 = ErrorTypes.MESSAGE(7029, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   "The wasm FMU export does not serve the deprecated FMI 1.0. Ask for version=\"2.0\" or version=\"3.0\", or drop \"wasm\" from platforms to export a C FMU.");
 
@@ -1429,11 +1431,11 @@ algorithm
   end match;
 end getCurrentComponent;
 
-public function checkCancel "Fails with a USER_CANCELLED message if the user requested cancellation.
-  A coarse chokepoint for the frontend/backend driver loops."
+public function checkCancel "Fails if cancellation was requested, either by a user or by the alarm
+  running out. A coarse chokepoint for the frontend/backend driver loops."
 algorithm
   if System.isCancelled() then
-    addMessage(USER_CANCELLED, {});
+    addMessage(if System.alarmExpired() then ALARM_EXPIRED else USER_CANCELLED, {});
     fail();
   end if;
 end checkCancel;

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1104,7 +1104,7 @@ constant ConfigFlag CALCULATE_SENSITIVITIES = CONFIG_FLAG(92, "calculateSensitiv
   "Generates sensitivities variables and matrices.");
 constant ConfigFlag ALARM = CONFIG_FLAG(93, "alarm",
   SOME("r"), EXTERNAL(), INT_FLAG(0), NONE(),
-  "Sets the number seconds until omc timeouts and exits. Used by the testing framework to terminate infinite running processes.");
+  "Sets the number of seconds until omc times out. Used by the testing framework to terminate infinite running processes. The running command is first asked to stop, so that omc can still report how far it got; it exits outright a tenth of that time later (at least 5 and at most 60 seconds) if the command has no cancellation point to stop at.");
 constant ConfigFlag TOTAL_TEARING = CONFIG_FLAG(94, "totalTearing",
   NONE(), EXTERNAL(), INT_LIST_FLAG({}), NONE(),
   "Activates total tearing (determination of all possible tearing sets) for the specified components.\nUse '-d=tearingdump' to find out the relevant indexes.");

--- a/OMCompiler/Compiler/Util/System.mo
+++ b/OMCompiler/Compiler/Util/System.mo
@@ -1298,6 +1298,11 @@ public function isCancelled "True if the user has requested cancellation of the 
   external "C" cancelled = System_isCancelled() annotation(Library = "omcruntime");
 end isCancelled;
 
+public function alarmExpired "True if the cancellation being reported came from the alarm running out rather than from a user."
+  output Boolean expired;
+  external "C" expired = System_alarmExpired() annotation(Library = "omcruntime");
+end alarmExpired;
+
 public function reportProgress "Report progress of the running operation to the host UI. permille is 0..1000 or -1 (indeterminate); phase is one of the metamodelica::cancel PHASE_* constants (2 parse, 3 instantiate, 4 backend, 5 simulate)."
   input Integer permille;
   input Integer phase;

--- a/OMCompiler/Compiler/runtime/System_omc.c
+++ b/OMCompiler/Compiler/runtime/System_omc.c
@@ -130,6 +130,9 @@ extern void System_realtimeTick(int ix)
 extern double System_realtimeTock(int ix)
 {
   if (ix < 0 || ix >= NUM_USER_RT_CLOCKS) MMC_THROW();
+  /* Never started, or cleared and not restarted: the tick is an earlier
+   * command's. -1 is the "did not run" answer the callers test for. */
+  if (rt_ncall(ix) == 0) return -1.0;
   return rt_tock(ix);
 }
 
@@ -321,6 +324,11 @@ extern int System_isCancelled()
     pumpCallback();
   }
   return cancelRequested;
+}
+
+extern int System_alarmExpired()
+{
+  return cancelledByAlarm;
 }
 
 extern void System_setPumpCallback(void (*cb)(void))

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -188,6 +188,8 @@ static const char *select_from_dir = NULL;
  * port. The flag is set from another context (an OMEdit Cancel button) and
  * polled at the frontend/backend chokepoints via System_isCancelled. */
 static volatile int cancelRequested = 0;
+/* Tracks that the alarm, rather than a host, asked for the cancellation. */
+static volatile int cancelledByAlarm = 0;
 static volatile int progressPermille = -1;
 static volatile int progressPhase = 0;
 /* Free-form label for the step in progress, shown by the host instead of the
@@ -3107,13 +3109,34 @@ int SystemImpl__alarm(int seconds)
 #else
 
 static int default_alarm_action_set = 0;
-static struct sigaction default_alarm_action;
+
+/* Seconds to unwind in before the process is killed outright: a tenth of the
+ * deadline, bounded. OpenModelicaLibraryTesting/shared.py mirrors the formula,
+ * because the harness has to outwait it. */
+#define OMC_ALARM_GRACE_MIN 5
+#define OMC_ALARM_GRACE_MAX 60
+static volatile int alarmGraceSeconds = OMC_ALARM_GRACE_MIN;
 
 static void alarm_handler(int signo, siginfo_t *si, void *ptr)
 {
   assert(signo == SIGALRM);
-  kill(-getpid(), SIGALRM);
-  sigaction(SIGALRM, &default_alarm_action, 0);
+  /* Our own group broadcast coming back, not a second deadline. */
+  if (si != NULL && si->si_code == SI_USER && si->si_pid == getpid()) {
+    return;
+  }
+  if (!cancelledByAlarm) {
+    /* Ask the running command to unwind, so that omc survives to report the
+     * phases it completed. The group kill only lands when omc leads its own
+     * group; the re-armed alarm is what ends the process when it does not. */
+    cancelledByAlarm = 1;
+    cancelRequested = 1;
+    kill(-getpid(), signo);
+    alarm(alarmGraceSeconds);
+    return;
+  }
+  /* The grace ran out: what is running has no cancellation point. */
+  signal(SIGALRM, SIG_DFL);
+  raise(signo);
 }
 
 int SystemImpl__alarm(int seconds)
@@ -3125,6 +3148,16 @@ int SystemImpl__alarm(int seconds)
     };
     sigaction(SIGALRM, &sa, NULL);
     default_alarm_action_set = 1;
+  }
+  /* Re-arming or clearing withdraws the previous deadline's request. */
+  if (cancelledByAlarm) {
+    cancelledByAlarm = 0;
+    cancelRequested = 0;
+  }
+  if (seconds > 0) {
+    alarmGraceSeconds = seconds / 10;
+    if (alarmGraceSeconds < OMC_ALARM_GRACE_MIN) alarmGraceSeconds = OMC_ALARM_GRACE_MIN;
+    if (alarmGraceSeconds > OMC_ALARM_GRACE_MAX) alarmGraceSeconds = OMC_ALARM_GRACE_MAX;
   }
   return alarm(seconds);
 }


### PR DESCRIPTION
## The alarm has never terminated anything

`alarm()` and `--alarm=N` were no-ops. The handler broadcast to the process group and then restored the default disposition:

    kill(-getpid(), SIGALRM);
    sigaction(SIGALRM, &default_alarm_action, 0);

`kill(-pid, ...)` addresses the process *group* `pid`, which exists only when omc leads its own group. Started by a test harness it does not, the call fails with ESRCH, no signal is left pending, and omc runs on. `omc --alarm=3` over a 30 s script ran the full 30 s; the same under `setsid` died at 3 s.

The deadline is now two-stage. At N the running command is asked to unwind through the cancellation flag `Error.checkCancel()` already polls, so omc survives to report the phases it completed, and the signal still goes to the group to take a child simulation with it. At N + grace the process is killed outright, whether or not it leads a group. The grace is a tenth of the deadline, clamped to [5, 60] s.

`si_code == SI_USER && si_pid == getpid()` tells the group broadcast coming back to us from a real second deadline. Re-arming or clearing withdraws what the alarm asked for and leaves a host's own Cancel alone, which `System.alarmExpired()` also uses to report `ALARM_EXPIRED` rather than `USER_CANCELLED`.

Chokepoints for the phases that used to run for minutes without one: `sanityCheckArtificialStates`, the two `removeEdges*` passes, `getEqnsforIndexReduction1`, `matchingExternal`, `mapCausalizeDAE`, `mapSortEqnsDAE` and `pantelidesIndexReduction`. Two fallback arms check first, so a cancel is not reported as the transformation module failing.

    alarm(20); translateModel(SteamPipe_N_640)  -> false after 20 s
    alarm(0)                                    -> 5
    getErrorString()  "Operation aborted: the time limit set by the
                       alarm ran out."
    clocks            {20.048, 19.394, -1, -1, -1}

## A stopwatch that never started reported a stale time

`System.realtimeTock` on a clock that was never ticked, or was cleared and not ticked again, reported the time since a tick belonging to an earlier command. The C runtime reads a stale `tick_tp[ix]`; the Rust port answered 0.0. Both now answer -1, which is what `timerTock` already gave callers (it guards on `rt_ncall(ix) > 0`) and what those callers test for.

`translateModel` also clears `RT_CLOCK_BUILD_MODEL`, which only starts once the translation is through. A translation that fails before then used to leave it holding whatever the last `buildModel` in the session started it at. The wasm-jit lane probes each
`__OpenModelica_simulationFlags` entry with a `simulate()` of a trivial model before the real export, and that is what had started it.

Together these are what made OpenModelicaLibraryTesting record negative `templates` times, since it derives a phase's own time by subtracting the next clock in:

| model | templates |
| --- | ---: |
| `ManyEventsManyConditions_N_1000_M_10` | -4.54 | | `ManyEvents_N_8000_M_10` | -271.34 |

## A wasm FMU refused to build over a flag it could ignore

A wasm FMU folds the class's `__OpenModelica_simulationFlags` into `--fmiFlags`, and `cs_method_from` took `-s` from the resulting `_flags.json` without checking it. `check_fmu_method` then failed the whole export, so a `me_cs` build lost its Model Exchange and plain simulation faces over a Co-Simulation restriction.

`ScalableTestSuite`'s twelve `WhenEvents.ScaledExperiments` models ask for `s = "rungekuttaSsc"`, which is not a valid `-s` value in the C runtime either — it became one of GBODE's Runge-Kutta methods, selected with `-s=gbode -gbm=rungekuttaSsc`. The C lane drops it after probing the executable, so those models have quietly been running on DASSL; the wasm lane refused to build them at all.

An annotation entry the FMU cannot honour is now left out with a notification naming it, which is what `simulate()` effectively does at its own parse. `--fmiFlags` given explicitly still fails, since that is a caller asking for something the component cannot serve. `fmu_solver_flags` reports the entries it drops rather than dropping them silently.

    Notification: Leaving the __OpenModelica_simulationFlags entry
    s="rungekuttaSsc" out of the FMU: it cannot honour it.

A model naming `s = "ida", lv = "LOG_STATS", nls = "newton"` keeps all three; the four `fmi3_wasm_*` tests are unchanged.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
