### PR TITLE
NBackend: give implicit-promoted algebraic loops their own Jacobian name tag

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBStrongComponent.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBStrongComponent.mo
@@ -164,6 +164,12 @@ public
     Boolean mixed               "true for systems that have discrete variables";
     Boolean homotopy            "true if contains homotopy()";
     Solve.Status status;
+    Boolean implicitlyCreated   "true if this component was promoted straight from a
+                                 single/multi/resizable component by NBSolve.mo's
+                                 Tearing.implicit() rather than found and torn by
+                                 NBTearing.mo's own tearing pass. The two are numbered
+                                 (idx) via separate counters that can coincide, so this
+                                 flag lets the generated Jacobian's name stay unique.";
   end ALGEBRAIC_LOOP;
 
   record ALIAS
@@ -1212,7 +1218,8 @@ public
             linear  = false,
             mixed   = false,
             homotopy = Pointer.access(homotopy),
-            status  = NBSolve.Status.IMPLICIT);
+            status  = NBSolve.Status.IMPLICIT,
+            implicitlyCreated = false);
         end match;
       then comp;
 

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBJacobian.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBJacobian.mo
@@ -614,7 +614,22 @@ protected
           comps              = Array.appendList(strict.innerEquations, residual_comps),
           full               = full,
           funcMap            = funcMap,
-          name               = Partition.Partition.kindToString(kind) + (if comp.linear then "_LS_JAC_" else "_NLS_JAC_") + intString(comp.idx),
+          // comp.idx is assigned from two disjoint, independently-numbered sources:
+          // NBSolve.mo's Tearing.implicit() (single-equation loops promoted from an
+          // unsolvable explicit equation) and NBTearing.mo's initialize() (genuine
+          // multi-equation torn loops), each restarting its own count at 1 per
+          // partition kind. Two components from different sources can therefore
+          // share the same (kind, idx), which previously collided on the exact same
+          // generated Jacobian name (e.g. both "INI_NLS_JAC_1") -- note comp.status
+          // alone can't distinguish them, since NBSolve.mo's solveStrongComponent
+          // marks EVERY algebraic loop status=IMPLICIT, torn or not. Tag
+          // comp.implicitlyCreated components distinctly so the two numbering
+          // spaces can never collide, without changing either one's actual numbers
+          // (which existing reference test outputs depend on).
+          name               = Partition.Partition.kindToString(kind)
+                                + (if comp.implicitlyCreated then "_NLS_IMPL_"
+                                   else if comp.linear then "_LS_JAC_" else "_NLS_JAC_")
+                                + intString(comp.idx),
           staticAsContinuous = staticAsContinuous);
         comp.strict := strict;
 
@@ -1764,7 +1779,8 @@ protected
       linear   = true,
       mixed    = mixed,
       homotopy = homotopy,
-      status   = NBSolve.Status.IMPLICIT
+      status   = NBSolve.Status.IMPLICIT,
+      implicitlyCreated = false
     );
   end makeLinearAlgebraicLoop;
 

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBSolve.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBSolve.mo
@@ -283,7 +283,7 @@ public
                 // create the algebraic loop, already torn
                 strict := Tearing.TEARING_SET(list(Slice.SLICE(BVariable.getVarPointer(c, sourceInfo()), {}) for c in UnorderedSet.toList(solved_inputs)), list(Slice.SLICE(e, {}) for e in tmp_eqns), listArray({comp}), NONE());
                 // ToDo: set all the booleans correctly
-                solved_comp := StrongComponent.ALGEBRAIC_LOOP(implicit_index, strict, NONE(), false, false, false, solve_status);
+                solved_comp := StrongComponent.ALGEBRAIC_LOOP(implicit_index, strict, NONE(), false, false, false, solve_status, true);
 
                 // add new equations and new variables
                 EqData.addTypedList(eqData, tmp_eqns, NBEquation.EqData.EqType.CONTINUOUS);

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBTearing.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBTearing.mo
@@ -194,7 +194,8 @@ public
           linear  = false,
           mixed   = false,
           homotopy = Pointer.access(homotopy),
