### PR TITLE
NBackend: fix vacuous-linear misclassification and a parameter-index crash in torn linear systems

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBTearing.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBTearing.mo
@@ -338,6 +338,15 @@ protected
     b := true;
   end noFilterEqn;
 
+  function tolerantSubMap
+    "Like UnorderedMap.subMap, but silently skips keys that don't exist in
+     map instead of crashing (UnorderedMap.subMap uses getSafe)."
+    input UnorderedMap<ComponentRef, Integer> map;
+    input list<ComponentRef> lst;
+    output UnorderedMap<ComponentRef, Integer> sub_map =
+      UnorderedMap.subMap(map, list(k for k guard UnorderedMap.contains(k, map) in lst));
+  end tolerantSubMap;
+
   function initialize
     extends Module.tearingInterface;
     input checkVarInit varFunc = noFilterVar;
@@ -347,9 +356,10 @@ protected
     end checkVarInit;
   protected
     Tearing strict;
-    list<ComponentRef> vars_lst, eqns_lst;
+    list<ComponentRef> vars_lst, eqns_lst, all_vars_lst, all_eqns_lst;
     UnorderedSet<ComponentRef> vars_set       "all loop vars, used to determine solvability";
     UnorderedMap<ComponentRef, Integer> v, e  "all loop vars and equations map";
+    UnorderedMap<ComponentRef, Integer> v_all, e_all "unfiltered loop vars/equations map, used for the linearity check";
     constant Boolean init = Partition.kindIsInitial(kind);
   algorithm
     (comp, full, index) := match comp
@@ -370,7 +380,19 @@ protected
 
         // refine the adjacency matrix by updating solvability information
         full := Adjacency.Matrix.refine(full, funcMap, v, e, variables, equations, vars_set, Partition.kindIsInitial(kind));
-        comp.linear := checkLinearity(full, v, e);
+
+        // checkLinearity needs the loop's full (unfiltered) variable/equation set: varFunc/eqnFunc
+        // (e.g. omcTearing's isDiscontinuous filter) narrow vars_lst/eqns_lst down to only the
+        // discontinuous members, which is often empty for a purely continuous loop. Feeding that
+        // empty set to checkLinearity made it vacuously return "linear" for any such loop.
+        // Use a tolerant lookup here (unlike the strict subMap above): not every name in the
+        // untorn iteration_vars/residual_eqns is necessarily registered in variables.map/
+        // equations.map yet, and subMap's getSafe would crash on those.
+        all_vars_lst := list(BVariable.getVarName(Slice.getT(var)) for var in strict.iteration_vars);
+        all_eqns_lst := list(Equation.getEqnName(Slice.getT(eqn)) for eqn in strict.residual_eqns);
+        v_all := tolerantSubMap(variables.map, all_vars_lst);
+        e_all := tolerantSubMap(equations.map, all_eqns_lst);
+        comp.linear := checkLinearity(full, v_all, e_all);
       then (comp, full, index);
       else (comp, full, index);
     end match;

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -8227,15 +8227,37 @@ template crefVarDimension(ComponentRef cr)
       'data->modelData-><%varArrayName(var)%>Data[<%index%>] /* <%crefCComment(var, crefStrNoUnderscore(name))%> */ .dimension'
 end crefVarDimension;
 
+template lsVarKind(SimVar var)
+"var_kind enum constant matching this var, for initializeStaticLSVars."
+::=
+  match var
+    case SIMVAR(varKind=PARAM()) then 'VAR_KIND_PARAMETER'
+    case SIMVAR(__)              then 'VAR_KIND_VARIABLE'
+end lsVarKind;
+
 template initializeStaticLSVars(list<SimVar> vars, Integer index)
 ::=
   let len = listLength(vars)
   let indices = (vars |> var as SIMVAR(__) => '<%index%> /* <%crefCComment(var, crefStrNoUnderscore(name))%> */' ;separator=",\n")
+  // A torn linear system's own iteration variables can be `fixed=false`
+  // PARAMETERS (solved via an initial-equation call, e.g. a filter's
+  // coefficient array) rather than ordinary VARIABLEs -- their scalar
+  // index lives in realParamsIndex/nParametersReal, a completely
+  // different space than realVarsIndex/nVariablesReal. Hardcoding
+  // VAR_KIND_VARIABLE here (as opposed to the equivalent, correct
+  // per-var dispatch in generateStaticInitialData for NONLINEAR_SYSTEM_DATA)
+  // looked up a variable-space index using a parameter-space index value,
+  // failing getNominalFromScalarIdx's out-of-bounds assertion whenever the
+  // parameter index exceeds nVariablesReal.
+  let kinds = (vars |> var as SIMVAR(__) => lsVarKind(var) ;separator=",\n")
   <<
   void initializeStaticLSData<%index%>(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsePattern)
   {
     const int indices[<%len%>] = {
       <%indices%>
+    };
+    const enum var_kind kinds[<%len%>] = {
+      <%kinds%>
     };
     for (int i = 0; i < <%len%>; ++i) {
       if (indices[i] < 0) {
@@ -8243,9 +8265,9 @@ template initializeStaticLSVars(list<SimVar> vars, Integer index)
         linearSystemData->min[i]     = -DBL_MAX;
         linearSystemData->max[i]     = DBL_MAX;
       } else {
-        linearSystemData->nominal[i] = getNominalFromScalarIdx(data->simulationInfo, data->modelData, VAR_KIND_VARIABLE, indices[i]);
-        linearSystemData->min[i]     = getMinFromScalarIdx(data->simulationInfo, data->modelData, VAR_TYPE_REAL, VAR_KIND_VARIABLE, indices[i]);
-        linearSystemData->max[i]     = getMaxFromScalarIdx(data->simulationInfo, data->modelData, VAR_TYPE_REAL, VAR_KIND_VARIABLE, indices[i]);
+        linearSystemData->nominal[i] = getNominalFromScalarIdx(data->simulationInfo, data->modelData, kinds[i], indices[i]);
+        linearSystemData->min[i]     = getMinFromScalarIdx(data->simulationInfo, data->modelData, VAR_TYPE_REAL, kinds[i], indices[i]);
+        linearSystemData->max[i]     = getMaxFromScalarIdx(data->simulationInfo, data->modelData, VAR_TYPE_REAL, kinds[i], indices[i]);
       }
     }
   }

--- a/testsuite/simulation/modelica/NBackend/Buildings/Buildings.DHC.ETS.Combined.Subsystems.Validation.HeatPump.mos
+++ b/testsuite/simulation/modelica/NBackend/Buildings/Buildings.DHC.ETS.Combined.Subsystems.Validation.HeatPump.mos
@@ -15,15 +15,7 @@ simulate(Buildings.DHC.ETS.Combined.Subsystems.Validation.HeatPump); getErrorStr
 // record SimulationResult
 //     resultFile = "Buildings.DHC.ETS.Combined.Subsystems.Validation.HeatPump_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 172800.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Buildings.DHC.ETS.Combined.Subsystems.Validation.HeatPump', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_STDOUT        | info    | Using sparse solver kinsol for nonlinear system 3 (699),
