### PR TITLE
wasm FMU: leave importer-owned simflags alone

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -714,11 +714,18 @@ pub fn fmuAcceptsFlag(name: ArcStr, value: ArcStr) -> bool {
     fmu_accepts_flag(name.as_str(), value.as_str())
 }
 
+/// Flags the importer owns: it sets start values through `fmi3Set*` and decides
+/// when the co-simulation ends. `-variableFilter` is refused by [`fmu_capabilities`].
+const IMPORTER_FLAGS: &[&str] = &["override", "overrideFile", "steadyState", "steadyStateTol"];
+
 fn fmu_accepts_flag(name: &str, value: &str) -> bool {
     if name == "s" {
         // Baked into the component rather than parsed at instantiation, so only
         // what it linked can serve it.
         return fmu_cs_solvers().contains(&value);
+    }
+    if IMPORTER_FLAGS.contains(&name) {
+        return false;
     }
     let arg = if value.is_empty() { format!("-{name}") } else { format!("-{name}={value}") };
     match simflags::parse(&["model".to_string(), arg]) {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -778,9 +778,14 @@ fn apply_baked_solver_flags(flags: &str) -> Option<()> {
     let argv: Vec<String> = core::iter::once("model".to_string())
         .chain(flags.split_whitespace().map(str::to_string))
         .collect();
+    // An FMU writes no result file; `-variableFilter` is the importer's.
+    let cap = simflags::Capabilities {
+        variable_filter: true,
+        ..openmodelica_codegen_wasm_jit_runtime::sim_capabilities()
+    };
     let parsed = simflags::parse(&argv)
         .and_then(|f| {
-            simflags::check(&f, openmodelica_codegen_wasm_jit_runtime::sim_capabilities())?;
+            simflags::check(&f, cap)?;
             Ok(f)
         })
         .map_err(|e| {


### PR DESCRIPTION
A wasm FMU refused to instantiate when `--fmiFlags` had baked `-variableFilter` into its metadata: the flag check rejects it because the runtime has no regex engine. But an FMU writes no result file -- which variables are output is the importer's decision, so the flag is inert in the component rather than unhonourable and must not fail `fmi3InstantiateCoSimulation`.

Sweeping the rest of the flag set through an export and a `-s fmi3:cs` run found three more the importer owns, mishandled by other routes:

| Flag | Before |
| --- | --- |
| `-overrideFile=f` | instantiate failed; the component cannot read the path | | `-override=p=v` | baked, reported fine, silently did nothing | | `-steadyState` | failed the run where C finishes it successfully |

The export drops these now instead of baking them, so `createFMISimulationFlags` reports them the way it already reports a flag the FMU cannot honour. An override passed at run time through `-s fmi3:cs` keeps working; it reaches the model as `fmi3Set*` calls.

Verified on the failing library-testing model
AES.Coursework.Typical_control_structures.Hi_gain_linearising: it runs, and diffSimulationResults against the C target reports no differing variables.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
