### PR TITLE
Solve for consistent DAE values as events settle

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -6156,6 +6156,15 @@ fn build_sim_model(
         )?);
         idx
     };
+    // C's `setupDataStruc` half: the constant defaults, written before the solver is
+    // allocated. The expression-bound ones stay in the update function.
+    let attr_defaults_idx = {
+        let idx = import_base + bodies.len() as u32;
+        let defaults: Vec<(u32, f64)> =
+            nominal_defaults.iter().chain(max_defaults.iter()).copied().collect();
+        bodies.push(build_attr_defaults_fn(&defaults, &var_map, &by_name, &mut literals)?);
+        idx
+    };
     // Always exported (empty when the backend generated none) so the standalone
     // merge resolves regardless of the model.
     let linz_jac_idx = {
@@ -6316,6 +6325,7 @@ fn build_sim_model(
     functions.function(eqfn_type); // functionInitSpatialDistribution: (i32) -> ()
     functions.function(eqfn_type); // functionUpdateBoundParameters: (i32) -> ()
     functions.function(eqfn_type); // functionUpdateBoundVariableAttributes: (i32) -> ()
+    functions.function(eqfn_type); // functionAttrDefaults: (i32) -> ()
     for _ in 0..4 {
         functions.function(eqfn_type); // linearJacA..linearJacD: (i32) -> ()
     }
@@ -6441,6 +6451,7 @@ fn build_sim_model(
         ("functionInitSpatialDistribution", init_spatial_idx),
         ("functionUpdateBoundParameters", update_bound_params_idx),
         ("functionUpdateBoundVariableAttributes", update_bound_attrs_idx),
+        ("functionAttrDefaults", attr_defaults_idx),
         ("functionRemovedInitialEquations", removed_init_idx),
         ("functionInitSynchronous", sync_idx.0),
         ("symbolicInlineSystem", sym_inline_idx),
@@ -6504,6 +6515,7 @@ fn build_sim_model(
     exports.export("functionInitSpatialDistribution", we::ExportKind::Func, init_spatial_idx);
     exports.export("functionUpdateBoundParameters", we::ExportKind::Func, update_bound_params_idx);
     exports.export("functionUpdateBoundVariableAttributes", we::ExportKind::Func, update_bound_attrs_idx);
+    exports.export("functionAttrDefaults", we::ExportKind::Func, attr_defaults_idx);
     for (k, name) in ["linearJacA", "linearJacB", "linearJacC", "linearJacD"].iter().enumerate() {
         exports.export(name, we::ExportKind::Func, linz_jac_idx + k as u32);
     }
@@ -6575,6 +6587,7 @@ fn build_sim_model(
         ("functionInitSpatialDistribution", init_spatial_idx),
         ("functionUpdateBoundParameters", update_bound_params_idx),
         ("functionUpdateBoundVariableAttributes", update_bound_attrs_idx),
+        ("functionAttrDefaults", attr_defaults_idx),
         ("linearJacA", linz_jac_idx),
         ("linearJacB", linz_jac_idx + 1),
         ("linearJacC", linz_jac_idx + 2),
@@ -8554,6 +8567,24 @@ fn build_update_bound_attrs_fn(
     let sim = sim_ctx(var_map);
     let mut ctx = FnCtx::new_sim(sim, by_name, literals);
     ctx.emit_update_bound_attrs(defaults, int_defaults, &attrs)?;
+    let (locals, instrs) = ctx.finish_sim();
+    let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
+    for i in &instrs {
+        func.instruction(i);
+    }
+    Ok(func)
+}
+
+/// Build `functionAttrDefaults(SimData*)`: the constant attribute defaults only, for
+/// a solver built before initialization.
+fn build_attr_defaults_fn(
+    defaults: &[(u32, f64)],
+    var_map: &SimVarMap,
+    by_name: &HashMap<String, FnInfo>,
+    literals: &mut Literals,
+) -> Result<we::Function> {
+    let mut ctx = FnCtx::new_sim(sim_ctx(var_map), by_name, literals);
+    ctx.emit_update_bound_attrs(defaults, &[], &[])?;
     let (locals, instrs) = ctx.finish_sim();
     let mut func = we::Function::new(locals.into_iter().map(|t| (1u32, t)));
     for i in &instrs {

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/driver.rs
@@ -350,6 +350,7 @@ pub const MODEL_FNS: &[&str] = &[
     "functionInitSpatialDistribution",
     "functionUpdateBoundParameters",
     "functionUpdateBoundVariableAttributes",
+    "functionAttrDefaults",
     "evaluateDAEResiduals",
     "functionInitSynchronous",
     "functionUpdateSynchronous",
@@ -2069,7 +2070,7 @@ pub fn run_initialization(
     inputs: &[crate::InputVar],
     start_time: f64,
 ) -> Result<()> {
-    init_model(e, sim_data, layout, inputs, start_time, None)?;
+    init_model(e, sim_data, layout, inputs, start_time, None, None)?;
     signal_init_done();
     terminate_at_init(e, sim_data, layout)
 }
@@ -2077,7 +2078,7 @@ pub fn run_initialization(
 /// [`run_initialization`] where the caller has the metadata the `LOG_SOTI` dump
 /// and the discrete start attributes need.
 pub fn run_initialization_model(e: &mut dyn SimEngine, sim_data: u32, model: &SimMeta) -> Result<()> {
-    init_model(e, sim_data, &model.layout, &model.inputs, model.start_time, Some(model))?;
+    init_model(e, sim_data, &model.layout, &model.inputs, model.start_time, Some(model), None)?;
     signal_init_done();
     terminate_at_init(e, sim_data, &model.layout)
 }
@@ -2098,8 +2099,9 @@ pub fn run_initialization_with_clocks(
     e: &mut dyn SimEngine,
     sim_data: u32,
     model: &SimMeta,
+    dae: Option<&mut dyn FnMut(&mut dyn SimEngine) -> Result<()>>,
 ) -> Result<crate::sync::Sync> {
-    init_model(e, sim_data, &model.layout, &model.inputs, model.start_time, Some(model))?;
+    init_model(e, sim_data, &model.layout, &model.inputs, model.start_time, Some(model), dae)?;
     let mut sync = crate::sync::Sync::new(e, model, sim_data)?;
     // An event clock whose `when` already fired during the initial discrete update
     // is only *scheduled* here (C's `data->simulationInfo->initial` case).
@@ -2117,6 +2119,7 @@ fn init_model(
     inputs: &[crate::InputVar],
     start_time: f64,
     model: Option<&SimMeta>,
+    dae: Option<&mut dyn FnMut(&mut dyn SimEngine) -> Result<()>>,
 ) -> Result<()> {
     INIT_NOTICE_LOGGED.store(false, Ordering::Relaxed);
     // C's `initializeNonlinearSystems`, which reports its dropped patterns here.
@@ -2149,7 +2152,10 @@ fn init_model(
     // sitting in a branch no evaluation takes (`if a then .. else if b then ..`,
     // entered on the `a` side) is reached by nothing but the exact sweep.
     refresh_relations(e, sim_data, layout)?;
-    iterate_discrete(e, sim_data, layout)?;
+    match dae {
+        Some(dae) => iterate_discrete_dae(e, sim_data, layout, dae)?,
+        None => iterate_discrete(e, sim_data, layout)?,
+    }
     // C's generated `functionDAE` throws on a system that did not converge, and the
     // throw is still inside `initializeModel`.
     check_nls(e, sim_data, layout)?;
@@ -3760,7 +3766,7 @@ fn discrete_snapshot(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Re
 /// consistent set and chatter on the integrator instead. Assumes the event time is
 /// already written.
 pub(crate) fn iterate_discrete(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
-    iterate_discrete_from(e, sim_data, layout, false)
+    iterate_discrete_from(e, sim_data, layout, false, None)
 }
 
 /// [`iterate_discrete`] entered after the first `functionDAE` has already run, as
@@ -3772,7 +3778,18 @@ pub(crate) fn iterate_discrete_after_eval(
     sim_data: u32,
     layout: &SimLayout,
 ) -> Result<()> {
-    iterate_discrete_from(e, sim_data, layout, true)
+    iterate_discrete_from(e, sim_data, layout, true, None)
+}
+
+/// [`iterate_discrete`] where DAE mode makes `functionDAE` C's `ida_event_update`:
+/// `dae` ends every pass, so each settles around consistent algebraic unknowns.
+pub(crate) fn iterate_discrete_dae(
+    e: &mut dyn SimEngine,
+    sim_data: u32,
+    layout: &SimLayout,
+    dae: &mut dyn FnMut(&mut dyn SimEngine) -> Result<()>,
+) -> Result<()> {
+    iterate_discrete_from(e, sim_data, layout, false, Some(dae))
 }
 
 fn iterate_discrete_from(
@@ -3780,6 +3797,7 @@ fn iterate_discrete_from(
     sim_data: u32,
     layout: &SimLayout,
     evaluated: bool,
+    mut dae: Option<&mut dyn FnMut(&mut dyn SimEngine) -> Result<()>>,
 ) -> Result<()> {
     rtclock::tick(rtclock::DISCRETE); // C's `callStatistics.updateDiscreteSystem`
     // Each pass freezes `relationsPre = relations` so the NLS in `functionODE` holds
@@ -3802,6 +3820,9 @@ fn iterate_discrete_from(
         let events_v = omclog::active(omclog::EVENTS_V);
         let before = if events_v { Some(discrete_pre_values(e, sim_data)?) } else { None };
         eval_discrete(e, sim_data, layout)?;
+        if let Some(dae) = dae.as_deref_mut() {
+            dae(e)?;
+        }
         log_reinits(e);
         if let Some(before) = &before {
             log_discrete_changes(e, sim_data, before)?;
@@ -5741,17 +5762,22 @@ fn log_dassl_stats(idid: i32, t: f64, rwork: &[f64], iwork: &[i32]) {
     omclog::info(omclog::DASSL, false, "Finished DASSL step.");
 }
 
-/// C's `realVarsData[i].attribute.nominal` for the states, floored at 1e-32 by
-/// `functionUpdateBoundVariableAttributes` and so only readable after
-/// initialization. In DAE mode the algebraic unknowns' nominals follow (C's
-/// `getAlgebraicDAEVarNominals`), one per extra component of IDA's `y`. Length ≥ 1
-/// so daskr never sees an empty array.
+/// C's `realVarsData[i].attribute.nominal` for the states; in DAE mode the algebraic
+/// unknowns' nominals follow (C's `getAlgebraicDAEVarNominals`), one per extra
+/// component of IDA's `y`. Length ≥ 1 so daskr never sees an empty array.
+///
+/// `fmax(fabs(n), 1e-32)` as `ida_solver_setNominals` does: read before
+/// `initializeModel` has floored them, a zero nominal is a zero `atol` and so an
+/// infinite error weight.
 fn read_state_nominals(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<Vec<f64>> {
     let mut nominals: Vec<f64> = (0..layout.n_states)
         .map(|i| read_f64(e, sim_data + layout.state_nom_off + i * 8))
         .collect::<Result<_>>()?;
     for k in 0..layout.n_dae_alg {
         nominals.push(read_f64(e, sim_data + layout.dae_alg_nom_off + k * 8)?);
+    }
+    for n in nominals.iter_mut() {
+        *n = libm::fmax(libm::fabs(*n), 1e-32);
     }
     if nominals.is_empty() {
         nominals.push(1.0);
@@ -7142,17 +7168,10 @@ impl SolverCore {
     /// the algebraic unknowns and derivatives, answer back into `SimData`. `ctx` must
     /// be the live callback context — `IDACalcIC` evaluates the residual.
     fn dae_restart(&mut self, e: &mut dyn SimEngine, ctx: *mut ResCtx) -> Result<()> {
+        let _ = ctx; // DAE mode needs SUNDIALS, so without it there is nothing to do
         e.call2(MODEL_FN_DAE, self.sim_data, eval_stage::DISCRETE)?;
         self.read_states(e)?;
         self.restart()?;
-        self.dae_consistent(e, ctx)
-    }
-
-    /// `ida_event_update`'s second half: `IDACalcIC`, then the consistent point back
-    /// into `SimData` (C's `IDAGetConsistentIC` + `setAlgebraicDAEVars`). `ctx` must
-    /// be the live callback context — `IDACalcIC` evaluates the residual.
-    fn dae_consistent(&mut self, e: &mut dyn SimEngine, ctx: *mut ResCtx) -> Result<()> {
-        let _ = ctx; // DAE mode needs SUNDIALS, so without it there is nothing to do
         #[cfg(sundials)]
         if let Solver::Ida(s) = &mut self.solver
             && let Some(ida) = s.ida.as_mut()
@@ -7177,43 +7196,42 @@ impl SolverCore {
         }
     }
 
-    /// The `IDACalcIC` C's initialization performs before the first output row —
-    /// which already reports the algebraic unknowns and derivatives IDA solves for.
-    ///
-    /// C builds the solver ahead of `initializeModel` so that the initial
-    /// `updateDiscreteSystem` is already `ida_event_update` (`solver_main.c` says so).
-    /// The solver here exists only once the parameters are final, so that pass is
-    /// made good afterwards, snapshots included.
-    fn prime(&mut self, e: &mut (dyn SimEngine + 'static), layout: &SimLayout) -> Result<()> {
+    /// C's `ida_event_update` as the initial `updateDiscreteSystem` calls it: the IDA
+    /// block on first use, then the ordinary restart. Interleaving it with the event
+    /// iteration is what makes it work — a pass that flips a relation is what hands
+    /// the next `IDACalcIC` a system to solve.
+    fn dae_event_update(&mut self, e: &mut dyn SimEngine, ctx: *mut ResCtx) -> Result<()> {
         if !self.dae {
             return Ok(());
         }
-        self.read_states(e)?;
-        let mut ctx = self.res_ctx(e, layout);
-        let ctx_ptr = &mut ctx as *mut ResCtx;
-        RES_CTX.store(ctx_ptr, Ordering::Relaxed);
-        let _guard = ResCtxGuard;
-        let (t, sim_data) = (self.t, self.sim_data);
         #[cfg(sundials)]
-        if let Solver::Ida(state) = &mut self.solver {
-            let e = unsafe { &mut *ctx.engine };
-            state.ensure(e, sim_data, t, &mut self.y, &mut self.yp, ctx_ptr)?;
-        }
-        for _ in 0..max_event_iter() {
-            let before = discrete_snapshot(e, sim_data, layout)?;
-            self.dae_consistent(e, ctx_ptr)?;
-            update_discrete_system(e, sim_data, layout)?;
-            if discrete_snapshot(e, sim_data, layout)? == before {
-                break;
+        {
+            let (t, sim_data) = (self.t, self.sim_data);
+            self.read_states(e)?;
+            if let Solver::Ida(state) = &mut self.solver {
+                state.ensure(e, sim_data, t, &mut self.y, &mut self.yp, ctx)?;
             }
         }
-        update_relations_pre(e, sim_data, layout)?;
-        if layout.n_zc > 0 {
-            save_zc_pre(e, sim_data, layout)?;
-            e.call2(MODEL_FN_ZC, sim_data, sim_data + layout.zc_off)?;
-        }
-        if let Some(err) = ctx.err.take() {
-            return Err(err);
+        self.dae_restart(e, ctx)
+    }
+
+    /// C's `updateSolverNominals`, for the DAE-mode core built before
+    /// `initializeModel`: the nominals it took its tolerances from are only final now.
+    fn refresh_nominals(&mut self, e: &dyn SimEngine, layout: &SimLayout) -> Result<()> {
+        self.nominals = read_state_nominals(e, self.sim_data, layout)?;
+        self.maxs = read_state_maxs(e, self.sim_data, layout)?;
+        let (_, atol) = dassl_tolerances(self.tol, &self.nominals);
+        #[cfg(sundials)]
+        {
+            let t = self.t;
+            if let Solver::Ida(s) = &mut self.solver {
+                if let Some(ida) = s.ida.as_mut()
+                    && !ida.set_tolerances(t, s.rtol, &atol)
+                {
+                    return Err("CodegenWasmJit: IDA tolerances failed");
+                }
+                s.atol = atol;
+            }
         }
         Ok(())
     }
@@ -8360,26 +8378,56 @@ impl EventsDriver {
         model: &SimModel,
         sim_data: u32,
         method: &str,
-        gbode: Option<alloc::boxed::Box<crate::gbode::Gbode>>,
+        mut gbode: Option<alloc::boxed::Box<crate::gbode::Gbode>>,
     ) -> Result<Self> {
         daskr::auxiliary::xsetf(1); // see `DasslDriver::new`
         let layout = &model.layout;
         // Init (with homotopy fallback). Relation mode 2 and `initSample` are handled
         // inside run_initialization; seed the hysteresis direction from the relations.
         crate::sync::clear_fire_flags(e, sim_data, layout)?;
-        let sync = run_initialization_with_clocks(e, sim_data, model)?;
+        // C's `setupDataStruc`, before `initializeSolverData`: the DAE core below
+        // reads nominals and maxes, not slots nothing has written yet.
+        e.call1_if_present("functionAttrDefaults", sim_data)?;
+        let start = model.start_time;
+        // C's `solver_main` builds the solver before `initializeModel` in DAE mode,
+        // "since the solver is used to obtain consistent values also via
+        // updateDiscreteSystem". Only DAE mode needs it, and only there is the
+        // `refresh_nominals` that repairs the not-yet-final nominals wanted.
+        let mut early = match layout.dae_mode() {
+            false => None,
+            true => Some(SolverCore::new(&*e, model, sim_data, start, method, gbode.take())?),
+        };
+        let sync = match early.as_mut() {
+            None => run_initialization_with_clocks(e, sim_data, model, None)?,
+            Some(core) => {
+                let mut ctx = core.res_ctx(e, layout);
+                let ctx_ptr = &mut ctx as *mut ResCtx;
+                RES_CTX.store(ctx_ptr, Ordering::Relaxed);
+                let _guard = ResCtxGuard;
+                let mut dae = |e: &mut dyn SimEngine| core.dae_event_update(e, ctx_ptr);
+                let sync = run_initialization_with_clocks(e, sim_data, model, Some(&mut dae))?;
+                if let Some(err) = ctx.err.take() {
+                    return Err(err);
+                }
+                sync
+            }
+        };
+        let mut core = match early {
+            Some(mut core) => {
+                core.refresh_nominals(&*e, layout)?;
+                core
+            }
+            None => SolverCore::new(&*e, model, sim_data, start, method, gbode)?,
+        };
         store_relations(e, sim_data, layout)?;
 
         let n_states = layout.n_states as usize;
         let states_base = sim_data + REAL_OFF;
         let n_rows = model.n_output_rows();
         let n_reals = layout.n_row_total();
-        let start = model.start_time;
 
         let samp = Samples::load(e, sim_data, layout, start)?;
         let mut rows: Vec<f64> = Vec::with_capacity((n_rows * n_reals) as usize);
-        let mut core = SolverCore::new(&*e, model, sim_data, start, method, gbode)?;
-        core.prime(e, layout)?;
         // A sample due at the start time is left to the first step, which C shortens
         // to zero length and handles as an ordinary time event.
         let dss = StateSelection::initial(e, sim_data, model)?;

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/sundials.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/sundials.rs
@@ -755,6 +755,20 @@ impl Ida {
         unsafe { IDAGetConsistentIC(self.mem, self.y, self.yp) == IDA_SUCCESS }
     }
 
+    /// C's `updateSolverNominals`: the tolerances again, once the nominals the block
+    /// was built with are final. `IDASVtolerances` clears `ida_edata` for
+    /// `IDAInitialSetup` to put back, which `IDACalcIC` has already run — hence the
+    /// re-initialize.
+    pub fn set_tolerances(&mut self, t: f64, rtol: f64, atol: &[f64]) -> bool {
+        unsafe {
+            core::ptr::copy_nonoverlapping(atol.as_ptr(), N_VGetArrayPointer(self.atol), atol.len());
+            if IDASVtolerances(self.mem, rtol, self.atol) != IDA_SUCCESS {
+                return false;
+            }
+        }
+        self.reinit(t)
+    }
+
     /// C's `ida_event_update`: `IDACalcIC` over the algebraic unknowns and every
     /// derivative at `t`, directed by the step IDA would take next (floored, so a
     /// zero step still gives a direction), retried at `t + tol` with the line search


### PR DESCRIPTION
C builds the solver before `initializeModel` when the model is in DAE mode -- `solver_main.c` says why: "for the DAEmode we need to initialize solverData before the initialization, since the solver is used to obtain consistent values also via updateDiscreteSystem". `functionDAE` there *is* `ida_event_update`, so every pass of the initial event iteration ends in `IDACalcIC` and writes the consistent algebraic unknowns and derivatives back.

The interleaving is the point. A pass that flips a discrete variable switches which equation a residual row carries, and the *next* `IDACalcIC` then has a system worth solving; its corrector lands the rows that are linear in their unknown exactly on the value they are solved for. This driver ran the whole event iteration first and asked for consistency afterwards, by which time nothing was left to solve: `IDACalcIC` returned having taken 0 nonlinear iterations, both times.

On `Dynawo.Examples.IEEE118.TestCases.IEEE118NoEvent`, whose generators compare `UStatorPu == UStatorRefPu` exactly, that left 39 of 54 sitting ~6e-15 off their reference at `startTime` and crossing as the first steps snapped them:

| | before | after | C |
| --- | --- | --- | --- |
| exact at `startTime` | 8/54 | 47/54 | 47/54 |
| `IDACalcIC` iterations | 0, 0 | 1, 4 | 0, 3 |
| state events | 45 | 6 | 2 |
| steps | 222 | 83 | 52 |
| max relative deviation | 8.5e-4 | 7.3e-6 | -- |

`iterate_discrete_dae` takes the hook the initial `updateDiscreteSystem` runs at the end of each pass, `EventsDriver` builds the solver ahead of `run_initialization_with_clocks` and supplies it, and `prime` -- the after-the-fact `IDACalcIC` that could not work -- is gone. Only DAE mode constructs early, so every other solver keeps reading its nominals once, after initialization.

Two things had to come with it, both C's:

* `read_state_nominals` floors with `fmax(fabs(n), 1e-32)`, as `ida_solver_setNominals` does. Read before the model has floored them, a zero nominal is a zero `atol` and an infinite error weight, which IDA rejects with `MSG_BAD_EWT`.
* `refresh_nominals` is C's `updateSolverNominals`: a block built before initialization took its tolerances from nominals that were not final. `IDASVtolerances` clears `ida_edata` for `IDAInitialSetup` to restore, and `IDACalcIC` has already run that -- so `Ida::set_tolerances` re-initializes, or the next `IDASolve` calls `ida_efun` through a null and segfaults in `IDAEwtSet`.

`simulation/modelica/{nonlinear_system,initialization}`: 0 of 141 failed on `--simCodeTarget=wasm-jit`, 0 of 141 on `--simCodeTarget=C+Rust`.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