-// |                 | |       | because density of 0.09 remains under threshold of 0.10.
-// LOG_STDOUT        | info    | Using sparse solver kinsol for nonlinear system 4 (1495),
-// |                 | |       | because density of 0.10 remains under threshold of 0.10.
-// LOG_STDOUT        | info    | Using sparse solver kinsol for nonlinear system 6 (1847),
-// |                 | |       | because density of 0.08 remains under threshold of 0.10.
-// LOG_STDOUT        | info    | The maximum density for using sparse solvers can be specified
-// |                 | |       | using the runtime flag '<-nlssMaxDensity=value>'.
-// LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/NBackend/ModelicaTest/ModelicaTest.Media.TestAllProperties.IncompleteMedia.ReferenceAir_dT.mos
+++ b/testsuite/simulation/modelica/NBackend/ModelicaTest/ModelicaTest.Media.TestAllProperties.IncompleteMedia.ReferenceAir_dT.mos
@@ -16,8 +16,7 @@ diffSimulationResults("ModelicaTest.Media.TestAllProperties.IncompleteMedia.Refe
 // record SimulationResult
 //     resultFile = "ModelicaTest.Media.TestAllProperties.IncompleteMedia.ReferenceAir_dT_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 0.1, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ModelicaTest.Media.TestAllProperties.IncompleteMedia.ReferenceAir_dT', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_STDOUT        | warning | The default linear solver fails, the fallback solver with total pivoting is started at time 0.000000. That might raise performance issues, for more information use -lv LOG_LS.
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/NBackend/basics/simpleNonlinearLoop.mos
+++ b/testsuite/simulation/modelica/NBackend/basics/simpleNonlinearLoop.mos
@@ -24,15 +24,11 @@ val(y,1);
 // record SimulationResult
 //     resultFile = "simpleNonlinearLoop_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'simpleNonlinearLoop', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_STDOUT        | warning | The default linear solver fails, the fallback solver with total pivoting is started at time 0.000000. That might raise performance issues, for more information use -lv LOG_LS.
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_STDOUT        | warning | The default linear solver fails, the fallback solver with total pivoting is started at time 0.274000. That might raise performance issues, for more information use -lv LOG_LS.
-// LOG_STDOUT        | info    | Too many warnings, reached display limit of 3. Suppressing further warning messages of the same type.
-// LOG_STDOUT        | info    | Change limit with simulation flag -lvMaxWarn=<newLimit>
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
 // ""
-// 1.7929323546379894
-// 0.9754287990854195
+// 1.7929327169004785
+// 0.9754289990012507
 // endResult

--- a/testsuite/simulation/modelica/NBackend/basics/solveSingleEquation.mos
+++ b/testsuite/simulation/modelica/NBackend/basics/solveSingleEquation.mos
@@ -28,8 +28,7 @@ simulate(singleEquations); getErrorString();
 // record SimulationResult
 //     resultFile = "singleEquations_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'singleEquations', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_STDOUT        | warning | The default linear solver fails, the fallback solver with total pivoting is started at time 0.000000. That might raise performance issues, for more information use -lv LOG_LS.
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/NBackend/index_reduction/static_IR.mos
+++ b/testsuite/simulation/modelica/NBackend/index_reduction/static_IR.mos
@@ -57,7 +57,6 @@ simulate(static_IR_2); getErrorString();
 //     resultFile = "static_IR_1_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'static_IR_1', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_STDOUT        | warning | The default linear solver fails, the fallback solver with total pivoting is started at time 0.032767. That might raise performance issues, for more information use -lv LOG_LS.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
@@ -87,7 +86,6 @@ simulate(static_IR_2); getErrorString();
 //     resultFile = "static_IR_2_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'static_IR_2', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// LOG_STDOUT        | warning | The default linear solver fails, the fallback solver with total pivoting is started at time 0.032766. That might raise performance issues, for more information use -lv LOG_LS.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/NBackend/initialization/TestInversePlant.mos
+++ b/testsuite/simulation/modelica/NBackend/initialization/TestInversePlant.mos
@@ -328,45 +328,45 @@ regexBool(msg, "Sparsity pattern for non-linear system 2 is not regular");
 //   (1) [SNGL]: {{$i1 | start:1, step:1, stop:5, size: 5}}
 // 	plant.G[$i1] = (0.2 * plant.NTU) * plant.w ^ 0.8
 //
-// =========================================================
-//   SimCode Jacobian INI_LS_JAC_1(idx = 0, partition = 0)
-// =========================================================
+// ==========================================================
+//   SimCode Jacobian INI_NLS_JAC_1(idx = 0, partition = 0)
+// ==========================================================
 //
 // SeedVars (size = 33)
 // **********************
-//   (0)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.w
-//   (1)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.wfg
-//   (2)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Tfg[1]
-//   (3)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Tfg[2]
-//   (4)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Tfg[3]
-//   (5)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Tfg[4]
-//   (6)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Tfg[5]
-//   (7)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Tfg[6]
-//   (8)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.G[1]
-//   (9)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.G[2]
-//   (10)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.G[3]
-//   (11)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.G[4]
-//   (12)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.G[5]
-//   (13)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Q[1]
-//   (14)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Q[2]
-//   (15)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Q[3]
-//   (16)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Q[4]
-//   (17)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.Q[5]
-//   (18)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.T[1]
-//   (19)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.T[2]
-//   (20)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.T[3]
-//   (21)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.T[4]
-//   (22)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.T[5]
-//   (23)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.T[6]
-//   (24)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.TIT
-//   (25)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.TIP
-//   (26)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.p[1]
-//   (27)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.p[2]
-//   (28)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.p[3]
-//   (29)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.p[4]
-//   (30)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.p[5]
-//   (31)[SEED] (1) Real $SEED_INI_LS_JAC_1.plant.p[6]
-//   (32)[SEED] (1) Real $SEED_INI_LS_JAC_1.$FUN_1
+//   (0)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.w
+//   (1)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.wfg
+//   (2)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.Tfg[1]
+//   (3)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.Tfg[2]
+//   (4)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.Tfg[3]
+//   (5)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.Tfg[4]
+//   (6)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.Tfg[5]
+//   (7)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.Tfg[6]
+//   (8)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.G[1]
+//   (9)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.G[2]
+//   (10)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.G[3]
+//   (11)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.G[4]
+//   (12)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.G[5]
+//   (13)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.Q[1]
+//   (14)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.Q[2]
+//   (15)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.Q[3]
+//   (16)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.Q[4]
+//   (17)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.Q[5]
+//   (18)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.T[1]
+//   (19)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.T[2]
+//   (20)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.T[3]
+//   (21)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.T[4]
+//   (22)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.T[5]
+//   (23)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.T[6]
+//   (24)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.TIT
+//   (25)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.TIP
+//   (26)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.p[1]
+//   (27)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.p[2]
+//   (28)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.p[3]
+//   (29)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.p[4]
+//   (30)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.p[5]
+//   (31)[SEED] (1) Real $SEED_INI_NLS_JAC_1.plant.p[6]
+//   (32)[SEED] (1) Real $SEED_INI_NLS_JAC_1.$FUN_1
 //
 // TmpVars (size = 0)
 // ********************
@@ -378,37 +378,37 @@ regexBool(msg, "Sparsity pattern for non-linear system 2 is not regular");
 // -----------------------------
 //   (21) Algorithm
 //   for $i1 in 1:5 loop
-//     $pDER_INI_LS_JAC_1.$RES_SIM_10[$i1] := (plant.cp * $SEED_INI_LS_JAC_1.plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) + plant.cp * plant.wfg * ($SEED_INI_LS_JAC_1.plant.Tfg[6 - $i1] - $SEED_INI_LS_JAC_1.plant.Tfg[7 - $i1])) - $SEED_INI_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_NLS_JAC_1.$RES_SIM_10[$i1] := (plant.cp * $SEED_INI_NLS_JAC_1.plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) + plant.cp * plant.wfg * ($SEED_INI_NLS_JAC_1.plant.Tfg[6 - $i1] - $SEED_INI_NLS_JAC_1.plant.Tfg[7 - $i1])) - $SEED_INI_NLS_JAC_1.plant.Q[$i1];
 //   end for;
 //   (20) Algorithm
 //   for $i1 in 1:5 loop
-//     $pDER_INI_LS_JAC_1.$RES_SIM_12[$i1] := ((0.5 * ($SEED_INI_LS_JAC_1.plant.Tfg[7 - $i1] + $SEED_INI_LS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_INI_LS_JAC_1.plant.T[1 + $i1] + $SEED_INI_LS_JAC_1.plant.T[$i1])) * plant.G[$i1] + (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * $SEED_INI_LS_JAC_1.plant.G[$i1]) - $SEED_INI_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_NLS_JAC_1.$RES_SIM_12[$i1] := ((0.5 * ($SEED_INI_NLS_JAC_1.plant.Tfg[7 - $i1] + $SEED_INI_NLS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_INI_NLS_JAC_1.plant.T[1 + $i1] + $SEED_INI_NLS_JAC_1.plant.T[$i1])) * plant.G[$i1] + (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * $SEED_INI_NLS_JAC_1.plant.G[$i1]) - $SEED_INI_NLS_JAC_1.plant.Q[$i1];
 //   end for;
 //   (19) Algorithm
 //   for $i1 in 1:5 loop
-//     $pDER_INI_LS_JAC_1.$RES_SIM_14[$i1] := (0.2 * plant.NTU) * (0.8 * plant.w ^ (-0.19999999999999996) * $SEED_INI_LS_JAC_1.plant.w) - $SEED_INI_LS_JAC_1.plant.G[$i1];
+//     $pDER_INI_NLS_JAC_1.$RES_SIM_14[$i1] := (0.2 * plant.NTU) * (0.8 * plant.w ^ (-0.19999999999999996) * $SEED_INI_NLS_JAC_1.plant.w) - $SEED_INI_NLS_JAC_1.plant.G[$i1];
 //   end for;
 //   (18) Algorithm
 //   for $i1 in 1:5 loop
-//     $pDER_INI_LS_JAC_1.$RES_SIM_8[$i1] := (plant.cp * $SEED_INI_LS_JAC_1.plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.cp * plant.w * ($SEED_INI_LS_JAC_1.plant.T[$i1] - $SEED_INI_LS_JAC_1.plant.T[1 + $i1])) + $SEED_INI_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_NLS_JAC_1.$RES_SIM_8[$i1] := (plant.cp * $SEED_INI_NLS_JAC_1.plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.cp * plant.w * ($SEED_INI_NLS_JAC_1.plant.T[$i1] - $SEED_INI_NLS_JAC_1.plant.T[1 + $i1])) + $SEED_INI_NLS_JAC_1.plant.Q[$i1];
 //   end for;
-//   (17) $pDER_INI_LS_JAC_1.$RES_BND_20 := $SEED_INI_LS_JAC_1.plant.T[6] - $SEED_INI_LS_JAC_1.plant.TIT
-//   (16) $pDER_INI_LS_JAC_1.$RES_SIM_6 := $SEED_INI_LS_JAC_1.plant.TIT * plant.cp * plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * $SEED_INI_LS_JAC_1.plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * plant.w * (((plant.gamma - 1.0) / plant.gamma) * (plant.TOP / plant.TIP) ^ ((-1.0) + (plant.gamma - 1.0) / plant.gamma) * ((plant.TOP * $SEED_INI_LS_JAC_1.plant.TIP) / plant.TIP ^ 2.0))
-//   (15) $pDER_INI_LS_JAC_1.$RES_BND_22 := $SEED_INI_LS_JAC_1.plant.p[6] - $SEED_INI_LS_JAC_1.plant.TIP
-//   (14) $pDER_INI_LS_JAC_1.$RES_SIM_7 := (($SEED_INI_LS_JAC_1.plant.p[6] * plant.Kt) * $FUN_1 - $SEED_INI_LS_JAC_1.$FUN_1 * plant.p[6] * plant.Kt) / $FUN_1 ^ 2.0 - $SEED_INI_LS_JAC_1.plant.w
-//   (13) $pDER_INI_LS_JAC_1.$RES_AUX_24 := (0.5 / (plant.TIT / plant.Tnom) ^ 0.5) * (($SEED_INI_LS_JAC_1.plant.TIT * plant.Tnom) / plant.Tnom ^ 2.0) - $SEED_INI_LS_JAC_1.$FUN_1
+//   (17) $pDER_INI_NLS_JAC_1.$RES_BND_20 := $SEED_INI_NLS_JAC_1.plant.T[6] - $SEED_INI_NLS_JAC_1.plant.TIT
+//   (16) $pDER_INI_NLS_JAC_1.$RES_SIM_6 := $SEED_INI_NLS_JAC_1.plant.TIT * plant.cp * plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * $SEED_INI_NLS_JAC_1.plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * plant.w * (((plant.gamma - 1.0) / plant.gamma) * (plant.TOP / plant.TIP) ^ ((-1.0) + (plant.gamma - 1.0) / plant.gamma) * ((plant.TOP * $SEED_INI_NLS_JAC_1.plant.TIP) / plant.TIP ^ 2.0))
+//   (15) $pDER_INI_NLS_JAC_1.$RES_BND_22 := $SEED_INI_NLS_JAC_1.plant.p[6] - $SEED_INI_NLS_JAC_1.plant.TIP
+//   (14) $pDER_INI_NLS_JAC_1.$RES_SIM_7 := (($SEED_INI_NLS_JAC_1.plant.p[6] * plant.Kt) * $FUN_1 - $SEED_INI_NLS_JAC_1.$FUN_1 * plant.p[6] * plant.Kt) / $FUN_1 ^ 2.0 - $SEED_INI_NLS_JAC_1.plant.w
+//   (13) $pDER_INI_NLS_JAC_1.$RES_AUX_24 := (0.5 / (plant.TIT / plant.Tnom) ^ 0.5) * (($SEED_INI_NLS_JAC_1.plant.TIT * plant.Tnom) / plant.Tnom ^ 2.0) - $SEED_INI_NLS_JAC_1.$FUN_1
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_SIM_10 ... {$pDER_INI_LS_JAC_1.$RES_SIM_10[:]} ... {($SEED_INI_LS_JAC_1.plant.Q[$i1], {}, false), ($SEED_INI_LS_JAC_1.plant.Tfg[7 - $i1], {}, false), ($SEED_INI_LS_JAC_1.plant.Tfg[6 - $i1], {}, false), ($SEED_INI_LS_JAC_1.plant.wfg, {}, false)}
-// $RES_SIM_12 ... {$pDER_INI_LS_JAC_1.$RES_SIM_12[:]} ... {($SEED_INI_LS_JAC_1.plant.Q[$i1], {}, false), ($SEED_INI_LS_JAC_1.plant.G[$i1], {}, false), ($SEED_INI_LS_JAC_1.plant.T[$i1], {}, false), ($SEED_INI_LS_JAC_1.plant.T[1 + $i1], {}, false), ($SEED_INI_LS_JAC_1.plant.Tfg[6 - $i1], {}, false), ($SEED_INI_LS_JAC_1.plant.Tfg[7 - $i1], {}, false)}
-// $RES_SIM_14 ... {$pDER_INI_LS_JAC_1.$RES_SIM_14[:]} ... {($SEED_INI_LS_JAC_1.plant.G[$i1], {}, false), ($SEED_INI_LS_JAC_1.plant.w, {}, false)}
-// $RES_SIM_8 ... {$pDER_INI_LS_JAC_1.$RES_SIM_8[:]} ... {($SEED_INI_LS_JAC_1.plant.Q[$i1], {}, false), ($SEED_INI_LS_JAC_1.plant.T[1 + $i1], {}, false), ($SEED_INI_LS_JAC_1.plant.T[$i1], {}, false), ($SEED_INI_LS_JAC_1.plant.w, {}, false)}
-// $RES_BND_20 ... {$pDER_INI_LS_JAC_1.$RES_BND_20} ... {($SEED_INI_LS_JAC_1.plant.TIT, {}, false), ($SEED_INI_LS_JAC_1.plant.T[6], {}, false)}
-// $RES_SIM_6 ... {$pDER_INI_LS_JAC_1.$RES_SIM_6} ... {($SEED_INI_LS_JAC_1.plant.TIP, {}, false), ($SEED_INI_LS_JAC_1.plant.w, {}, false), ($SEED_INI_LS_JAC_1.plant.TIT, {}, false)}
-// $RES_BND_22 ... {$pDER_INI_LS_JAC_1.$RES_BND_22} ... {($SEED_INI_LS_JAC_1.plant.TIP, {}, false), ($SEED_INI_LS_JAC_1.plant.p[6], {}, false)}
-// $RES_SIM_7 ... {$pDER_INI_LS_JAC_1.$RES_SIM_7} ... {($SEED_INI_LS_JAC_1.plant.w, {}, false), ($SEED_INI_LS_JAC_1.$FUN_1, {}, false), ($SEED_INI_LS_JAC_1.plant.p[6], {}, false)}
-// $RES_AUX_24 ... {$pDER_INI_LS_JAC_1.$RES_AUX_24} ... {($SEED_INI_LS_JAC_1.$FUN_1, {}, false), ($SEED_INI_LS_JAC_1.plant.TIT, {}, true)}
+// $RES_SIM_10 ... {$pDER_INI_NLS_JAC_1.$RES_SIM_10[:]} ... {($SEED_INI_NLS_JAC_1.plant.Q[$i1], {}, false), ($SEED_INI_NLS_JAC_1.plant.Tfg[7 - $i1], {}, false), ($SEED_INI_NLS_JAC_1.plant.Tfg[6 - $i1], {}, false), ($SEED_INI_NLS_JAC_1.plant.wfg, {}, false)}
+// $RES_SIM_12 ... {$pDER_INI_NLS_JAC_1.$RES_SIM_12[:]} ... {($SEED_INI_NLS_JAC_1.plant.Q[$i1], {}, false), ($SEED_INI_NLS_JAC_1.plant.G[$i1], {}, false), ($SEED_INI_NLS_JAC_1.plant.T[$i1], {}, false), ($SEED_INI_NLS_JAC_1.plant.T[1 + $i1], {}, false), ($SEED_INI_NLS_JAC_1.plant.Tfg[6 - $i1], {}, false), ($SEED_INI_NLS_JAC_1.plant.Tfg[7 - $i1], {}, false)}
+// $RES_SIM_14 ... {$pDER_INI_NLS_JAC_1.$RES_SIM_14[:]} ... {($SEED_INI_NLS_JAC_1.plant.G[$i1], {}, false), ($SEED_INI_NLS_JAC_1.plant.w, {}, false)}
+// $RES_SIM_8 ... {$pDER_INI_NLS_JAC_1.$RES_SIM_8[:]} ... {($SEED_INI_NLS_JAC_1.plant.Q[$i1], {}, false), ($SEED_INI_NLS_JAC_1.plant.T[1 + $i1], {}, false), ($SEED_INI_NLS_JAC_1.plant.T[$i1], {}, false), ($SEED_INI_NLS_JAC_1.plant.w, {}, false)}
+// $RES_BND_20 ... {$pDER_INI_NLS_JAC_1.$RES_BND_20} ... {($SEED_INI_NLS_JAC_1.plant.TIT, {}, false), ($SEED_INI_NLS_JAC_1.plant.T[6], {}, false)}
+// $RES_SIM_6 ... {$pDER_INI_NLS_JAC_1.$RES_SIM_6} ... {($SEED_INI_NLS_JAC_1.plant.TIP, {}, false), ($SEED_INI_NLS_JAC_1.plant.w, {}, false), ($SEED_INI_NLS_JAC_1.plant.TIT, {}, false)}
+// $RES_BND_22 ... {$pDER_INI_NLS_JAC_1.$RES_BND_22} ... {($SEED_INI_NLS_JAC_1.plant.TIP, {}, false), ($SEED_INI_NLS_JAC_1.plant.p[6], {}, false)}
+// $RES_SIM_7 ... {$pDER_INI_NLS_JAC_1.$RES_SIM_7} ... {($SEED_INI_NLS_JAC_1.plant.w, {}, false), ($SEED_INI_NLS_JAC_1.$FUN_1, {}, false), ($SEED_INI_NLS_JAC_1.plant.p[6], {}, false)}
+// $RES_AUX_24 ... {$pDER_INI_NLS_JAC_1.$RES_AUX_24} ... {($SEED_INI_NLS_JAC_1.$FUN_1, {}, false), ($SEED_INI_NLS_JAC_1.plant.TIT, {}, true)}
 //
 // ===========================================================
 //   SimCode Jacobian INI_0_LS_JAC_1(idx = 1, partition = 1)
@@ -461,47 +461,47 @@ regexBool(msg, "Sparsity pattern for non-linear system 2 is not regular");
 // $RES_SIM_10 ... {$pDER_INI_0_LS_JAC_1.$RES_SIM_10[:]} ... {($SEED_INI_0_LS_JAC_1.plant.Q[$i1], {}, false), ($SEED_INI_0_LS_JAC_1.plant.Tfg[7 - $i1], {}, false), ($SEED_INI_0_LS_JAC_1.plant.Tfg[6 - $i1], {}, false)}
 // $RES_SIM_8 ... {$pDER_INI_0_LS_JAC_1.$RES_SIM_8[:]} ... {($SEED_INI_0_LS_JAC_1.plant.Q[$i1], {}, false), ($SEED_INI_0_LS_JAC_1.plant.T[1 + $i1], {}, false), ($SEED_INI_0_LS_JAC_1.plant.T[$i1], {}, false)}
 //
-// =========================================================
-//   SimCode Jacobian ALG_LS_JAC_1(idx = 2, partition = 2)
-// =========================================================
+// ==========================================================
+//   SimCode Jacobian ALG_NLS_JAC_1(idx = 2, partition = 2)
+// ==========================================================
 //
 // SeedVars (size = 35)
 // **********************
-//   (0)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.w
-//   (1)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Ts
-//   (2)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.wfg
-//   (3)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Tfg[1]
-//   (4)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Tfg[2]
-//   (5)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Tfg[3]
-//   (6)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Tfg[4]
-//   (7)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Tfg[5]
-//   (8)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Tfg[6]
-//   (9)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Q[1]
-//   (10)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Q[2]
-//   (11)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Q[3]
-//   (12)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Q[4]
-//   (13)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.Q[5]
-//   (14)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.TIT
-//   (15)[SEED] (1) Real $SEED_ALG_LS_JAC_1.$FUN_1
-//   (16)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.p[1]
-//   (17)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.p[2]
-//   (18)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.p[3]
-//   (19)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.p[4]
-//   (20)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.p[5]
-//   (21)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.p[6]
-//   (22)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.TIP
-//   (23)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.P
-//   (24)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.T[1]
-//   (25)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.T[2]
-//   (26)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.T[3]
-//   (27)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.T[4]
-//   (28)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.T[5]
-//   (29)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.T[6]
-//   (30)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.G[1]
-//   (31)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.G[2]
-//   (32)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.G[3]
-//   (33)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.G[4]
-//   (34)[SEED] (1) Real $SEED_ALG_LS_JAC_1.plant.G[5]
+//   (0)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.w
+//   (1)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.Ts
+//   (2)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.wfg
+//   (3)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.Tfg[1]
+//   (4)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.Tfg[2]
+//   (5)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.Tfg[3]
+//   (6)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.Tfg[4]
+//   (7)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.Tfg[5]
+//   (8)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.Tfg[6]
+//   (9)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.Q[1]
+//   (10)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.Q[2]
+//   (11)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.Q[3]
+//   (12)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.Q[4]
+//   (13)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.Q[5]
+//   (14)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.TIT
+//   (15)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.$FUN_1
+//   (16)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.p[1]
+//   (17)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.p[2]
+//   (18)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.p[3]
+//   (19)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.p[4]
+//   (20)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.p[5]
+//   (21)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.p[6]
+//   (22)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.TIP
+//   (23)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.P
+//   (24)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.T[1]
+//   (25)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.T[2]
+//   (26)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.T[3]
+//   (27)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.T[4]
+//   (28)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.T[5]
+//   (29)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.T[6]
+//   (30)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.G[1]
+//   (31)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.G[2]
+//   (32)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.G[3]
+//   (33)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.G[4]
+//   (34)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.plant.G[5]
 //
 // TmpVars (size = 0)
 // ********************
@@ -511,45 +511,45 @@ regexBool(msg, "Sparsity pattern for non-linear system 2 is not regular");
 //
 // Column Equations (size = 12)
 // ------------------------------
-//   (74) $pDER_ALG_LS_JAC_1.$RES_BND_21 := $SEED_ALG_LS_JAC_1.plant.Tfg[6] - $SEED_ALG_LS_JAC_1.plant.Ts
-//   (73) $pDER_ALG_LS_JAC_1.$RES_SIM_2 := -$SEED_ALG_LS_JAC_1.plant.Ts
+//   (74) $pDER_ALG_NLS_JAC_1.$RES_BND_21 := $SEED_ALG_NLS_JAC_1.plant.Tfg[6] - $SEED_ALG_NLS_JAC_1.plant.Ts
+//   (73) $pDER_ALG_NLS_JAC_1.$RES_SIM_2 := -$SEED_ALG_NLS_JAC_1.plant.Ts
 //   (72) Algorithm
 //   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_12[$i1] := ((0.5 * ($SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1] + $SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_ALG_LS_JAC_1.plant.T[1 + $i1] + $SEED_ALG_LS_JAC_1.plant.T[$i1])) * plant.G[$i1] + (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * $SEED_ALG_LS_JAC_1.plant.G[$i1]) - $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_ALG_NLS_JAC_1.$RES_SIM_12[$i1] := ((0.5 * ($SEED_ALG_NLS_JAC_1.plant.Tfg[7 - $i1] + $SEED_ALG_NLS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_ALG_NLS_JAC_1.plant.T[1 + $i1] + $SEED_ALG_NLS_JAC_1.plant.T[$i1])) * plant.G[$i1] + (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * $SEED_ALG_NLS_JAC_1.plant.G[$i1]) - $SEED_ALG_NLS_JAC_1.plant.Q[$i1];
 //   end for;
 //   (71) Algorithm
 //   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_10[$i1] := (plant.cp * $SEED_ALG_LS_JAC_1.plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) + plant.cp * plant.wfg * ($SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1] - $SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1])) - $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_ALG_NLS_JAC_1.$RES_SIM_10[$i1] := (plant.cp * $SEED_ALG_NLS_JAC_1.plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) + plant.cp * plant.wfg * ($SEED_ALG_NLS_JAC_1.plant.Tfg[6 - $i1] - $SEED_ALG_NLS_JAC_1.plant.Tfg[7 - $i1])) - $SEED_ALG_NLS_JAC_1.plant.Q[$i1];
 //   end for;
-//   (70) $pDER_ALG_LS_JAC_1.$RES_BND_20 := $SEED_ALG_LS_JAC_1.plant.T[6] - $SEED_ALG_LS_JAC_1.plant.TIT
-//   (69) $pDER_ALG_LS_JAC_1.$RES_AUX_24 := (0.5 / (plant.TIT / plant.Tnom) ^ 0.5) * (($SEED_ALG_LS_JAC_1.plant.TIT * plant.Tnom) / plant.Tnom ^ 2.0) - $SEED_ALG_LS_JAC_1.$FUN_1
-//   (68) $pDER_ALG_LS_JAC_1.$RES_SIM_7 := (($SEED_ALG_LS_JAC_1.plant.p[6] * plant.Kt) * $FUN_1 - $SEED_ALG_LS_JAC_1.$FUN_1 * plant.p[6] * plant.Kt) / $FUN_1 ^ 2.0 - $SEED_ALG_LS_JAC_1.plant.w
-//   (67) $pDER_ALG_LS_JAC_1.$RES_BND_22 := $SEED_ALG_LS_JAC_1.plant.p[6] - $SEED_ALG_LS_JAC_1.plant.TIP
-//   (66) $pDER_ALG_LS_JAC_1.$RES_SIM_6 := ($SEED_ALG_LS_JAC_1.plant.TIT * plant.cp * plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * $SEED_ALG_LS_JAC_1.plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * plant.w * (((plant.gamma - 1.0) / plant.gamma) * (plant.TOP / plant.TIP) ^ ((-1.0) + (plant.gamma - 1.0) / plant.gamma) * ((plant.TOP * $SEED_ALG_LS_JAC_1.plant.TIP) / plant.TIP ^ 2.0))) - $SEED_ALG_LS_JAC_1.plant.P
-//   (65) $pDER_ALG_LS_JAC_1.$RES_SIM_5 := -$SEED_ALG_LS_JAC_1.plant.P
+//   (70) $pDER_ALG_NLS_JAC_1.$RES_BND_20 := $SEED_ALG_NLS_JAC_1.plant.T[6] - $SEED_ALG_NLS_JAC_1.plant.TIT
+//   (69) $pDER_ALG_NLS_JAC_1.$RES_AUX_24 := (0.5 / (plant.TIT / plant.Tnom) ^ 0.5) * (($SEED_ALG_NLS_JAC_1.plant.TIT * plant.Tnom) / plant.Tnom ^ 2.0) - $SEED_ALG_NLS_JAC_1.$FUN_1
+//   (68) $pDER_ALG_NLS_JAC_1.$RES_SIM_7 := (($SEED_ALG_NLS_JAC_1.plant.p[6] * plant.Kt) * $FUN_1 - $SEED_ALG_NLS_JAC_1.$FUN_1 * plant.p[6] * plant.Kt) / $FUN_1 ^ 2.0 - $SEED_ALG_NLS_JAC_1.plant.w
+//   (67) $pDER_ALG_NLS_JAC_1.$RES_BND_22 := $SEED_ALG_NLS_JAC_1.plant.p[6] - $SEED_ALG_NLS_JAC_1.plant.TIP
+//   (66) $pDER_ALG_NLS_JAC_1.$RES_SIM_6 := ($SEED_ALG_NLS_JAC_1.plant.TIT * plant.cp * plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * $SEED_ALG_NLS_JAC_1.plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * plant.w * (((plant.gamma - 1.0) / plant.gamma) * (plant.TOP / plant.TIP) ^ ((-1.0) + (plant.gamma - 1.0) / plant.gamma) * ((plant.TOP * $SEED_ALG_NLS_JAC_1.plant.TIP) / plant.TIP ^ 2.0))) - $SEED_ALG_NLS_JAC_1.plant.P
+//   (65) $pDER_ALG_NLS_JAC_1.$RES_SIM_5 := -$SEED_ALG_NLS_JAC_1.plant.P
 //   (64) Algorithm
 //   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_8[$i1] := (plant.cp * $SEED_ALG_LS_JAC_1.plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.cp * plant.w * ($SEED_ALG_LS_JAC_1.plant.T[$i1] - $SEED_ALG_LS_JAC_1.plant.T[1 + $i1])) + $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_ALG_NLS_JAC_1.$RES_SIM_8[$i1] := (plant.cp * $SEED_ALG_NLS_JAC_1.plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.cp * plant.w * ($SEED_ALG_NLS_JAC_1.plant.T[$i1] - $SEED_ALG_NLS_JAC_1.plant.T[1 + $i1])) + $SEED_ALG_NLS_JAC_1.plant.Q[$i1];
 //   end for;
 //   (63) Algorithm
 //   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_14[$i1] := (0.2 * plant.NTU) * (0.8 * plant.w ^ (-0.19999999999999996) * $SEED_ALG_LS_JAC_1.plant.w) - $SEED_ALG_LS_JAC_1.plant.G[$i1];
+//     $pDER_ALG_NLS_JAC_1.$RES_SIM_14[$i1] := (0.2 * plant.NTU) * (0.8 * plant.w ^ (-0.19999999999999996) * $SEED_ALG_NLS_JAC_1.plant.w) - $SEED_ALG_NLS_JAC_1.plant.G[$i1];
 //   end for;
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_BND_21 ... {$pDER_ALG_LS_JAC_1.$RES_BND_21} ... {($SEED_ALG_LS_JAC_1.plant.Ts, {}, false), ($SEED_ALG_LS_JAC_1.plant.Tfg[6], {}, false)}
-// $RES_SIM_2 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_2} ... {($SEED_ALG_LS_JAC_1.plant.Ts, {}, false)}
-// $RES_SIM_12 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_12[:]} ... {($SEED_ALG_LS_JAC_1.plant.Q[$i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.G[$i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.T[$i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.T[1 + $i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1], {}, false)}
-// $RES_SIM_10 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_10[:]} ... {($SEED_ALG_LS_JAC_1.plant.Q[$i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.wfg, {}, false)}
-// $RES_BND_20 ... {$pDER_ALG_LS_JAC_1.$RES_BND_20} ... {($SEED_ALG_LS_JAC_1.plant.TIT, {}, false), ($SEED_ALG_LS_JAC_1.plant.T[6], {}, false)}
-// $RES_AUX_24 ... {$pDER_ALG_LS_JAC_1.$RES_AUX_24} ... {($SEED_ALG_LS_JAC_1.$FUN_1, {}, false), ($SEED_ALG_LS_JAC_1.plant.TIT, {}, true)}
-// $RES_SIM_7 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_7} ... {($SEED_ALG_LS_JAC_1.plant.w, {}, false), ($SEED_ALG_LS_JAC_1.$FUN_1, {}, false), ($SEED_ALG_LS_JAC_1.plant.p[6], {}, false)}
-// $RES_BND_22 ... {$pDER_ALG_LS_JAC_1.$RES_BND_22} ... {($SEED_ALG_LS_JAC_1.plant.TIP, {}, false), ($SEED_ALG_LS_JAC_1.plant.p[6], {}, false)}
-// $RES_SIM_6 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_6} ... {($SEED_ALG_LS_JAC_1.plant.P, {}, false), ($SEED_ALG_LS_JAC_1.plant.TIP, {}, false), ($SEED_ALG_LS_JAC_1.plant.w, {}, false), ($SEED_ALG_LS_JAC_1.plant.TIT, {}, false)}
-// $RES_SIM_5 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_5} ... {($SEED_ALG_LS_JAC_1.plant.P, {}, false)}
-// $RES_SIM_8 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_8[:]} ... {($SEED_ALG_LS_JAC_1.plant.Q[$i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.T[1 + $i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.T[$i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.w, {}, false)}
-// $RES_SIM_14 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_14[:]} ... {($SEED_ALG_LS_JAC_1.plant.G[$i1], {}, false), ($SEED_ALG_LS_JAC_1.plant.w, {}, false)}
+// $RES_BND_21 ... {$pDER_ALG_NLS_JAC_1.$RES_BND_21} ... {($SEED_ALG_NLS_JAC_1.plant.Ts, {}, false), ($SEED_ALG_NLS_JAC_1.plant.Tfg[6], {}, false)}
+// $RES_SIM_2 ... {$pDER_ALG_NLS_JAC_1.$RES_SIM_2} ... {($SEED_ALG_NLS_JAC_1.plant.Ts, {}, false)}
+// $RES_SIM_12 ... {$pDER_ALG_NLS_JAC_1.$RES_SIM_12[:]} ... {($SEED_ALG_NLS_JAC_1.plant.Q[$i1], {}, false), ($SEED_ALG_NLS_JAC_1.plant.G[$i1], {}, false), ($SEED_ALG_NLS_JAC_1.plant.T[$i1], {}, false), ($SEED_ALG_NLS_JAC_1.plant.T[1 + $i1], {}, false), ($SEED_ALG_NLS_JAC_1.plant.Tfg[6 - $i1], {}, false), ($SEED_ALG_NLS_JAC_1.plant.Tfg[7 - $i1], {}, false)}
+// $RES_SIM_10 ... {$pDER_ALG_NLS_JAC_1.$RES_SIM_10[:]} ... {($SEED_ALG_NLS_JAC_1.plant.Q[$i1], {}, false), ($SEED_ALG_NLS_JAC_1.plant.Tfg[7 - $i1], {}, false), ($SEED_ALG_NLS_JAC_1.plant.Tfg[6 - $i1], {}, false), ($SEED_ALG_NLS_JAC_1.plant.wfg, {}, false)}
+// $RES_BND_20 ... {$pDER_ALG_NLS_JAC_1.$RES_BND_20} ... {($SEED_ALG_NLS_JAC_1.plant.TIT, {}, false), ($SEED_ALG_NLS_JAC_1.plant.T[6], {}, false)}
+// $RES_AUX_24 ... {$pDER_ALG_NLS_JAC_1.$RES_AUX_24} ... {($SEED_ALG_NLS_JAC_1.$FUN_1, {}, false), ($SEED_ALG_NLS_JAC_1.plant.TIT, {}, true)}
+// $RES_SIM_7 ... {$pDER_ALG_NLS_JAC_1.$RES_SIM_7} ... {($SEED_ALG_NLS_JAC_1.plant.w, {}, false), ($SEED_ALG_NLS_JAC_1.$FUN_1, {}, false), ($SEED_ALG_NLS_JAC_1.plant.p[6], {}, false)}
+// $RES_BND_22 ... {$pDER_ALG_NLS_JAC_1.$RES_BND_22} ... {($SEED_ALG_NLS_JAC_1.plant.TIP, {}, false), ($SEED_ALG_NLS_JAC_1.plant.p[6], {}, false)}
+// $RES_SIM_6 ... {$pDER_ALG_NLS_JAC_1.$RES_SIM_6} ... {($SEED_ALG_NLS_JAC_1.plant.P, {}, false), ($SEED_ALG_NLS_JAC_1.plant.TIP, {}, false), ($SEED_ALG_NLS_JAC_1.plant.w, {}, false), ($SEED_ALG_NLS_JAC_1.plant.TIT, {}, false)}
+// $RES_SIM_5 ... {$pDER_ALG_NLS_JAC_1.$RES_SIM_5} ... {($SEED_ALG_NLS_JAC_1.plant.P, {}, false)}
+// $RES_SIM_8 ... {$pDER_ALG_NLS_JAC_1.$RES_SIM_8[:]} ... {($SEED_ALG_NLS_JAC_1.plant.Q[$i1], {}, false), ($SEED_ALG_NLS_JAC_1.plant.T[1 + $i1], {}, false), ($SEED_ALG_NLS_JAC_1.plant.T[$i1], {}, false), ($SEED_ALG_NLS_JAC_1.plant.w, {}, false)}
+// $RES_SIM_14 ... {$pDER_ALG_NLS_JAC_1.$RES_SIM_14[:]} ... {($SEED_ALG_NLS_JAC_1.plant.G[$i1], {}, false), ($SEED_ALG_NLS_JAC_1.plant.w, {}, false)}
 //
 // ======================================================
 //   [EMPTY] SimCode Jacobian A(idx = 3, partition = 0)
@@ -618,28 +618,28 @@ regexBool(msg, "Sparsity pattern for non-linear system 2 is not regular");
 // 	61: plant.cp * plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.Q[$i1] (FOR_RESIDUAL)
 // 	62: 0.2 * plant.NTU * plant.w ^ 0.8 - plant.G[$i1] (FOR_RESIDUAL)
 // 	Jacobian idx: 2
-// 	74: $pDER_ALG_LS_JAC_1.$RES_BND_21=$SEED_ALG_LS_JAC_1.plant.Tfg[6] - $SEED_ALG_LS_JAC_1.plant.Ts [Real]
-// 	73: $pDER_ALG_LS_JAC_1.$RES_SIM_2=-$SEED_ALG_LS_JAC_1.plant.Ts [Real]
+// 	74: $pDER_ALG_NLS_JAC_1.$RES_BND_21=$SEED_ALG_NLS_JAC_1.plant.Tfg[6] - $SEED_ALG_NLS_JAC_1.plant.Ts [Real]
+// 	73: $pDER_ALG_NLS_JAC_1.$RES_SIM_2=-$SEED_ALG_NLS_JAC_1.plant.Ts [Real]
 // 	72:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_12[$i1] := (0.5 * ($SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1] + $SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_ALG_LS_JAC_1.plant.T[1 + $i1] + $SEED_ALG_LS_JAC_1.plant.T[$i1])) * plant.G[$i1] + (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * $SEED_ALG_LS_JAC_1.plant.G[$i1] - $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_ALG_NLS_JAC_1.$RES_SIM_12[$i1] := (0.5 * ($SEED_ALG_NLS_JAC_1.plant.Tfg[7 - $i1] + $SEED_ALG_NLS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_ALG_NLS_JAC_1.plant.T[1 + $i1] + $SEED_ALG_NLS_JAC_1.plant.T[$i1])) * plant.G[$i1] + (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * $SEED_ALG_NLS_JAC_1.plant.G[$i1] - $SEED_ALG_NLS_JAC_1.plant.Q[$i1];
 //   end for;
 //
 // 	71:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_10[$i1] := plant.cp * $SEED_ALG_LS_JAC_1.plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) + plant.cp * plant.wfg * ($SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1] - $SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1]) - $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_ALG_NLS_JAC_1.$RES_SIM_10[$i1] := plant.cp * $SEED_ALG_NLS_JAC_1.plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) + plant.cp * plant.wfg * ($SEED_ALG_NLS_JAC_1.plant.Tfg[6 - $i1] - $SEED_ALG_NLS_JAC_1.plant.Tfg[7 - $i1]) - $SEED_ALG_NLS_JAC_1.plant.Q[$i1];
 //   end for;
 //
-// 	70: $pDER_ALG_LS_JAC_1.$RES_BND_20=$SEED_ALG_LS_JAC_1.plant.T[6] - $SEED_ALG_LS_JAC_1.plant.TIT [Real]
-// 	69: $pDER_ALG_LS_JAC_1.$RES_AUX_24=0.5 / (plant.TIT / plant.Tnom) ^ 0.5 * $SEED_ALG_LS_JAC_1.plant.TIT * plant.Tnom / plant.Tnom ^ 2.0 - $SEED_ALG_LS_JAC_1.$FUN_1 [Real]
-// 	68: $pDER_ALG_LS_JAC_1.$RES_SIM_7=($SEED_ALG_LS_JAC_1.plant.p[6] * plant.Kt * $FUN_1 - $SEED_ALG_LS_JAC_1.$FUN_1 * plant.p[6] * plant.Kt) / $FUN_1 ^ 2.0 - $SEED_ALG_LS_JAC_1.plant.w [Real]
-// 	67: $pDER_ALG_LS_JAC_1.$RES_BND_22=$SEED_ALG_LS_JAC_1.plant.p[6] - $SEED_ALG_LS_JAC_1.plant.TIP [Real]
-// 	66: $pDER_ALG_LS_JAC_1.$RES_SIM_6=$SEED_ALG_LS_JAC_1.plant.TIT * plant.cp * plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * $SEED_ALG_LS_JAC_1.plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * plant.w * (plant.gamma - 1.0) / plant.gamma * (plant.TOP / plant.TIP) ^ (-1.0 + (plant.gamma - 1.0) / plant.gamma) * plant.TOP * $SEED_ALG_LS_JAC_1.plant.TIP / plant.TIP ^ 2.0 - $SEED_ALG_LS_JAC_1.plant.P [Real]
-// 	65: $pDER_ALG_LS_JAC_1.$RES_SIM_5=-$SEED_ALG_LS_JAC_1.plant.P [Real]
+// 	70: $pDER_ALG_NLS_JAC_1.$RES_BND_20=$SEED_ALG_NLS_JAC_1.plant.T[6] - $SEED_ALG_NLS_JAC_1.plant.TIT [Real]
+// 	69: $pDER_ALG_NLS_JAC_1.$RES_AUX_24=0.5 / (plant.TIT / plant.Tnom) ^ 0.5 * $SEED_ALG_NLS_JAC_1.plant.TIT * plant.Tnom / plant.Tnom ^ 2.0 - $SEED_ALG_NLS_JAC_1.$FUN_1 [Real]
+// 	68: $pDER_ALG_NLS_JAC_1.$RES_SIM_7=($SEED_ALG_NLS_JAC_1.plant.p[6] * plant.Kt * $FUN_1 - $SEED_ALG_NLS_JAC_1.$FUN_1 * plant.p[6] * plant.Kt) / $FUN_1 ^ 2.0 - $SEED_ALG_NLS_JAC_1.plant.w [Real]
+// 	67: $pDER_ALG_NLS_JAC_1.$RES_BND_22=$SEED_ALG_NLS_JAC_1.plant.p[6] - $SEED_ALG_NLS_JAC_1.plant.TIP [Real]
+// 	66: $pDER_ALG_NLS_JAC_1.$RES_SIM_6=$SEED_ALG_NLS_JAC_1.plant.TIT * plant.cp * plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * $SEED_ALG_NLS_JAC_1.plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * plant.w * (plant.gamma - 1.0) / plant.gamma * (plant.TOP / plant.TIP) ^ (-1.0 + (plant.gamma - 1.0) / plant.gamma) * plant.TOP * $SEED_ALG_NLS_JAC_1.plant.TIP / plant.TIP ^ 2.0 - $SEED_ALG_NLS_JAC_1.plant.P [Real]
+// 	65: $pDER_ALG_NLS_JAC_1.$RES_SIM_5=-$SEED_ALG_NLS_JAC_1.plant.P [Real]
 // 	64:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_8[$i1] := plant.cp * $SEED_ALG_LS_JAC_1.plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.cp * plant.w * ($SEED_ALG_LS_JAC_1.plant.T[$i1] - $SEED_ALG_LS_JAC_1.plant.T[1 + $i1]) + $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_ALG_NLS_JAC_1.$RES_SIM_8[$i1] := plant.cp * $SEED_ALG_NLS_JAC_1.plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.cp * plant.w * ($SEED_ALG_NLS_JAC_1.plant.T[$i1] - $SEED_ALG_NLS_JAC_1.plant.T[1 + $i1]) + $SEED_ALG_NLS_JAC_1.plant.Q[$i1];
 //   end for;
 //
 // 	63:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_14[$i1] := 0.2 * plant.NTU * 0.8 * plant.w ^ (-0.19999999999999996) * $SEED_ALG_LS_JAC_1.plant.w - $SEED_ALG_LS_JAC_1.plant.G[$i1];
+//     $pDER_ALG_NLS_JAC_1.$RES_SIM_14[$i1] := 0.2 * plant.NTU * 0.8 * plant.w ^ (-0.19999999999999996) * $SEED_ALG_NLS_JAC_1.plant.w - $SEED_ALG_NLS_JAC_1.plant.G[$i1];
 //   end for;
 //
 // 	
@@ -675,28 +675,28 @@ regexBool(msg, "Sparsity pattern for non-linear system 2 is not regular");
 // 	61: plant.cp * plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.Q[$i1] (FOR_RESIDUAL)
 // 	62: 0.2 * plant.NTU * plant.w ^ 0.8 - plant.G[$i1] (FOR_RESIDUAL)
 // 	Jacobian idx: 2
-// 	74: $pDER_ALG_LS_JAC_1.$RES_BND_21=$SEED_ALG_LS_JAC_1.plant.Tfg[6] - $SEED_ALG_LS_JAC_1.plant.Ts [Real]
-// 	73: $pDER_ALG_LS_JAC_1.$RES_SIM_2=-$SEED_ALG_LS_JAC_1.plant.Ts [Real]
+// 	74: $pDER_ALG_NLS_JAC_1.$RES_BND_21=$SEED_ALG_NLS_JAC_1.plant.Tfg[6] - $SEED_ALG_NLS_JAC_1.plant.Ts [Real]
+// 	73: $pDER_ALG_NLS_JAC_1.$RES_SIM_2=-$SEED_ALG_NLS_JAC_1.plant.Ts [Real]
 // 	72:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_12[$i1] := (0.5 * ($SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1] + $SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_ALG_LS_JAC_1.plant.T[1 + $i1] + $SEED_ALG_LS_JAC_1.plant.T[$i1])) * plant.G[$i1] + (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * $SEED_ALG_LS_JAC_1.plant.G[$i1] - $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_ALG_NLS_JAC_1.$RES_SIM_12[$i1] := (0.5 * ($SEED_ALG_NLS_JAC_1.plant.Tfg[7 - $i1] + $SEED_ALG_NLS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_ALG_NLS_JAC_1.plant.T[1 + $i1] + $SEED_ALG_NLS_JAC_1.plant.T[$i1])) * plant.G[$i1] + (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * $SEED_ALG_NLS_JAC_1.plant.G[$i1] - $SEED_ALG_NLS_JAC_1.plant.Q[$i1];
 //   end for;
 //
 // 	71:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_10[$i1] := plant.cp * $SEED_ALG_LS_JAC_1.plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) + plant.cp * plant.wfg * ($SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1] - $SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1]) - $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_ALG_NLS_JAC_1.$RES_SIM_10[$i1] := plant.cp * $SEED_ALG_NLS_JAC_1.plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) + plant.cp * plant.wfg * ($SEED_ALG_NLS_JAC_1.plant.Tfg[6 - $i1] - $SEED_ALG_NLS_JAC_1.plant.Tfg[7 - $i1]) - $SEED_ALG_NLS_JAC_1.plant.Q[$i1];
 //   end for;
 //
-// 	70: $pDER_ALG_LS_JAC_1.$RES_BND_20=$SEED_ALG_LS_JAC_1.plant.T[6] - $SEED_ALG_LS_JAC_1.plant.TIT [Real]
-// 	69: $pDER_ALG_LS_JAC_1.$RES_AUX_24=0.5 / (plant.TIT / plant.Tnom) ^ 0.5 * $SEED_ALG_LS_JAC_1.plant.TIT * plant.Tnom / plant.Tnom ^ 2.0 - $SEED_ALG_LS_JAC_1.$FUN_1 [Real]
-// 	68: $pDER_ALG_LS_JAC_1.$RES_SIM_7=($SEED_ALG_LS_JAC_1.plant.p[6] * plant.Kt * $FUN_1 - $SEED_ALG_LS_JAC_1.$FUN_1 * plant.p[6] * plant.Kt) / $FUN_1 ^ 2.0 - $SEED_ALG_LS_JAC_1.plant.w [Real]
-// 	67: $pDER_ALG_LS_JAC_1.$RES_BND_22=$SEED_ALG_LS_JAC_1.plant.p[6] - $SEED_ALG_LS_JAC_1.plant.TIP [Real]
-// 	66: $pDER_ALG_LS_JAC_1.$RES_SIM_6=$SEED_ALG_LS_JAC_1.plant.TIT * plant.cp * plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * $SEED_ALG_LS_JAC_1.plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * plant.w * (plant.gamma - 1.0) / plant.gamma * (plant.TOP / plant.TIP) ^ (-1.0 + (plant.gamma - 1.0) / plant.gamma) * plant.TOP * $SEED_ALG_LS_JAC_1.plant.TIP / plant.TIP ^ 2.0 - $SEED_ALG_LS_JAC_1.plant.P [Real]
-// 	65: $pDER_ALG_LS_JAC_1.$RES_SIM_5=-$SEED_ALG_LS_JAC_1.plant.P [Real]
+// 	70: $pDER_ALG_NLS_JAC_1.$RES_BND_20=$SEED_ALG_NLS_JAC_1.plant.T[6] - $SEED_ALG_NLS_JAC_1.plant.TIT [Real]
+// 	69: $pDER_ALG_NLS_JAC_1.$RES_AUX_24=0.5 / (plant.TIT / plant.Tnom) ^ 0.5 * $SEED_ALG_NLS_JAC_1.plant.TIT * plant.Tnom / plant.Tnom ^ 2.0 - $SEED_ALG_NLS_JAC_1.$FUN_1 [Real]
+// 	68: $pDER_ALG_NLS_JAC_1.$RES_SIM_7=($SEED_ALG_NLS_JAC_1.plant.p[6] * plant.Kt * $FUN_1 - $SEED_ALG_NLS_JAC_1.$FUN_1 * plant.p[6] * plant.Kt) / $FUN_1 ^ 2.0 - $SEED_ALG_NLS_JAC_1.plant.w [Real]
+// 	67: $pDER_ALG_NLS_JAC_1.$RES_BND_22=$SEED_ALG_NLS_JAC_1.plant.p[6] - $SEED_ALG_NLS_JAC_1.plant.TIP [Real]
+// 	66: $pDER_ALG_NLS_JAC_1.$RES_SIM_6=$SEED_ALG_NLS_JAC_1.plant.TIT * plant.cp * plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * $SEED_ALG_NLS_JAC_1.plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * plant.w * (plant.gamma - 1.0) / plant.gamma * (plant.TOP / plant.TIP) ^ (-1.0 + (plant.gamma - 1.0) / plant.gamma) * plant.TOP * $SEED_ALG_NLS_JAC_1.plant.TIP / plant.TIP ^ 2.0 - $SEED_ALG_NLS_JAC_1.plant.P [Real]
+// 	65: $pDER_ALG_NLS_JAC_1.$RES_SIM_5=-$SEED_ALG_NLS_JAC_1.plant.P [Real]
 // 	64:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_8[$i1] := plant.cp * $SEED_ALG_LS_JAC_1.plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.cp * plant.w * ($SEED_ALG_LS_JAC_1.plant.T[$i1] - $SEED_ALG_LS_JAC_1.plant.T[1 + $i1]) + $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_ALG_NLS_JAC_1.$RES_SIM_8[$i1] := plant.cp * $SEED_ALG_NLS_JAC_1.plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.cp * plant.w * ($SEED_ALG_NLS_JAC_1.plant.T[$i1] - $SEED_ALG_NLS_JAC_1.plant.T[1 + $i1]) + $SEED_ALG_NLS_JAC_1.plant.Q[$i1];
 //   end for;
 //
 // 	63:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_14[$i1] := 0.2 * plant.NTU * 0.8 * plant.w ^ (-0.19999999999999996) * $SEED_ALG_LS_JAC_1.plant.w - $SEED_ALG_LS_JAC_1.plant.G[$i1];
+//     $pDER_ALG_NLS_JAC_1.$RES_SIM_14[$i1] := 0.2 * plant.NTU * 0.8 * plant.w ^ (-0.19999999999999996) * $SEED_ALG_NLS_JAC_1.plant.w - $SEED_ALG_NLS_JAC_1.plant.G[$i1];
 //   end for;
 //
 // 	
@@ -732,26 +732,26 @@ regexBool(msg, "Sparsity pattern for non-linear system 2 is not regular");
 // 	12: sqrt(plant.TIT / plant.Tnom) - $FUN_1 (RESIDUAL)
 // 	Jacobian idx: 0
 // 	21:   for $i1 in 1:5 loop
-//     $pDER_INI_LS_JAC_1.$RES_SIM_10[$i1] := plant.cp * $SEED_INI_LS_JAC_1.plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) + plant.cp * plant.wfg * ($SEED_INI_LS_JAC_1.plant.Tfg[6 - $i1] - $SEED_INI_LS_JAC_1.plant.Tfg[7 - $i1]) - $SEED_INI_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_NLS_JAC_1.$RES_SIM_10[$i1] := plant.cp * $SEED_INI_NLS_JAC_1.plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) + plant.cp * plant.wfg * ($SEED_INI_NLS_JAC_1.plant.Tfg[6 - $i1] - $SEED_INI_NLS_JAC_1.plant.Tfg[7 - $i1]) - $SEED_INI_NLS_JAC_1.plant.Q[$i1];
 //   end for;
 //
 // 	20:   for $i1 in 1:5 loop
-//     $pDER_INI_LS_JAC_1.$RES_SIM_12[$i1] := (0.5 * ($SEED_INI_LS_JAC_1.plant.Tfg[7 - $i1] + $SEED_INI_LS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_INI_LS_JAC_1.plant.T[1 + $i1] + $SEED_INI_LS_JAC_1.plant.T[$i1])) * plant.G[$i1] + (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * $SEED_INI_LS_JAC_1.plant.G[$i1] - $SEED_INI_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_NLS_JAC_1.$RES_SIM_12[$i1] := (0.5 * ($SEED_INI_NLS_JAC_1.plant.Tfg[7 - $i1] + $SEED_INI_NLS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_INI_NLS_JAC_1.plant.T[1 + $i1] + $SEED_INI_NLS_JAC_1.plant.T[$i1])) * plant.G[$i1] + (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * $SEED_INI_NLS_JAC_1.plant.G[$i1] - $SEED_INI_NLS_JAC_1.plant.Q[$i1];
 //   end for;
 //
 // 	19:   for $i1 in 1:5 loop
-//     $pDER_INI_LS_JAC_1.$RES_SIM_14[$i1] := 0.2 * plant.NTU * 0.8 * plant.w ^ (-0.19999999999999996) * $SEED_INI_LS_JAC_1.plant.w - $SEED_INI_LS_JAC_1.plant.G[$i1];
+//     $pDER_INI_NLS_JAC_1.$RES_SIM_14[$i1] := 0.2 * plant.NTU * 0.8 * plant.w ^ (-0.19999999999999996) * $SEED_INI_NLS_JAC_1.plant.w - $SEED_INI_NLS_JAC_1.plant.G[$i1];
 //   end for;
 //
 // 	18:   for $i1 in 1:5 loop
-//     $pDER_INI_LS_JAC_1.$RES_SIM_8[$i1] := plant.cp * $SEED_INI_LS_JAC_1.plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.cp * plant.w * ($SEED_INI_LS_JAC_1.plant.T[$i1] - $SEED_INI_LS_JAC_1.plant.T[1 + $i1]) + $SEED_INI_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_NLS_JAC_1.$RES_SIM_8[$i1] := plant.cp * $SEED_INI_NLS_JAC_1.plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.cp * plant.w * ($SEED_INI_NLS_JAC_1.plant.T[$i1] - $SEED_INI_NLS_JAC_1.plant.T[1 + $i1]) + $SEED_INI_NLS_JAC_1.plant.Q[$i1];
 //   end for;
 //
-// 	17: $pDER_INI_LS_JAC_1.$RES_BND_20=$SEED_INI_LS_JAC_1.plant.T[6] - $SEED_INI_LS_JAC_1.plant.TIT [Real]
-// 	16: $pDER_INI_LS_JAC_1.$RES_SIM_6=$SEED_INI_LS_JAC_1.plant.TIT * plant.cp * plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * $SEED_INI_LS_JAC_1.plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * plant.w * (plant.gamma - 1.0) / plant.gamma * (plant.TOP / plant.TIP) ^ (-1.0 + (plant.gamma - 1.0) / plant.gamma) * plant.TOP * $SEED_INI_LS_JAC_1.plant.TIP / plant.TIP ^ 2.0 [Real]
-// 	15: $pDER_INI_LS_JAC_1.$RES_BND_22=$SEED_INI_LS_JAC_1.plant.p[6] - $SEED_INI_LS_JAC_1.plant.TIP [Real]
-// 	14: $pDER_INI_LS_JAC_1.$RES_SIM_7=($SEED_INI_LS_JAC_1.plant.p[6] * plant.Kt * $FUN_1 - $SEED_INI_LS_JAC_1.$FUN_1 * plant.p[6] * plant.Kt) / $FUN_1 ^ 2.0 - $SEED_INI_LS_JAC_1.plant.w [Real]
-// 	13: $pDER_INI_LS_JAC_1.$RES_AUX_24=0.5 / (plant.TIT / plant.Tnom) ^ 0.5 * $SEED_INI_LS_JAC_1.plant.TIT * plant.Tnom / plant.Tnom ^ 2.0 - $SEED_INI_LS_JAC_1.$FUN_1 [Real]
+// 	17: $pDER_INI_NLS_JAC_1.$RES_BND_20=$SEED_INI_NLS_JAC_1.plant.T[6] - $SEED_INI_NLS_JAC_1.plant.TIT [Real]
+// 	16: $pDER_INI_NLS_JAC_1.$RES_SIM_6=$SEED_INI_NLS_JAC_1.plant.TIT * plant.cp * plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * $SEED_INI_NLS_JAC_1.plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * plant.w * (plant.gamma - 1.0) / plant.gamma * (plant.TOP / plant.TIP) ^ (-1.0 + (plant.gamma - 1.0) / plant.gamma) * plant.TOP * $SEED_INI_NLS_JAC_1.plant.TIP / plant.TIP ^ 2.0 [Real]
+// 	15: $pDER_INI_NLS_JAC_1.$RES_BND_22=$SEED_INI_NLS_JAC_1.plant.p[6] - $SEED_INI_NLS_JAC_1.plant.TIP [Real]
+// 	14: $pDER_INI_NLS_JAC_1.$RES_SIM_7=($SEED_INI_NLS_JAC_1.plant.p[6] * plant.Kt * $FUN_1 - $SEED_INI_NLS_JAC_1.$FUN_1 * plant.p[6] * plant.Kt) / $FUN_1 ^ 2.0 - $SEED_INI_NLS_JAC_1.plant.w [Real]
+// 	13: $pDER_INI_NLS_JAC_1.$RES_AUX_24=0.5 / (plant.TIT / plant.Tnom) ^ 0.5 * $SEED_INI_NLS_JAC_1.plant.TIT * plant.Tnom / plant.Tnom ^ 2.0 - $SEED_INI_NLS_JAC_1.$FUN_1 [Real]
 // 	
 //
 // 3:  (SES_RESIZABLE_ASSIGN)  call index: 0
@@ -840,26 +840,26 @@ regexBool(msg, "Sparsity pattern for non-linear system 2 is not regular");
 // ========================================
 // 	Jacobian idx: 0
 // 	21:   for $i1 in 1:5 loop
-//     $pDER_INI_LS_JAC_1.$RES_SIM_10[$i1] := plant.cp * $SEED_INI_LS_JAC_1.plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) + plant.cp * plant.wfg * ($SEED_INI_LS_JAC_1.plant.Tfg[6 - $i1] - $SEED_INI_LS_JAC_1.plant.Tfg[7 - $i1]) - $SEED_INI_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_NLS_JAC_1.$RES_SIM_10[$i1] := plant.cp * $SEED_INI_NLS_JAC_1.plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) + plant.cp * plant.wfg * ($SEED_INI_NLS_JAC_1.plant.Tfg[6 - $i1] - $SEED_INI_NLS_JAC_1.plant.Tfg[7 - $i1]) - $SEED_INI_NLS_JAC_1.plant.Q[$i1];
 //   end for;
 //
 // 	20:   for $i1 in 1:5 loop
-//     $pDER_INI_LS_JAC_1.$RES_SIM_12[$i1] := (0.5 * ($SEED_INI_LS_JAC_1.plant.Tfg[7 - $i1] + $SEED_INI_LS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_INI_LS_JAC_1.plant.T[1 + $i1] + $SEED_INI_LS_JAC_1.plant.T[$i1])) * plant.G[$i1] + (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * $SEED_INI_LS_JAC_1.plant.G[$i1] - $SEED_INI_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_NLS_JAC_1.$RES_SIM_12[$i1] := (0.5 * ($SEED_INI_NLS_JAC_1.plant.Tfg[7 - $i1] + $SEED_INI_NLS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_INI_NLS_JAC_1.plant.T[1 + $i1] + $SEED_INI_NLS_JAC_1.plant.T[$i1])) * plant.G[$i1] + (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * $SEED_INI_NLS_JAC_1.plant.G[$i1] - $SEED_INI_NLS_JAC_1.plant.Q[$i1];
 //   end for;
 //
 // 	19:   for $i1 in 1:5 loop
-//     $pDER_INI_LS_JAC_1.$RES_SIM_14[$i1] := 0.2 * plant.NTU * 0.8 * plant.w ^ (-0.19999999999999996) * $SEED_INI_LS_JAC_1.plant.w - $SEED_INI_LS_JAC_1.plant.G[$i1];
+//     $pDER_INI_NLS_JAC_1.$RES_SIM_14[$i1] := 0.2 * plant.NTU * 0.8 * plant.w ^ (-0.19999999999999996) * $SEED_INI_NLS_JAC_1.plant.w - $SEED_INI_NLS_JAC_1.plant.G[$i1];
 //   end for;
 //
 // 	18:   for $i1 in 1:5 loop
-//     $pDER_INI_LS_JAC_1.$RES_SIM_8[$i1] := plant.cp * $SEED_INI_LS_JAC_1.plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.cp * plant.w * ($SEED_INI_LS_JAC_1.plant.T[$i1] - $SEED_INI_LS_JAC_1.plant.T[1 + $i1]) + $SEED_INI_LS_JAC_1.plant.Q[$i1];
+//     $pDER_INI_NLS_JAC_1.$RES_SIM_8[$i1] := plant.cp * $SEED_INI_NLS_JAC_1.plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.cp * plant.w * ($SEED_INI_NLS_JAC_1.plant.T[$i1] - $SEED_INI_NLS_JAC_1.plant.T[1 + $i1]) + $SEED_INI_NLS_JAC_1.plant.Q[$i1];
 //   end for;
 //
-// 	17: $pDER_INI_LS_JAC_1.$RES_BND_20=$SEED_INI_LS_JAC_1.plant.T[6] - $SEED_INI_LS_JAC_1.plant.TIT [Real]
-// 	16: $pDER_INI_LS_JAC_1.$RES_SIM_6=$SEED_INI_LS_JAC_1.plant.TIT * plant.cp * plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * $SEED_INI_LS_JAC_1.plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * plant.w * (plant.gamma - 1.0) / plant.gamma * (plant.TOP / plant.TIP) ^ (-1.0 + (plant.gamma - 1.0) / plant.gamma) * plant.TOP * $SEED_INI_LS_JAC_1.plant.TIP / plant.TIP ^ 2.0 [Real]
-// 	15: $pDER_INI_LS_JAC_1.$RES_BND_22=$SEED_INI_LS_JAC_1.plant.p[6] - $SEED_INI_LS_JAC_1.plant.TIP [Real]
-// 	14: $pDER_INI_LS_JAC_1.$RES_SIM_7=($SEED_INI_LS_JAC_1.plant.p[6] * plant.Kt * $FUN_1 - $SEED_INI_LS_JAC_1.$FUN_1 * plant.p[6] * plant.Kt) / $FUN_1 ^ 2.0 - $SEED_INI_LS_JAC_1.plant.w [Real]
-// 	13: $pDER_INI_LS_JAC_1.$RES_AUX_24=0.5 / (plant.TIT / plant.Tnom) ^ 0.5 * $SEED_INI_LS_JAC_1.plant.TIT * plant.Tnom / plant.Tnom ^ 2.0 - $SEED_INI_LS_JAC_1.$FUN_1 [Real]
+// 	17: $pDER_INI_NLS_JAC_1.$RES_BND_20=$SEED_INI_NLS_JAC_1.plant.T[6] - $SEED_INI_NLS_JAC_1.plant.TIT [Real]
+// 	16: $pDER_INI_NLS_JAC_1.$RES_SIM_6=$SEED_INI_NLS_JAC_1.plant.TIT * plant.cp * plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * $SEED_INI_NLS_JAC_1.plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * plant.w * (plant.gamma - 1.0) / plant.gamma * (plant.TOP / plant.TIP) ^ (-1.0 + (plant.gamma - 1.0) / plant.gamma) * plant.TOP * $SEED_INI_NLS_JAC_1.plant.TIP / plant.TIP ^ 2.0 [Real]
+// 	15: $pDER_INI_NLS_JAC_1.$RES_BND_22=$SEED_INI_NLS_JAC_1.plant.p[6] - $SEED_INI_NLS_JAC_1.plant.TIP [Real]
+// 	14: $pDER_INI_NLS_JAC_1.$RES_SIM_7=($SEED_INI_NLS_JAC_1.plant.p[6] * plant.Kt * $FUN_1 - $SEED_INI_NLS_JAC_1.$FUN_1 * plant.p[6] * plant.Kt) / $FUN_1 ^ 2.0 - $SEED_INI_NLS_JAC_1.plant.w [Real]
+// 	13: $pDER_INI_NLS_JAC_1.$RES_AUX_24=0.5 / (plant.TIT / plant.Tnom) ^ 0.5 * $SEED_INI_NLS_JAC_1.plant.TIT * plant.Tnom / plant.Tnom ^ 2.0 - $SEED_INI_NLS_JAC_1.$FUN_1 [Real]
 // 	
 // 	Jacobian idx: 1
 // 	42:   for $i1 in 1:5 loop
@@ -876,28 +876,28 @@ regexBool(msg, "Sparsity pattern for non-linear system 2 is not regular");
 //
 // 	
 // 	Jacobian idx: 2
-// 	74: $pDER_ALG_LS_JAC_1.$RES_BND_21=$SEED_ALG_LS_JAC_1.plant.Tfg[6] - $SEED_ALG_LS_JAC_1.plant.Ts [Real]
-// 	73: $pDER_ALG_LS_JAC_1.$RES_SIM_2=-$SEED_ALG_LS_JAC_1.plant.Ts [Real]
+// 	74: $pDER_ALG_NLS_JAC_1.$RES_BND_21=$SEED_ALG_NLS_JAC_1.plant.Tfg[6] - $SEED_ALG_NLS_JAC_1.plant.Ts [Real]
+// 	73: $pDER_ALG_NLS_JAC_1.$RES_SIM_2=-$SEED_ALG_NLS_JAC_1.plant.Ts [Real]
 // 	72:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_12[$i1] := (0.5 * ($SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1] + $SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_ALG_LS_JAC_1.plant.T[1 + $i1] + $SEED_ALG_LS_JAC_1.plant.T[$i1])) * plant.G[$i1] + (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * $SEED_ALG_LS_JAC_1.plant.G[$i1] - $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_ALG_NLS_JAC_1.$RES_SIM_12[$i1] := (0.5 * ($SEED_ALG_NLS_JAC_1.plant.Tfg[7 - $i1] + $SEED_ALG_NLS_JAC_1.plant.Tfg[6 - $i1]) - 0.5 * ($SEED_ALG_NLS_JAC_1.plant.T[1 + $i1] + $SEED_ALG_NLS_JAC_1.plant.T[$i1])) * plant.G[$i1] + (0.5 * (plant.Tfg[7 - $i1] + plant.Tfg[6 - $i1]) - 0.5 * (plant.T[1 + $i1] + plant.T[$i1])) * $SEED_ALG_NLS_JAC_1.plant.G[$i1] - $SEED_ALG_NLS_JAC_1.plant.Q[$i1];
 //   end for;
 //
 // 	71:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_10[$i1] := plant.cp * $SEED_ALG_LS_JAC_1.plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) + plant.cp * plant.wfg * ($SEED_ALG_LS_JAC_1.plant.Tfg[6 - $i1] - $SEED_ALG_LS_JAC_1.plant.Tfg[7 - $i1]) - $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_ALG_NLS_JAC_1.$RES_SIM_10[$i1] := plant.cp * $SEED_ALG_NLS_JAC_1.plant.wfg * (plant.Tfg[6 - $i1] - plant.Tfg[7 - $i1]) + plant.cp * plant.wfg * ($SEED_ALG_NLS_JAC_1.plant.Tfg[6 - $i1] - $SEED_ALG_NLS_JAC_1.plant.Tfg[7 - $i1]) - $SEED_ALG_NLS_JAC_1.plant.Q[$i1];
 //   end for;
 //
-// 	70: $pDER_ALG_LS_JAC_1.$RES_BND_20=$SEED_ALG_LS_JAC_1.plant.T[6] - $SEED_ALG_LS_JAC_1.plant.TIT [Real]
-// 	69: $pDER_ALG_LS_JAC_1.$RES_AUX_24=0.5 / (plant.TIT / plant.Tnom) ^ 0.5 * $SEED_ALG_LS_JAC_1.plant.TIT * plant.Tnom / plant.Tnom ^ 2.0 - $SEED_ALG_LS_JAC_1.$FUN_1 [Real]
-// 	68: $pDER_ALG_LS_JAC_1.$RES_SIM_7=($SEED_ALG_LS_JAC_1.plant.p[6] * plant.Kt * $FUN_1 - $SEED_ALG_LS_JAC_1.$FUN_1 * plant.p[6] * plant.Kt) / $FUN_1 ^ 2.0 - $SEED_ALG_LS_JAC_1.plant.w [Real]
-// 	67: $pDER_ALG_LS_JAC_1.$RES_BND_22=$SEED_ALG_LS_JAC_1.plant.p[6] - $SEED_ALG_LS_JAC_1.plant.TIP [Real]
-// 	66: $pDER_ALG_LS_JAC_1.$RES_SIM_6=$SEED_ALG_LS_JAC_1.plant.TIT * plant.cp * plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * $SEED_ALG_LS_JAC_1.plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * plant.w * (plant.gamma - 1.0) / plant.gamma * (plant.TOP / plant.TIP) ^ (-1.0 + (plant.gamma - 1.0) / plant.gamma) * plant.TOP * $SEED_ALG_LS_JAC_1.plant.TIP / plant.TIP ^ 2.0 - $SEED_ALG_LS_JAC_1.plant.P [Real]
-// 	65: $pDER_ALG_LS_JAC_1.$RES_SIM_5=-$SEED_ALG_LS_JAC_1.plant.P [Real]
+// 	70: $pDER_ALG_NLS_JAC_1.$RES_BND_20=$SEED_ALG_NLS_JAC_1.plant.T[6] - $SEED_ALG_NLS_JAC_1.plant.TIT [Real]
+// 	69: $pDER_ALG_NLS_JAC_1.$RES_AUX_24=0.5 / (plant.TIT / plant.Tnom) ^ 0.5 * $SEED_ALG_NLS_JAC_1.plant.TIT * plant.Tnom / plant.Tnom ^ 2.0 - $SEED_ALG_NLS_JAC_1.$FUN_1 [Real]
+// 	68: $pDER_ALG_NLS_JAC_1.$RES_SIM_7=($SEED_ALG_NLS_JAC_1.plant.p[6] * plant.Kt * $FUN_1 - $SEED_ALG_NLS_JAC_1.$FUN_1 * plant.p[6] * plant.Kt) / $FUN_1 ^ 2.0 - $SEED_ALG_NLS_JAC_1.plant.w [Real]
+// 	67: $pDER_ALG_NLS_JAC_1.$RES_BND_22=$SEED_ALG_NLS_JAC_1.plant.p[6] - $SEED_ALG_NLS_JAC_1.plant.TIP [Real]
+// 	66: $pDER_ALG_NLS_JAC_1.$RES_SIM_6=$SEED_ALG_NLS_JAC_1.plant.TIT * plant.cp * plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * $SEED_ALG_NLS_JAC_1.plant.w * (1.0 - (plant.TOP / plant.TIP) ^ ((plant.gamma - 1.0) / plant.gamma)) + plant.TIT * plant.cp * plant.w * (plant.gamma - 1.0) / plant.gamma * (plant.TOP / plant.TIP) ^ (-1.0 + (plant.gamma - 1.0) / plant.gamma) * plant.TOP * $SEED_ALG_NLS_JAC_1.plant.TIP / plant.TIP ^ 2.0 - $SEED_ALG_NLS_JAC_1.plant.P [Real]
+// 	65: $pDER_ALG_NLS_JAC_1.$RES_SIM_5=-$SEED_ALG_NLS_JAC_1.plant.P [Real]
 // 	64:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_8[$i1] := plant.cp * $SEED_ALG_LS_JAC_1.plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.cp * plant.w * ($SEED_ALG_LS_JAC_1.plant.T[$i1] - $SEED_ALG_LS_JAC_1.plant.T[1 + $i1]) + $SEED_ALG_LS_JAC_1.plant.Q[$i1];
+//     $pDER_ALG_NLS_JAC_1.$RES_SIM_8[$i1] := plant.cp * $SEED_ALG_NLS_JAC_1.plant.w * (plant.T[$i1] - plant.T[1 + $i1]) + plant.cp * plant.w * ($SEED_ALG_NLS_JAC_1.plant.T[$i1] - $SEED_ALG_NLS_JAC_1.plant.T[1 + $i1]) + $SEED_ALG_NLS_JAC_1.plant.Q[$i1];
 //   end for;
 //
 // 	63:   for $i1 in 1:5 loop
-//     $pDER_ALG_LS_JAC_1.$RES_SIM_14[$i1] := 0.2 * plant.NTU * 0.8 * plant.w ^ (-0.19999999999999996) * $SEED_ALG_LS_JAC_1.plant.w - $SEED_ALG_LS_JAC_1.plant.G[$i1];
+//     $pDER_ALG_NLS_JAC_1.$RES_SIM_14[$i1] := 0.2 * plant.NTU * 0.8 * plant.w ^ (-0.19999999999999996) * $SEED_ALG_NLS_JAC_1.plant.w - $SEED_ALG_NLS_JAC_1.plant.G[$i1];
 //   end for;
 //
 // 	

--- a/testsuite/simulation/modelica/NBackend/initialization/experimental_initialSimplified.mos
+++ b/testsuite/simulation/modelica/NBackend/initialization/experimental_initialSimplified.mos
@@ -101,17 +101,17 @@ simulate(P.experimental_initialSimplified); getErrorString();
 // Event Partition
 // -----------------
 //
-// =========================================================
-//   SimCode Jacobian INI_LS_JAC_1(idx = 0, partition = 0)
-// =========================================================
+// ==========================================================
+//   SimCode Jacobian INI_NLS_JAC_1(idx = 0, partition = 0)
+// ==========================================================
 //
 // SeedVars (size = 5)
 // *********************
-//   (0)[SEED] (1) Real $SEED_INI_LS_JAC_1.u
-//   (1)[SEED] (1) Real $SEED_INI_LS_JAC_1.$FUN_3
-//   (2)[SEED] (1) Real $SEED_INI_LS_JAC_1.$FUN_2
-//   (3)[SEED] (1) Real $SEED_INI_LS_JAC_1.y1
-//   (4)[SEED] (1) Real $SEED_INI_LS_JAC_1.$FUN_1
+//   (0)[SEED] (1) Real $SEED_INI_NLS_JAC_1.u
+//   (1)[SEED] (1) Real $SEED_INI_NLS_JAC_1.$FUN_3
+//   (2)[SEED] (1) Real $SEED_INI_NLS_JAC_1.$FUN_2
+//   (3)[SEED] (1) Real $SEED_INI_NLS_JAC_1.y1
+//   (4)[SEED] (1) Real $SEED_INI_NLS_JAC_1.$FUN_1
 //
 // TmpVars (size = 0)
 // ********************
@@ -121,32 +121,32 @@ simulate(P.experimental_initialSimplified); getErrorString();
 //
 // Column Equations (size = 5)
 // -----------------------------
-//   (10) $pDER_INI_LS_JAC_1.$RES_AUX_5 := cos(1e-6 * u) * (1e-6 * $SEED_INI_LS_JAC_1.u) - $SEED_INI_LS_JAC_1.$FUN_3
-//   (9) $pDER_INI_LS_JAC_1.$RES_SIM_0 := $SEED_INI_LS_JAC_1.$FUN_2 + $SEED_INI_LS_JAC_1.$FUN_3
-//   (8) $pDER_INI_LS_JAC_1.$RES_AUX_6 := (0.5 / y1 ^ 0.5) * $SEED_INI_LS_JAC_1.y1 - $SEED_INI_LS_JAC_1.$FUN_2
-//   (7) $pDER_INI_LS_JAC_1.$RES_SIM_1 := (3.0 * u ^ 2.0 * $SEED_INI_LS_JAC_1.u + $SEED_INI_LS_JAC_1.$FUN_1) - $SEED_INI_LS_JAC_1.y1
-//   (6) $pDER_INI_LS_JAC_1.$RES_AUX_7 := cos(u) * $SEED_INI_LS_JAC_1.u - $SEED_INI_LS_JAC_1.$FUN_1
+//   (10) $pDER_INI_NLS_JAC_1.$RES_AUX_5 := cos(1e-6 * u) * (1e-6 * $SEED_INI_NLS_JAC_1.u) - $SEED_INI_NLS_JAC_1.$FUN_3
+//   (9) $pDER_INI_NLS_JAC_1.$RES_SIM_0 := $SEED_INI_NLS_JAC_1.$FUN_2 + $SEED_INI_NLS_JAC_1.$FUN_3
+//   (8) $pDER_INI_NLS_JAC_1.$RES_AUX_6 := (0.5 / y1 ^ 0.5) * $SEED_INI_NLS_JAC_1.y1 - $SEED_INI_NLS_JAC_1.$FUN_2
+//   (7) $pDER_INI_NLS_JAC_1.$RES_SIM_1 := (3.0 * u ^ 2.0 * $SEED_INI_NLS_JAC_1.u + $SEED_INI_NLS_JAC_1.$FUN_1) - $SEED_INI_NLS_JAC_1.y1
+//   (6) $pDER_INI_NLS_JAC_1.$RES_AUX_7 := cos(u) * $SEED_INI_NLS_JAC_1.u - $SEED_INI_NLS_JAC_1.$FUN_1
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_AUX_5 ... {$pDER_INI_LS_JAC_1.$RES_AUX_5} ... {($SEED_INI_LS_JAC_1.$FUN_3, {}, false), ($SEED_INI_LS_JAC_1.u, {}, true)}
-// $RES_SIM_0 ... {$pDER_INI_LS_JAC_1.$RES_SIM_0} ... {($SEED_INI_LS_JAC_1.$FUN_3, {}, false), ($SEED_INI_LS_JAC_1.$FUN_2, {}, false)}
-// $RES_AUX_6 ... {$pDER_INI_LS_JAC_1.$RES_AUX_6} ... {($SEED_INI_LS_JAC_1.$FUN_2, {}, false), ($SEED_INI_LS_JAC_1.y1, {}, true)}
-// $RES_SIM_1 ... {$pDER_INI_LS_JAC_1.$RES_SIM_1} ... {($SEED_INI_LS_JAC_1.y1, {}, false), ($SEED_INI_LS_JAC_1.$FUN_1, {}, false), ($SEED_INI_LS_JAC_1.u, {}, false)}
-// $RES_AUX_7 ... {$pDER_INI_LS_JAC_1.$RES_AUX_7} ... {($SEED_INI_LS_JAC_1.$FUN_1, {}, false), ($SEED_INI_LS_JAC_1.u, {}, true)}
+// $RES_AUX_5 ... {$pDER_INI_NLS_JAC_1.$RES_AUX_5} ... {($SEED_INI_NLS_JAC_1.$FUN_3, {}, false), ($SEED_INI_NLS_JAC_1.u, {}, true)}
+// $RES_SIM_0 ... {$pDER_INI_NLS_JAC_1.$RES_SIM_0} ... {($SEED_INI_NLS_JAC_1.$FUN_3, {}, false), ($SEED_INI_NLS_JAC_1.$FUN_2, {}, false)}
+// $RES_AUX_6 ... {$pDER_INI_NLS_JAC_1.$RES_AUX_6} ... {($SEED_INI_NLS_JAC_1.$FUN_2, {}, false), ($SEED_INI_NLS_JAC_1.y1, {}, true)}
+// $RES_SIM_1 ... {$pDER_INI_NLS_JAC_1.$RES_SIM_1} ... {($SEED_INI_NLS_JAC_1.y1, {}, false), ($SEED_INI_NLS_JAC_1.$FUN_1, {}, false), ($SEED_INI_NLS_JAC_1.u, {}, false)}
+// $RES_AUX_7 ... {$pDER_INI_NLS_JAC_1.$RES_AUX_7} ... {($SEED_INI_NLS_JAC_1.$FUN_1, {}, false), ($SEED_INI_NLS_JAC_1.u, {}, true)}
 //
-// =========================================================
-//   SimCode Jacobian ALG_LS_JAC_1(idx = 1, partition = 1)
-// =========================================================
+// ==========================================================
+//   SimCode Jacobian ALG_NLS_JAC_1(idx = 1, partition = 1)
+// ==========================================================
 //
 // SeedVars (size = 6)
 // *********************
-//   (0)[SEED] (1) Real $SEED_ALG_LS_JAC_1.$FUN_3
-//   (1)[SEED] (1) Real $SEED_ALG_LS_JAC_1.u
-//   (2)[SEED] (1) Real $SEED_ALG_LS_JAC_1.y2
-//   (3)[SEED] (1) Real $SEED_ALG_LS_JAC_1.$FUN_2
-//   (4)[SEED] (1) Real $SEED_ALG_LS_JAC_1.y1
-//   (5)[SEED] (1) Real $SEED_ALG_LS_JAC_1.$FUN_1
+//   (0)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.$FUN_3
+//   (1)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.u
+//   (2)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.y2
+//   (3)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.$FUN_2
+//   (4)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.y1
+//   (5)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.$FUN_1
 //
 // TmpVars (size = 0)
 // ********************
@@ -156,21 +156,21 @@ simulate(P.experimental_initialSimplified); getErrorString();
 //
 // Column Equations (size = 6)
 // -----------------------------
-//   (30) $pDER_ALG_LS_JAC_1.$RES_AUX_5 := cos(1e-6 * u) * (1e-6 * $SEED_ALG_LS_JAC_1.u) - $SEED_ALG_LS_JAC_1.$FUN_3
-//   (29) $pDER_ALG_LS_JAC_1.$RES_SIM_4 := -$SEED_ALG_LS_JAC_1.y2
-//   (28) $pDER_ALG_LS_JAC_1.$RES_SIM_0 := ($SEED_ALG_LS_JAC_1.$FUN_2 + $SEED_ALG_LS_JAC_1.$FUN_3) - $SEED_ALG_LS_JAC_1.y2
-//   (27) $pDER_ALG_LS_JAC_1.$RES_AUX_6 := (0.5 / y1 ^ 0.5) * $SEED_ALG_LS_JAC_1.y1 - $SEED_ALG_LS_JAC_1.$FUN_2
-//   (26) $pDER_ALG_LS_JAC_1.$RES_SIM_1 := (3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.$FUN_1) - $SEED_ALG_LS_JAC_1.y1
-//   (25) $pDER_ALG_LS_JAC_1.$RES_AUX_7 := cos(u) * $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.$FUN_1
+//   (30) $pDER_ALG_NLS_JAC_1.$RES_AUX_5 := cos(1e-6 * u) * (1e-6 * $SEED_ALG_NLS_JAC_1.u) - $SEED_ALG_NLS_JAC_1.$FUN_3
+//   (29) $pDER_ALG_NLS_JAC_1.$RES_SIM_4 := -$SEED_ALG_NLS_JAC_1.y2
+//   (28) $pDER_ALG_NLS_JAC_1.$RES_SIM_0 := ($SEED_ALG_NLS_JAC_1.$FUN_2 + $SEED_ALG_NLS_JAC_1.$FUN_3) - $SEED_ALG_NLS_JAC_1.y2
+//   (27) $pDER_ALG_NLS_JAC_1.$RES_AUX_6 := (0.5 / y1 ^ 0.5) * $SEED_ALG_NLS_JAC_1.y1 - $SEED_ALG_NLS_JAC_1.$FUN_2
+//   (26) $pDER_ALG_NLS_JAC_1.$RES_SIM_1 := (3.0 * u ^ 2.0 * $SEED_ALG_NLS_JAC_1.u + $SEED_ALG_NLS_JAC_1.$FUN_1) - $SEED_ALG_NLS_JAC_1.y1
+//   (25) $pDER_ALG_NLS_JAC_1.$RES_AUX_7 := cos(u) * $SEED_ALG_NLS_JAC_1.u - $SEED_ALG_NLS_JAC_1.$FUN_1
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_AUX_5 ... {$pDER_ALG_LS_JAC_1.$RES_AUX_5} ... {($SEED_ALG_LS_JAC_1.$FUN_3, {}, false), ($SEED_ALG_LS_JAC_1.u, {}, true)}
-// $RES_SIM_4 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_4} ... {($SEED_ALG_LS_JAC_1.y2, {}, false)}
-// $RES_SIM_0 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_0} ... {($SEED_ALG_LS_JAC_1.y2, {}, false), ($SEED_ALG_LS_JAC_1.$FUN_3, {}, false), ($SEED_ALG_LS_JAC_1.$FUN_2, {}, false)}
-// $RES_AUX_6 ... {$pDER_ALG_LS_JAC_1.$RES_AUX_6} ... {($SEED_ALG_LS_JAC_1.$FUN_2, {}, false), ($SEED_ALG_LS_JAC_1.y1, {}, true)}
-// $RES_SIM_1 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_1} ... {($SEED_ALG_LS_JAC_1.y1, {}, false), ($SEED_ALG_LS_JAC_1.$FUN_1, {}, false), ($SEED_ALG_LS_JAC_1.u, {}, false)}
-// $RES_AUX_7 ... {$pDER_ALG_LS_JAC_1.$RES_AUX_7} ... {($SEED_ALG_LS_JAC_1.$FUN_1, {}, false), ($SEED_ALG_LS_JAC_1.u, {}, true)}
+// $RES_AUX_5 ... {$pDER_ALG_NLS_JAC_1.$RES_AUX_5} ... {($SEED_ALG_NLS_JAC_1.$FUN_3, {}, false), ($SEED_ALG_NLS_JAC_1.u, {}, true)}
+// $RES_SIM_4 ... {$pDER_ALG_NLS_JAC_1.$RES_SIM_4} ... {($SEED_ALG_NLS_JAC_1.y2, {}, false)}
+// $RES_SIM_0 ... {$pDER_ALG_NLS_JAC_1.$RES_SIM_0} ... {($SEED_ALG_NLS_JAC_1.y2, {}, false), ($SEED_ALG_NLS_JAC_1.$FUN_3, {}, false), ($SEED_ALG_NLS_JAC_1.$FUN_2, {}, false)}
+// $RES_AUX_6 ... {$pDER_ALG_NLS_JAC_1.$RES_AUX_6} ... {($SEED_ALG_NLS_JAC_1.$FUN_2, {}, false), ($SEED_ALG_NLS_JAC_1.y1, {}, true)}
+// $RES_SIM_1 ... {$pDER_ALG_NLS_JAC_1.$RES_SIM_1} ... {($SEED_ALG_NLS_JAC_1.y1, {}, false), ($SEED_ALG_NLS_JAC_1.$FUN_1, {}, false), ($SEED_ALG_NLS_JAC_1.u, {}, false)}
+// $RES_AUX_7 ... {$pDER_ALG_NLS_JAC_1.$RES_AUX_7} ... {($SEED_ALG_NLS_JAC_1.$FUN_1, {}, false), ($SEED_ALG_NLS_JAC_1.u, {}, true)}
 //
 // ======================================================
 //   [EMPTY] SimCode Jacobian A(idx = 2, partition = 0)
@@ -231,12 +231,12 @@ simulate(P.experimental_initialSimplified); getErrorString();
 // 	23: u ^ 3.0 + $FUN_1 - y1 (RESIDUAL)
 // 	24: sin(u) - $FUN_1 (RESIDUAL)
 // 	Jacobian idx: 1
-// 	30: $pDER_ALG_LS_JAC_1.$RES_AUX_5=cos(1e-6 * u) * 1e-6 * $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.$FUN_3 [Real]
-// 	29: $pDER_ALG_LS_JAC_1.$RES_SIM_4=-$SEED_ALG_LS_JAC_1.y2 [Real]
-// 	28: $pDER_ALG_LS_JAC_1.$RES_SIM_0=$SEED_ALG_LS_JAC_1.$FUN_2 + $SEED_ALG_LS_JAC_1.$FUN_3 - $SEED_ALG_LS_JAC_1.y2 [Real]
-// 	27: $pDER_ALG_LS_JAC_1.$RES_AUX_6=0.5 / y1 ^ 0.5 * $SEED_ALG_LS_JAC_1.y1 - $SEED_ALG_LS_JAC_1.$FUN_2 [Real]
-// 	26: $pDER_ALG_LS_JAC_1.$RES_SIM_1=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.$FUN_1 - $SEED_ALG_LS_JAC_1.y1 [Real]
-// 	25: $pDER_ALG_LS_JAC_1.$RES_AUX_7=cos(u) * $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.$FUN_1 [Real]
+// 	30: $pDER_ALG_NLS_JAC_1.$RES_AUX_5=cos(1e-6 * u) * 1e-6 * $SEED_ALG_NLS_JAC_1.u - $SEED_ALG_NLS_JAC_1.$FUN_3 [Real]
+// 	29: $pDER_ALG_NLS_JAC_1.$RES_SIM_4=-$SEED_ALG_NLS_JAC_1.y2 [Real]
+// 	28: $pDER_ALG_NLS_JAC_1.$RES_SIM_0=$SEED_ALG_NLS_JAC_1.$FUN_2 + $SEED_ALG_NLS_JAC_1.$FUN_3 - $SEED_ALG_NLS_JAC_1.y2 [Real]
+// 	27: $pDER_ALG_NLS_JAC_1.$RES_AUX_6=0.5 / y1 ^ 0.5 * $SEED_ALG_NLS_JAC_1.y1 - $SEED_ALG_NLS_JAC_1.$FUN_2 [Real]
+// 	26: $pDER_ALG_NLS_JAC_1.$RES_SIM_1=3.0 * u ^ 2.0 * $SEED_ALG_NLS_JAC_1.u + $SEED_ALG_NLS_JAC_1.$FUN_1 - $SEED_ALG_NLS_JAC_1.y1 [Real]
+// 	25: $pDER_ALG_NLS_JAC_1.$RES_AUX_7=cos(u) * $SEED_ALG_NLS_JAC_1.u - $SEED_ALG_NLS_JAC_1.$FUN_1 [Real]
 //
 //
 // ========================================
@@ -260,12 +260,12 @@ simulate(P.experimental_initialSimplified); getErrorString();
 // 	23: u ^ 3.0 + $FUN_1 - y1 (RESIDUAL)
 // 	24: sin(u) - $FUN_1 (RESIDUAL)
 // 	Jacobian idx: 1
-// 	30: $pDER_ALG_LS_JAC_1.$RES_AUX_5=cos(1e-6 * u) * 1e-6 * $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.$FUN_3 [Real]
-// 	29: $pDER_ALG_LS_JAC_1.$RES_SIM_4=-$SEED_ALG_LS_JAC_1.y2 [Real]
-// 	28: $pDER_ALG_LS_JAC_1.$RES_SIM_0=$SEED_ALG_LS_JAC_1.$FUN_2 + $SEED_ALG_LS_JAC_1.$FUN_3 - $SEED_ALG_LS_JAC_1.y2 [Real]
-// 	27: $pDER_ALG_LS_JAC_1.$RES_AUX_6=0.5 / y1 ^ 0.5 * $SEED_ALG_LS_JAC_1.y1 - $SEED_ALG_LS_JAC_1.$FUN_2 [Real]
-// 	26: $pDER_ALG_LS_JAC_1.$RES_SIM_1=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.$FUN_1 - $SEED_ALG_LS_JAC_1.y1 [Real]
-// 	25: $pDER_ALG_LS_JAC_1.$RES_AUX_7=cos(u) * $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.$FUN_1 [Real]
+// 	30: $pDER_ALG_NLS_JAC_1.$RES_AUX_5=cos(1e-6 * u) * 1e-6 * $SEED_ALG_NLS_JAC_1.u - $SEED_ALG_NLS_JAC_1.$FUN_3 [Real]
+// 	29: $pDER_ALG_NLS_JAC_1.$RES_SIM_4=-$SEED_ALG_NLS_JAC_1.y2 [Real]
+// 	28: $pDER_ALG_NLS_JAC_1.$RES_SIM_0=$SEED_ALG_NLS_JAC_1.$FUN_2 + $SEED_ALG_NLS_JAC_1.$FUN_3 - $SEED_ALG_NLS_JAC_1.y2 [Real]
+// 	27: $pDER_ALG_NLS_JAC_1.$RES_AUX_6=0.5 / y1 ^ 0.5 * $SEED_ALG_NLS_JAC_1.y1 - $SEED_ALG_NLS_JAC_1.$FUN_2 [Real]
+// 	26: $pDER_ALG_NLS_JAC_1.$RES_SIM_1=3.0 * u ^ 2.0 * $SEED_ALG_NLS_JAC_1.u + $SEED_ALG_NLS_JAC_1.$FUN_1 - $SEED_ALG_NLS_JAC_1.y1 [Real]
+// 	25: $pDER_ALG_NLS_JAC_1.$RES_AUX_7=cos(u) * $SEED_ALG_NLS_JAC_1.u - $SEED_ALG_NLS_JAC_1.$FUN_1 [Real]
 //
 //
 // ========================================
@@ -288,11 +288,11 @@ simulate(P.experimental_initialSimplified); getErrorString();
 // 	4: u ^ 3.0 + $FUN_1 - y1 (RESIDUAL)
 // 	5: sin(u) - $FUN_1 (RESIDUAL)
 // 	Jacobian idx: 0
-// 	10: $pDER_INI_LS_JAC_1.$RES_AUX_5=cos(1e-6 * u) * 1e-6 * $SEED_INI_LS_JAC_1.u - $SEED_INI_LS_JAC_1.$FUN_3 [Real]
-// 	9: $pDER_INI_LS_JAC_1.$RES_SIM_0=$SEED_INI_LS_JAC_1.$FUN_2 + $SEED_INI_LS_JAC_1.$FUN_3 [Real]
-// 	8: $pDER_INI_LS_JAC_1.$RES_AUX_6=0.5 / y1 ^ 0.5 * $SEED_INI_LS_JAC_1.y1 - $SEED_INI_LS_JAC_1.$FUN_2 [Real]
-// 	7: $pDER_INI_LS_JAC_1.$RES_SIM_1=3.0 * u ^ 2.0 * $SEED_INI_LS_JAC_1.u + $SEED_INI_LS_JAC_1.$FUN_1 - $SEED_INI_LS_JAC_1.y1 [Real]
-// 	6: $pDER_INI_LS_JAC_1.$RES_AUX_7=cos(u) * $SEED_INI_LS_JAC_1.u - $SEED_INI_LS_JAC_1.$FUN_1 [Real]
+// 	10: $pDER_INI_NLS_JAC_1.$RES_AUX_5=cos(1e-6 * u) * 1e-6 * $SEED_INI_NLS_JAC_1.u - $SEED_INI_NLS_JAC_1.$FUN_3 [Real]
+// 	9: $pDER_INI_NLS_JAC_1.$RES_SIM_0=$SEED_INI_NLS_JAC_1.$FUN_2 + $SEED_INI_NLS_JAC_1.$FUN_3 [Real]
+// 	8: $pDER_INI_NLS_JAC_1.$RES_AUX_6=0.5 / y1 ^ 0.5 * $SEED_INI_NLS_JAC_1.y1 - $SEED_INI_NLS_JAC_1.$FUN_2 [Real]
+// 	7: $pDER_INI_NLS_JAC_1.$RES_SIM_1=3.0 * u ^ 2.0 * $SEED_INI_NLS_JAC_1.u + $SEED_INI_NLS_JAC_1.$FUN_1 - $SEED_INI_NLS_JAC_1.y1 [Real]
+// 	6: $pDER_INI_NLS_JAC_1.$RES_AUX_7=cos(u) * $SEED_INI_NLS_JAC_1.u - $SEED_INI_NLS_JAC_1.$FUN_1 [Real]
 //
 //
 // ========================================
@@ -344,19 +344,19 @@ simulate(P.experimental_initialSimplified); getErrorString();
 // jacobianMatrices:
 // ========================================
 // 	Jacobian idx: 0
-// 	10: $pDER_INI_LS_JAC_1.$RES_AUX_5=cos(1e-6 * u) * 1e-6 * $SEED_INI_LS_JAC_1.u - $SEED_INI_LS_JAC_1.$FUN_3 [Real]
-// 	9: $pDER_INI_LS_JAC_1.$RES_SIM_0=$SEED_INI_LS_JAC_1.$FUN_2 + $SEED_INI_LS_JAC_1.$FUN_3 [Real]
-// 	8: $pDER_INI_LS_JAC_1.$RES_AUX_6=0.5 / y1 ^ 0.5 * $SEED_INI_LS_JAC_1.y1 - $SEED_INI_LS_JAC_1.$FUN_2 [Real]
-// 	7: $pDER_INI_LS_JAC_1.$RES_SIM_1=3.0 * u ^ 2.0 * $SEED_INI_LS_JAC_1.u + $SEED_INI_LS_JAC_1.$FUN_1 - $SEED_INI_LS_JAC_1.y1 [Real]
-// 	6: $pDER_INI_LS_JAC_1.$RES_AUX_7=cos(u) * $SEED_INI_LS_JAC_1.u - $SEED_INI_LS_JAC_1.$FUN_1 [Real]
+// 	10: $pDER_INI_NLS_JAC_1.$RES_AUX_5=cos(1e-6 * u) * 1e-6 * $SEED_INI_NLS_JAC_1.u - $SEED_INI_NLS_JAC_1.$FUN_3 [Real]
+// 	9: $pDER_INI_NLS_JAC_1.$RES_SIM_0=$SEED_INI_NLS_JAC_1.$FUN_2 + $SEED_INI_NLS_JAC_1.$FUN_3 [Real]
+// 	8: $pDER_INI_NLS_JAC_1.$RES_AUX_6=0.5 / y1 ^ 0.5 * $SEED_INI_NLS_JAC_1.y1 - $SEED_INI_NLS_JAC_1.$FUN_2 [Real]
+// 	7: $pDER_INI_NLS_JAC_1.$RES_SIM_1=3.0 * u ^ 2.0 * $SEED_INI_NLS_JAC_1.u + $SEED_INI_NLS_JAC_1.$FUN_1 - $SEED_INI_NLS_JAC_1.y1 [Real]
+// 	6: $pDER_INI_NLS_JAC_1.$RES_AUX_7=cos(u) * $SEED_INI_NLS_JAC_1.u - $SEED_INI_NLS_JAC_1.$FUN_1 [Real]
 //
 // 	Jacobian idx: 1
-// 	30: $pDER_ALG_LS_JAC_1.$RES_AUX_5=cos(1e-6 * u) * 1e-6 * $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.$FUN_3 [Real]
-// 	29: $pDER_ALG_LS_JAC_1.$RES_SIM_4=-$SEED_ALG_LS_JAC_1.y2 [Real]
-// 	28: $pDER_ALG_LS_JAC_1.$RES_SIM_0=$SEED_ALG_LS_JAC_1.$FUN_2 + $SEED_ALG_LS_JAC_1.$FUN_3 - $SEED_ALG_LS_JAC_1.y2 [Real]
-// 	27: $pDER_ALG_LS_JAC_1.$RES_AUX_6=0.5 / y1 ^ 0.5 * $SEED_ALG_LS_JAC_1.y1 - $SEED_ALG_LS_JAC_1.$FUN_2 [Real]
-// 	26: $pDER_ALG_LS_JAC_1.$RES_SIM_1=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.$FUN_1 - $SEED_ALG_LS_JAC_1.y1 [Real]
-// 	25: $pDER_ALG_LS_JAC_1.$RES_AUX_7=cos(u) * $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.$FUN_1 [Real]
+// 	30: $pDER_ALG_NLS_JAC_1.$RES_AUX_5=cos(1e-6 * u) * 1e-6 * $SEED_ALG_NLS_JAC_1.u - $SEED_ALG_NLS_JAC_1.$FUN_3 [Real]
+// 	29: $pDER_ALG_NLS_JAC_1.$RES_SIM_4=-$SEED_ALG_NLS_JAC_1.y2 [Real]
+// 	28: $pDER_ALG_NLS_JAC_1.$RES_SIM_0=$SEED_ALG_NLS_JAC_1.$FUN_2 + $SEED_ALG_NLS_JAC_1.$FUN_3 - $SEED_ALG_NLS_JAC_1.y2 [Real]
+// 	27: $pDER_ALG_NLS_JAC_1.$RES_AUX_6=0.5 / y1 ^ 0.5 * $SEED_ALG_NLS_JAC_1.y1 - $SEED_ALG_NLS_JAC_1.$FUN_2 [Real]
+// 	26: $pDER_ALG_NLS_JAC_1.$RES_SIM_1=3.0 * u ^ 2.0 * $SEED_ALG_NLS_JAC_1.u + $SEED_ALG_NLS_JAC_1.$FUN_1 - $SEED_ALG_NLS_JAC_1.y1 [Real]
+// 	25: $pDER_ALG_NLS_JAC_1.$RES_AUX_7=cos(u) * $SEED_ALG_NLS_JAC_1.u - $SEED_ALG_NLS_JAC_1.$FUN_1 [Real]
 //
 // 	Jacobian idx: 2
 //

--- a/testsuite/simulation/modelica/NBackend/initialization/homotopy_no_loop.mos
+++ b/testsuite/simulation/modelica/NBackend/initialization/homotopy_no_loop.mos
@@ -64,14 +64,14 @@ simulate(homotopy_no_loop); getErrorString();
 // Event Partition
 // -----------------
 //
-// =========================================================
-//   SimCode Jacobian INI_LS_JAC_1(idx = 0, partition = 0)
-// =========================================================
+// ==========================================================
+//   SimCode Jacobian INI_NLS_JAC_1(idx = 0, partition = 0)
+// ==========================================================
 //
 // SeedVars (size = 2)
 // *********************
-//   (0)[SEED] (1) Real $SEED_INI_LS_JAC_1.u
-//   (1)[SEED] (1) Real $SEED_INI_LS_JAC_1.y
+//   (0)[SEED] (1) Real $SEED_INI_NLS_JAC_1.u
+//   (1)[SEED] (1) Real $SEED_INI_NLS_JAC_1.y
 //
 // TmpVars (size = 0)
 // ********************
@@ -81,13 +81,13 @@ simulate(homotopy_no_loop); getErrorString();
 //
 // Column Equations (size = 2)
 // -----------------------------
-//   (4) $pDER_INI_LS_JAC_1.$RES_SIM_0 := (3.0 * u ^ 2.0 * $SEED_INI_LS_JAC_1.u + $SEED_INI_LS_JAC_1.u) - $SEED_INI_LS_JAC_1.y
-//   (3) $pDER_INI_LS_JAC_1.$RES_SIM_1 := -homotopy($SEED_INI_LS_JAC_1.u, $SEED_INI_LS_JAC_1.y + 2.0 * y * $SEED_INI_LS_JAC_1.y)
+//   (4) $pDER_INI_NLS_JAC_1.$RES_SIM_0 := (3.0 * u ^ 2.0 * $SEED_INI_NLS_JAC_1.u + $SEED_INI_NLS_JAC_1.u) - $SEED_INI_NLS_JAC_1.y
+//   (3) $pDER_INI_NLS_JAC_1.$RES_SIM_1 := -homotopy($SEED_INI_NLS_JAC_1.u, $SEED_INI_NLS_JAC_1.y + 2.0 * y * $SEED_INI_NLS_JAC_1.y)
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_SIM_0 ... {$pDER_INI_LS_JAC_1.$RES_SIM_0} ... {($SEED_INI_LS_JAC_1.y, {}, false), ($SEED_INI_LS_JAC_1.u, {}, false)}
-// $RES_SIM_1 ... {$pDER_INI_LS_JAC_1.$RES_SIM_1} ... {($SEED_INI_LS_JAC_1.y, {}, true), ($SEED_INI_LS_JAC_1.u, {}, true)}
+// $RES_SIM_0 ... {$pDER_INI_NLS_JAC_1.$RES_SIM_0} ... {($SEED_INI_NLS_JAC_1.y, {}, false), ($SEED_INI_NLS_JAC_1.u, {}, false)}
+// $RES_SIM_1 ... {$pDER_INI_NLS_JAC_1.$RES_SIM_1} ... {($SEED_INI_NLS_JAC_1.y, {}, true), ($SEED_INI_NLS_JAC_1.u, {}, true)}
 //
 // ============================================================
 //   SimCode Jacobian INI_0_NLS_JAC_1(idx = 2, partition = 2)
@@ -133,14 +133,14 @@ simulate(homotopy_no_loop); getErrorString();
 // ----------------------------
 // $RES_SIM_0 ... {$pDER_INI_0_NLS_JAC_2.$RES_SIM_0} ... {($SEED_INI_0_NLS_JAC_2.u, {}, false)}
 //
-// =========================================================
-//   SimCode Jacobian ALG_LS_JAC_1(idx = 3, partition = 3)
-// =========================================================
+// ==========================================================
+//   SimCode Jacobian ALG_NLS_JAC_1(idx = 3, partition = 3)
+// ==========================================================
 //
 // SeedVars (size = 2)
 // *********************
-//   (0)[SEED] (1) Real $SEED_ALG_LS_JAC_1.y
-//   (1)[SEED] (1) Real $SEED_ALG_LS_JAC_1.u
+//   (0)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.y
+//   (1)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.u
 //
 // TmpVars (size = 0)
 // ********************
@@ -150,13 +150,13 @@ simulate(homotopy_no_loop); getErrorString();
 //
 // Column Equations (size = 2)
 // -----------------------------
-//   (15) $pDER_ALG_LS_JAC_1.$RES_SIM_0 := (3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u) - $SEED_ALG_LS_JAC_1.y
-//   (14) $pDER_ALG_LS_JAC_1.$RES_SIM_1 := -$SEED_ALG_LS_JAC_1.u
+//   (15) $pDER_ALG_NLS_JAC_1.$RES_SIM_0 := (3.0 * u ^ 2.0 * $SEED_ALG_NLS_JAC_1.u + $SEED_ALG_NLS_JAC_1.u) - $SEED_ALG_NLS_JAC_1.y
+//   (14) $pDER_ALG_NLS_JAC_1.$RES_SIM_1 := -$SEED_ALG_NLS_JAC_1.u
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_SIM_0 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_0} ... {($SEED_ALG_LS_JAC_1.y, {}, false), ($SEED_ALG_LS_JAC_1.u, {}, false)}
-// $RES_SIM_1 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_1} ... {($SEED_ALG_LS_JAC_1.u, {}, false)}
+// $RES_SIM_0 ... {$pDER_ALG_NLS_JAC_1.$RES_SIM_0} ... {($SEED_ALG_NLS_JAC_1.y, {}, false), ($SEED_ALG_NLS_JAC_1.u, {}, false)}
+// $RES_SIM_1 ... {$pDER_ALG_NLS_JAC_1.$RES_SIM_1} ... {($SEED_ALG_NLS_JAC_1.u, {}, false)}
 //
 // ======================================================
 //   [EMPTY] SimCode Jacobian A(idx = 4, partition = 0)
