### PR TITLE
wasm-jit: a system assigns its unknowns too

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -7736,23 +7736,56 @@ fn is_computed(key: &str, computed: &std::collections::HashSet<String>) -> bool 
     }
 }
 
-/// Keys of the crefs assigned by a `SimEqSystem` list (scalar/array assigns).
+/// Keys of the crefs a `SimEqSystem` list assigns, a system's iteration
+/// variables included.
 fn assigned_cref_keys(eqs: &[Arc<SimCode::SimEqSystem>]) -> std::collections::HashSet<String> {
     use SimCode::SimEqSystem as E;
     let mut set = std::collections::HashSet::new();
+    let mut add = |cr: &DAE::ComponentRef| {
+        if let Ok(k) = sim_cref_key(cr) {
+            set.insert(k);
+        }
+    };
     for eq in eqs {
-        let cr = match &**eq {
-            E::SES_SIMPLE_ASSIGN { cref, .. } => Some(cref.clone()),
-            E::SES_ARRAY_CALL_ASSIGN { lhs, .. } => match &**lhs {
-                DAE::Exp::CREF { componentRef, .. } => Some(componentRef.clone()),
-                _ => None,
-            },
-            _ => None,
-        };
-        if let Some(cr) = cr {
-            if let Ok(k) = sim_cref_key(&cr) {
-                set.insert(k);
+        match &**eq {
+            E::SES_SIMPLE_ASSIGN { cref, .. }
+            | E::SES_SIMPLE_ASSIGN_CONSTRAINTS { cref, .. }
+            | E::SES_FOR_LOOP { cref, .. } => add(cref),
+            E::SES_ARRAY_CALL_ASSIGN { lhs, .. } => {
+                if let DAE::Exp::CREF { componentRef, .. } = &**lhs {
+                    add(componentRef);
+                }
             }
+            E::SES_LINEAR { lSystem, alternativeTearing, .. } => {
+                for s in std::iter::once(lSystem).chain(alternativeTearing.iter()) {
+                    for v in lst(&s.vars) {
+                        add(&v.name);
+                    }
+                }
+            }
+            E::SES_NONLINEAR { nlSystem, alternativeTearing, .. } => {
+                for s in std::iter::once(nlSystem).chain(alternativeTearing.iter()) {
+                    for c in lst(&s.crefs) {
+                        add(c);
+                    }
+                }
+            }
+            E::SES_MIXED { discVars, .. } => {
+                for v in lst(discVars) {
+                    add(&v.name);
+                }
+            }
+            E::SES_ALGORITHM { statements, .. } | E::SES_INVERSE_ALGORITHM { statements, .. } => {
+                let defs = openmodelica_frontend_base::Expression::extractUniqueCrefsFromStatmentS(
+                    statements.clone(),
+                );
+                if let Ok((defs, _)) = defs {
+                    for c in lst(&defs) {
+                        add(c);
+                    }
+                }
+            }
+            _ => {}
         }
     }
     set


### PR DESCRIPTION
`collect_param_bindings` stores a parameter's binding in the prelude that runs ahead of the parameter and initial equation lists, and skips the ones an equation computes -- but `assigned_cref_keys` only looked at `SES_SIMPLE_ASSIGN` and `SES_ARRAY_CALL_ASSIGN`. A parameter a linear or nonlinear system, a mixed system or an algorithm computes was therefore pre-assigned from its binding, and every one of those reads the slot it assigns: for a system it is the solver's initial guess.

```modelica
package P
  model Pipe
    parameter Real dh(fixed=false, start=0.01, min=0.001);
    parameter Real fac = 1;
    parameter Real dp_nominal = 2500;
    final parameter Real dpStraight = 1e6*dh^2 + 1e5*sin(dh);
  initial equation
    dp_nominal = fac*dpStraight;
  end Pipe;

  model Net
    parameter Real dhEnd(fixed=false, start=0.05, min=0.01);
    Pipe pipEnd(final dh(fixed=true) = dhEnd, fac=1);
    Real x(start=1, fixed=true);
  equation
    der(x) = -pipEnd.dh*x;
  end Net;
end P;
```

The backend solves the binding for `dhEnd` (`dhEnd := pipEnd.dh`, after the system) and the initial equation for `pipEnd.dh`, whose `start` the alias set drops -- so C enters the solve at 0, where wasm-jit entered at `dhEnd`'s 0.05. `-lv=LOG_NLS` now prints the same guess for both.

The guess only picks the root when there is more than one. `Buildings.DHC.Loads.BaseClasses.Validation.FlowDistributionPumpControl` has a zero-length end pipe, so its `pressureLoss_m_flow(dh) = 0` holds for every `dh`: wasm-jit stopped at the 0.05 it had been handed and reported `dis.pipEnd.dh`, `dis.pipEnd.deltaM` and `dis.dhEnd` where C reports its own. The model now matches the C target on all 1250 result variables.

`assigned_cref_keys` covers the kinds that name their left-hand side: both scalar assigns and the for-loop, the array-call assign, a linear system's `vars` and a nonlinear system's `crefs` (either tearing set), a mixed system's `discVars`, and an algorithm's defined crefs. A torn system's inner assigns already arrive as separate entries.

Verified with `--simCodeTarget=wasm-jit` over
`simulation/modelica/{initialization,parameters,equations,arrays,events, algorithms_functions,linear_system,nonlinear_system}`: 347 tests, the one failure (`arrays/ticket_6099`, which only fails inside a batch) failing the same way on the C target. Re-running 17 Buildings/ClaRa/MSL models against the C target changes only FlowDistributionPumpControl.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