-          status  = NBSolve.Status.IMPLICIT);
+          status  = NBSolve.Status.IMPLICIT,
+          implicitlyCreated = true);
         index := index + 1;
       then finalize(new_comp, dummy, funcMap, index, VariablePointers.empty(), EquationPointers.empty(), Pointer.create(0), kind);
 
@@ -207,7 +208,8 @@ public
           linear  = false,
           mixed   = false,
           homotopy = Pointer.access(homotopy),
-          status  = NBSolve.Status.IMPLICIT);
+          status  = NBSolve.Status.IMPLICIT,
+          implicitlyCreated = true);
         index := index + 1;
       then finalize(new_comp, dummy, funcMap, index, VariablePointers.empty(), EquationPointers.empty(), Pointer.create(0), kind);
 
@@ -220,7 +222,8 @@ public
           linear  = false,
           mixed   = false,
           homotopy = Pointer.access(homotopy),
-          status  = NBSolve.Status.IMPLICIT);
+          status  = NBSolve.Status.IMPLICIT,
+          implicitlyCreated = true);
         index := index + 1;
       then finalize(new_comp, dummy, funcMap, index, VariablePointers.empty(), EquationPointers.empty(), Pointer.create(0), kind);
 

--- a/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
@@ -244,7 +244,7 @@ public
         casual := Util.applyOption(comp.casual, function differentiateTearing(diffArguments_ptr=diffArguments_ptr, idx=idx, context=context, name=name));
         // if we differentiate for jacobian, the algebraic loops will always be linear
         linear := match Pointer.access(diffArguments_ptr) case DIFFERENTIATION_ARGUMENTS(diffType = NBDifferentiate.DifferentiationType.JACOBIAN) then true; else comp.linear; end match;
-      then StrongComponent.ALGEBRAIC_LOOP(-1, strict, casual, linear, false, comp.homotopy, comp.status);
+      then StrongComponent.ALGEBRAIC_LOOP(-1, strict, casual, linear, false, comp.homotopy, comp.status, comp.implicitlyCreated);
 
       case StrongComponent.ENTWINED_COMPONENT() algorithm
         Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " not implemented for entwined equation:\n" + StrongComponent.toString(comp)});

--- a/testsuite/simulation/modelica/NBackend/basics/implicitEquation.mos
+++ b/testsuite/simulation/modelica/NBackend/basics/implicitEquation.mos
@@ -48,13 +48,13 @@ simulate(implicitEquation); getErrorString();
 // Event Partition
 // -----------------
 //
-// ==========================================================
-//   SimCode Jacobian INI_NLS_JAC_1(idx = 0, partition = 0)
-// ==========================================================
+// ===========================================================
+//   SimCode Jacobian INI_NLS_IMPL_1(idx = 0, partition = 0)
+// ===========================================================
 //
 // SeedVars (size = 1)
 // *********************
-//   (0)[SEED] (1) Real $SEED_INI_NLS_JAC_1.x
+//   (0)[SEED] (1) Real $SEED_INI_NLS_IMPL_1.x
 //
 // TmpVars (size = 0)
 // ********************
@@ -64,11 +64,11 @@ simulate(implicitEquation); getErrorString();
 //
 // Column Equations (size = 1)
 // -----------------------------
-//   (2) $pDER_INI_NLS_JAC_1.$RES_SIM_0 := -(($SEED_INI_NLS_JAC_1.x + 3.0 * x ^ 2.0 * $SEED_INI_NLS_JAC_1.x) - 2.0 * x * $SEED_INI_NLS_JAC_1.x)
+//   (2) $pDER_INI_NLS_IMPL_1.$RES_SIM_0 := -(($SEED_INI_NLS_IMPL_1.x + 3.0 * x ^ 2.0 * $SEED_INI_NLS_IMPL_1.x) - 2.0 * x * $SEED_INI_NLS_IMPL_1.x)
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_SIM_0 ... {$pDER_INI_NLS_JAC_1.$RES_SIM_0} ... {($SEED_INI_NLS_JAC_1.x, {}, false)}
+// $RES_SIM_0 ... {$pDER_INI_NLS_IMPL_1.$RES_SIM_0} ... {($SEED_INI_NLS_IMPL_1.x, {}, false)}
 //
 // ======================================================
 //   [EMPTY] SimCode Jacobian A(idx = 1, partition = 0)
