### PR TITLE
Collect host solver archives without a Rust omc

### DIFF
--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -110,6 +110,11 @@ endif()
 if(NOT OM_OMC_ENABLE_RUST)
   omc_add_subdirectory(Parser)
 endif()
+# Before Compiler: rust_omc.cmake puts these archives in the omc cdylib's cargo
+# environment, and SimulationRuntime/rust in libSimulationRuntimeRust's.
+if(NOT OM_OMC_WASM AND NOT RUST_OMC_PREBUILT_CDYLIB)
+  include(${CMAKE_CURRENT_SOURCE_DIR}/SimulationRuntime/rust/native_solver_archives.cmake)
+endif()
 omc_add_subdirectory(Compiler)
 # libSimulationRuntimeRust, what `--simCodeTarget=C+Rust` links instead of
 # libSimulationRuntimeC. After Compiler, which is where the Rust working copy and

--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -592,59 +592,14 @@ target_include_directories(primme PRIVATE
     COMMENT "Rust: collecting SUNDIALS/KLU/Lis/PRIMME wasm archives + headers -> ${RUST_SUNDIALS_WASM_DIR}/"
     VERBATIM)
   add_dependencies(rust_sundials_collect rust_sundials_wasm rust_lis_wasm rust_primme_wasm)
-
-  # The host KINSOL/CVODE/IDAS the Rust runtimes link are the C runtime's own
-  # archives (3rdParty), not a second build: they are already
-  # position-independent (`libSimulationRuntimeC.so` links them), and reusing them
-  # leaves the two copies identical should both end up in one process. Collected
-  # into a fixed directory because the cargo env cannot carry a generator
-  # expression. IDA's default linear solver is KLU, so SuiteSparse comes too.
-  if(TARGET sundials_cvode_static)
-    set(RUST_SUNDIALS_NATIVE_DIR ${CMAKE_BINARY_DIR}/rust-sundials-native
-        CACHE PATH "Directory the host SUNDIALS archives are collected into.")
-    set(_native_sundials_libs
-      sundials_kinsol_static
-      sundials_cvode_static sundials_idas_static sundials_sunlinsolklu_static
-      sundials_sunlinsoldense_static sundials_sunmatrixsparse_static
-      sundials_sunmatrixdense_static sundials_nvecserial_static
-      sundials_core_static
-      KLU_static AMD_static COLAMD_static BTF_static SuiteSparseConfig_static)
-    set(_native_sundials_files "")
-    foreach(_lib IN LISTS _native_sundials_libs)
-      list(APPEND _native_sundials_files $<TARGET_FILE:${_lib}>)
-    endforeach()
-    add_custom_target(rust_sundials_native_collect
-      COMMAND ${CMAKE_COMMAND} -E make_directory ${RUST_SUNDIALS_NATIVE_DIR}/lib
-      COMMAND ${CMAKE_COMMAND} -E copy
-        ${_native_sundials_files} ${RUST_SUNDIALS_NATIVE_DIR}/lib/
-      DEPENDS ${_native_sundials_libs}
-      COMMENT "Rust: collecting host SUNDIALS archives -> ${RUST_SUNDIALS_NATIVE_DIR}/lib/"
-      VERBATIM)
-  endif()
 endif()
 
-# ---------------------------------------------------------------------------
-# Ipopt for `method="optimization"` (the classic dynamic-optimization runtime),
-# collected like the host SUNDIALS archives above. Host-only: MUMPS is Fortran 90,
-# so there is no wasm build and an in-wasm runtime reports the same
-# "Ipopt is needed but not available" a C runtime without OMC_HAVE_IPOPT does.
-# ---------------------------------------------------------------------------
-if(OM_OMC_ENABLE_OPTIMIZATION AND TARGET ipopt)
-  set(RUST_IPOPT_NATIVE_DIR ${CMAKE_BINARY_DIR}/rust-ipopt-native
-      CACHE PATH "Directory the host Ipopt archives are collected into.")
-  set(_native_ipopt_libs ipopt dmumps mumps_common seq metis)
-  set(_native_ipopt_files "")
-  foreach(_lib IN LISTS _native_ipopt_libs)
-    list(APPEND _native_ipopt_files $<TARGET_FILE:${_lib}>)
-  endforeach()
-  add_custom_target(rust_ipopt_native_collect
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${RUST_IPOPT_NATIVE_DIR}/lib
-    COMMAND ${CMAKE_COMMAND} -E copy
-      ${_native_ipopt_files} ${RUST_IPOPT_NATIVE_DIR}/lib/
-    DEPENDS ${_native_ipopt_libs}
-    COMMENT "Rust: collecting host Ipopt archives -> ${RUST_IPOPT_NATIVE_DIR}/lib/"
-    VERBATIM)
-endif()
+# The host SUNDIALS and Ipopt archives are collected by
+# SimulationRuntime/rust/native_solver_archives.cmake, which runs before this
+# file so that libSimulationRuntimeRust gets them without a Rust omc.
+get_property(RUST_SUNDIALS_NATIVE_DIR GLOBAL PROPERTY OMC_RUST_SUNDIALS_NATIVE_DIR)
+get_property(RUST_SUNDIALS_NATIVE_INDEX_SIZE GLOBAL PROPERTY OMC_RUST_SUNDIALS_INDEX_SIZE)
+get_property(RUST_IPOPT_NATIVE_DIR GLOBAL PROPERTY OMC_RUST_IPOPT_NATIVE_DIR)
 
 # ---------------------------------------------------------------------------
 # Preview1→preview2 reactor adapter (mandatory for FMI wasm FMU export).