@@ -213,8 +213,8 @@ simulate(homotopy_no_loop); getErrorString();
 // 	12: u ^ 3.0 + u - y (RESIDUAL)
 // 	13: 1.0 - u (RESIDUAL)
 // 	Jacobian idx: 3
-// 	15: $pDER_ALG_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.y [Real]
-// 	14: $pDER_ALG_LS_JAC_1.$RES_SIM_1=-$SEED_ALG_LS_JAC_1.u [Real]
+// 	15: $pDER_ALG_NLS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_NLS_JAC_1.u + $SEED_ALG_NLS_JAC_1.u - $SEED_ALG_NLS_JAC_1.y [Real]
+// 	14: $pDER_ALG_NLS_JAC_1.$RES_SIM_1=-$SEED_ALG_NLS_JAC_1.u [Real]
 //
 //
 // ========================================
@@ -234,8 +234,8 @@ simulate(homotopy_no_loop); getErrorString();
 // 	12: u ^ 3.0 + u - y (RESIDUAL)
 // 	13: 1.0 - u (RESIDUAL)
 // 	Jacobian idx: 3
-// 	15: $pDER_ALG_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.y [Real]
-// 	14: $pDER_ALG_LS_JAC_1.$RES_SIM_1=-$SEED_ALG_LS_JAC_1.u [Real]
+// 	15: $pDER_ALG_NLS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_NLS_JAC_1.u + $SEED_ALG_NLS_JAC_1.u - $SEED_ALG_NLS_JAC_1.y [Real]
+// 	14: $pDER_ALG_NLS_JAC_1.$RES_SIM_1=-$SEED_ALG_NLS_JAC_1.u [Real]
 //
 //
 // ========================================