@@ -152,7 +152,7 @@ simulate(implicitEquation); getErrorString();
 // crefs: x
 // 	1: $FUN_1 - (x + x ^ 3.0 - x ^ 2.0) (RESIDUAL)
 // 	Jacobian idx: 0
-// 	2: $pDER_INI_NLS_JAC_1.$RES_SIM_0=-($SEED_INI_NLS_JAC_1.x + 3.0 * x ^ 2.0 * $SEED_INI_NLS_JAC_1.x - 2.0 * x * $SEED_INI_NLS_JAC_1.x) [Real]
+// 	2: $pDER_INI_NLS_IMPL_1.$RES_SIM_0=-($SEED_INI_NLS_IMPL_1.x + 3.0 * x ^ 2.0 * $SEED_INI_NLS_IMPL_1.x - 2.0 * x * $SEED_INI_NLS_IMPL_1.x) [Real]
 //
 //
 // ========================================
@@ -198,7 +198,7 @@ simulate(implicitEquation); getErrorString();
 // jacobianMatrices:
 // ========================================
 // 	Jacobian idx: 0
-// 	2: $pDER_INI_NLS_JAC_1.$RES_SIM_0=-($SEED_INI_NLS_JAC_1.x + 3.0 * x ^ 2.0 * $SEED_INI_NLS_JAC_1.x - 2.0 * x * $SEED_INI_NLS_JAC_1.x) [Real]
+// 	2: $pDER_INI_NLS_IMPL_1.$RES_SIM_0=-($SEED_INI_NLS_IMPL_1.x + 3.0 * x ^ 2.0 * $SEED_INI_NLS_IMPL_1.x - 2.0 * x * $SEED_INI_NLS_IMPL_1.x) [Real]
 //
 // 	Jacobian idx: 1
 //

--- a/testsuite/simulation/modelica/NBackend/initialization/homotopy_no_loop.mos
+++ b/testsuite/simulation/modelica/NBackend/initialization/homotopy_no_loop.mos
@@ -89,13 +89,13 @@ simulate(homotopy_no_loop); getErrorString();
 // $RES_SIM_0 ... {$pDER_INI_NLS_JAC_1.$RES_SIM_0} ... {($SEED_INI_NLS_JAC_1.y, {}, false), ($SEED_INI_NLS_JAC_1.u, {}, false)}
 // $RES_SIM_1 ... {$pDER_INI_NLS_JAC_1.$RES_SIM_1} ... {($SEED_INI_NLS_JAC_1.y, {}, true), ($SEED_INI_NLS_JAC_1.u, {}, true)}
 //
-// ============================================================
-//   SimCode Jacobian INI_0_NLS_JAC_1(idx = 2, partition = 2)
-// ============================================================
+// =============================================================
+//   SimCode Jacobian INI_0_NLS_IMPL_1(idx = 2, partition = 2)
+// =============================================================
 //
 // SeedVars (size = 1)
 // *********************
-//   (0)[SEED] (1) Real $SEED_INI_0_NLS_JAC_1.y
+//   (0)[SEED] (1) Real $SEED_INI_0_NLS_IMPL_1.y
 //
 // TmpVars (size = 0)
 // ********************
@@ -105,19 +105,19 @@ simulate(homotopy_no_loop); getErrorString();
 //
 // Column Equations (size = 1)
 // -----------------------------
