### PR TITLE
Keep the NLS sparsity pattern without a Jacobian

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -6820,6 +6820,25 @@ impl NlsJacPattern {
         sparsity_sanity_check(&self.colptr, &self.rowidx, self.colptr.len() - 1, n)
     }
 
+    /// C's `colorCols`, 0-based. A column the backend left out of the colouring gets
+    /// one of its own.
+    fn color_of_column(&self, n: usize) -> Vec<i32> {
+        let mut of = vec![-1i32; n];
+        for (c, cols) in self.colors.iter().enumerate() {
+            for &col in cols {
+                if let Some(slot) = of.get_mut(col as usize) {
+                    *slot = c as i32;
+                }
+            }
+        }
+        let mut next = self.colors.len() as i32;
+        for slot in of.iter_mut().filter(|s| **s < 0) {
+            *slot = next;
+            next += 1;
+        }
+        of
+    }
+
     /// C keeps a pattern that is not `n × n`; no solver here could use one.
     fn is_square(&self, n: usize) -> bool {
         self.colptr.len() == n + 1 && self.rowidx.iter().all(|&r| (r as usize) < n)
@@ -9364,7 +9383,6 @@ fn collect_nls_jobs(
                     }
                 });
                 let pat = pat.filter(|p| p.is_square(n as usize));