@@ -254,8 +254,8 @@ simulate(homotopy_no_loop); getErrorString();
 // 	1: u ^ 3.0 + u - y (RESIDUAL)
 // 	2: 1.0 - homotopy(u, y + y ^ 2.0) (RESIDUAL)
 // 	Jacobian idx: 0
-// 	4: $pDER_INI_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_LS_JAC_1.u + $SEED_INI_LS_JAC_1.u - $SEED_INI_LS_JAC_1.y [Real]
-// 	3: $pDER_INI_LS_JAC_1.$RES_SIM_1=-homotopy($SEED_INI_LS_JAC_1.u, $SEED_INI_LS_JAC_1.y + 2.0 * y * $SEED_INI_LS_JAC_1.y) [Real]
+// 	4: $pDER_INI_NLS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_NLS_JAC_1.u + $SEED_INI_NLS_JAC_1.u - $SEED_INI_NLS_JAC_1.y [Real]
+// 	3: $pDER_INI_NLS_JAC_1.$RES_SIM_1=-homotopy($SEED_INI_NLS_JAC_1.u, $SEED_INI_NLS_JAC_1.y + 2.0 * y * $SEED_INI_NLS_JAC_1.y) [Real]
 //
 //
 // ========================================
@@ -315,8 +315,8 @@ simulate(homotopy_no_loop); getErrorString();
 // jacobianMatrices:
 // ========================================
 // 	Jacobian idx: 0