-//   (10) $pDER_INI_0_NLS_JAC_1.$RES_SIM_1 := -($SEED_INI_0_NLS_JAC_1.y + 2.0 * y * $SEED_INI_0_NLS_JAC_1.y)
+//   (10) $pDER_INI_0_NLS_IMPL_1.$RES_SIM_1 := -($SEED_INI_0_NLS_IMPL_1.y + 2.0 * y * $SEED_INI_0_NLS_IMPL_1.y)
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_SIM_1 ... {$pDER_INI_0_NLS_JAC_1.$RES_SIM_1} ... {($SEED_INI_0_NLS_JAC_1.y, {}, false)}
+// $RES_SIM_1 ... {$pDER_INI_0_NLS_IMPL_1.$RES_SIM_1} ... {($SEED_INI_0_NLS_IMPL_1.y, {}, false)}
 //
-// ============================================================
-//   SimCode Jacobian INI_0_NLS_JAC_2(idx = 1, partition = 1)
-// ============================================================
+// =============================================================
+//   SimCode Jacobian INI_0_NLS_IMPL_2(idx = 1, partition = 1)
+// =============================================================
 //
 // SeedVars (size = 1)
 // *********************
-//   (0)[SEED] (1) Real $SEED_INI_0_NLS_JAC_2.u
+//   (0)[SEED] (1) Real $SEED_INI_0_NLS_IMPL_2.u
 //
 // TmpVars (size = 0)
 // ********************
@@ -127,11 +127,11 @@ simulate(homotopy_no_loop); getErrorString();
 //
 // Column Equations (size = 1)
 // -----------------------------
-//   (7) $pDER_INI_0_NLS_JAC_2.$RES_SIM_0 := 3.0 * u ^ 2.0 * $SEED_INI_0_NLS_JAC_2.u + $SEED_INI_0_NLS_JAC_2.u
+//   (7) $pDER_INI_0_NLS_IMPL_2.$RES_SIM_0 := 3.0 * u ^ 2.0 * $SEED_INI_0_NLS_IMPL_2.u + $SEED_INI_0_NLS_IMPL_2.u
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_SIM_0 ... {$pDER_INI_0_NLS_JAC_2.$RES_SIM_0} ... {($SEED_INI_0_NLS_JAC_2.u, {}, false)}
+// $RES_SIM_0 ... {$pDER_INI_0_NLS_IMPL_2.$RES_SIM_0} ... {($SEED_INI_0_NLS_IMPL_2.u, {}, false)}
 //
 // ==========================================================
 //   SimCode Jacobian ALG_NLS_JAC_1(idx = 3, partition = 3)
@@ -268,14 +268,14 @@ simulate(homotopy_no_loop); getErrorString();
 // crefs: y
 // 	9: 1.0 - (y + y ^ 2.0) (RESIDUAL)
 // 	Jacobian idx: 2
-// 	10: $pDER_INI_0_NLS_JAC_1.$RES_SIM_1=-($SEED_INI_0_NLS_JAC_1.y + 2.0 * y * $SEED_INI_0_NLS_JAC_1.y) [Real]
+// 	10: $pDER_INI_0_NLS_IMPL_1.$RES_SIM_1=-($SEED_INI_0_NLS_IMPL_1.y + 2.0 * y * $SEED_INI_0_NLS_IMPL_1.y) [Real]
 //
 //
 // 8:  (NONLINEAR) index:1 jacobian: true
 // crefs: u
 // 	6: u ^ 3.0 + u - y (RESIDUAL)
 // 	Jacobian idx: 1
-// 	7: $pDER_INI_0_NLS_JAC_2.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_0_NLS_JAC_2.u + $SEED_INI_0_NLS_JAC_2.u [Real]
+// 	7: $pDER_INI_0_NLS_IMPL_2.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_0_NLS_IMPL_2.u + $SEED_INI_0_NLS_IMPL_2.u [Real]
 //
 //
 //
