### PR TITLE
Fix initialization of discrete outputs in FMUs

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -1919,7 +1919,13 @@ algorithm
         newCref := ComponentReference.prependStringCref(BackendDAE.outputAliasPrefix, cref);
         newVar := BackendVariable.copyVarNewName(newCref, v);
         newVar := BackendVariable.setVarDirection(newVar, DAE.BIDIR());
-        newVar := BackendVariable.setVarKind(newVar, BackendDAE.VARIABLE());
+        /* A discrete output's alias stays discrete; as a continuous variable it
+         * also gets "$PRE.alias = alias", which over-specifies the initial system.
+         */
+        newVar := match v.varKind
+          case BackendDAE.DISCRETE() then newVar;
+          else BackendVariable.setVarKind(newVar, BackendDAE.VARIABLE());
+        end match;
         /* fix issue https://github.com/OpenModelica/OpenModelica/issues/15311
          * force StateSelect.never on the alias variable so that state selection never picks the alias
          * instead of original state variable, which would cause wrong code generation and simulation results.

--- a/OMCompiler/Compiler/BackEnd/Initialization.mo
+++ b/OMCompiler/Compiler/BackEnd/Initialization.mo
@@ -615,7 +615,7 @@ algorithm
   for cr in inCrLst loop
     identType := ComponentReference.crefTypeConsiderSubs(cr);
     crefExp := DAE.CREF(cr, identType);
-    crefPreExp := Expression.makePureBuiltinCall("pre", {crefExp}, DAE.T_BOOL_DEFAULT);
+    crefPreExp := Expression.makePureBuiltinCall("pre", {crefExp}, identType);
     eqn := BackendDAE.EQUATION(crefExp, crefPreExp, inSource, BackendDAE.EQ_ATTR_DEFAULT_DYNAMIC);
     outEqns := eqn::outEqns;
   end for;

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/Makefile
@@ -26,6 +26,7 @@ fmi3_terminals_alias.mos \
 fmi3_terminals.mos \
 fmi3_types.mos \
 fmi3_wasm_daemode_me.mos \
+fmi3_wasm_discrete_output_init.mos \
 fmi3_wasm_native_record.mos \
 fmi3_wasm_output_record.mos
 

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_wasm_discrete_output_init.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_wasm_discrete_output_init.mos
@@ -1,0 +1,97 @@
+// name: fmi3_wasm_discrete_output_init
+// keywords: FMI 3.0 export wasm initialization discrete output
+// status: correct
+// suite: wasm
+// teardown_command: rm -rf DiscOut* plain* sim_res.mat me_res.mat cs_res.mat diff_*
+//
+// A top-level output is replaced by an internal $outputAlias_ on export. The alias
+// of a discrete output used to be forced continuous, which gave it
+// "$PRE.alias = alias" from collectInitialVars on top of the inactive when equation
+// "alias = pre(alias)" -- two copies of one equation, a singular system, and the
+// model's own initial equation demoted to a consistency check that the solution had
+// no reason to satisfy. A plain simulation cannot produce this: there the alias does
+// not exist and such a cycle is a purely discrete algebraic loop, which the backend
+// rejects rather than solves.
+//
+// All three faces of the artifact have to agree with the plain simulation.
+
+setCommandLineOptions("--simCodeTarget=wasm-jit"); getErrorString();
+setCommandLineOptions("--fmuDirectory=true"); getErrorString();
+
+loadString("model DiscOut
+  output Real y;
+initial equation
+  y = 3;
+equation
+  when sample(0, 0.1) then
+    y = pre(y) + 1;
+  end when;
+end DiscOut;"); getErrorString();
+
+simulate(DiscOut, fileNamePrefix="plain"); getErrorString();
+buildModelFMU(DiscOut, fileNamePrefix="DiscOut", fmuType="me_cs", version="3.0", platforms={"wasm"}); getErrorString();
+
+simulate(DiscOut, simflags="-r=sim_res.mat", resimulateExecutable="DiscOut.fmu"); getErrorString();
+simulate(DiscOut, simflags="-s fmi3:me -r=me_res.mat", resimulateExecutable="DiscOut.fmu"); getErrorString();
+simulate(DiscOut, simflags="-s fmi3:cs -r=cs_res.mat", resimulateExecutable="DiscOut.fmu"); getErrorString();
+
+diffSimulationResults("sim_res.mat", "plain_res.mat", "diff_sim", 1e-6, 1e-6);
+diffSimulationResults("me_res.mat", "plain_res.mat", "diff_me", 1e-6, 1e-6);
+diffSimulationResults("cs_res.mat", "plain_res.mat", "diff_cs", 1e-6, 1e-6);
+
+// The initial equation, then one increment per sample.
+val(y, 0.0, "sim_res.mat");
+val(y, 1.0, "sim_res.mat");
+// Result:
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "plain_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'plain', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// "DiscOut.fmu"
+// "Notification: Building FMU for platform 'wasm' (1/1).
+// Notification: Finished FMU for platform 'wasm' (1/1).
+// "
+// record SimulationResult
+//     resultFile = "sim_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'DiscOut', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-r=sim_res.mat'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// record SimulationResult
+//     resultFile = "me_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'DiscOut', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s fmi3:me -r=me_res.mat'",
+//     messages = "LOG_STDOUT        | info    | wasm artifact loaded (model kernel linked against the cached adapter)
+// LOG_STDOUT        | info    | ModelExchange instantiated
+// LOG_STDOUT        | info    | ModelExchange run: 500 steps, 500 evaluations, 0 Jacobians, 0 state events, 10 time events, 521 samples
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// record SimulationResult
+//     resultFile = "cs_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'DiscOut', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s fmi3:cs -r=cs_res.mat'",
+//     messages = "LOG_STDOUT        | info    | wasm artifact loaded (model kernel linked against the cached adapter)
+// LOG_STDOUT        | info    | CoSimulation instantiated
+// LOG_STDOUT        | info    | CoSimulation run: 500 communication steps, 10 events, 0 early returns, 511 samples
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// (true, {})
+// (true, {})
+// (true, {})
+// 4.0
+// 14.0
+// endResult


### PR DESCRIPTION
An FMU export replaces every top-level output `y` by an internal `$outputAlias_y`. A `Buildings.Occupants.BaseClasses.Validation.Logit1D` artifact reported

    The initialization problem is inconsistent due to the
    following equation: 0 != -0.75 = y

`introduceOutputAliases` forced the alias to `BackendDAE.VARIABLE()`. For a discrete output that made the alias continuous, so `collectInitialVars` gave it `$PRE.alias = alias` on top of the inactive when equation `alias = pre(alias)`. The initial system was then over-specified, and the model's own initial equation was demoted to a removed initial equation, i.e. a consistency check that the solution has no reason to satisfy. The alias now keeps a discrete kind; a state's alias is still demoted, which is what #15311/#15374 needed.

A plain simulation cannot reach this. There the alias does not exist, and the only way to put `$PRE.y` in a cycle -- writing `initial equation pre(y) = y` -- is a purely discrete algebraic loop, which `analyseStrongComponentBlock` rejects rather than solves. It took the alias, continuous, to turn two copies of one equation into a system a numeric solver would accept.

Behind that sat a second defect, latent again now that no such system forms. `generateInactiveWhenEquationForInitialization` built the `pre(alias)` call with a hard-coded `DAE.T_BOOL_DEFAULT` result type, so `$PRE.alias` travelled through the backend typed Boolean. Once the duplicate equations formed a torn linear system,
`Expression.createResidualExp` built `alias - $PRE.alias` and `ExpressionSimplify` rewrote it to `alias + negate($PRE.alias)` -- `negate` sees `T_BOOL` and emits `not`, not unary minus. Both targets emitted a logical `not` of a Real:

    res[0] = $outputAlias_y + (!realVarsPre[0]);

and the Jacobian likewise, so the 1x1 system had J = 2 rather than 0 and the residual never converged. The call now takes the cref's type, which also fixes the `_info.json` and backend dumps of any such equation.

Both are target-independent: the C FMU export generated the same `!`. The new test drives the wasm artifact's three faces because that needs no importFMU wrapper around the export.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