@@ -729,15 +684,12 @@ list(APPEND CARGO_ENV "OMC_FMU_LOADERS_OUT=${RUST_FMU_LOADERS_DIR}")
 
 if(RUST_OMC_ENABLE_SUNDIALS)
   list(APPEND CARGO_ENV "OMC_SUNDIALS_WASM_DIR=${RUST_SUNDIALS_WASM_DIR}")
-  if(TARGET sundials_cvode_static)
-    # The wasm archives are 32-bit-index builds and this one is whatever the C
-    # runtime uses, so the bindings' `sunindextype` follows the archive.
+  # Off leaves the omc cdylib without the wasm-jit sundials feature, so it does
+  # not get the host archives either; libSimulationRuntimeRust still does.
+  if(RUST_SUNDIALS_NATIVE_DIR)
     list(APPEND CARGO_ENV
          "OMC_SUNDIALS_NATIVE_DIR=${RUST_SUNDIALS_NATIVE_DIR}"
-         "OMC_SUNDIALS_NATIVE_INDEX_SIZE=${SUNDIALS_INDEX_SIZE}")
-    # The sibling libSimulationRuntimeRust build needs the same hand-off.
-    set_property(GLOBAL PROPERTY OMC_RUST_SUNDIALS_NATIVE_DIR ${RUST_SUNDIALS_NATIVE_DIR})
-    set_property(GLOBAL PROPERTY OMC_RUST_SUNDIALS_INDEX_SIZE ${SUNDIALS_INDEX_SIZE})
+         "OMC_SUNDIALS_NATIVE_INDEX_SIZE=${RUST_SUNDIALS_NATIVE_INDEX_SIZE}")
   endif()
 endif()
 