@@ -319,10 +319,10 @@ simulate(homotopy_no_loop); getErrorString();
 // 	3: $pDER_INI_NLS_JAC_1.$RES_SIM_1=-homotopy($SEED_INI_NLS_JAC_1.u, $SEED_INI_NLS_JAC_1.y + 2.0 * y * $SEED_INI_NLS_JAC_1.y) [Real]
 //
 // 	Jacobian idx: 2
-// 	10: $pDER_INI_0_NLS_JAC_1.$RES_SIM_1=-($SEED_INI_0_NLS_JAC_1.y + 2.0 * y * $SEED_INI_0_NLS_JAC_1.y) [Real]
+// 	10: $pDER_INI_0_NLS_IMPL_1.$RES_SIM_1=-($SEED_INI_0_NLS_IMPL_1.y + 2.0 * y * $SEED_INI_0_NLS_IMPL_1.y) [Real]
 //
 // 	Jacobian idx: 1
-// 	7: $pDER_INI_0_NLS_JAC_2.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_0_NLS_JAC_2.u + $SEED_INI_0_NLS_JAC_2.u [Real]
+// 	7: $pDER_INI_0_NLS_IMPL_2.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_0_NLS_IMPL_2.u + $SEED_INI_0_NLS_IMPL_2.u [Real]
 //
 // 	Jacobian idx: 3
 // 	15: $pDER_ALG_NLS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_NLS_JAC_1.u + $SEED_ALG_NLS_JAC_1.u - $SEED_ALG_NLS_JAC_1.y [Real]

--- a/testsuite/simulation/modelica/NBackend/initialization/init_if_eq.mos
+++ b/testsuite/simulation/modelica/NBackend/initialization/init_if_eq.mos
@@ -61,13 +61,13 @@ simulate(init_if_eq); getErrorString();
 // Event Partition
 // -----------------
 //
-// ==========================================================
-//   SimCode Jacobian INI_NLS_JAC_1(idx = 1, partition = 1)
-// ==========================================================
+// ===========================================================
+//   SimCode Jacobian INI_NLS_IMPL_1(idx = 1, partition = 1)
+// ===========================================================
 //
 // SeedVars (size = 1)
 // *********************
-//   (0)[SEED] (1) Real $SEED_INI_NLS_JAC_1.y
+//   (0)[SEED] (1) Real $SEED_INI_NLS_IMPL_1.y
 //
 // TmpVars (size = 0)
 // ********************
@@ -77,19 +77,19 @@ simulate(init_if_eq); getErrorString();
 //
 // Column Equations (size = 1)
 // -----------------------------
-//   (5) $pDER_INI_NLS_JAC_1.$RES_SIM_2 := -($SEED_INI_NLS_JAC_1.y + 2.0 * y * $SEED_INI_NLS_JAC_1.y)
+//   (5) $pDER_INI_NLS_IMPL_1.$RES_SIM_2 := -($SEED_INI_NLS_IMPL_1.y + 2.0 * y * $SEED_INI_NLS_IMPL_1.y)
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_SIM_2 ... {$pDER_INI_NLS_JAC_1.$RES_SIM_2} ... {($SEED_INI_NLS_JAC_1.y, {}, false)}
+// $RES_SIM_2 ... {$pDER_INI_NLS_IMPL_1.$RES_SIM_2} ... {($SEED_INI_NLS_IMPL_1.y, {}, false)}
 //
-// ==========================================================
-//   SimCode Jacobian INI_NLS_JAC_2(idx = 0, partition = 0)
-// ==========================================================
+// ===========================================================
+//   SimCode Jacobian INI_NLS_IMPL_2(idx = 0, partition = 0)
+// ===========================================================
 //
 // SeedVars (size = 1)
 // *********************
-//   (0)[SEED] (1) Real $SEED_INI_NLS_JAC_2.u
+//   (0)[SEED] (1) Real $SEED_INI_NLS_IMPL_2.u
 //
 // TmpVars (size = 0)
 // ********************
