### PR TITLE
Allow shrinking OMPlot plots and adapt axis tick labels

### DIFF
--- a/OMPlot/OMPlot/OMPlotGUI/Legend.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/Legend.cpp
@@ -63,7 +63,7 @@ Legend::Legend(Plot *pParent)
   mpToggleAxisAction = new QAction(tr("Right Y-Axis"), this);
   mpToggleAxisAction->setCheckable(true);
   connect(mpToggleAxisAction, SIGNAL(triggered(bool)), SLOT(switchAxis(bool)));
-    
+
   mpSetupAction = new QAction(tr("Setup"), this);
   connect(mpSetupAction, SIGNAL(triggered()), SLOT(showSetupDialog()));
 
@@ -244,7 +244,6 @@ void Legend::mouseDoubleClickEvent(QMouseEvent *event)
       } else {
         pPlotCurve->toggleVisibility(false);
       }
-
     }
   }
 }

--- a/OMPlot/OMPlot/OMPlotGUI/OMPlot.h
+++ b/OMPlot/OMPlot/OMPlotGUI/OMPlot.h
@@ -94,6 +94,24 @@ public:
   static QString convertUnitToSymbol(const QString &displayUnit);
   static QString convertSymbolToUnit(const QString &symbol);
   static void getUnitPrefixAndExponent(double lowerBound, double upperBound, QString &unitPrefix, int &exponent);
+private:
+  void updateMaxMajorSteps();
+protected:
+  void resizeEvent(QResizeEvent *event) override;
+  /* Override the minimum size hint so that the window can be shrunk vertically.
+   * QwtPlot::sizeHint() (used by the default minimumSizeHint()) adds extra
+   * required height/width proportional to the current number of y/x axis major
+   * ticks, which prevents shrinking the plot to a small size. The tick labels
+   * are reduced instead by updateMaxMajorSteps(). See #15788.
+   */
+  QSize minimumSizeHint() const override;
+  /* Override the size hint for the same reason as minimumSizeHint(): do not
+   * ask for space that is proportional to the current number of tick labels,
+   * otherwise the plot (and the window/MDI-subwindow containing it) can not be
+   * shrunk to a small size. Ticks are reduced by updateMaxMajorSteps().
+   * See #15788.
+   */
+  QSize sizeHint() const override;
 public slots:
   virtual void replot() override;
 };

--- a/OMPlot/OMPlot/OMPlotGUI/Plot.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/Plot.cpp
@@ -53,6 +53,8 @@
 #include "qwt_text_label.h"
 
 #include <QtMath>
+#include <QFontMetrics>
+#include <QResizeEvent>
 
 namespace OMPlot{
 
@@ -430,12 +432,114 @@ void Plot::getUnitPrefixAndExponent(double lowerBound, double upperBound, QStrin
   }
 }
 