-// 	4: $pDER_INI_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_LS_JAC_1.u + $SEED_INI_LS_JAC_1.u - $SEED_INI_LS_JAC_1.y [Real]
-// 	3: $pDER_INI_LS_JAC_1.$RES_SIM_1=-homotopy($SEED_INI_LS_JAC_1.u, $SEED_INI_LS_JAC_1.y + 2.0 * y * $SEED_INI_LS_JAC_1.y) [Real]
+// 	4: $pDER_INI_NLS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_NLS_JAC_1.u + $SEED_INI_NLS_JAC_1.u - $SEED_INI_NLS_JAC_1.y [Real]
+// 	3: $pDER_INI_NLS_JAC_1.$RES_SIM_1=-homotopy($SEED_INI_NLS_JAC_1.u, $SEED_INI_NLS_JAC_1.y + 2.0 * y * $SEED_INI_NLS_JAC_1.y) [Real]
 //
 // 	Jacobian idx: 2
 // 	10: $pDER_INI_0_NLS_JAC_1.$RES_SIM_1=-($SEED_INI_0_NLS_JAC_1.y + 2.0 * y * $SEED_INI_0_NLS_JAC_1.y) [Real]
@@ -325,8 +325,8 @@ simulate(homotopy_no_loop); getErrorString();
 // 	7: $pDER_INI_0_NLS_JAC_2.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_0_NLS_JAC_2.u + $SEED_INI_0_NLS_JAC_2.u [Real]
 //
 // 	Jacobian idx: 3