@@ -99,11 +99,11 @@ simulate(init_if_eq); getErrorString();
 //
 // Column Equations (size = 1)
 // -----------------------------
-//   (2) $pDER_INI_NLS_JAC_2.$RES_SIM_0 := 3.0 * u ^ 2.0 * $SEED_INI_NLS_JAC_2.u + $SEED_INI_NLS_JAC_2.u
+//   (2) $pDER_INI_NLS_IMPL_2.$RES_SIM_0 := 3.0 * u ^ 2.0 * $SEED_INI_NLS_IMPL_2.u + $SEED_INI_NLS_IMPL_2.u
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_SIM_0 ... {$pDER_INI_NLS_JAC_2.$RES_SIM_0} ... {($SEED_INI_NLS_JAC_2.u, {}, false)}
+// $RES_SIM_0 ... {$pDER_INI_NLS_IMPL_2.$RES_SIM_0} ... {($SEED_INI_NLS_IMPL_2.u, {}, false)}
 //
 // =========================================================
 //   SimCode Jacobian ALG_LS_JAC_1(idx = 2, partition = 2)
@@ -235,14 +235,14 @@ simulate(init_if_eq); getErrorString();
 // crefs: y
 // 	4: 1.0 - (y + y ^ 2.0) (RESIDUAL)
 // 	Jacobian idx: 1
-// 	5: $pDER_INI_NLS_JAC_1.$RES_SIM_2=-($SEED_INI_NLS_JAC_1.y + 2.0 * y * $SEED_INI_NLS_JAC_1.y) [Real]
+// 	5: $pDER_INI_NLS_IMPL_1.$RES_SIM_2=-($SEED_INI_NLS_IMPL_1.y + 2.0 * y * $SEED_INI_NLS_IMPL_1.y) [Real]
 //
 //
 // 3:  (NONLINEAR) index:0 jacobian: true
 // crefs: u
 // 	1: u ^ 3.0 + u - y (RESIDUAL)
 // 	Jacobian idx: 0
-// 	2: $pDER_INI_NLS_JAC_2.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_NLS_JAC_2.u + $SEED_INI_NLS_JAC_2.u [Real]
+// 	2: $pDER_INI_NLS_IMPL_2.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_NLS_IMPL_2.u + $SEED_INI_NLS_IMPL_2.u [Real]
 //
 //
 // ========================================
@@ -288,10 +288,10 @@ simulate(init_if_eq); getErrorString();
 // jacobianMatrices:
 // ========================================
 // 	Jacobian idx: 1
-// 	5: $pDER_INI_NLS_JAC_1.$RES_SIM_2=-($SEED_INI_NLS_JAC_1.y + 2.0 * y * $SEED_INI_NLS_JAC_1.y) [Real]
+// 	5: $pDER_INI_NLS_IMPL_1.$RES_SIM_2=-($SEED_INI_NLS_IMPL_1.y + 2.0 * y * $SEED_INI_NLS_IMPL_1.y) [Real]
 //
 // 	Jacobian idx: 0
-// 	2: $pDER_INI_NLS_JAC_2.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_NLS_JAC_2.u + $SEED_INI_NLS_JAC_2.u [Real]
+// 	2: $pDER_INI_NLS_IMPL_2.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_NLS_IMPL_2.u + $SEED_INI_NLS_IMPL_2.u [Real]
 //
 // 	Jacobian idx: 2
 // 	10: $pDER_ALG_LS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_LS_JAC_1.u + $SEED_ALG_LS_JAC_1.u - $SEED_ALG_LS_JAC_1.y [Real]

--- a/testsuite/simulation/modelica/NBackend/initialization/init_if_exp.mos
+++ b/testsuite/simulation/modelica/NBackend/initialization/init_if_exp.mos
@@ -57,13 +57,13 @@ simulate(init_if_exp); getErrorString();
 // Event Partition
 // -----------------
 //