+/*!
+ * \brief Plot::resizeEvent
+ * Reimplementation of QWidget::resizeEvent.
+ * Recomputes the number of axis major ticks whenever the plot is resized so
+ * that the labels adapt to the available canvas size (see #15788).
+ * \param event
+ */
+void Plot::resizeEvent(QResizeEvent *event)
+{
+  QwtPlot::resizeEvent(event);
+  updateMaxMajorSteps();
+}
+
+/*!
+ * \brief Plot::minimumSizeHint
+ * Reimplementation of QWidget::minimumSizeHint().
+ * QwtPlot::sizeHint() returns a size that grows with the number of major axis
+ * ticks (the default minimumSizeHint() delegates to sizeHint()). Since the
+ * tick labels are already reduced to fit the available canvas size by
+ * updateMaxMajorSteps() (see #15788), we must not ask for extra space that is
+ * proportional to the current tick count, otherwise the plot window can not be
+ * shrunk vertically.
+ */
+QSize Plot::minimumSizeHint() const
+{
+  return QwtPlot::minimumSizeHint();
+}
+
+/*!
+ * \brief Plot::sizeHint
+ * Reimplementation of QWidget::sizeHint().
+ * QwtPlot::sizeHint() adds dh/dw proportional to the number of major axis ticks
+ * (see QwtPlot::sizeHint()), which makes the plot (and its containing window or
+ * MDI subwindow) impossible to shrink below a height driven by the tick count.
+ * Since the tick labels are already kept small enough for the canvas by
+ * updateMaxMajorSteps() (see #15788), we return the true minimum size instead
+ * so the plot can be shrunk as far as desired.
+ */
+QSize Plot::sizeHint() const
+{
+  return QwtPlot::minimumSizeHint();
+}
+
+/*!
+ * \brief Plot::updateMaxMajorSteps
+ * Reduces the number of axis tick labels in order to allow smaller plots.
+ * When the plot (and thus its canvas) is small only a few major ticks fit,
+ * so we decrease the number of major steps that Qwt uses to build the scale
+ * division. The labels are then spread further apart which lets the plot be
+ * shrunk more before labels start to overlap. See #15788.
+ */
+void Plot::updateMaxMajorSteps()
+{
+  if (!canvas()) {
+    return;
+  }
+
+  const int canvasWidth = canvas()->width();
+  const int canvasHeight = canvas()->height();
+
+  // x-axis (bottom): fit the labels horizontally.
+  int maxMajorX = 8;  // Qwt default
+  if (canvasWidth > 0) {
+    QFontMetrics xFm(axisWidget(QwtPlot::xBottom)->font());
+    // A typical numeric label is a few characters wide. Use a fixed sample to
+    // estimate the label width when no unit prefix is active, otherwise the
+    // scaled values are shorter (e.g. "12k").
+    const int sampleWidth = xFm.horizontalAdvance("1000");
+    const int labelWidth = qMax(sampleWidth, 20) + 8;  // + spacing/borders
+    maxMajorX = qBound(2, canvasWidth / labelWidth, 8);
+  }
+  if (axisMaxMajor(QwtPlot::xBottom) != maxMajorX) {
+    setAxisMaxMajor(QwtPlot::xBottom, maxMajorX);
+  }
+
+  // y-axis (left): fit the labels vertically.
+  int maxMajorY = 8;  // Qwt default
+  if (canvasHeight > 0) {
+    QFontMetrics yFm(axisWidget(QwtPlot::yLeft)->font());
+    const int labelHeight = yFm.height() + 6;  // + spacing between labels
+    maxMajorY = qBound(2, canvasHeight / labelHeight, 8);
+  }
+  if (axisMaxMajor(QwtPlot::yLeft) != maxMajorY) {
+    setAxisMaxMajor(QwtPlot::yLeft, maxMajorY);
+  }
+
+  // y-axis (right): use the same density as the left axis.
+  if (axisMaxMajor(QwtPlot::yRight) != maxMajorY) {
+    setAxisMaxMajor(QwtPlot::yRight, maxMajorY);
+  }
+}
+
 // just overloaded this function to get colors for curves.
 void Plot::replot()
 {
   mpXScaleDraw->invalidateCache();
   mpYScaleDraw->invalidateCache();
   mpYRightScaleDraw->invalidateCache();
+
+  // Recompute the number of major axis ticks so that labels do not overlap
+  // when the plot is small. Disable autoscaling replot while doing this to
+  // avoid recursing back into Plot::replot() (setAxisMaxMajor triggers an
+  // autoRefresh when autoReplot is enabled).
+  const bool doAutoReplot = autoReplot();
+  setAutoReplot(false);
+  updateMaxMajorSteps();
+  setAutoReplot(doAutoReplot);
+
   QwtPlot::replot();
 
   // Now we need to again loop through curves to set the color and title.

--- a/OMPlot/OMPlot/OMPlotGUI/PlotCurve.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotCurve.cpp
@@ -70,7 +70,7 @@ PlotCurve::PlotCurve(const QString &fileName, const QString &absoluteFilePath, c
   setCurveStyle(mpParentPlot->getParentPlotWindow()->getCurveStyle());
 #if QWT_VERSION > 0x060000
   setLegendAttribute(QwtPlotCurve::LegendShowLine);
-  setLegendIconSize(QSize(30, 30));
+  setLegendIconSize(QSize(25, 8));
 #endif
   mpPlotDirectPainter = new QwtPlotDirectPainter();
   mpPointMarker = new QwtPlotMarker();


### PR DESCRIPTION
### Related Issues

Fixes #15788

Reduce the minimum size of OMPlot plots so they can be shrunk to very small sizes. Override sizeHint()/minimumSizeHint()

Keep axis tick labels from overlapping when the canvas is small. Recompute the number of x/y axis major ticks from the current canvas size on resize and replot (updateMaxMajorSteps), producing coarser ticks as the plot shrinks.

Reduce the legend icon size from 30x30 to 25x8 so the legend bar no longer forces extra vertical space.