-                let pat = if has_jac { pat } else { None };
                 let nnz = pat.as_ref().map_or(0, |p| p.rowidx.len() as u32);
                 let sparse_default = nnz != 0 && nls_use_sparse(n as usize, nnz as usize);
                 if std::env::var("OMC_WASM_SIM_BENCH").is_ok() {
@@ -9379,10 +9397,11 @@ fn collect_nls_jobs(
                 if let Some(p) = &pat {
                     patterns.extend_from_slice(&p.colptr);
                     patterns.extend_from_slice(&p.rowidx);
+                    patterns.extend_from_slice(&p.color_of_column(n as usize));
                 }
                 jobs.insert(nlSystem.index, NlsJob { k: systems.len() as u32, n, eq_index: nlSystem.index as u32, hist_off, nominal_off, has_jac, mixed, nnz, pat_off, sparse_default, homotopy_support: nlSystem.homotopySupport, casual });
                 if nnz != 0 {
-                    pat_off += 4 * (n + 1 + nnz);
+                    pat_off += 4 * (2 * n + 1 + nnz);
                 }
                 hist_off += crate::CodegenWasmJitFunctions::nls_hist_bytes(n);
                 nominal_off += 8 * n;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -318,6 +318,51 @@ pub extern "C" fn rt_div_sim(a: f64, b: f64, msg: u32, time: f64, initial: i32) 
     res
 }
 
+/// [`nls::kinsol`]'s `numeric_csc` for the runtime's own sparse Newton: C's
+/// `nlsSparseJac`, one residual evaluation per colour group. `fx` is the residual at
+/// `x`; an empty `colors` leaves every column its own colour.
+#[allow(clippy::too_many_arguments)]
+fn numeric_csc(
+    n: usize,
+    colptr: &[usize],
+    rowidx: &[usize],
+    colors: &[u32],
+    max: &[f64],
+    x: &mut [f64],
+    fx: &[f64],
+    vals: &mut [f64],
+    eval: &mut dyn FnMut(&[f64], &mut [f64]),
+) {
+    /// `sqrt(DBL_EPSILON * 2e1)`, C's difference step.
+    const DELTA_H: f64 = 6.664001874625056e-08;
+    let n_colors = colors.iter().max().map_or(n, |&c| c as usize + 1);
+    let in_color = |c: usize, color: usize| match colors.is_empty() {
+        true => c == color,
+        false => colors[c] as usize == color,
+    };
+    let mut fres = vec![0.0f64; n];
+    let mut xsave = vec![0.0f64; n];
+    let mut inv = vec![0.0f64; n];
+    for color in 0..n_colors {
+        for c in (0..n).filter(|&c| in_color(c, color)) {
+            xsave[c] = x[c];
+            let mut dh = DELTA_H * (libm::fabs(xsave[c]) + 1.0);
+            if xsave[c] + dh >= max.get(c).copied().unwrap_or(f64::MAX) {
+                dh = -dh;
+            }
+            x[c] = xsave[c] + dh;
+            inv[c] = 1.0 / dh;
+        }
+        eval(x, &mut fres);
+        for c in (0..n).filter(|&c| in_color(c, color)) {
+            for k in colptr[c]..colptr[c + 1] {
+                vals[k] = (fres[rowidx[k]] - fx[rowidx[k]]) * inv[c];
+            }
+            x[c] = xsave[c];
+        }
+    }
+}
+
 /// Build the Jacobian-assemble closure used by both kinsol and newton sparse paths.
 /// `gather` is the pattern block where `jac` fills a dense `n×n` rather than the CSC
 /// values — a system `-nls=kinsol` solves sparsely though the codegen chose dense.
@@ -514,6 +559,8 @@ fn kinsol_sparse_solve(
     eq_index: u32,
     time: f64,
     has_jacobian: bool,
+    colors: &[u32],
+    max: &[f64],
     old_values: &[f64],
     load_guess: &mut dyn FnMut(&mut [f64]),
     eval: &mut dyn FnMut(&[f64], &mut [f64]),
@@ -525,17 +572,23 @@ fn kinsol_sparse_solve(
         let colptr: alloc::vec::Vec<i32> = pattern[..n + 1].iter().map(|v| *v as i32).collect();
         let rowidx: alloc::vec::Vec<i32> =
             pattern[n + 1..n + 1 + nnz].iter().map(|v| *v as i32).collect();
-        let gather = (!jac_csc).then(|| pattern.to_vec());
+        // Without a column function KINSOL differences the pattern itself, so
+        // `make_assemble`'s dense gather buffer is never needed.
+        let gather = (has_jacobian && !jac_csc).then(|| pattern.to_vec());
         let mut assemble = make_assemble(n, jac, gather);
+        let pat = nls::kinsol::Pattern { nnz, colptr: &colptr, rowidx: &rowidx, colors, max };
         return crate::sundials::kinsol_solve_selected(
-            handle, n, nnz, &colptr, &rowidx, nominal, guess, old_values, x, eq_index, time,
-            has_jacobian, load_guess, eval, &mut assemble,
+            handle, n, &pat, nominal, guess, old_values, x, eq_index, time, has_jacobian,
+            load_guess, eval, &mut assemble,
         );
     }
-    // only the KINSOL path names the system it dumps, or differences its own Jacobian
-    let _ = (eq_index, time, has_jacobian, old_values);
+    // only the KINSOL path names the system it dumps
+    let _ = (eq_index, time, old_values);
     let _ = load_guess; // only the KINSOL-B rung re-reads the model's own values
-    newton_sparse_solve(n, x, guess, warm, nominal, jac, pattern, nnz, jac_csc, handle, eval)
+    newton_sparse_solve(
+        n, x, guess, warm, nominal, jac, pattern, nnz, jac_csc, handle, has_jacobian, colors, max,
+        eval,
+    )
 }
 
 /// C's `-nls=experimental-kinsol` on a system with no sparsity pattern: the dense
@@ -585,6 +638,9 @@ fn newton_sparse_solve(
     nnz: usize,
     jac_csc: bool,
     handle: u32,
+    has_jacobian: bool,
+    colors: &[u32],
+    max: &[f64],
     eval: &mut dyn FnMut(&[f64], &mut [f64]),
 ) -> bool {
     let colptr: alloc::vec::Vec<usize> = (0..=n).map(|k| pattern[k] as usize).collect();
@@ -604,7 +660,7 @@ fn newton_sparse_solve(
     }
 
     let mut vals = vec![0.0f64; nnz];
-    let gather = (!jac_csc).then(|| pattern.to_vec());
+    let gather = (has_jacobian && !jac_csc).then(|| pattern.to_vec());
     let mut assemble = make_assemble(n, jac, gather);
 
     let mut f = vec![0.0f64; n];
@@ -633,7 +689,13 @@ fn newton_sparse_solve(
             *s = 1.0;
         }
         if scaled {
-            assemble(x, &mut vals);
+            match has_jacobian {
+                true => assemble(x, &mut vals),
+                false => {
+                    eval(x, &mut f);
+                    numeric_csc(n, &colptr, &rowidx, colors, max, x, &f, &mut vals, eval);
+                }
+            }
             let mut rowmax = vec![1.0e-12f64; n];
             for c in 0..n {
                 for k in colptr[c]..colptr[c + 1] {
@@ -658,7 +720,11 @@ fn newton_sparse_solve(
                 solved = true;
                 break;
             }
-            assemble(x, &mut vals);
+            match has_jacobian {
+                true => assemble(x, &mut vals),
+                // `f` is the residual at `x`, which the norm above just took.
+                false => numeric_csc(n, &colptr, &rowidx, colors, max, x, &f, &mut vals, eval),
+            }
             for (k, v) in vals.iter().enumerate() {
                 unsafe { store_f64(val_ptr + (k * 8) as u32, *v) };
             }
@@ -859,8 +925,8 @@ impl NlsBackend for WasmBackend<'_> {
     ) -> bool {
         kinsol_sparse_solve(
             req.n, req.x, req.guess, req.warm, req.nominal, jac, self.pattern, self.nnz,
-            self.jac_csc, self.handle, req.eq_index, req.time, req.has_jacobian, req.old_values,
-            load_guess, eval,
+            self.jac_csc, self.handle, req.eq_index, req.time, req.has_jacobian, req.colors,
+            req.max, req.old_values, load_guess, eval,
         )
     }
 
@@ -974,8 +1040,12 @@ pub extern "C" fn rt_solve_nls(
     for (i, v) in bounds.iter_mut().enumerate() {
         *v = unsafe { load_f64(bounds_addr + (i * 8) as u32) };
     }
-    let pattern: alloc::vec::Vec<u32> = if has_jacobian && nnz != 0 {
-        (0..size + 1 + nnz as usize).map(|k| unsafe { load_u32(pat_addr + (k * 4) as u32) }).collect()
+    // `colptr[size+1] ++ rowidx[nnz] ++ colorCols[size]`; C keeps `sparsePattern`
+    // whether or not the model carries an analytic Jacobian, and so does this.
+    let pattern: alloc::vec::Vec<u32> = if nnz != 0 {
+        (0..2 * size + 1 + nnz as usize)
+            .map(|k| unsafe { load_u32(pat_addr + (k * 4) as u32) })
+            .collect()
     } else {
         alloc::vec::Vec::new()
     };

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_nls/src/kinsol.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_nls/src/kinsol.rs
@@ -12,6 +12,18 @@
 //! one written in a crate that has none compiles the call *out* silently. Ask
 //! [`AVAILABLE`] instead, and take the dense ladder when it is false.
 
+/// C's `SPARSE_PATTERN` in CSC addressing, plus the bounds a difference step must
+/// not cross.
+pub struct Pattern<'a> {
+    pub nnz: usize,
+    pub colptr: &'a [i32],
+    pub rowidx: &'a [i32],
+    /// C's `colorCols`, 0-based; empty leaves every column its own colour.
+    pub colors: &'a [u32],
+    /// C's `nlsData->max`; empty leaves the columns unbounded.
+    pub max: &'a [f64],
+}
+
 /// The SUNDIALS-facing half: KINSOL over the sparse Jacobian with KLU as its
 /// linear solver (C's `kinsolSolver.c`), and the explicitly scaled variant
 /// `kinsol_b.c` runs. [`solve`] and [`b_solve`] below are what a backend calls.
@@ -115,9 +127,32 @@ pub mod sun {
         assemble: &'a mut dyn FnMut(&[f64], &mut [f64]),
         /// Difference the Jacobian rather than assemble it analytically.
         numeric: bool,
+        colors: &'a [u32],
+        max: &'a [f64],
         /// What the `LOG_NLS_DERIVATIVE_TEST` header names.
         eq_index: u32,
         time: f64,
+    }
+
+    impl Ud<'_> {
+        /// C's `sparsePattern->maxColors`, or one column at a time without a colouring.
+        fn n_colors(&self) -> usize {
+            match self.colors.iter().max() {
+                Some(&c) => c as usize + 1,
+                None => self.n,
+            }
+        }
+
+        fn in_color(&self, col: usize, color: usize) -> bool {
+            match self.colors.is_empty() {
+                true => col == color,
+                false => self.colors[col] as usize == color,
+            }
+        }
+
+        fn max_of(&self, col: usize) -> f64 {
+            self.max.get(col).copied().unwrap_or(f64::MAX)
+        }
     }
 
     /// Extract the backing array pointer from an N_Vector.
@@ -139,24 +174,38 @@ pub mod sun {
         crate::assert_hit() as c_int
     }
 
-    /// C's `nlsSparseJac`: forward differences into the pattern's CSC values. C
-    /// perturbs a whole colour group per evaluation; column at a time gives the same
-    /// entries (no row sees two columns of a group) for more evaluations, and only on
-    /// the systems whose analytic Jacobian KINSOL has already rejected.
+    /// C's `nlsSparseJac`: forward differences into the pattern's CSC values, one
+    /// residual evaluation per colour group — no row sees two columns of a group, so
+    /// the whole group can be perturbed at once.
     fn numeric_csc(ud: &mut Ud, x: &mut [f64], fx: &[f64], vals: &mut [f64]) {
         /// `sqrt(DBL_EPSILON * 2e1)`, C's difference step.
         const DELTA_H: f64 = 6.664001874625056e-08;
         let mut fres = vec![0.0f64; ud.n];
-        for c in 0..ud.n {
-            let saved = x[c];
-            let dh = DELTA_H * (libm::fabs(saved) + 1.0);
-            x[c] = saved + dh;
+        let mut xsave = vec![0.0f64; ud.n];
+        let mut inv = vec![0.0f64; ud.n];
+        for color in 0..ud.n_colors() {
+            for c in 0..ud.n {
+                if !ud.in_color(c, color) {
+                    continue;
+                }
+                xsave[c] = x[c];
+                let mut dh = DELTA_H * (libm::fabs(xsave[c]) + 1.0);
+                if xsave[c] + dh >= ud.max_of(c) {
+                    dh = -dh;
+                }
+                x[c] = xsave[c] + dh;
+                inv[c] = 1.0 / dh;
+            }
             (ud.eval)(x, &mut fres);
-            x[c] = saved;
-            let inv = 1.0 / dh;
-            for k in ud.colptr[c] as usize..ud.colptr[c + 1] as usize {
-                let row = ud.rowidx[k] as usize;
-                vals[k] = (fres[row] - fx[row]) * inv;
+            for c in 0..ud.n {
+                if !ud.in_color(c, color) {
+                    continue;
+                }
+                for k in ud.colptr[c] as usize..ud.colptr[c + 1] as usize {
+                    let row = ud.rowidx[k] as usize;
+                    vals[k] = (fres[row] - fx[row]) * inv[c];
+                }
+                x[c] = xsave[c];
             }
         }
     }
@@ -408,8 +457,7 @@ pub mod sun {
             &mut self,
             guess: &[f64],
             nominal: &[f64],
-            colptr: &[i32],
-            rowidx: &[i32],
+            pat: &super::Pattern,
             x: &mut [f64],
             eq_index: u32,
             time: f64,
@@ -425,8 +473,10 @@ pub mod sun {
             let mut ud = Ud {
                 n: self.n,
                 nnz: self.nnz,
-                colptr,
-                rowidx,
+                colptr: pat.colptr,
+                rowidx: pat.rowidx,
+                colors: pat.colors,
+                max: pat.max,
                 eval,
                 assemble,
                 numeric: self.numeric_jac,
@@ -1195,9 +1245,7 @@ pub fn b_solve<'a>(
 pub fn solve(
     handle: u32,
     n: usize,
-    nnz: usize,
-    colptr: &[i32],
-    rowidx: &[i32],
+    pat: &Pattern,
     nominal: &[f64],
     guess: &[f64],
     x: &mut [f64],
@@ -1207,8 +1255,8 @@ pub fn solve(
     eval: &mut dyn FnMut(&[f64], &mut [f64]),
     assemble: &mut dyn FnMut(&[f64], &mut [f64]),
 ) -> bool {
-    KIN_CACHE.with(handle, || sun::Solver::new(n, nnz), |solver| {
-        solver.solve(guess, nominal, colptr, rowidx, x, eq_index, time, has_jacobian, eval, assemble)
+    KIN_CACHE.with(handle, || sun::Solver::new(n, pat.nnz), |solver| {
+        solver.solve(guess, nominal, pat, x, eq_index, time, has_jacobian, eval, assemble)
     })
 }
 
@@ -1245,9 +1293,7 @@ mod stub {
     pub fn solve(
         _handle: u32,
         _n: usize,
-        _nnz: usize,
-        _colptr: &[i32],
-        _rowidx: &[i32],
+        _pat: &super::Pattern,
         _nominal: &[f64],
         _guess: &[f64],
         _x: &mut [f64],
@@ -1271,9 +1317,7 @@ pub use stub::{b_solve, reset_caches, solve};
 pub fn solve_selected(
     handle: u32,
     n: usize,
-    nnz: usize,
-    colptr: &[i32],
-    rowidx: &[i32],
+    pat: &Pattern,
     nominal: &[f64],
     guess: &[f64],
     old_values: &[f64],
@@ -1290,12 +1334,9 @@ pub fn solve_selected(
         // which is the start point the caller already picked.
         let start = x.to_vec();
         return b_solve(
-            handle, n, nnz, Some((colptr, rowidx)), nominal, &start, old_values, x, eq_index, time,
-            load_guess, eval, has_jacobian.then_some(assemble),
+            handle, n, pat.nnz, Some((pat.colptr, pat.rowidx)), nominal, &start, old_values, x,
+            eq_index, time, load_guess, eval, has_jacobian.then_some(assemble),
         );
     }
-    solve(
-        handle, n, nnz, colptr, rowidx, nominal, guess, x, eq_index, time, has_jacobian, eval,
-        assemble,
-    )
+    solve(handle, n, pat, nominal, guess, x, eq_index, time, has_jacobian, eval, assemble)
 }

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_nls/src/lib.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_nls/src/lib.rs
@@ -232,10 +232,19 @@ pub struct NlsSpec<'a> {
     pub nominal: &'a [f64],
     /// The `min`/`max` pairs a restart point is held inside.
     pub bounds: &'a [f64],
-    /// `colptr[size+1] ++ rowidx[nnz]`; empty without a pattern.
+    /// `colptr[size+1] ++ rowidx[nnz] ++ colorCols[size]`; empty without a pattern.
+    /// The colours are 0-based, unlike C's.
     pub pattern: &'a [u32],
     /// C's `analyticalJacobianColumn != NULL`.
     pub has_jacobian: bool,
+}
+
+impl NlsSpec<'_> {
+    /// The pattern's `colorCols` tail; empty where the host emitted no colouring.
+    fn colors(&self) -> &[u32] {
+        let base = self.size + 1 + self.nnz as usize;
+        self.pattern.get(base..base + self.size).unwrap_or(&[])
+    }
 }
 
 /// The model side of one nonlinear system: C's `NONLINEAR_SYSTEM_DATA` function
@@ -285,6 +294,10 @@ pub struct NlsRequest<'a> {
     pub eq_index: u32,
     pub time: f64,
     pub has_jacobian: bool,
+    /// C's `colorCols`, 0-based; empty leaves every column its own colour.
+    pub colors: &'a [u32],
+    /// C's `nlsData->max`.
+    pub max: &'a [f64],
 }
 
 /// The nonlinear solvers a runtime supplies beyond the core's own dense ladder:
@@ -3603,7 +3616,9 @@ pub fn solve_nls(
     // `-nls=` overrides the codegen-time choice (C's per-system `nlsMethod`): `kinsol`
     // takes every patterned system, the dense solvers force dense, unset keeps it.
     let pick = solverflags::nls();
-    let sparse = has_jac
+    // C's `initializeNonlinearSystemData` hands a patterned sparse system to KINSOL
+    // whatever `analyticalJacobianColumn` is; `nlsSparseJac` differences the pattern.
+    let sparse = !lambda_unknown
         && nnz != 0
         && backend.has_sparse()
         && match pick {
@@ -3615,6 +3630,8 @@ pub fn solve_nls(
     // A dense solver over a CSC-emitting `jac`: C's `evalJacobian` with `isDense`.
     let scatter = !sparse && jac_csc;
     let pat: &[u32] = if scatter { spec.pattern } else { &[] };
+    let colors: &[u32] = if lambda_unknown { &[] } else { spec.colors() };
+    let max: alloc::vec::Vec<f64> = bounds.chunks_exact(2).map(|b| b[1]).collect();
     let mut jaceval = |xs: &[f64], fj: &mut [f64]| {
         stat_inc(STAT_NLS_JAC);
         note_jac_eval();
@@ -3840,7 +3857,7 @@ pub fn solve_nls(
                 backend.solve_kinsol_dense(
                     NlsRequest {
                         n, x: &mut x, guess: &start_point, warm: &warm, nominal, old_values: &nlsx_old,
-                        eq_index, time, has_jacobian: has_jac,
+                        eq_index, time, has_jacobian: has_jac, colors, max: &max,
                     },
                     &mut load_guess,
                     &mut eval,
@@ -3850,7 +3867,7 @@ pub fn solve_nls(
                 backend.solve_sparse(
                     NlsRequest {
                         n, x: &mut x, guess: &start_point, warm: &warm, nominal, old_values: &nlsx_old,
-                        eq_index, time, has_jacobian: has_jac,
+                        eq_index, time, has_jacobian: has_jac, colors, max: &max,
                     },
                     &mut load_guess,
                     &mut eval,

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/driver.rs
@@ -7141,11 +7141,18 @@ impl SolverCore {
     /// the discrete context, re-initialize at what they leave behind, `IDACalcIC` for
     /// the algebraic unknowns and derivatives, answer back into `SimData`. `ctx` must
     /// be the live callback context — `IDACalcIC` evaluates the residual.
-    fn dae_restart(&mut self, e: &mut (dyn SimEngine + 'static), ctx: *mut ResCtx) -> Result<()> {
-        let _ = ctx; // DAE mode needs SUNDIALS, so without it there is nothing to do
+    fn dae_restart(&mut self, e: &mut dyn SimEngine, ctx: *mut ResCtx) -> Result<()> {
         e.call2(MODEL_FN_DAE, self.sim_data, eval_stage::DISCRETE)?;
         self.read_states(e)?;
         self.restart()?;
+        self.dae_consistent(e, ctx)
+    }
+
+    /// `ida_event_update`'s second half: `IDACalcIC`, then the consistent point back
+    /// into `SimData` (C's `IDAGetConsistentIC` + `setAlgebraicDAEVars`). `ctx` must
+    /// be the live callback context — `IDACalcIC` evaluates the residual.
+    fn dae_consistent(&mut self, e: &mut dyn SimEngine, ctx: *mut ResCtx) -> Result<()> {
+        let _ = ctx; // DAE mode needs SUNDIALS, so without it there is nothing to do
         #[cfg(sundials)]
         if let Solver::Ida(s) = &mut self.solver
             && let Some(ida) = s.ida.as_mut()
@@ -7158,8 +7165,7 @@ impl SolverCore {
             self.yp.copy_from_slice(ida.yp());
         }
         e.call2(MODEL_FN_DAE, self.sim_data, eval_stage::DISCRETE)?;
-        self.write_states(e)?;
-        Ok(())
+        self.write_states(e)
     }
 
     /// C's `didEventStep`: drop the step history at the post-event state, which in
@@ -7173,6 +7179,11 @@ impl SolverCore {
 
     /// The `IDACalcIC` C's initialization performs before the first output row —
     /// which already reports the algebraic unknowns and derivatives IDA solves for.
+    ///
+    /// C builds the solver ahead of `initializeModel` so that the initial
+    /// `updateDiscreteSystem` is already `ida_event_update` (`solver_main.c` says so).
+    /// The solver here exists only once the parameters are final, so that pass is
+    /// made good afterwards, snapshots included.
     fn prime(&mut self, e: &mut (dyn SimEngine + 'static), layout: &SimLayout) -> Result<()> {
         if !self.dae {
             return Ok(());
@@ -7187,6 +7198,19 @@ impl SolverCore {
         if let Solver::Ida(state) = &mut self.solver {
             let e = unsafe { &mut *ctx.engine };
             state.ensure(e, sim_data, t, &mut self.y, &mut self.yp, ctx_ptr)?;
+        }
+        for _ in 0..max_event_iter() {
+            let before = discrete_snapshot(e, sim_data, layout)?;
+            self.dae_consistent(e, ctx_ptr)?;
+            update_discrete_system(e, sim_data, layout)?;
+            if discrete_snapshot(e, sim_data, layout)? == before {
+                break;
+            }
+        }
+        update_relations_pre(e, sim_data, layout)?;
+        if layout.n_zc > 0 {
+            save_zc_pre(e, sim_data, layout)?;
+            e.call2(MODEL_FN_ZC, sim_data, sim_data + layout.zc_off)?;
         }
         if let Some(err) = ctx.err.take() {
             return Err(err);
@@ -7318,7 +7342,7 @@ impl SolverCore {
     /// that moved a state behind DASKR's back. In DAE mode the algebraic unknowns
     /// follow the states in `y` (C's `getAlgebraicDAEVars`); only the states' `y'`
     /// moves, as C's `statesDer` keeps what the last `IDAGetConsistentIC` left there.
-    fn read_states(&mut self, e: &mut (dyn SimEngine + 'static)) -> Result<()> {
+    fn read_states(&mut self, e: &mut dyn SimEngine) -> Result<()> {
         self.read_y(e)?;
         self.yp.resize(self.n_unknowns, 0.0);
         for i in 0..self.n_states {
@@ -7329,7 +7353,7 @@ impl SolverCore {
 
     /// The `y` half of [`read_states`](SolverCore::read_states), for the callers
     /// that must not disturb the integrator's own `y'`.
-    fn read_y(&mut self, e: &mut (dyn SimEngine + 'static)) -> Result<()> {
+    fn read_y(&mut self, e: &mut dyn SimEngine) -> Result<()> {
         self.y = (0..self.n_states)
             .map(|i| read_f64(e, self.states_base + (i as u32) * 8))
             .collect::<Result<_>>()?;
@@ -7342,7 +7366,7 @@ impl SolverCore {
     /// The integrator's accepted point back into `SimData`. For an explicit ODE only
     /// the states move (the model computes `y'`); in DAE mode `y'` and the algebraic
     /// unknowns are solver results too.
-    fn write_states(&self, e: &mut (dyn SimEngine + 'static)) -> Result<()> {
+    fn write_states(&self, e: &mut dyn SimEngine) -> Result<()> {
         for i in 0..self.n_states {
             write_f64(e, self.states_base + (i as u32) * 8, self.y[i])?;
         }

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/nls.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/nls.rs
@@ -342,9 +342,16 @@ impl nls::NlsBackend for CBackend<'_> {
         eval: &mut dyn FnMut(&[f64], &mut [f64]),
         jac: &mut dyn FnMut(&[f64], &mut [f64]),
     ) -> bool {
+        let pat = nls::kinsol::Pattern {
+            nnz: self.nnz,
+            colptr: self.colptr,
+            rowidx: self.rowidx,
+            colors: req.colors,
+            max: req.max,
+        };
         nls::kinsol::solve_selected(
-            self.handle, req.n, self.nnz, self.colptr, self.rowidx, req.nominal, req.guess,
-            req.old_values, req.x, req.eq_index, req.time, req.has_jacobian, load_guess, eval, jac,
+            self.handle, req.n, &pat, req.nominal, req.guess, req.old_values, req.x, req.eq_index,
+            req.time, req.has_jacobian, load_guess, eval, jac,
         )
     }
 
@@ -445,9 +452,13 @@ pub fn initialize_nonlinear_systems(data: *mut DATA, thread_data: *mut threadDat
         register_names(data, sys);
         sys.nlsMethod = si.nlsMethod;
         sys.nlsLinearSolver = si.nlsLinearSolver;
-        let (colptr, rowidx) = csc_pattern(sys, size);
-        let pattern: Vec<u32> =
-            colptr.iter().chain(rowidx.iter()).map(|v| *v as u32).collect();
+        let (colptr, rowidx, colors) = csc_pattern(sys, size);
+        let pattern: Vec<u32> = colptr
+            .iter()
+            .chain(rowidx.iter())
+            .map(|v| *v as u32)
+            .chain(colors.iter().copied())
+            .collect();
         sys.solverData = Box::into_raw(Box::new(Scratch {
             colptr,
             rowidx,
@@ -493,12 +504,13 @@ fn register_names(data: *mut DATA, sys: &NONLINEAR_SYSTEM_DATA) {
     );
 }
 
-/// The system's `SPARSE_PATTERN` as CSC, or empty where the backend chose a dense
-/// factorization or the pattern does not survive C's `sparsitySanityCheck`.
-fn csc_pattern(sys: &mut NONLINEAR_SYSTEM_DATA, size: usize) -> (Vec<i32>, Vec<i32>) {
-    if sys.matrixFormat != OMC_MATRIX_SPARSE || sys.sparsePattern.is_null() || sys.jacobianIndex < 0
-    {
-        return (Vec::new(), Vec::new());
+/// The system's `SPARSE_PATTERN` as CSC plus its colouring, or empty where the
+/// backend chose a dense factorization or the pattern does not survive C's
+/// `sparsitySanityCheck`. A missing `analyticalJacobianColumn` is not a reason to
+/// drop it -- `nlsSparseJac` differences the pattern instead.
+fn csc_pattern(sys: &mut NONLINEAR_SYSTEM_DATA, size: usize) -> (Vec<i32>, Vec<i32>, Vec<u32>) {
+    if sys.matrixFormat != OMC_MATRIX_SPARSE || sys.sparsePattern.is_null() {
+        return (Vec::new(), Vec::new(), Vec::new());
     }
     let sp = unsafe { &*sys.sparsePattern };
     let cols = (sp.sizeCols as usize).min(size);
@@ -512,7 +524,18 @@ fn csc_pattern(sys: &mut NONLINEAR_SYSTEM_DATA, size: usize) -> (Vec<i32>, Vec<i
     }
     let nnz = colptr[size] as usize;
     let rowidx = (0..nnz).map(|k| unsafe { *sp.index.add(k) } as i32).collect();
-    (colptr, rowidx)
+    // C's `colorCols` counts from 1; a column past `sizeCols` gets its own colour.
+    let mut next = sp.maxColors;
+    let colors = (0..size)
+        .map(|c| match c < cols {
+            true => unsafe { *sp.colorCols.add(c) }.saturating_sub(1),
+            false => {
+                next += 1;
+                next - 1
+            }
+        })
+        .collect();
+    (colptr, rowidx, colors)
 }
 
 /// C's `sparsitySanityCheck`: every column has an entry, every row is hit, and
@@ -631,7 +654,7 @@ pub extern "C" fn solve_nonlinear_system(
         sys_num: sys_number as u32,
         nominal: &nominal,
         bounds: &bounds,
-        pattern: if csc { &sd.pattern } else { &[] },
+        pattern: if csc || full_pattern { &sd.pattern } else { &[] },
         has_jacobian,
     };
 


### PR DESCRIPTION
`collect_nls_jobs` dropped a nonlinear system's sparsity pattern unless the system also had a usable analytic Jacobian:

```rust
let pat = if has_jac { pat } else { None };
```

C keeps the two apart. `M_02nls.c` emits `allocSparsePattern(1178, 7822, 22)` beside `analyticalJacobianColumn = NULL`, and `nonlinearSystem.c:498` then hands any sparse-format system with a pattern to KINSOL + KLU whatever the column function is -- there, `nlsSparseJac` differences the pattern one colour group per residual evaluation.

Without the pattern such a system took the *dense* ladder with an uncoloured column-at-a-time difference quotient. On `Dynawo.Examples.IEEE118.TestCases.IEEE118NoEvent` (`--daeMode`, one n=1178 initialization system, no analytic Jacobian) that is 7076 residual evaluations and 11.2 s against C's 80 and 0.008 s, and it lands on a different root of the same system. Dynawo compares `UStatorPu == UStatorRefPu` exactly, so the generators picked the wrong `qStatus` branch in the DAE residual and IDA could not converge:

```
##IDA## -4 error occurred at time = 0.023116726371064
wasm-jit simulation failed: CodegenWasmJit: IDA failed
```

Without `-nls=kinsol` the same run survived but chattered through 3544 state events where C takes 2.

The pattern now goes in whenever it exists, and `NlsJacPattern` appends the 0-based colouring after `colptr`/`rowidx` (the per-system stride is `4*(2n+1+nnz)`). `solve_nls` drops `has_jac` from its sparse choice, and `NlsSpec::colors()` / `NlsRequest::{colors,max}` carry the colouring and C's `nlsData->max` to the backends. `kinsol.rs` gained a `Pattern` struct, and its `numeric_csc` is now `nlsSparseJac` proper: a colour group per evaluation, with the `xsave + dh >= max` sign flip. The wasm-jit runtime's own sparse Newton differences the same way where no column function exists, and `openmodelica_simulation_runtime` stops dropping the pattern on `jacobianIndex < 0`.

`SolverCore::prime` also never wrote `IDACalcIC`'s answer back into `SimData`, where C's `ida_event_update` ends with `IDAGetConsistentIC` + `setAlgebraicDAEVars`. C builds the solver ahead of `initializeModel` so its first `updateDiscreteSystem` already is `ida_event_update`; this one exists only once the parameters are final, so that pass is made good afterwards, relation and zero-crossing snapshots included. It does not move IEEE118NoEvent, but it was wrong.

IEEE118NoEvent, wasm-jit against the C target:

| | before | after | C |
| --- | --- | --- | --- |
| the run | IDA failed | completes | completes |
| init NLS residual evals | 7076 | 81 | 80 |
| Jacobian colours | none | 22 | 22 |
| initialization | 11.2 s | 0.020 s | 0.062 s |
| max relative deviation, t > 0 | -- | 8e-6 | -- |

`simulation/modelica/{nonlinear_system,initialization}`: 0 of 141 failed on `--simCodeTarget=wasm-jit`, 0 of 141 on `--simCodeTarget=C+Rust`.

Two gaps left, noted in the handoff: the initialization NLS still lands ~1e-4 from C's root on `B55_G1.QGenPu`, which Dynawo's exact comparisons turn into 45 state events against C's 2; and `LOG_STATS_V` reports 0 iterations and 0 Jacobian evaluations for the KINSOL path, where C reads them back with `KINGetNumNonlinSolvIters` and `numberOfJEval`.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