-// ==========================================================
-//   SimCode Jacobian INI_NLS_JAC_1(idx = 1, partition = 1)
-// ==========================================================
+// ===========================================================
+//   SimCode Jacobian INI_NLS_IMPL_1(idx = 1, partition = 1)
+// ===========================================================
 //
 // SeedVars (size = 1)
 // *********************
-//   (0)[SEED] (1) Real $SEED_INI_NLS_JAC_1.y
+//   (0)[SEED] (1) Real $SEED_INI_NLS_IMPL_1.y
 //
 // TmpVars (size = 0)
 // ********************
@@ -73,19 +73,19 @@ simulate(init_if_exp); getErrorString();
 //
 // Column Equations (size = 1)
 // -----------------------------
-//   (5) $pDER_INI_NLS_JAC_1.$RES_SIM_1 := $SEED_INI_NLS_JAC_1.y + 2.0 * y * $SEED_INI_NLS_JAC_1.y
+//   (5) $pDER_INI_NLS_IMPL_1.$RES_SIM_1 := $SEED_INI_NLS_IMPL_1.y + 2.0 * y * $SEED_INI_NLS_IMPL_1.y
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_SIM_1 ... {$pDER_INI_NLS_JAC_1.$RES_SIM_1} ... {($SEED_INI_NLS_JAC_1.y, {}, false)}
+// $RES_SIM_1 ... {$pDER_INI_NLS_IMPL_1.$RES_SIM_1} ... {($SEED_INI_NLS_IMPL_1.y, {}, false)}
 //
-// ==========================================================
-//   SimCode Jacobian INI_NLS_JAC_2(idx = 0, partition = 0)
-// ==========================================================
+// ===========================================================
+//   SimCode Jacobian INI_NLS_IMPL_2(idx = 0, partition = 0)
+// ===========================================================
 //
 // SeedVars (size = 1)
 // *********************
-//   (0)[SEED] (1) Real $SEED_INI_NLS_JAC_2.u
+//   (0)[SEED] (1) Real $SEED_INI_NLS_IMPL_2.u
 //
 // TmpVars (size = 0)
 // ********************
@@ -95,11 +95,11 @@ simulate(init_if_exp); getErrorString();
 //
 // Column Equations (size = 1)
 // -----------------------------
-//   (2) $pDER_INI_NLS_JAC_2.$RES_SIM_0 := 3.0 * u ^ 2.0 * $SEED_INI_NLS_JAC_2.u + $SEED_INI_NLS_JAC_2.u
+//   (2) $pDER_INI_NLS_IMPL_2.$RES_SIM_0 := 3.0 * u ^ 2.0 * $SEED_INI_NLS_IMPL_2.u + $SEED_INI_NLS_IMPL_2.u
 //
 // Resizable Sparsity Pattern
 // ----------------------------
-// $RES_SIM_0 ... {$pDER_INI_NLS_JAC_2.$RES_SIM_0} ... {($SEED_INI_NLS_JAC_2.u, {}, false)}
+// $RES_SIM_0 ... {$pDER_INI_NLS_IMPL_2.$RES_SIM_0} ... {($SEED_INI_NLS_IMPL_2.u, {}, false)}
 //
 // ==========================================================
 //   SimCode Jacobian ALG_NLS_JAC_1(idx = 2, partition = 2)
@@ -221,14 +221,14 @@ simulate(init_if_exp); getErrorString();
 // crefs: y
 // 	4: -1.0 + y + y ^ 2.0 (RESIDUAL)
 // 	Jacobian idx: 1
-// 	5: $pDER_INI_NLS_JAC_1.$RES_SIM_1=$SEED_INI_NLS_JAC_1.y + 2.0 * y * $SEED_INI_NLS_JAC_1.y [Real]
+// 	5: $pDER_INI_NLS_IMPL_1.$RES_SIM_1=$SEED_INI_NLS_IMPL_1.y + 2.0 * y * $SEED_INI_NLS_IMPL_1.y [Real]
 //
 //
 // 3:  (NONLINEAR) index:0 jacobian: true
 // crefs: u
 // 	1: u ^ 3.0 + u - y (RESIDUAL)
 // 	Jacobian idx: 0