-// 	15: $pDER_ALG_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.y [Real]
-// 	14: $pDER_ALG_LS_JAC_1.$RES_SIM_1=-$SEED_ALG_LS_JAC_1.u [Real]
+// 	15: $pDER_ALG_NLS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_NLS_JAC_1.u + $SEED_ALG_NLS_JAC_1.u - $SEED_ALG_NLS_JAC_1.y [Real]
+// 	14: $pDER_ALG_NLS_JAC_1.$RES_SIM_1=-$SEED_ALG_NLS_JAC_1.u [Real]
 //
 // 	Jacobian idx: 4
 //

--- a/testsuite/simulation/modelica/NBackend/initialization/initParamLinearSystem.mos
+++ b/testsuite/simulation/modelica/NBackend/initialization/initParamLinearSystem.mos
@@ -1,0 +1,45 @@
+// name: initParamLinearSystem
+// keywords: NewBackend
+// status: correct
+
+// A torn init-time linear system whose iteration variables are fixed=false
+// parameters (not continuous-time variables). initializeStaticLSVars used to
+// hardcode VAR_KIND_VARIABLE for every iteration variable regardless of its
+// actual kind, so looking up nominal/min/max for a, b, c below indexed into
+// the wrong (too-small) array and crashed with
+// "getNominalFromScalarIdx: scalar_idx N out of bounds [...]" instead of
+// reaching the (still failing, but non-crashing) linear solve below.
+
+loadString("
+model initParamLinearSystem
+  parameter Real a(fixed=false), b(fixed=false), c(fixed=false);
+  Real x(start=1);
+initial equation
+  a + 2*b - c = 1;
+  2*a - b + c = 2;
+  a + b + c = 6;
+equation
+  der(x) = a*x + b - c;
+end initParamLinearSystem;
+"); getErrorString();
+
+setCommandLineOptions("--newBackend");
+simulate(initParamLinearSystem); getErrorString();
+// Result:
+// true
+// ""
+// true
+// record SimulationResult
+//     resultFile = "",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'initParamLinearSystem', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "Simulation execution failed for model: initParamLinearSystem
+// LOG_STDOUT        | warning | The default linear solver fails, the fallback solver with total pivoting is started at time 0.000000. That might raise performance issues, for more information use -lv LOG_LS.
+// LOG_STDOUT        | warning | Error solving linear system of equations (no. 8) at time 0.000000.
+// LOG_STDOUT        | warning | Solving linear system 8 fails at time 0. For more information use -lv LOG_LS.
+// LOG_ASSERT        | debug   | Solving linear system 8 failed at time=0.
+// |                 | |       | For more information please use -lv LOG_LS.
+// LOG_ASSERT        | info    | simulation terminated by an assertion at initialization
+// "
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/simulation/modelica/NBackend/initialization/init_if_exp.mos
+++ b/testsuite/simulation/modelica/NBackend/initialization/init_if_exp.mos
@@ -49,7 +49,8 @@ simulate(init_if_exp); getErrorString();
 //
 // Algebraic Partition 1
 // -----------------------
-//   (11) Linear System (size = 2, jacobian = false, mixed = false, torn = true)
+//   (11) Nonlinear System (size = 2, homotopy = false, mixed = false, torn = true)
+//   --Iteration Vars:{y, u}
 //   --(7) 0 = (u ^ 3.0 + u) - y
 //   --(8) 0 = (-1.0) + u
 //
@@ -100,14 +101,14 @@ simulate(init_if_exp); getErrorString();
 // ----------------------------
 // $RES_SIM_0 ... {$pDER_INI_NLS_JAC_2.$RES_SIM_0} ... {($SEED_INI_NLS_JAC_2.u, {}, false)}
 //
-// =========================================================
-//   SimCode Jacobian ALG_LS_JAC_1(idx = 2, partition = 2)
-// =========================================================
+// ==========================================================
+//   SimCode Jacobian ALG_NLS_JAC_1(idx = 2, partition = 2)
+// ==========================================================
 //
 // SeedVars (size = 2)
 // *********************
-//   (0)[SEED] (1) Real $SEED_ALG_LS_JAC_1.y
-//   (1)[SEED] (1) Real $SEED_ALG_LS_JAC_1.u
+//   (0)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.y
+//   (1)[SEED] (1) Real $SEED_ALG_NLS_JAC_1.u
 //
 // TmpVars (size = 0)
 // ********************
@@ -117,13 +118,13 @@ simulate(init_if_exp); getErrorString();
 //
 // Column Equations (size = 2)
 // -----------------------------
-//   (10) $pDER_ALG_LS_JAC_1.$RES_SIM_0 := (3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u) - $SEED_ALG_LS_JAC_1.y
-//   (9) $pDER_ALG_LS_JAC_1.$RES_SIM_1 := $SEED_ALG_LS_JAC_1.u
+//   (10) $pDER_ALG_NLS_JAC_1.$RES_SIM_0 := (3.0 * u ^ 2.0 * $SEED_ALG_NLS_JAC_1.u + $SEED_ALG_NLS_JAC_1.u) - $SEED_ALG_NLS_JAC_1.y
+//   (9) $pDER_ALG_NLS_JAC_1.$RES_SIM_1 := $SEED_ALG_NLS_JAC_1.u
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_SIM_0 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_0} ... {($SEED_ALG_LS_JAC_1.y, {}, false), ($SEED_ALG_LS_JAC_1.u, {}, false)}
-// $RES_SIM_1 ... {$pDER_ALG_LS_JAC_1.$RES_SIM_1} ... {($SEED_ALG_LS_JAC_1.u, {}, false)}
+// $RES_SIM_0 ... {$pDER_ALG_NLS_JAC_1.$RES_SIM_0} ... {($SEED_ALG_NLS_JAC_1.y, {}, false), ($SEED_ALG_NLS_JAC_1.u, {}, false)}
+// $RES_SIM_1 ... {$pDER_ALG_NLS_JAC_1.$RES_SIM_1} ... {($SEED_ALG_NLS_JAC_1.u, {}, false)}
 //
 // ======================================================
 //   [EMPTY] SimCode Jacobian A(idx = 3, partition = 0)