--- a/OMCompiler/SimulationRuntime/rust/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/rust/CMakeLists.txt
@@ -51,9 +51,9 @@ set(_simrt_so ${_simrt_target_dir}/${_simrt_profile_dir}/${CMAKE_SHARED_LIBRARY_
 set(_simrt_headers "${CMAKE_CURRENT_SOURCE_DIR}/../c|${CMAKE_CURRENT_SOURCE_DIR}/../../3rdParty/gc/include")
 
 set(_simrt_env ${CMAKE_COMMAND} -E env "OMC_SIMRT_INCLUDE_DIRS=${_simrt_headers}")
-# Same SUNDIALS hand-off the omc build uses, so the driver gets CVODE/IDA. Both
-# or neither: openmodelica_solvers' build script needs the index size whenever the
-# archive directory is given.
+# The archives native_solver_archives.cmake collected, so the driver gets
+# CVODE/IDA. Both or neither: openmodelica_solvers' build script needs the index
+# size whenever the archive directory is given.
 get_property(_simrt_sundials GLOBAL PROPERTY OMC_RUST_SUNDIALS_NATIVE_DIR)
 get_property(_simrt_sundials_ix GLOBAL PROPERTY OMC_RUST_SUNDIALS_INDEX_SIZE)
 if(_simrt_sundials AND _simrt_sundials_ix)
@@ -64,8 +64,9 @@ endif()
 # The same hand-off for Ipopt, which `method="optimization"` needs; without it
 # `openmodelica_sim_meta` builds without `cfg(ipopt)` and the driver reports the
 # solver as unavailable, exactly as a C runtime without OMC_HAVE_IPOPT does.
-if(RUST_IPOPT_NATIVE_DIR)
-  list(APPEND _simrt_env "OMC_IPOPT_NATIVE_DIR=${RUST_IPOPT_NATIVE_DIR}")
+get_property(_simrt_ipopt GLOBAL PROPERTY OMC_RUST_IPOPT_NATIVE_DIR)
+if(_simrt_ipopt)
+  list(APPEND _simrt_env "OMC_IPOPT_NATIVE_DIR=${_simrt_ipopt}")
 endif()
 
 add_custom_target(SimulationRuntimeRust ALL

--- a/OMCompiler/SimulationRuntime/rust/native_solver_archives.cmake
+++ b/OMCompiler/SimulationRuntime/rust/native_solver_archives.cmake
@@ -1,0 +1,61 @@
+# The host SUNDIALS and Ipopt archives the Rust crates link, collected into fixed
+# directories and published as global properties: the cargo environment cannot
+# carry a generator expression, and both libSimulationRuntimeRust and (when omc
+# is the Rust port) libOpenModelicaCompiler need the same hand-off.
+#
+# Included from OMCompiler/CMakeLists.txt after 3rdParty and before Compiler, so
+# that `--simCodeTarget=C+Rust` gets CVODE/IDA and `method="optimization"` in a
+# build of the bootstrapped C omc as well.
+
+# The archives are the C runtime's own (3rdParty), not a second build: they are
+# already position-independent (`libSimulationRuntimeC.so` links them), and
+# reusing them leaves the two copies identical should both end up in one process.
+# IDA's default linear solver is KLU, so SuiteSparse comes too.
+if(TARGET sundials_cvode_static)
+  set(RUST_SUNDIALS_NATIVE_DIR ${CMAKE_BINARY_DIR}/rust-sundials-native
+      CACHE PATH "Directory the host SUNDIALS archives are collected into.")
+  set(_native_sundials_libs
+    sundials_kinsol_static
+    sundials_cvode_static sundials_idas_static sundials_sunlinsolklu_static
+    sundials_sunlinsoldense_static sundials_sunmatrixsparse_static
+    sundials_sunmatrixdense_static sundials_nvecserial_static
+    sundials_core_static
+    KLU_static AMD_static COLAMD_static BTF_static SuiteSparseConfig_static)
+  set(_native_sundials_files "")
+  foreach(_lib IN LISTS _native_sundials_libs)
+    list(APPEND _native_sundials_files $<TARGET_FILE:${_lib}>)
+  endforeach()
+  add_custom_target(rust_sundials_native_collect
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${RUST_SUNDIALS_NATIVE_DIR}/lib
+    COMMAND ${CMAKE_COMMAND} -E copy
+      ${_native_sundials_files} ${RUST_SUNDIALS_NATIVE_DIR}/lib/
+    DEPENDS ${_native_sundials_libs}
+    COMMENT "Rust: collecting host SUNDIALS archives -> ${RUST_SUNDIALS_NATIVE_DIR}/lib/"
+    VERBATIM)
+  # The wasm archives are 32-bit-index builds and this one is whatever the C
+  # runtime uses, so the bindings' `sunindextype` follows the archive.
+  set_property(GLOBAL PROPERTY OMC_RUST_SUNDIALS_NATIVE_DIR ${RUST_SUNDIALS_NATIVE_DIR})
+  set_property(GLOBAL PROPERTY OMC_RUST_SUNDIALS_INDEX_SIZE ${SUNDIALS_INDEX_SIZE})
+endif()
+
+# Ipopt for `method="optimization"` (the classic dynamic-optimization runtime).
+# Host-only: MUMPS is Fortran 90, so there is no wasm build and an in-wasm runtime
+# reports the same "Ipopt is needed but not available" a C runtime without
+# OMC_HAVE_IPOPT does.
+if(OM_OMC_ENABLE_OPTIMIZATION AND TARGET ipopt)
+  set(RUST_IPOPT_NATIVE_DIR ${CMAKE_BINARY_DIR}/rust-ipopt-native
+      CACHE PATH "Directory the host Ipopt archives are collected into.")
+  set(_native_ipopt_libs ipopt dmumps mumps_common seq metis)
+  set(_native_ipopt_files "")
+  foreach(_lib IN LISTS _native_ipopt_libs)
+    list(APPEND _native_ipopt_files $<TARGET_FILE:${_lib}>)
+  endforeach()
+  add_custom_target(rust_ipopt_native_collect
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${RUST_IPOPT_NATIVE_DIR}/lib
+    COMMAND ${CMAKE_COMMAND} -E copy
+      ${_native_ipopt_files} ${RUST_IPOPT_NATIVE_DIR}/lib/
+    DEPENDS ${_native_ipopt_libs}
+    COMMENT "Rust: collecting host Ipopt archives -> ${RUST_IPOPT_NATIVE_DIR}/lib/"
+    VERBATIM)
+  set_property(GLOBAL PROPERTY OMC_RUST_IPOPT_NATIVE_DIR ${RUST_IPOPT_NATIVE_DIR})
+endif()


### PR DESCRIPTION
The host SUNDIALS and Ipopt archives libSimulationRuntimeRust links were collected by Compiler/.cmake/rust_omc.cmake, which is only included when OM_OMC_ENABLE_RUST is on. A cmake build of the bootstrapped C omc therefore produced a runtime without cfg(sundials) or cfg(ipopt), and --simCodeTarget=C+Rust rejected -s=cvode, -s=ida and method="optimization" up front.

Move the two collect targets to
SimulationRuntime/rust/native_solver_archives.cmake, included from OMCompiler/CMakeLists.txt between 3rdParty, which builds the archives for the C runtime, and Compiler, where rust_omc.cmake reads them back. Both consumers take the directories from the global properties that were already there for the sibling build.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