-// 	2: $pDER_INI_NLS_JAC_2.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_NLS_JAC_2.u + $SEED_INI_NLS_JAC_2.u [Real]
+// 	2: $pDER_INI_NLS_IMPL_2.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_NLS_IMPL_2.u + $SEED_INI_NLS_IMPL_2.u [Real]
 //
 //
 // ========================================
@@ -274,10 +274,10 @@ simulate(init_if_exp); getErrorString();
 // jacobianMatrices:
 // ========================================
 // 	Jacobian idx: 1
-// 	5: $pDER_INI_NLS_JAC_1.$RES_SIM_1=$SEED_INI_NLS_JAC_1.y + 2.0 * y * $SEED_INI_NLS_JAC_1.y [Real]
+// 	5: $pDER_INI_NLS_IMPL_1.$RES_SIM_1=$SEED_INI_NLS_IMPL_1.y + 2.0 * y * $SEED_INI_NLS_IMPL_1.y [Real]
 //
 // 	Jacobian idx: 0
-// 	2: $pDER_INI_NLS_JAC_2.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_NLS_JAC_2.u + $SEED_INI_NLS_JAC_2.u [Real]
+// 	2: $pDER_INI_NLS_IMPL_2.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_INI_NLS_IMPL_2.u + $SEED_INI_NLS_IMPL_2.u [Real]
 //
 // 	Jacobian idx: 2
 // 	10: $pDER_ALG_NLS_JAC_1.$RES_SIM_0=3.0 * u ^ 2.0 * $SEED_ALG_NLS_JAC_1.u + $SEED_ALG_NLS_JAC_1.u - $SEED_ALG_NLS_JAC_1.y [Real]


### PR DESCRIPTION
Two independent counters number StrongComponent.ALGEBRAIC_LOOP.idx: NBTearing.mo's initialize() for genuine multi-equation torn loops (found via Tarjan/SCC in NBSorting.mo), and NBSolve.mo's solveStrongComponent()/Tearing.implicit() for single-equation components promoted to a trivial loop when they can't be solved explicitly. Each restarts its own count at 1 per partition kind, so a component from one source can share (kind, idx) with an unrelated component from the other, and NBJacobian.mo's compJacobian names the Jacobian purely from kind + linear + idx -- causing two genuinely different Jacobians to collide on the exact same generated C name (e.g. both "INI_NLS_JAC_1"), a straight redefinition compile error.

comp.status can't distinguish the two sources: NBSolve.mo's solveStrongComponent marks *every* algebraic loop status=IMPLICIT, torn or not, once it starts solving it. Added a dedicated `implicitlyCreated` boolean to StrongComponent.ALGEBRAIC_LOOP instead, set at all 7 construction sites, and tag implicit-promoted loops "_NLS_IMPL_" in the generated name so the two numbering spaces can never collide -- without changing either one's actual numbers, which existing reference test outputs depend on.

Root cause of a newInst-newBackend regression (Verify -> Templates) in ModelicaTest.Fluid.TestComponents.Fittings.TestWallFriction and Modelica.Media.Examples.Tests.MediaTestModels.Water.WaterIF97OnePhase_ph, both reproduced and confirmed fixed locally. Two further regressions in the same report (Buildings.Fluid.HeatPumps.Validation.Carnot_y_etaPL, ModelicaTest.Fluid.TestComponents.Valves.TestValvesIncompressibleReverse) turned out to be a separate, unrelated NFDimension.size/dimensionCount bug not touched by this change.

Full local NBackend suite verified clean; 4 reference outputs rebaselined (basics/implicitEquation.mos,
initialization/{homotopy_no_loop,init_if_eq,init_if_exp}.mos) to reflect the new, correct "_NLS_IMPL_" tag on components that were always implicit-promoted single equations, never genuine loops.