@@ -175,18 +176,13 @@ simulate(init_if_exp); getErrorString();
 // allEquations:
 // ========================================
 //
-// 11:  (LINEAR) index:0 jacobian: true
-// 	variables:
-// index:1: y (no alias)  initial: 	no arrCref index:(2) []
-// index:0: u (no alias)  initial: 	no arrCref index:(1) []
-// 	b-vector:
+// 11:  (NONLINEAR) index:2 jacobian: true
+// crefs: y , u
 // 	7: u ^ 3.0 + u - y (RESIDUAL)
 // 	8: -1.0 + u (RESIDUAL)
 // 	Jacobian idx: 2
-// 	10: $pDER_ALG_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.y [Real]
-// 	9: $pDER_ALG_LS_JAC_1.$RES_SIM_1=$SEED_ALG_LS_JAC_1.u [Real]
-//
-// 	simJac:
+// 	10: $pDER_ALG_NLS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_NLS_JAC_1.u + $SEED_ALG_NLS_JAC_1.u - $SEED_ALG_NLS_JAC_1.y [Real]
+// 	9: $pDER_ALG_NLS_JAC_1.$RES_SIM_1=$SEED_ALG_NLS_JAC_1.u [Real]
 //
 //
 // ========================================
@@ -201,18 +197,13 @@ simulate(init_if_exp); getErrorString();
 //
 // algebraicEquations (1 systems):
 // ========================================
