### PR TITLE
NBDifferentiate: use OR-fold containsContinuousVar, not ALL-fold isContinuous, for call-arg differentiation

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
@@ -1370,9 +1370,16 @@ public
           arguments_inputs := List.zip(call.arguments, func.inputs);
           for tpl in arguments_inputs loop
             (arg, inp) := tpl;
-            // check if it is continuous
-            // do not check for continuous if it is for functions (differentiating a function inside a function) crefs are not lowered there! assume it is continuous
-            isCont := ((diffArguments.diffType == DifferentiationType.FUNCTION) or BackendUtil.isContinuous(arg, false));
+            // check if it is (or contains) something continuous -- do not check for functions
+            // (differentiating a function inside a function) since crefs are not lowered
+            // there, assume continuous. Use an OR-fold (does this expression contain AT LEAST
+            // ONE continuous variable), not isContinuous's ALL-fold (are ALL crefs in it
+            // continuous): a mixed expression like a constant parameter times a genuinely
+            // time-varying variable (e.g. "e * a", a unit-vector parameter times an
+            // acceleration) genuinely needs differentiating -- isContinuous's ALL-fold wrongly
+            // judged it "not continuous" purely because the parameter "e" is present, silently
+            // dropping every argument built this way from the derivative computation entirely.
+            isCont := ((diffArguments.diffType == DifferentiationType.FUNCTION) or BackendUtil.containsContinuousVar(arg));
 
             // input type has to be real value or a function pointer, skip if its in the interface diff info
             isReal    := Type.isReal(Type.arrayElementType(Expression.typeOf(arg)));

--- a/testsuite/simulation/modelica/NBackend/differentation/jacobianCallArgContinuityDrop.mos
+++ b/testsuite/simulation/modelica/NBackend/differentation/jacobianCallArgContinuityDrop.mos
@@ -1,0 +1,82 @@
+// name: jacobianCallArgContinuityDrop
+// keywords: NewBackend
+// status: correct
+//
+// Regression test for NBDifferentiate.mo's differentiateCall using
+// BackendUtil.isContinuous's ALL-fold ("are ALL crefs in this expression
+// continuous") instead of containsContinuousVar's OR-fold ("does this
+// expression contain AT LEAST ONE continuous variable") to decide whether
+// a user-defined function's call argument needs its own derivative
+// computed for the current (JACOBIAN-mode) differentiation.
+//
+// f_der/g_der are called directly (annotation(Inline=false) keeps them
+// from being algebraically inlined away before Jacobian codegen), each
+// with a "k*a1" argument that mixes a constant parameter (k) with the
+// torn algebraic loop's own seed variable (a1). Under the old ALL-fold,
+// "k*a1" was wrongly judged "not continuous" purely because k is a
+// parameter, so a1's contribution to d(f_der(...))/d(a1) was silently
+// dropped from BOTH residual equations -- leaving the whole first
+// (a1) Jacobian column structurally zero for this loop, corrupting the
+// analytic Jacobian used by the nonlinear solver.
+//
+// Symptom before the fix: solving the resulting 2x2 nonlinear system hit
+// repeated "Matrix (nearly) singular" / homotopy pivot warnings and took
+// ~2000 Jacobian evaluations to (mis-)converge to a wrong root
+// (a1 = -0.0281... instead of the true -1/18 = -0.0555...). After the
+// fix: 2 Newton iterations, no warnings, exact root.
+
+loadString("
+function f_der
+  input Real x;
+  input Real dx;
+  output Real dy;
+algorithm
+  dy := 2*x*dx;
+  annotation(Inline = false);
+end f_der;
+
+function g_der
+  input Real x;
+  input Real dx;
+  output Real dy;
+algorithm
+  dy := 2*x*dx;
+  annotation(Inline = false);
+end g_der;
+
+model jacobianCallArgContinuityDrop
+  parameter Real k = 3;
+  Real s(start=1, fixed=true);
+  Real w(start=1, fixed=true);
+  Real a1, a2;
+equation
+  der(s) = w;
+  der(w) = a1;
+  0 = f_der(k*s, k*a1) - 2*a2 - 1;
+  0 = g_der(k*s, k*a1) - 3*a2 - 2;
+end jacobianCallArgContinuityDrop;
+"); getErrorString();
+
+setCommandLineOptions("--newBackend"); getErrorString();
+
+simulate(jacobianCallArgContinuityDrop, stopTime=0.02, numberOfIntervals=2); getErrorString();
+
+val(a1, 0.0);
+val(a2, 0.0);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "jacobianCallArgContinuityDrop_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.02, numberOfIntervals = 2, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'jacobianCallArgContinuityDrop', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// -0.05555555555555555
+// -1.0
+// endResult


### PR DESCRIPTION
differentiateCall decided whether a user-defined function's call argument needed its own derivative by checking BackendUtil.isContinuous(arg, false), which does an ALL-fold over the argument's crefs ("are ALL crefs in this expression continuous"). A mixed expression like "e*a" (a constant parameter times a genuinely time-varying variable, e.g. MultiBody's unit vectors times joint accelerations) was wrongly judged "not continuous" purely because the parameter is present, silently dropping that argument's contribution from JACOBIAN-mode differentiation of a torn loop's residual. isContinuous's own OR-fold sibling, containsContinuousVar ("does this expression contain at least one continuous variable"), is the correct check here and was already available as a drop-in replacement.

Root cause of ModelicaTest.MultiBody.Forces.Damper/Damper2's original init-time singular-matrix crash (now separately routed around the bug by #16516's checkLinearity fix, but the underlying bug was still live and could resurface for any model hitting this path directly). Confirmed by temporarily reverting checkLinearity locally to force Damper back onto the old broken linear-system path: fixes it via the correct mechanism (the Jacobian column is properly populated), not just rerouting.

Added a fully synthetic, MSL-independent regression test (jacobianCallArgContinuityDrop.mos): two torn-loop residual equations each call an Inline=false, non-inlined user function with a "parameter*seed" argument. Pre-fix this corrupts an entire Jacobian column to structural zero (never referencing the seed at all), causing repeated "matrix nearly singular" warnings, ~2000 Jacobian evaluations, and convergence to a wrong root. Post-fix: 2 iterations, no warnings, exact root.

Full 243-test NBackend suite verified clean (only pre-existing, unrelated failures: one Buildings test with a stale local MSL version banner, one benchmark test whose expected status is itself "erroneous").
