### PR TITLE
Fix Expression.dimensionCount for typename dimensions

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -2864,10 +2864,13 @@ public
 
   function dimensionCount
     input Expression exp;
+    input Boolean isDim = false;
     output Integer dimCount;
   algorithm
     dimCount := match exp
-      case TYPENAME() then 1;
+      // Typenames expand to arrays when used as e.g. iteration ranges, but when used as a
+      // dimension they work the same as an Integer and are treated as scalars.
+      case TYPENAME() then if isDim then 0 else 1;
       case ARRAY(ty = Type.UNKNOWN())
         then 1 + dimensionCount(arrayGet(exp.elements, 1));
       case MATRIX() then 2;

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -846,7 +846,7 @@ protected
   InstNode parent;
   list<Subscript> subs;
 algorithm
-  exp_dims := Expression.dimensionCount(dimExp);
+  exp_dims := Expression.dimensionCount(dimExp, true);
 
   if exp_dims == 0 then
     // If the expression is a scalar like it should we don't need to do anything.
@@ -1801,7 +1801,7 @@ algorithm
   // We don't yet know the number of dimensions, but the index must at least be 1.
   if dimIndex < 1 then
     dim := Dimension.UNKNOWN();
-    error := TypingError.OUT_OF_BOUNDS(Expression.dimensionCount(arrayExp));
+    error := TypingError.OUT_OF_BOUNDS(Expression.dimensionCount(arrayExp, true));
   else
     (dim, error) := typeArrayDim2(arrayExp, dimIndex);
   end if;


### PR DESCRIPTION
- Typenames can be considered to be scalars when used as dimensions, and arrays otherwise.