### PR TITLE
Make OM_ENABLE_RUST_SIM_RUNTIME opt-in

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -491,12 +491,14 @@ void buildRustOMC() {
   standardSetup()
   // RUST_OMC_THREADS=4 parallelises the rustc front-end on the (near-serial)
   // generated-crate chain. Linking uses mold (RUST_OMC_MOLD defaults ON); the
-  // image ships a current mold.
+  // image ships a current mold. OM_ENABLE_RUST_SIM_RUNTIME is what the
+  // RUST_PARTEST_SIMCODETARGET=C+Rust partest links against.
   sh """
     cmake -S . -B build_cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DOM_OMC_ENABLE_RUST=ON \
       -DRUST_OMC_CI=ON \
+      -DOM_ENABLE_RUST_SIM_RUNTIME=ON \
       -DOM_ENABLE_GUI_CLIENTS=OFF \
       -DRUST_OMC_SCRIPTING_API=ON \
       -DOM_USE_CCACHE=OFF \

--- a/OMCompiler/SimulationRuntime/rust/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/rust/CMakeLists.txt
@@ -7,8 +7,9 @@
 # port (OM_OMC_ENABLE_RUST). When it is, build from the same per-build working
 # copy rust_omc.cmake mirrors into, so the two cargo builds share a target dir.
 
+# Opt-in: building it needs a Rust toolchain a C-only build does not require.
 option(OM_ENABLE_RUST_SIM_RUNTIME
-       "Build libSimulationRuntimeRust, the runtime --simCodeTarget=C+Rust links." ON)
+       "Build libSimulationRuntimeRust, the runtime --simCodeTarget=C+Rust links." OFF)
 if(NOT OM_ENABLE_RUST_SIM_RUNTIME)
   return()
 endif()


### PR DESCRIPTION
libSimulationRuntimeRust is only reachable through `--simCodeTarget=C+Rust`, which is not what a standard installation simulates with, yet building it by default required a Rust toolchain from every C-only build. Default it to OFF.

The one job that needs it is the Rust omc CI build, whose optional `RUST_PARTEST_SIMCODETARGET=C+Rust` partest links against the library, so pass the flag explicitly there. OpenModelicaLibraryTesting enables it the same way for its C+Rust runs.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