-// 11:  (LINEAR) index:0 jacobian: true
-// 	variables:
-// index:1: y (no alias)  initial: 	no arrCref index:(2) []
-// index:0: u (no alias)  initial: 	no arrCref index:(1) []
-// 	b-vector:
+// 11:  (NONLINEAR) index:2 jacobian: true
+// crefs: y , u
 // 	7: u ^ 3.0 + u - y (RESIDUAL)
 // 	8: -1.0 + u (RESIDUAL)
 // 	Jacobian idx: 2
-// 	10: $pDER_ALG_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.y [Real]
-// 	9: $pDER_ALG_LS_JAC_1.$RES_SIM_1=$SEED_ALG_LS_JAC_1.u [Real]
-//
-// 	simJac:
+// 	10: $pDER_ALG_NLS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_NLS_JAC_1.u + $SEED_ALG_NLS_JAC_1.u - $SEED_ALG_NLS_JAC_1.y [Real]
+// 	9: $pDER_ALG_NLS_JAC_1.$RES_SIM_1=$SEED_ALG_NLS_JAC_1.u [Real]
 //
 //
 // ========================================
@@ -289,8 +280,8 @@ simulate(init_if_exp); getErrorString();
 // 	2: $pDER_INI_NLS_JAC_2.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_NLS_JAC_2.u + $SEED_INI_NLS_JAC_2.u [Real]
 //
 // 	Jacobian idx: 2
-// 	10: $pDER_ALG_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.y [Real]
-// 	9: $pDER_ALG_LS_JAC_1.$RES_SIM_1=$SEED_ALG_LS_JAC_1.u [Real]
+// 	10: $pDER_ALG_NLS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_NLS_JAC_1.u + $SEED_ALG_NLS_JAC_1.u - $SEED_ALG_NLS_JAC_1.y [Real]
+// 	9: $pDER_ALG_NLS_JAC_1.$RES_SIM_1=$SEED_ALG_NLS_JAC_1.u [Real]
 //
 // 	Jacobian idx: 3
 //
@@ -325,8 +316,7 @@ simulate(init_if_exp); getErrorString();
 // record SimulationResult
 //     resultFile = "init_if_exp_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'init_if_exp', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_STDOUT        | warning | The default linear solver fails, the fallback solver with total pivoting is started at time 0.000000. That might raise performance issues, for more information use -lv LOG_LS.
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;


### PR DESCRIPTION
NBTearing.mo: checkLinearity was fed the varFunc/eqnFunc-filtered (e.g. omcTearing's isDiscontinuous filter) variable/equation lists, which are typically empty for a purely continuous loop. UnorderedMap.all over an empty map vacuously returns true, so any such loop was classified "linear" without ever checking it, sending genuinely nonlinear residuals (atan, products of loop unknowns, etc.) through a direct linear solve that can't converge. Fixed by computing the linearity check from the loop's full unfiltered iteration_vars/residual_eqns instead, via a new tolerant submap helper (subMap's getSafe crashes on names not yet registered in variables.map/equations.map, which the unfiltered set can contain).

CodegenCFunctions.tpl: initializeStaticLSVars hardcoded VAR_KIND_VARIABLE for every torn linear system's iteration variable, but a fixed=false parameter solved via initial equations (e.g. a filter coefficient) lives in a separate parameter index space. This looked up nominal/min/max with the wrong kind, tripping getNominalFromScalarIdx's out-of-bounds assert. Now dispatches per-variable kind like the equivalent NONLINEAR_SYSTEM_DATA codegen already does.

Together these fix ModelicaTest.Electrical.Analog.TestSaturatingInductor, which crashed before and now simulates successfully end to end.

Verified against the full 240-test NBackend testsuite: no regressions, 9 reference files rebaselined (previously-forced "linear solver fails, fallback" warnings disappear as loops are correctly reclassified nonlinear, same converged results). Added initialization/ initParamLinearSystem.mos as a minimal regression test for the crash fix.