### PR TITLE
Open and save Modelica packages from cloud storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,11 @@ trace.txt
 
 # Claude handoffs
 **/HANDOFF*.md
+
+# Cloud storage OAuth client registrations. Not ignored because the contents are
+# secret - a browser client serves them to every visitor - but because the consent
+# screen carries the registering organisation's name, so another party's app built
+# on a committed client would appear to users as OpenModelica, and could get the
+# client suspended for everyone. Ship the .example; supply the real file at deploy
+# time. (GOCSPX- values also trip GitHub secret scanning.)
+cloud_config.json

--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -1716,10 +1716,35 @@ function(omc_rust_omedit_qt_web_page)
             ${_qt_bld}/OMEdit-qt.wasm ${_qt_bld}/qtloader.js
             ${_qt_bld}/qtlogo.svg ${_qt_pkgdir}/
     COMMAND ${CMAKE_COMMAND} -E copy ${RUST_OMC_DIR}/omshell_omc/omc_worker.js ${_web_dir}/omc_worker.js
+    # The OAuth callback goes at the web ROOT, not in the versioned page directory:
+    # neither Google nor Microsoft allows a wildcard redirect URI, so one page at
+    # the origin root is a single registered URI that every deployed version
+    # shares. It works because the code comes back over a BroadcastChannel, which
+    # is scoped to the origin rather than the path.
+    COMMAND ${CMAKE_COMMAND} -E copy
+            ${_qt_src}/oauth-callback.html ${_web_dir}/oauth-callback.html
     COMMAND ${CMAKE_COMMAND} -E copy
             ${CMAKE_SOURCE_DIR}/OMEdit/OMEditLIB/Resources/icons/omedit_splashscreen.png ${_qt_pkgdir}/
     COMMENT "Qt: building OMEdit-qt web page -> ${_qt_pkgdir}"
     VERBATIM)
+  # Cloud storage OAuth client registrations. Kept out of the source tree so that one
+  # deployment's applications do not become every build's default - the consent
+  # screen shows the registering organisation's name. Point this at the deployment's
+  # own file; without it the web build simply reports that cloud storage has not
+  # been set up. See OMEdit/OMEditGUI/wasm/cloud_config.json.example.
+  set(OMEDIT_CLOUD_CONFIG "" CACHE FILEPATH
+      "cloud_config.json to stage at the web root (Google/OneDrive OAuth client IDs).")
+  if(OMEDIT_CLOUD_CONFIG)
+    if(EXISTS ${OMEDIT_CLOUD_CONFIG})
+      add_custom_command(TARGET rust_omedit_qt_web POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy ${OMEDIT_CLOUD_CONFIG} ${_qt_pkgdir}/cloud_config.json
+        COMMENT "Staging cloud_config.json -> ${_qt_pkgdir}")
+    else()
+      message(WARNING "OMEDIT_CLOUD_CONFIG is set but ${OMEDIT_CLOUD_CONFIG} does not exist; "
+                      "the web build will report cloud storage as not set up.")
+    endif()
+  endif()
+
   if(NOT RUST_OMC_WEB_QT_STANDALONE)
     add_dependencies(rust_omedit_qt_web rust_wasm)
   endif()

--- a/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/wasm_api.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/wasm_api.rs
@@ -243,6 +243,50 @@ pub fn wasi_write_file(path: &str, bytes: &[u8]) {
     openmodelica_wasi::write(path, bytes.to_vec());
 }
 
+/// Write many files in one call, from an array of `{ path: string, bytes:
+/// Uint8Array }`. Restoring a cached package tree is one postMessage rather than
+/// one per file. Returns how many were written; a malformed entry is skipped.
+#[wasm_bindgen]
+pub fn wasi_write_files(entries: JsValue) -> usize {
+    let Ok(arr) = entries.dyn_into::<js_sys::Array>() else {
+        return 0;
+    };
+    let mut written = 0;
+    for entry in arr.iter() {
+        let path = js_sys::Reflect::get(&entry, &JsValue::from_str("path"))
+            .ok()
+            .and_then(|v| v.as_string());
+        let bytes = js_sys::Reflect::get(&entry, &JsValue::from_str("bytes"))
+            .ok()
+            .and_then(|v| v.dyn_into::<js_sys::Uint8Array>().ok());
+        if let (Some(path), Some(bytes)) = (path, bytes) {
+            openmodelica_wasi::write(&path, bytes.to_vec());
+            written += 1;
+        }
+    }
+    written
+}
+
+/// Remove `path`, whether it is a file or a directory (the store's directories
+/// are implicit, so a directory means every key beneath it). Returns true if
+/// anything was removed. Embedded builtins are immutable and unaffected.
+#[wasm_bindgen]
+pub fn wasi_remove(path: &str) -> bool {
+    if openmodelica_wasi::remove(path) {
+        return true;
+    }
+    if openmodelica_wasi::is_dir(path) {
+        return openmodelica_wasi::fs::remove_dir_all(path).is_ok();
+    }
+    false
+}
+
+/// Move `from` to `to`, either a single file or a whole subtree.
+#[wasm_bindgen]
+pub fn wasi_rename(from: &str, to: &str) -> bool {
+    openmodelica_wasi::fs::rename(from, to).is_ok()
+}
+
 /// Drain the files the last command tried to download but did not find in the
 /// VFS, as an array of `{ urls: string[], filename: string }`. `omc_eval` is
 /// synchronous, so it cannot fetch over the network itself; instead the JS host

--- a/OMCompiler/Compiler/OpenModelica.rs/omshell_omc/omc_worker.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/omshell_omc/omc_worker.js
@@ -32,6 +32,9 @@ import init, {
   wasi_path_filestat_get,
   wasi_readdir,
   wasi_write_file,
+  wasi_write_files,
+  wasi_remove,
+  wasi_rename,
   omc_take_pending_downloads,
   omc_take_plot_commands,
 } from "./omc/OpenModelicaCompiler.js";
@@ -281,6 +284,21 @@ self.onmessage = async (e) => {
       let ok = true;
       try { wasi_write_file(msg.path, msg.bytes); } catch (e) { ok = false; }
       self.postMessage({ kind: "vfsPutResult", id: msg.id, ok });
+    } else if (msg.cmd === "vfsPutMany") {
+      // Bulk write, for restoring a cached cloud package tree in one round trip
+      // rather than one per file. `written` lets the page verify completeness.
+      let written = 0;
+      try { written = wasi_write_files(msg.entries); } catch (e) { written = -1; }
+      self.postMessage({ kind: "vfsPutManyResult", id: msg.id, written });
+    } else if (msg.cmd === "vfsRemove") {
+      // File or whole subtree; the store's directories are implicit.
+      let ok = false;
+      try { ok = wasi_remove(msg.path); } catch (e) { ok = false; }
+      self.postMessage({ kind: "vfsRemoveResult", id: msg.id, ok });
+    } else if (msg.cmd === "vfsRename") {
+      let ok = false;
+      try { ok = wasi_rename(msg.from, msg.to); } catch (e) { ok = false; }
+      self.postMessage({ kind: "vfsRenameResult", id: msg.id, ok });
     } else if (msg.cmd === "vfsStat") {
       // WASI path_filestat_get's size (-1 if absent), for the file engine's size().
       let size;

--- a/OMEdit/OMEditGUI/OMEditGUI.win.config.pri
+++ b/OMEdit/OMEditGUI/OMEditGUI.win.config.pri
@@ -44,10 +44,10 @@ LIBS += -L$$(OMBUILDDIR)/../OMEdit/OMEditLIB/Debugger/Parser -lGDBMIParser \
 msystem_prefix = $$(MSYSTEM_PREFIX)
 contains(msystem_prefix, .*ucrt64.*) {
   BFD_PATH = $$(MSYSTEM_PREFIX)/lib
-  BFD_LIBS = -lbfd -lintl -liberty -lsframe -lzstd -lzlib
+  BFD_LIBS = -lbfd -lintl -liberty -lsframe -lzstd -lzlib -lcrypt32
 } else {
   BFD_PATH = $$(MSYSTEM_PREFIX)/lib/binutils
-  BFD_LIBS = -lbfd -lintl -liberty -lzlib
+  BFD_LIBS = -lbfd -lintl -liberty -lzlib -lcrypt32
 }
 
 CONFIG(release, debug|release) { # release

--- a/OMEdit/OMEditGUI/OMEditGUI.win.config.pri
+++ b/OMEdit/OMEditGUI/OMEditGUI.win.config.pri
@@ -37,17 +37,17 @@ QMAKE_LFLAGS += -Wl,--stack,33554432,--enable-auto-import
 
 LIBS += -L$$(OMBUILDDIR)/../OMEdit/OMEditLIB/Debugger/Parser -lGDBMIParser \
   -L$$(OMBUILDDIR)/lib/omc -L$$(OMBUILDDIR)/../OMParser/install/lib -Wl,-Bstatic -lOMParser -lantlr4-runtime -Wl,-Bdynamic -lomantlr3 -lOMPlot -lomqwt -lomopcua -lzmq \
-  -lOpenModelicaCompiler -lOpenModelicaRuntimeC -lfmilib -lomcgc -lpthread -lshlwapi -lws2_32 -lgdi32 -lsimdjson \
+  -lOpenModelicaCompiler -lOpenModelicaRuntimeC -lfmilib -lomcgc -lpthread -lshlwapi -lws2_32 -lgdi32 -lcrypt32 -lsimdjson \
   -L$$(OMBUILDDIR)/bin -lOMSimulator
 
 # libbdf links differently on newer MSYS2, e.g. when using UCRT64
 msystem_prefix = $$(MSYSTEM_PREFIX)
 contains(msystem_prefix, .*ucrt64.*) {
   BFD_PATH = $$(MSYSTEM_PREFIX)/lib
-  BFD_LIBS = -lbfd -lintl -liberty -lsframe -lzstd -lzlib -lcrypt32
+  BFD_LIBS = -lbfd -lintl -liberty -lsframe -lzstd -lzlib
 } else {
   BFD_PATH = $$(MSYSTEM_PREFIX)/lib/binutils
-  BFD_LIBS = -lbfd -lintl -liberty -lzlib -lcrypt32
+  BFD_LIBS = -lbfd -lintl -liberty -lzlib
 }
 
 CONFIG(release, debug|release) { # release

--- a/OMEdit/OMEditGUI/main.cpp
+++ b/OMEdit/OMEditGUI/main.cpp
@@ -43,6 +43,8 @@
  */
 
 #include "OMEditApplication.h"
+#include "Util/PersistentStorage.h"
+#include "Cloud/CloudTypes.h"
 #ifndef GC_THREADS
 #define GC_THREADS
 #endif
@@ -251,7 +253,22 @@ int main(int argc, char *argv[])
   // before the QApplication. Without it WebEngine logs "Using Shared GL: no" and
   // crashes during GL init on Windows.
   QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+#if defined(__EMSCRIPTEN__)
+  // Before anything can queue a native event: works around a re-entrancy bug in
+  // Qt's event replay that hangs startup at random. See OMCProxy.cpp.
+  extern void omcInstallPendingEventsGuard();
+  omcInstallPendingEventsGuard();
+#endif
+  // Bring the persisted tree back before anything reads QSettings. On the web
+  // target that is the IndexedDB mirror; natively it only makes sure the settings
+  // directory exists. Failure just means this session starts with no history.
+  PersistentStorage::restore();
   OMEditApplication a(argc, argv, threadData);
+#if defined(__EMSCRIPTEN__)
+  // Needs the event dispatcher, so it cannot go with the guard above.
+  extern void omcInstallPendingEventsShiftGuard();
+  omcInstallPendingEventsShiftGuard();
+#endif
 // Do not use the signal handler OR exception filter if user is building a debug version.
 // Perhaps the user wants to use gdb.
 // moved the setting of the handler *after* OMEditApplication application definition
@@ -277,6 +294,7 @@ int main(int argc, char *argv[])
   extern bool g_omcMainLoopRunning;
   g_omcMainLoopRunning = true;
 #endif
+  PersistentStorage::startAutoSnapshot();
   return a.exec();
 
   MMC_CATCH_TOP(return execution_failed());

--- a/OMEdit/OMEditGUI/wasm/CLOUD-STORAGE.md
+++ b/OMEdit/OMEditGUI/wasm/CLOUD-STORAGE.md
@@ -1,0 +1,115 @@
+# Cloud storage in OMEdit
+
+OMEdit can open and save Modelica packages in Google Drive and OneDrive, keeping
+the whole directory structure. It works the same way on the desktop and in the
+browser, and on the web build it is the only place work survives a reload.
+
+A cloud folder is *mounted*: its contents are brought down to an ordinary local
+directory (the working copy), and everything else in OMEdit - the editors, the
+library browser, omc - sees a normal path. Synchronising is a three-way
+comparison of the working copy, the remote folder, and a manifest of the last
+synced state, so a file that changed on both sides is reported rather than
+guessed at, and a missing file is only ever treated as deleted when the working
+copy is otherwise intact.
+
+## Using it
+
+- **File > Open Model/Library from Cloud Storage** picks a folder (or a file in
+  one), brings it down, and opens it.
+- **File > Save to Cloud Storage** saves the active class into a folder you pick.
+  Make a new folder from the tree's context menu.
+- After that the folder stays mounted and every save is pushed automatically a
+  few seconds later. **Tools > Options > Cloud Storage** lists the mounted
+  folders; untick one to synchronise it only when asked, or forget it entirely
+  (which removes the local copy and touches nothing in the cloud).
+- If a file changed both locally and in the cloud, a dialog asks per file: keep
+  yours, take theirs, or keep both. Keeping both puts the cloud version at the
+  original name and yours beside it as `<name>.conflict-<timestamp>.<ext>`.
+
+On the web build the working copy is also mirrored into IndexedDB, so reopening a
+package after a reload revalidates rather than downloading everything again.
+Nothing is uploaded from that cache on its own: an edit that was cached but never
+pushed is uploaded by the next synchronisation.
+
+## Setting up the OAuth applications
+
+OMEdit ships no client registration. Each deployment registers its own, because
+the consent screen names the registering organisation. Registrations are runtime
+configuration - see `cloud_config.json.example` beside this file - and never
+compiled in.
+
+Two registrations per provider: the web build and the desktop build use different
+redirect mechanisms.
+
+### Google Drive
+
+At <https://console.cloud.google.com/apis/credentials>, in a project with the
+Google Drive API enabled:
+
+1. **Web application** client, for the web build.
+   - Authorised JavaScript origins: the origin the page is served from, e.g.
+     `https://playground.openmodelica.org` and `http://localhost:8110` for local
+     testing. Wildcards are not accepted.
+   - Authorised redirect URI: `<origin>/oauth-callback.html`. One URI covers
+     every versioned path (`/latest/`, `/v1.28/`, ...) because the page lives at
+     the origin root; see the note about the symlink in the deployment section.
+2. **Desktop app** client, for the desktop build. It uses a loopback port, which
+   Google allows without registering a URI.
+
+Both give a client ID and a client secret. Google's token endpoint rejects a PKCE
+exchange without the secret even for a public client, so both go into
+`cloud_config.json`. The secret is not confidential - the web build serves it to
+every visitor - and what protects the application is the registered redirect URI
+and origin.
+
+The scope is `drive.file`, which is non-sensitive: no app verification and no
+annual security assessment. OMEdit sees only the folder it creates
+(`OpenModelica`) and what it puts there. While the application is in *Testing*
+mode, add yourself under *Audience > Test users* or sign-in is refused.
+
+### OneDrive
+
+At <https://portal.azure.com> > *Microsoft Entra ID* > *App registrations* >
+*New registration*:
+
+1. Supported account types: personal Microsoft accounts, or personal plus work
+   and school, depending on who should be able to sign in.
+2. Platform **Single-page application**, redirect URI `<origin>/oauth-callback.html`.
+   The SPA platform is what makes the token endpoint send CORS headers; a "Web"
+   platform registration will fail in the browser.
+3. Add a second platform, **Mobile and desktop applications**, with the loopback
+   redirect `http://localhost` for the desktop build.
+4. API permissions, delegated: `Files.ReadWrite`, `offline_access`, `User.Read`.
+
+Microsoft needs no client secret for a public client, so only the client ID goes
+into `cloud_config.json`.
+
+## Deploying the configuration
+
+- **Web**: point the build at the file with
+  `-DOMEDIT_CLOUD_CONFIG=/path/to/cloud_config.json`; it is staged beside the
+  page. `oauth-callback.html` is staged at the **web bundle root**. That is the
+  origin root only on localhost - on a deployment that unpacks under `/latest/`,
+  serve the root copy as a symlink into it, and make sure the server follows
+  symlinks. If the origin root is not yours to serve, set `redirectUri` in
+  `cloud_config.json` and register that URI instead.
+- **Desktop**: put `cloud_config.json` in the directory that holds `omedit.ini`
+  (`~/.config/openmodelica` on Linux). Without it, cloud storage reports that it
+  has not been set up; individual users can also fill the fields in
+  *Tools > Options > Cloud Storage*.
+
+The callback page's channel name (`omedit-oauth`) and its `{code, state, error}`
+payload are a contract with every still-deployed version, since they all share
+the one page. Change them by adding a new channel alongside the old one, never by
+swapping.
+
+## Where the pieces live
+
+| | |
+|---|---|
+| OAuth, providers, sync | `OMEdit/OMEditLIB/Cloud/` |
+| Desktop redirect (loopback socket) | `Cloud/OAuth2RedirectLoopback.cpp` |
+| Web redirect (popup + BroadcastChannel) | `OMEditGUI/wasm/oauth_redirect_wasm.cpp`, `oauth-callback.html` |
+| Settings and token persistence | `OMEditLIB/Util/PersistentStorage.{h,cpp}`, `OMEditGUI/wasm/persist_store.cpp` |
+| Working-copy cache (web) | `OMEditGUI/wasm/cloud_cache_idb.cpp` |
+| Tests | `OMEdit/Testsuite/Cloud/` |

--- a/OMEdit/OMEditGUI/wasm/CMakeLists.txt
+++ b/OMEdit/OMEditGUI/wasm/CMakeLists.txt
@@ -127,6 +127,8 @@ endforeach()
 # IS compiled: the wasm-jit run drives it via runWasmJitSimulation() and its
 # QProcess/QTcpServer paths are guarded out under __EMSCRIPTEN__.
 set(WASM_EXCLUDE_FILES
+  # Desktop OAuth redirect (QTcpServer loopback); the browser uses a popup instead.
+  "Cloud/OAuth2RedirectLoopback.cpp"
   "Simulation/OpcUaClient.cpp"
   "OMS/OMSSimulationOutputWidget.cpp")
 foreach(f ${WASM_EXCLUDE_FILES})
@@ -161,9 +163,18 @@ list(APPEND OMEDITLIB_SOURCES
   # QAbstractFileEngineHandler that serves worker-VFS files to main-thread QFile.
   ${CMAKE_CURRENT_SOURCE_DIR}/worker_vfs_engine.cpp
   # Browser file picker / download, for the user's own filesystem.
-  ${CMAKE_CURRENT_SOURCE_DIR}/local_files.cpp)
+  ${CMAKE_CURRENT_SOURCE_DIR}/local_files.cpp
+  # localStorage persistence: settings, cloud mounts and their sync manifests.
+  ${CMAKE_CURRENT_SOURCE_DIR}/persist_store.cpp
+  # IndexedDB cache of the cloud working copies, so a reload does not re-download.
+  ${CMAKE_CURRENT_SOURCE_DIR}/cloud_cache_idb.cpp
+  # OAuth popup + same-origin callback page (the desktop half is a loopback socket).
+  ${CMAKE_CURRENT_SOURCE_DIR}/oauth_redirect_wasm.cpp)
 set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/worker_vfs_engine.cpp
-                            ${CMAKE_CURRENT_SOURCE_DIR}/local_files.cpp PROPERTIES SKIP_AUTOMOC ON)
+                            ${CMAKE_CURRENT_SOURCE_DIR}/local_files.cpp
+                            ${CMAKE_CURRENT_SOURCE_DIR}/persist_store.cpp
+                            ${CMAKE_CURRENT_SOURCE_DIR}/cloud_cache_idb.cpp
+                            ${CMAKE_CURRENT_SOURCE_DIR}/oauth_redirect_wasm.cpp PROPERTIES SKIP_AUTOMOC ON)
 # The simulation metadata tables OMCProxy reads (SOLVER_METHOD_NAME, FLAG_NAME,
 # OMC_LOG_STREAM_NAME, ...); native OMEdit gets them from libOpenModelicaCompiler.
 list(APPEND OMEDITLIB_SOURCES ${SIMRT}/util/simulation_options.c ${SIMRT}/util/omc_error.c)

--- a/OMEdit/OMEditGUI/wasm/cloud_cache_idb.cpp
+++ b/OMEdit/OMEditGUI/wasm/cloud_cache_idb.cpp
@@ -1,0 +1,272 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+// The working-copy cache for the web target, over IndexedDB. Keys are the
+// absolute working-copy paths, so a mount's contents are one key range and the
+// restore needs no index of its own.
+//
+// Nothing here runs during startup, which is what makes IndexedDB usable at all.
+// The callbacks arrive in JS frames, so the work they trigger is deferred to a
+// fresh turn of the event loop before it touches the omc worker: reaching it
+// needs an Asyncify suspend, and suspending inside a JS frame hangs the page.
+
+#if defined(__EMSCRIPTEN__)
+
+#include "Cloud/CloudCache.h"
+#include "Cloud/CloudTypes.h"
+
+#include <QByteArray>
+#include <QFile>
+#include <QHash>
+#include <QList>
+#include <QPair>
+#include <QString>
+#include <QStringList>
+#include <QTimer>
+
+#include <emscripten.h>
+#include <emscripten/em_js.h>
+
+#include <cstdlib>
+
+// Defined in OMEditLIB/OMC/OMCProxy.cpp; one round trip for the whole tree.
+int omcWorkerWriteFiles(const QList<QPair<QString, QByteArray> > &files);
+
+EM_JS(void, omedit_cache_open, (), {
+  if (Module.__omeditCacheOpen) return;
+  Module.__omeditCacheOpen = function () {
+    if (!Module.__omeditCacheDb) {
+      Module.__omeditCacheDb = new Promise((resolve, reject) => {
+        let request;
+        try {
+          request = indexedDB.open("omedit-cloud-cache", 1);
+        } catch (e) {
+          reject(e);
+          return;
+        }
+        request.onupgradeneeded = () => request.result.createObjectStore("files");
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      });
+    }
+    return Module.__omeditCacheDb;
+  };
+});
+
+EM_JS(void, omedit_cache_batch_add, (const char *key, const char *bytes, int length), {
+  if (!Module.__omeditCacheBatch) Module.__omeditCacheBatch = [];
+  Module.__omeditCacheBatch.push({ key: UTF8ToString(key), data: HEAPU8.slice(bytes, bytes + length) });
+});
+
+// One transaction for the whole mount: the stale range goes and the new contents
+// arrive together, so an interrupted write cannot leave a half-replaced package.
+EM_JS(void, omedit_cache_batch_commit, (const char *prefix), {
+  const entries = Module.__omeditCacheBatch || [];
+  Module.__omeditCacheBatch = null;
+  const range = UTF8ToString(prefix);
+  Module.__omeditCacheOpen().then((db) => {
+    const store = db.transaction("files", "readwrite").objectStore("files");
+    store.delete(IDBKeyRange.bound(range, range + String.fromCharCode(0xffff)));
+    for (const entry of entries) store.put(entry.data, entry.key);
+  }).catch((e) => console.warn("[OMEdit] could not cache the working copy", e));
+});
+
+EM_JS(void, omedit_cache_forget, (const char *prefix), {
+  const range = UTF8ToString(prefix);
+  Module.__omeditCacheOpen().then((db) => {
+    db.transaction("files", "readwrite").objectStore("files").delete(IDBKeyRange.bound(range, range + String.fromCharCode(0xffff)));
+  }).catch((e) => console.warn("[OMEdit] could not clear the cache", e));
+});
+
+EM_JS(void, omedit_cache_read_prefix, (const char *prefix, int token), {
+  const range = UTF8ToString(prefix);
+  Module.__omeditCacheEntries = [];
+  Module.__omeditCacheOpen().then((db) => new Promise((resolve, reject) => {
+    const request = db.transaction("files", "readonly").objectStore("files")
+                      .openCursor(IDBKeyRange.bound(range, range + String.fromCharCode(0xffff)));
+    const found = [];
+    request.onsuccess = () => {
+      const cursor = request.result;
+      if (!cursor) { resolve(found); return; }
+      found.push({ key: cursor.key, data: cursor.value });
+      cursor.continue();
+    };
+    request.onerror = () => reject(request.error);
+  })).then((found) => {
+    Module.__omeditCacheEntries = found;
+    Module._omedit_cache_read_done(token);
+  }).catch((e) => {
+    console.warn("[OMEdit] could not read the cache", e);
+    Module.__omeditCacheEntries = [];
+    Module._omedit_cache_read_done(token);
+  });
+});
+
+EM_JS(int, omedit_cache_entry_count, (), {
+  return (Module.__omeditCacheEntries || []).length;
+});
+
+EM_JS(char *, omedit_cache_entry_key, (int index), {
+  return stringToNewUTF8(Module.__omeditCacheEntries[index].key);
+});
+
+EM_JS(int, omedit_cache_entry_size, (int index), {
+  const data = Module.__omeditCacheEntries[index].data;
+  return data ? data.byteLength : 0;
+});
+
+EM_JS(void, omedit_cache_entry_copy, (int index, char *destination), {
+  const data = Module.__omeditCacheEntries[index].data;
+  HEAPU8.set(data instanceof Uint8Array ? data : new Uint8Array(data), destination);
+});
+
+EM_JS(void, omedit_cache_entries_clear, (), {
+  Module.__omeditCacheEntries = null;
+});
+
+namespace {
+
+QHash<int, std::function<void(int)>> gPending;
+int gNextToken = 1;
+
+QString prefixOf(const CloudMount &mount)
+{
+  return mount.localRoot + QLatin1Char('/');
+}
+
+void collect(const QString &directory, QList<QPair<QString, QByteArray> > *pFiles)
+{
+  const QStringList names = cloudListDirectory(directory);
+  for (const QString &raw : names) {
+    const bool isFolder = raw.endsWith(QLatin1Char('/'));
+    const QString name = isFolder ? raw.left(raw.size() - 1) : raw;
+    if (name.isEmpty()) {
+      continue;
+    }
+    const QString path = directory + QLatin1Char('/') + name;
+    if (isFolder) {
+      collect(path, pFiles);
+      continue;
+    }
+    QFile file(path);
+    if (file.open(QIODevice::ReadOnly)) {
+      pFiles->append(qMakePair(path, file.readAll()));
+    }
+  }
+}
+
+//! Hand the entries JS collected to the omc worker, in one round trip.
+void drainRestore(int token)
+{
+  const std::function<void(int)> done = gPending.take(token);
+  QList<QPair<QString, QByteArray> > files;
+  const int count = omedit_cache_entry_count();
+  for (int i = 0; i < count; ++i) {
+    char *key = omedit_cache_entry_key(i);
+    const QString path = QString::fromUtf8(key);
+    free(key);
+    QByteArray contents(omedit_cache_entry_size(i), '\0');
+    if (!contents.isEmpty()) {
+      omedit_cache_entry_copy(i, contents.data());
+    }
+    files.append(qMakePair(path, contents));
+  }
+  omedit_cache_entries_clear();
+  int written = 0;
+  if (!files.isEmpty()) {
+    written = omcWorkerWriteFiles(files);
+  }
+  if (done) {
+    done(written < 0 ? 0 : written);
+  }
+}
+
+} // namespace
+
+// Called from the IndexedDB callback, so it only hands the work to the event
+// loop; the drain talks to the omc worker.
+extern "C" EMSCRIPTEN_KEEPALIVE void omedit_cache_read_done(int token)
+{
+  QTimer::singleShot(0, [token]() { drainRestore(token); });
+}
+
+bool CloudCache::isAvailable()
+{
+  return true;
+}
+
+void CloudCache::save(const CloudMount &mount)
+{
+  if (!mount.isValid()) {
+    return;
+  }
+  omedit_cache_open();
+  QList<QPair<QString, QByteArray> > files;
+  collect(mount.localRoot, &files);
+  if (files.isEmpty()) {
+    // Either there is nothing worth keeping or the working copy could not be
+    // read; neither is a reason to throw away what the cache already holds.
+    return;
+  }
+  for (const auto &file : std::as_const(files)) {
+    omedit_cache_batch_add(file.first.toUtf8().constData(), file.second.constData(), file.second.size());
+  }
+  omedit_cache_batch_commit(prefixOf(mount).toUtf8().constData());
+}
+
+void CloudCache::restore(const CloudMount &mount, const std::function<void(int)> &done)
+{
+  if (!mount.isValid()) {
+    if (done) {
+      QTimer::singleShot(0, [done]() { done(0); });
+    }
+    return;
+  }
+  omedit_cache_open();
+  const int token = gNextToken++;
+  gPending.insert(token, done);
+  omedit_cache_read_prefix(prefixOf(mount).toUtf8().constData(), token);
+}
+
+void CloudCache::forget(const CloudMount &mount)
+{
+  if (!mount.isValid()) {
+    return;
+  }
+  omedit_cache_open();
+  omedit_cache_forget(prefixOf(mount).toUtf8().constData());
+}
+
+#endif // __EMSCRIPTEN__

--- a/OMEdit/OMEditGUI/wasm/cloud_config.json.example
+++ b/OMEdit/OMEditGUI/wasm/cloud_config.json.example
@@ -1,0 +1,37 @@
+{
+  "_comment": [
+    "Cloud storage OAuth client registrations for this deployment. Copy to",
+    "cloud_config.json and fill in. The web build reads it from the web root,",
+    "next to oauth-callback.html; the desktop build reads it from the directory",
+    "holding omedit.ini (~/.config/openmodelica on Linux).",
+    "",
+    "The filled-in file is gitignored - not because it is confidential, but so",
+    "that one deployment's registration does not become every build's default.",
+    "",
+    "Use the *Web application* client for the web build and the *Desktop app*",
+    "client for the desktop build - they are different registrations.",
+    "",
+    "clientSecret is required for Google even though this is a public client:",
+    "Google's token endpoint rejects a PKCE exchange without one. It is not",
+    "confidential - the web build serves it to every visitor. What actually",
+    "protects the application is the registered redirect URI and origin.",
+    "Microsoft needs no secret.",
+    "",
+    "redirectUri is optional. The web build defaults to /oauth-callback.html at",
+    "the origin root, so one registered URI covers every versioned deployment",
+    "path; set it only if the root is not yours to serve. The desktop build",
+    "always uses a loopback port and ignores it.",
+    "",
+    "fullDriveScope asks Google for access to the whole Drive instead of just",
+    "what OMEdit created. It is a restricted scope: turning it on means your",
+    "client needs Google app verification and an annual security assessment."
+  ],
+  "googledrive": {
+    "clientId": "<project>-<hash>.apps.googleusercontent.com",
+    "clientSecret": "GOCSPX-...",
+    "fullDriveScope": false
+  },
+  "onedrive": {
+    "clientId": "00000000-0000-0000-0000-000000000000"
+  }
+}

--- a/OMEdit/OMEditGUI/wasm/oauth-callback.html
+++ b/OMEdit/OMEditGUI/wasm/oauth-callback.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Signing in to OMEdit</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: system-ui, sans-serif; margin: 0; padding: 2.5rem 2rem;
+         display: flex; min-height: 100vh; box-sizing: border-box;
+         flex-direction: column; justify-content: center; align-items: center; text-align: center; }
+  h1 { font-size: 1.25rem; font-weight: 600; margin: 0 0 .5rem; }
+  p { margin: 0; max-width: 28rem; line-height: 1.5; opacity: .8; }
+  .error { color: #b3261e; }
+</style>
+</head>
+<body>
+<h1 id="title">Finishing sign-in…</h1>
+<p id="detail">You can close this window.</p>
+<script>
+// The OAuth redirect target for the OMEdit web application.
+//
+// This page exists because the application is served cross-origin isolated
+// (COOP: same-origin, required for the SharedArrayBuffer the omc worker bridge
+// uses). Under that policy a popup's window.opener is severed in both
+// directions, so the code cannot be posted back to the opener. It is
+// republished on a BroadcastChannel instead, which only needs the two pages to
+// share an origin - which they do, this page being served next to the
+// application. localStorage carries the same payload for browsers without
+// BroadcastChannel, and to cover the case where the application had not yet
+// attached its listener.
+(function () {
+  "use strict";
+  var KEY = "omedit-oauth-result";
+  // The authorization code arrives in the query string; an implicit-style
+  // response would use the fragment, so read both rather than assume.
+  var query = new URLSearchParams(location.search);
+  var fragment = new URLSearchParams((location.hash || "").replace(/^#/, ""));
+  var get = function (name) { return query.get(name) || fragment.get(name) || ""; };
+
+  var result = {
+    code: get("code"),
+    state: get("state"),
+    error: get("error_description") || get("error")
+  };
+  if (!result.code && !result.error) {
+    result.error = "The sign-in response contained no authorization code.";
+  }
+
+  try {
+    localStorage.setItem(KEY, JSON.stringify(result));
+  } catch (e) {
+    // Private windows and blocked site data; the channel below still works.
+  }
+  try {
+    var channel = new BroadcastChannel("omedit-oauth");
+    channel.postMessage(result);
+    channel.close();
+  } catch (e) {
+    // Left to the localStorage path.
+  }
+
+  if (result.error) {
+    document.getElementById("title").textContent = "Sign-in failed";
+    document.getElementById("title").className = "error";
+    document.getElementById("detail").textContent = result.error;
+    return;
+  }
+  document.getElementById("title").textContent = "Signed in";
+  document.getElementById("detail").textContent = "You can close this window and go back to OMEdit.";
+  // A window whose opener has been severed is often not allowed to close itself,
+  // so this is an attempt, not the plan - hence the message above.
+  setTimeout(function () { try { window.close(); } catch (e) {} }, 400);
+})();
+</script>
+</body>
+</html>

--- a/OMEdit/OMEditGUI/wasm/oauth_redirect_wasm.cpp
+++ b/OMEdit/OMEditGUI/wasm/oauth_redirect_wasm.cpp
@@ -1,0 +1,218 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+// Browser half of OAuth2Redirect.
+//
+// The page is served cross-origin isolated (COOP: same-origin) because the omc
+// worker bridge needs SharedArrayBuffer. That severs window.opener in both
+// directions, so the usual "popup posts the code back to its opener" does not
+// work at all here: the popup returns to oauth-callback.html, a static page of
+// our own origin, which republishes the code on a BroadcastChannel. Same origin
+// is all a BroadcastChannel needs - no opener, no postMessage.
+//
+// localStorage carries the same payload as a fallback for the rare browser with
+// no BroadcastChannel, and it is what lets a popup that the user closed manually
+// still be noticed.
+
+#if defined(__EMSCRIPTEN__)
+
+#include "Cloud/OAuth2Redirect.h"
+
+#include <QPointer>
+
+#include <emscripten.h>
+#include <emscripten/em_js.h>
+
+#include <cstdlib>
+
+namespace {
+
+// Where the service sends the user back to.
+//
+// At the origin root, not beside the application: neither Google nor Microsoft
+// allows a wildcard in a redirect URI, and the application is deployed under a
+// versioned path (/latest/, /v1.28/, ...). A callback page at the root is one
+// registered URI that every version shares - which works because the code comes
+// back over a BroadcastChannel, and those are scoped to the origin, not the path.
+EM_JS(char *, omedit_oauth_redirect_uri, (), {
+  try {
+    return stringToNewUTF8(new URL("/oauth-callback.html", location.href).href);
+  } catch (e) {
+    return stringToNewUTF8("");
+  }
+});
+
+/*!
+ * \brief Open the popup and hand the result back by calling into wasm.
+ *
+ * Deliberately not a blocking wait. Sitting in a nested QEventLoop while the user
+ * spends a minute on a consent screen leaves Qt's Asyncify machinery suspended,
+ * queueing pointer events the whole time; replaying them afterwards against DOM
+ * state that has since changed crashes inside QWasmWindow::processPointerEnterLeave
+ * and wedges the page. So the application stays live and JS calls _omedit_oauth_deliver
+ * when there is something to report.
+ */
+EM_JS(void, omedit_oauth_start, (const char *url, const char *expectedState), {
+  const KEY = "omedit-oauth-result";
+  const want = UTF8ToString(expectedState);
+  let settled = false;
+  console.log("[OMEdit] sign-in started, expecting state", JSON.stringify(want));
+  // A result left over from an earlier attempt carries that attempt's state, and
+  // consuming it would fail the new one as a mismatched response.
+  try { localStorage.removeItem(KEY); } catch (e) { /* private mode */ }
+  // Ignore anything that is not the answer to *this* request - a second OMEdit
+  // tab signing in shares the channel.
+  const isOurs = (r) => !want || !r || !r.state || r.state === want;
+
+  const deliver = (code, state, error) => {
+    if (settled) return;
+    settled = true;
+    try { channel.close(); } catch (e) { /* already closed */ }
+    removeEventListener("storage", onStorage);
+    clearTimeout(timer);
+    try { localStorage.removeItem(KEY); } catch (e) { /* private mode */ }
+    const pCode = stringToNewUTF8(code || "");
+    const pState = stringToNewUTF8(state || "");
+    const pError = stringToNewUTF8(error || "");
+    try {
+      Module._omedit_oauth_deliver(pCode, pState, pError);
+    } finally {
+      _free(pCode); _free(pState); _free(pError);
+    }
+  };
+  const settle = (r) => deliver(r && r.code, r && r.state, r && r.error);
+
+  let channel;
+  try {
+    channel = new BroadcastChannel("omedit-oauth");
+    channel.onmessage = (e) => {
+      const got = (e.data && e.data.state) || "";
+      if (!isOurs(e.data)) {
+        console.warn("[OMEdit] ignoring a sign-in result: state", JSON.stringify(got),
+                     "does not match", JSON.stringify(want));
+        return;
+      }
+      console.log("[OMEdit] sign-in result received over BroadcastChannel");
+      settle(e.data);
+    };
+  } catch (e) {
+    console.warn("[OMEdit] no BroadcastChannel; falling back to localStorage", e);
+    channel = { close() {} };
+  }
+  const onStorage = (e) => {
+    if (e.key !== KEY || !e.newValue) return;
+    try {
+      const result = JSON.parse(e.newValue);
+      if (isOurs(result)) settle(result);
+    } catch (err) { /* not ours */ }
+  };
+  addEventListener("storage", onStorage);
+
+  // No closed-detection: under COOP the handle is severed as soon as the popup
+  // navigates cross-origin, and a severed handle reports itself closed - which
+  // aborted every real sign-in the moment it left our origin.
+  const popup = window.open(UTF8ToString(url), "omedit-oauth", "popup,width=520,height=680");
+  if (!popup) {
+    deliver("", "", "The browser blocked the sign-in window. Allow pop-ups for this site and try again.");
+    return;
+  }
+  const timer = setTimeout(() => {
+    console.log("[OMEdit] timed out waiting for the sign-in result");
+    deliver("", "", "Timed out waiting for the sign-in to finish. If you closed the sign-in window, try again.");
+  }, 300000);
+});
+
+class PopupRedirect;
+//! The sign-in in flight, if any; JS calls back into this one.
+QPointer<PopupRedirect> gActiveRedirect;
+
+class PopupRedirect : public OAuth2Redirect
+{
+public:
+  PopupRedirect(const QString &configuredUri, QObject *pParent)
+    : OAuth2Redirect(pParent), mConfiguredUri(configuredUri) {}
+
+  QString redirectUri() override
+  {
+    // A deployment that cannot serve the root - behind a path-mapping proxy, say -
+    // names its own callback URL in cloud_config.json.
+    if (!mConfiguredUri.isEmpty()) {
+      return mConfiguredUri;
+    }
+    char *raw = omedit_oauth_redirect_uri();
+    const QString uri = QString::fromUtf8(raw);
+    free(raw);
+    return uri;
+  }
+
+  bool start(const QUrl &authorizationUrl, const QString &state) override
+  {
+    gActiveRedirect = this;
+    // Returns at once; the answer arrives through deliver().
+    omedit_oauth_start(authorizationUrl.toString().toUtf8().constData(), state.toUtf8().constData());
+    return true;
+  }
+
+  void cancel() override { deliver(QString(), QString(), tr("Sign-in was cancelled.")); }
+
+  void deliver(const QString &code, const QString &state, const QString &error)
+  {
+    if (mSettled) {
+      return;
+    }
+    mSettled = true;
+    emit finished(code, state, error.isEmpty() && code.isEmpty() ? tr("No authorization code was returned.") : error);
+  }
+
+private:
+  QString mConfiguredUri;
+  bool mSettled = false;
+};
+
+} // namespace
+
+extern "C" EMSCRIPTEN_KEEPALIVE void omedit_oauth_deliver(const char *code, const char *state, const char *error)
+{
+  if (gActiveRedirect) {
+    gActiveRedirect->deliver(QString::fromUtf8(code), QString::fromUtf8(state), QString::fromUtf8(error));
+  }
+}
+
+OAuth2Redirect *OAuth2Redirect::create(const QString &configuredUri, QObject *pParent)
+{
+  return new PopupRedirect(configuredUri, pParent);
+}
+
+#endif // __EMSCRIPTEN__

--- a/OMEdit/OMEditGUI/wasm/persist_store.cpp
+++ b/OMEdit/OMEditGUI/wasm/persist_store.cpp
@@ -1,0 +1,323 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+// Persistence for the web target, over localStorage. The page filesystem and the
+// omc worker's VFS are both in memory, so the tree under /persist (settings, the
+// mount list, the sync manifests) is mirrored into browser storage; tokens get
+// keys of their own so clearing one does not clear the other.
+//
+// localStorage and not IndexedDB because restore() must run before QSettings is
+// first read - during startup - and waiting on IndexedDB there means an Asyncify
+// suspend, which hangs the application. Working-copy contents are too big for
+// this store and belong in IndexedDB, which is fine long after startup.
+//
+// /persist stays in the page MEMFS; worker_vfs_engine.cpp excludes that prefix.
+
+#if defined(__EMSCRIPTEN__)
+
+#include "Util/PersistentStorage.h"
+
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QDateTime>
+#include <QDebug>
+#include <QDir>
+#include <QDirIterator>
+#include <QFile>
+#include <QFileInfo>
+#include <QHash>
+#include <QStringList>
+#include <QTimer>
+
+#include <emscripten.h>
+#include <emscripten/em_js.h>
+
+#include <cstdlib>
+
+// Every key this application owns, so clearing site data by hand is predictable
+// and so nothing else on the origin is disturbed.
+EM_JS(char *, omedit_storage_keys, (const char *prefix), {
+  const wanted = UTF8ToString(prefix);
+  const keys = [];
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith(wanted)) keys.push(key.slice(wanted.length));
+    }
+  } catch (e) {
+    // Private windows and blocked site data; the session runs without persistence.
+    console.warn("[OMEdit] no browser storage; nothing will survive a reload", e);
+  }
+  return stringToNewUTF8(keys.join("\n"));
+});
+
+EM_JS(char *, omedit_storage_get, (const char *key), {
+  try {
+    return stringToNewUTF8(localStorage.getItem(UTF8ToString(key)) || "");
+  } catch (e) {
+    return stringToNewUTF8("");
+  }
+});
+
+EM_JS(void, omedit_storage_set, (const char *key, const char *value), {
+  try {
+    localStorage.setItem(UTF8ToString(key), UTF8ToString(value));
+  } catch (e) {
+    // Quota exceeded, or storage blocked. Losing this costs the user their
+    // settings on the next reload, not their work.
+    console.warn("[OMEdit] could not store", UTF8ToString(key), e);
+  }
+});
+
+EM_JS(void, omedit_storage_remove, (const char *key), {
+  try { localStorage.removeItem(UTF8ToString(key)); } catch (e) { /* blocked */ }
+});
+
+//! Restore the tree straight into the page filesystem. Not QDir/QFile: this runs
+//! before QApplication exists.
+EM_JS(int, omedit_storage_restore_tree, (const char *prefix, const char *root), {
+  const wanted = UTF8ToString(prefix);
+  const base = UTF8ToString(root);
+  let restored = 0;
+  try {
+    FS.mkdirTree(base);
+  } catch (e) {
+    // already there
+  }
+  let keys = [];
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith(wanted)) keys.push(key);
+    }
+  } catch (e) {
+    console.warn("[OMEdit] no browser storage; nothing will survive a reload", e);
+    return 0;
+  }
+  for (const key of keys) {
+    const relative = key.slice(wanted.length);
+    // A key is a relative path; anything climbing out of the tree is not ours.
+    if (!relative || relative.startsWith("/") || relative.includes("..")) continue;
+    const path = base + "/" + relative;
+    try {
+      const slash = path.lastIndexOf("/");
+      if (slash > 0) FS.mkdirTree(path.slice(0, slash));
+      const encoded = localStorage.getItem(key) || "";
+      const binary = atob(encoded);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+      FS.writeFile(path, bytes);
+      restored++;
+    } catch (e) {
+      console.warn("[OMEdit] could not restore", relative, e);
+    }
+  }
+  return restored;
+});
+
+namespace {
+
+const QLatin1String kPersistRoot("/persist");
+const char *const kFilePrefix = "omedit/persist/";
+const char *const kAuthPrefix = "omedit/auth/";
+
+QTimer *gSnapshotTimer = nullptr;
+QHash<QString, QByteArray> gSecrets;
+bool gSecretsLoaded = false;
+
+QString storageGet(const QString &key)
+{
+  char *raw = omedit_storage_get(key.toUtf8().constData());
+  const QString value = QString::fromUtf8(raw);
+  free(raw);
+  return value;
+}
+
+QStringList storageKeys(const char *prefix)
+{
+  char *raw = omedit_storage_keys(prefix);
+  const QString joined = QString::fromUtf8(raw);
+  free(raw);
+  return joined.isEmpty() ? QStringList() : joined.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+}
+
+//! Every file under /persist, as paths relative to it.
+QStringList persistedFiles()
+{
+  QStringList relative;
+  QDirIterator it(kPersistRoot, QDir::Files, QDirIterator::Subdirectories);
+  const int prefix = QString(kPersistRoot).size() + 1;
+  while (it.hasNext()) {
+    relative << it.next().mid(prefix);
+  }
+  return relative;
+}
+
+//! Cheap stand-in for a change notification: path, size and mtime of every file.
+QByteArray treeFingerprint()
+{
+  QByteArray fingerprint;
+  QStringList relatives = persistedFiles();
+  relatives.sort();
+  for (const QString &relative : std::as_const(relatives)) {
+    const QFileInfo info(kPersistRoot + QLatin1Char('/') + relative);
+    fingerprint += relative.toUtf8() + ':' + QByteArray::number(info.size()) + ':'
+                   + QByteArray::number(info.lastModified().toMSecsSinceEpoch()) + '\n';
+  }
+  return fingerprint;
+}
+
+void loadSecrets()
+{
+  if (gSecretsLoaded) {
+    return;
+  }
+  gSecretsLoaded = true;
+  const QStringList keys = storageKeys(kAuthPrefix);
+  for (const QString &key : keys) {
+    gSecrets.insert(key, QByteArray::fromBase64(storageGet(QLatin1String(kAuthPrefix) + key).toLatin1()));
+  }
+}
+
+} // namespace
+
+QString PersistentStorage::root()
+{
+  return kPersistRoot;
+}
+
+bool PersistentStorage::restore()
+{
+  omedit_storage_restore_tree(kFilePrefix, QString(kPersistRoot).toUtf8().constData());
+  loadSecrets();
+  return true;
+}
+
+void PersistentStorage::scheduleSnapshot()
+{
+  if (!gSnapshotTimer) {
+    gSnapshotTimer = new QTimer();
+    gSnapshotTimer->setSingleShot(true);
+    gSnapshotTimer->setInterval(1500);
+    QObject::connect(gSnapshotTimer, &QTimer::timeout, []() { PersistentStorage::snapshotNow(); });
+  }
+  gSnapshotTimer->start();
+}
+
+bool PersistentStorage::snapshotNow()
+{
+  const QStringList relatives = persistedFiles();
+  QStringList written;
+  for (const QString &relative : relatives) {
+    QFile file(kPersistRoot + QLatin1Char('/') + relative);
+    if (!file.open(QIODevice::ReadOnly)) {
+      continue;
+    }
+    omedit_storage_set((QLatin1String(kFilePrefix) + relative).toUtf8().constData(),
+                       file.readAll().toBase64().constData());
+    written << relative;
+  }
+  // Drop keys for files that are gone, so a deleted mount does not come back.
+  const QStringList stored = storageKeys(kFilePrefix);
+  for (const QString &relative : stored) {
+    if (!written.contains(relative)) {
+      omedit_storage_remove((QLatin1String(kFilePrefix) + relative).toUtf8().constData());
+    }
+  }
+  return true;
+}
+
+//! Write the tree back on the way out.
+extern "C" EMSCRIPTEN_KEEPALIVE void omedit_persist_flush()
+{
+  PersistentStorage::snapshotNow();
+}
+
+// pagehide is the event that actually fires when a tab is closed or bfcached;
+// visibilitychange covers a backgrounded tab the browser may later discard.
+EM_JS(void, omedit_install_unload_flush, (), {
+  const flush = () => { try { Module._omedit_persist_flush(); } catch (e) {} };
+  addEventListener("pagehide", flush);
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") flush();
+  });
+});
+
+void PersistentStorage::startAutoSnapshot()
+{
+  static QTimer *pollTimer = nullptr;
+  if (pollTimer) {
+    return;
+  }
+  static QByteArray lastFingerprint = treeFingerprint();
+  pollTimer = new QTimer();
+  QObject::connect(pollTimer, &QTimer::timeout, []() {
+    const QByteArray fingerprint = treeFingerprint();
+    if (fingerprint != lastFingerprint) {
+      lastFingerprint = fingerprint;
+      PersistentStorage::scheduleSnapshot();
+    }
+  });
+  pollTimer->start(5000);
+  QObject::connect(qApp, &QCoreApplication::aboutToQuit, []() { PersistentStorage::snapshotNow(); });
+  // A tab is usually closed without aboutToQuit ever arriving.
+  omedit_install_unload_flush();
+}
+
+QByteArray PersistentStorage::secret(const QString &key)
+{
+  return gSecrets.value(key);
+}
+
+bool PersistentStorage::setSecret(const QString &key, const QByteArray &value)
+{
+  gSecrets.insert(key, value);
+  omedit_storage_set((QLatin1String(kAuthPrefix) + key).toUtf8().constData(), value.toBase64().constData());
+  return true;
+}
+
+bool PersistentStorage::removeSecret(const QString &key)
+{
+  gSecrets.remove(key);
+  omedit_storage_remove((QLatin1String(kAuthPrefix) + key).toUtf8().constData());
+  return true;
+}
+
+QStringList PersistentStorage::secretKeys()
+{
+  return gSecrets.keys();
+}
+
+#endif // __EMSCRIPTEN__

--- a/OMEdit/OMEditGUI/wasm/worker_vfs_engine.cpp
+++ b/OMEdit/OMEditGUI/wasm/worker_vfs_engine.cpp
@@ -69,6 +69,8 @@
 QByteArray omcWorkerReadFile(const char *path);
 QStringList omcWorkerListDir(const char *path);
 bool omcWorkerWriteFile(const char *path, const QByteArray &data);
+bool omcWorkerRemoveFile(const char *path);
+bool omcWorkerRenameFile(const char *from, const char *to);
 
 // True if the page MEMFS already has the path (then the default engine handles it).
 EM_JS(int, omedit_memfs_exists, (const char *path), {
@@ -157,6 +159,35 @@ public:
     return true;
   }
 
+  // Without these QFile::remove/rename and QDir::rmdir fail on worker-owned paths,
+  // which the cloud sync engine needs to propagate a deletion. rmdir removes the
+  // whole subtree, since a store directory is only its keys.
+  bool remove() override
+  {
+    const bool ok = omcWorkerRemoveFile(mName.toUtf8().constData());
+    if (ok) invalidate();
+    return ok;
+  }
+
+  bool rmdir(const QString &path, bool recurseParents) const override
+  {
+    if (recurseParents) return false;
+    return omcWorkerRemoveFile(path.toUtf8().constData());
+  }
+
+  // The store overwrites on write, so an overwriting rename is the same operation.
+  // QSaveFile's temp-then-rename (how the sync manifest is written) needs it.
+  bool rename(const QString &newName) override { return renameOverwrite(newName); }
+
+  bool renameOverwrite(const QString &newName) override
+  {
+    if (!omcWorkerRenameFile(mName.toUtf8().constData(), newName.toUtf8().constData())) {
+      return false;
+    }
+    setFileName(newName);
+    return true;
+  }
+
   qint64 size() const override { ensureFetched(); return mExists ? mData.size() : 0; }
   qint64 pos() const override { return mPos; }
   bool seek(qint64 p) override
@@ -226,11 +257,17 @@ public:
 
   void setFileName(const QString &file) override
   {
-    mName = file; mFetched = false; mExists = false; mData.clear(); mPos = 0;
-    mDirFetched = false; mDirEntries.clear(); mWriting = false; mDirty = false;
+    mName = file;
+    invalidate();
   }
 
 private:
+  void invalidate()
+  {
+    mFetched = false; mExists = false; mData.clear(); mPos = 0;
+    mDirFetched = false; mDirEntries.clear(); mWriting = false; mDirty = false;
+  }
+
   bool ensureFetched() const
   {
     if (!mFetched) {
@@ -270,6 +307,10 @@ public:
     // Only absolute paths (Qt resources start with ':', relative paths don't start
     // with '/'). If the page MEMFS already has it, let the default engine serve it.
     if (fileName.isEmpty() || fileName.at(0) != QLatin1Char('/')) return nullptr;
+    // Page-local tree: settings, the cloud sync manifests, the session list. These
+    // are the main thread's own and are mirrored to IndexedDB, so they must stay in
+    // MEMFS — the "already exists" test below cannot see a file being created.
+    if (fileName.startsWith(QLatin1String("/persist/"))) return nullptr;
     if (omedit_memfs_exists(fileName.toUtf8().constData())) return nullptr;
     return std::make_unique<WorkerVfsFileEngine>(fileName);
   }

--- a/OMEdit/OMEditLIB/CMakeLists.txt
+++ b/OMEdit/OMEditLIB/CMakeLists.txt
@@ -469,7 +469,10 @@ endif()
 if(MINGW)
   target_link_libraries(OMEditLib PUBLIC binutils::bfd)
   target_link_libraries(OMEditLib PUBLIC zlib)
-  # PersistentStorage.cpp uses CryptProtectData/CryptUnprotectData which live in crypt32.
+endif()
+
+if(WIN32)
+  # PersistentStorage.cpp calls CryptProtectData/CryptUnprotectData.
   target_link_libraries(OMEditLib PUBLIC crypt32)
 endif()
 

--- a/OMEdit/OMEditLIB/CMakeLists.txt
+++ b/OMEdit/OMEditLIB/CMakeLists.txt
@@ -19,6 +19,21 @@ set(CMAKE_AUTOUIC ON)
 
 set(OMEDITLIB_SOURCES Util/Helper.cpp
                       Util/Utilities.cpp
+                      Util/PersistentStorage.cpp
+                      Cloud/CloudTypes.cpp
+                      Cloud/CloudConfig.cpp
+                      Cloud/CloudAccount.cpp
+                      Cloud/CloudProvider.cpp
+                      Cloud/GoogleDriveProvider.cpp
+                      Cloud/OneDriveProvider.cpp
+                      Cloud/CloudManifest.cpp
+                      Cloud/CloudMount.cpp
+                      Cloud/CloudCache.cpp
+                      Cloud/CloudSyncEngine.cpp
+                      Cloud/CloudBrowserDialog.cpp
+                      Cloud/CloudConflictDialog.cpp
+                      Cloud/OAuth2Client.cpp
+                      Cloud/OAuth2RedirectLoopback.cpp
                       Util/StringHandler.cpp
                       Util/OutputPlainTextEdit.cpp
                       Util/DirectoryOrFileSelector.cpp
@@ -153,6 +168,21 @@ set(OMEDITLIB_SOURCES Util/Helper.cpp
                       resource_omedit.qrc)
 
 set(OMEDITLIB_HEADERS Util/Helper.h
+                      Util/PersistentStorage.h
+                      Cloud/CloudTypes.h
+                      Cloud/CloudConfig.h
+                      Cloud/CloudAccount.h
+                      Cloud/CloudProvider.h
+                      Cloud/GoogleDriveProvider.h
+                      Cloud/OneDriveProvider.h
+                      Cloud/CloudManifest.h
+                      Cloud/CloudMount.h
+                      Cloud/CloudCache.h
+                      Cloud/CloudSyncEngine.h
+                      Cloud/CloudBrowserDialog.h
+                      Cloud/CloudConflictDialog.h
+                      Cloud/OAuth2Client.h
+                      Cloud/OAuth2Redirect.h
                       Util/Utilities.h
                       Util/StringHandler.h
                       Util/OutputPlainTextEdit.h

--- a/OMEdit/OMEditLIB/CMakeLists.txt
+++ b/OMEdit/OMEditLIB/CMakeLists.txt
@@ -469,6 +469,8 @@ endif()
 if(MINGW)
   target_link_libraries(OMEditLib PUBLIC binutils::bfd)
   target_link_libraries(OMEditLib PUBLIC zlib)
+  # PersistentStorage.cpp uses CryptProtectData/CryptUnprotectData which live in crypt32.
+  target_link_libraries(OMEditLib PUBLIC crypt32)
 endif()
 
 target_include_directories(OMEditLib PUBLIC ${OMC_SCRIPTING_API_QT_DIR})

--- a/OMEdit/OMEditLIB/Cloud/CloudAccount.cpp
+++ b/OMEdit/OMEditLIB/Cloud/CloudAccount.cpp
@@ -1,0 +1,260 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#include "Cloud/CloudAccount.h"
+#include "Cloud/CloudConfig.h"
+#include "Cloud/CloudProvider.h"
+#include "Cloud/GoogleDriveProvider.h"
+#include "Cloud/OAuth2Client.h"
+#include "Cloud/OneDriveProvider.h"
+#include "Util/NetworkAccessManager.h"
+#include "Util/PersistentStorage.h"
+#include "Util/Utilities.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSettings>
+
+namespace {
+
+const char *const kAccountsKey = "cloud/accounts";
+
+CloudProvider *makeProvider(CloudProviderKind kind, OAuth2Client *pOAuth2Client,
+                            QNetworkAccessManager *pNetworkAccessManager, QObject *pParent)
+{
+  switch (kind) {
+    case CloudProviderKind::GoogleDrive:
+      return new GoogleDriveProvider(pOAuth2Client, pNetworkAccessManager, pParent);
+    case CloudProviderKind::OneDrive:
+      return new OneDriveProvider(pOAuth2Client, pNetworkAccessManager, pParent);
+  }
+  return 0;
+}
+
+} // namespace
+
+CloudAccount::CloudAccount(CloudProviderKind kind, const QString &accountId, const QString &displayName,
+                           QNetworkAccessManager *pNetworkAccessManager, QObject *pParent)
+  : QObject(pParent), mKind(kind), mAccountId(accountId), mDisplayName(displayName)
+{
+  mpOAuth2Client = new OAuth2Client(CloudConfig::instance()->oauthConfig(kind), pNetworkAccessManager, this);
+  mpProvider = makeProvider(kind, mpOAuth2Client, pNetworkAccessManager, this);
+  // An account whose identity is not known yet - the candidate a sign-in starts
+  // with - has no key of its own to store anything under, and must not pick up
+  // whatever a previous candidate left behind. Doing so sends it down the silent
+  // refresh path instead of opening the sign-in window, and the retry that
+  // follows a failed refresh happens outside the user gesture, so the browser
+  // blocks the popup and nothing appears at all.
+  if (!mAccountId.isEmpty()) {
+    const QByteArray refreshToken = PersistentStorage::secret(key());
+    if (!refreshToken.isEmpty()) {
+      mpOAuth2Client->setTokens(QString::fromUtf8(refreshToken), QString(), QDateTime());
+    }
+  }
+  // Microsoft rotates the refresh token on every renewal, so it has to be written
+  // back each time or the next session starts with a token the service rejects.
+  connect(mpOAuth2Client, &OAuth2Client::tokensChanged, this, &CloudAccount::saveTokens);
+}
+
+QString CloudAccount::makeKey(CloudProviderKind kind, const QString &accountId)
+{
+  return QStringLiteral("%1:%2").arg(cloudProviderKindToString(kind), accountId);
+}
+
+bool CloudAccount::isSignedIn() const
+{
+  return mpOAuth2Client->isSignedIn();
+}
+
+void CloudAccount::signOut()
+{
+  mpOAuth2Client->signOut();
+  PersistentStorage::removeSecret(key());
+}
+
+void CloudAccount::saveTokens()
+{
+  if (mAccountId.isEmpty()) {
+    return; // nothing to key the secret on yet
+  }
+  const QString refreshToken = mpOAuth2Client->refreshToken();
+  if (refreshToken.isEmpty()) {
+    PersistentStorage::removeSecret(key());
+  } else {
+    PersistentStorage::setSecret(key(), refreshToken.toUtf8());
+  }
+}
+
+CloudAccountManager *CloudAccountManager::instance()
+{
+  static CloudAccountManager manager;
+  return &manager;
+}
+
+void CloudAccountManager::setNetworkAccessManager(QNetworkAccessManager *pNetworkAccessManager)
+{
+  mpNetworkAccessManager = pNetworkAccessManager;
+}
+
+QNetworkAccessManager *CloudAccountManager::networkAccessManager()
+{
+  if (!mpNetworkAccessManager) {
+    mpNetworkAccessManager = new NetworkAccessManager;
+  }
+  return mpNetworkAccessManager;
+}
+
+void CloudAccountManager::load()
+{
+  if (mLoaded) {
+    return;
+  }
+  mLoaded = true;
+  CloudConfig::instance()->ensureLoaded(networkAccessManager());
+  // Clear out anything an earlier build stored against an unidentified account.
+  PersistentStorage::removeSecret(CloudAccount::makeKey(CloudProviderKind::GoogleDrive, QString()));
+  PersistentStorage::removeSecret(CloudAccount::makeKey(CloudProviderKind::OneDrive, QString()));
+  const QJsonArray stored =
+      QJsonDocument::fromJson(Utilities::getApplicationSettings()->value(QLatin1String(kAccountsKey)).toByteArray()).array();
+  for (const QJsonValue &value : stored) {
+    const QJsonObject object = value.toObject();
+    CloudProviderKind kind;
+    if (!cloudProviderKindFromString(object.value(QStringLiteral("kind")).toString(), &kind)) {
+      continue;
+    }
+    mAccounts << new CloudAccount(kind, object.value(QStringLiteral("accountId")).toString(),
+                                  object.value(QStringLiteral("displayName")).toString(), networkAccessManager(), this);
+  }
+}
+
+void CloudAccountManager::save()
+{
+  QJsonArray stored;
+  for (const CloudAccount *pAccount : std::as_const(mAccounts)) {
+    QJsonObject object;
+    object.insert(QStringLiteral("kind"), cloudProviderKindToString(pAccount->kind()));
+    object.insert(QStringLiteral("accountId"), pAccount->accountId());
+    object.insert(QStringLiteral("displayName"), pAccount->displayName());
+    stored.append(object);
+  }
+  Utilities::getApplicationSettings()->setValue(QLatin1String(kAccountsKey),
+                                                QJsonDocument(stored).toJson(QJsonDocument::Compact));
+  PersistentStorage::scheduleSnapshot();
+  emit accountsChanged();
+}
+
+QList<CloudAccount *> CloudAccountManager::accounts()
+{
+  load();
+  return mAccounts;
+}
+
+CloudAccount *CloudAccountManager::account(const QString &key)
+{
+  load();
+  for (CloudAccount *pAccount : std::as_const(mAccounts)) {
+    if (pAccount->key() == key) {
+      return pAccount;
+    }
+  }
+  return 0;
+}
+
+void CloudAccountManager::addAccount(CloudProviderKind kind)
+{
+  load();
+  CloudConfig::instance()->ensureLoaded(networkAccessManager());
+  if (!CloudConfig::instance()->registration(kind).isConfigured()) {
+    emit addAccountFailed(CloudError(CloudError::Provider,
+                                     tr("%1 has not been set up for this installation. Add a client ID on the Cloud "
+                                        "Storage page of the options dialog.")
+                                         .arg(cloudProviderDisplayName(kind))));
+    return;
+  }
+
+  // Who signed in is only known once the service says so, so the account is built
+  // with a placeholder identity and adopted - or merged into the existing one -
+  // when userInfo() answers.
+  CloudAccount *pCandidate = new CloudAccount(kind, QString(), QString(), networkAccessManager(), this);
+  connect(pCandidate->oauth2Client(), &OAuth2Client::phaseChanged, this, &CloudAccountManager::addAccountPhase);
+  CloudReply *pReply = pCandidate->provider()->userInfo();
+  connect(pReply, &CloudReply::finished, this, [this, pReply, pCandidate, kind]() {
+    if (pReply->error().isError()) {
+      pCandidate->deleteLater();
+      emit addAccountFailed(pReply->error());
+      return;
+    }
+    const RemoteItem identity = pReply->item();
+    if (identity.id.isEmpty()) {
+      pCandidate->deleteLater();
+      emit addAccountFailed(CloudError(CloudError::Protocol,
+                                       tr("The service did not say which account signed in.")));
+      return;
+    }
+    const QString refreshToken = pCandidate->oauth2Client()->refreshToken();
+    const QString accessToken = pCandidate->oauth2Client()->accessToken();
+    const QDateTime accessExpiry = pCandidate->oauth2Client()->accessExpiry();
+    pCandidate->deleteLater();
+
+    CloudAccount *pAccount = account(CloudAccount::makeKey(kind, identity.id));
+    if (!pAccount) {
+      pAccount = new CloudAccount(kind, identity.id, identity.name, networkAccessManager(), this);
+      mAccounts << pAccount;
+    }
+    pAccount->setDisplayName(identity.name);
+    // Move the freshly issued tokens onto the account that keeps them, now that
+    // its key - which the secret store is keyed by - is known.
+    pAccount->oauth2Client()->setTokens(refreshToken, accessToken, accessExpiry);
+    pAccount->saveTokens();
+    save();
+    emit accountAdded(pAccount->key());
+  });
+}
+
+void CloudAccountManager::removeAccount(const QString &key)
+{
+  load();
+  for (int i = 0; i < mAccounts.size(); ++i) {
+    if (mAccounts.at(i)->key() != key) {
+      continue;
+    }
+    CloudAccount *pAccount = mAccounts.takeAt(i);
+    pAccount->signOut();
+    pAccount->deleteLater();
+    save();
+    return;
+  }
+}

--- a/OMEdit/OMEditLIB/Cloud/CloudAccount.h
+++ b/OMEdit/OMEditLIB/Cloud/CloudAccount.h
@@ -1,0 +1,128 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifndef CLOUDACCOUNT_H
+#define CLOUDACCOUNT_H
+
+#include "Cloud/CloudTypes.h"
+
+#include <QList>
+#include <QObject>
+#include <QString>
+
+class CloudProvider;
+class OAuth2Client;
+class QNetworkAccessManager;
+
+/*!
+ * \brief One signed-in cloud account and the provider that talks to it.
+ *
+ * The refresh token lives in PersistentStorage's secret store, never the settings
+ * ini - a file users routinely copy between machines.
+ */
+class CloudAccount : public QObject
+{
+  Q_OBJECT
+public:
+  CloudAccount(CloudProviderKind kind, const QString &accountId, const QString &displayName,
+               QNetworkAccessManager *pNetworkAccessManager, QObject *pParent = 0);
+
+  //! Stable across restarts, and the key both the settings and the secret use.
+  static QString makeKey(CloudProviderKind kind, const QString &accountId);
+  QString key() const { return makeKey(mKind, mAccountId); }
+
+  CloudProviderKind kind() const { return mKind; }
+  QString accountId() const { return mAccountId; }
+  QString displayName() const { return mDisplayName; }
+  void setDisplayName(const QString &displayName) { mDisplayName = displayName; }
+
+  CloudProvider *provider() const { return mpProvider; }
+  OAuth2Client *oauth2Client() const { return mpOAuth2Client; }
+
+  bool isSignedIn() const;
+  void signOut();
+
+public slots:
+  //! Write the current refresh token to the secret store.
+  void saveTokens();
+
+private:
+  CloudProviderKind mKind;
+  QString mAccountId;
+  QString mDisplayName;
+  OAuth2Client *mpOAuth2Client;
+  CloudProvider *mpProvider;
+};
+
+/*!
+ * \brief The set of accounts the user has added, and adding new ones.
+ */
+class CloudAccountManager : public QObject
+{
+  Q_OBJECT
+public:
+  static CloudAccountManager *instance();
+
+  //! Overrides the manager used for every cloud request; for tests. Left alone,
+  //! OMEdit's own is used, so desktop proxy authentication keeps working.
+  void setNetworkAccessManager(QNetworkAccessManager *pNetworkAccessManager);
+  QNetworkAccessManager *networkAccessManager();
+
+  QList<CloudAccount *> accounts();
+  CloudAccount *account(const QString &key);
+
+  //! Emits accountAdded() once the service says who signed in; signing in twice
+  //! to the same account updates it rather than duplicating it.
+  void addAccount(CloudProviderKind kind);
+  void removeAccount(const QString &key);
+
+signals:
+  void accountsChanged();
+  //! Progress of an in-flight addAccount(), for the options page.
+  void addAccountPhase(const QString &description);
+  void accountAdded(const QString &key);
+  void addAccountFailed(const CloudError &error);
+
+private:
+  CloudAccountManager() = default;
+  void load();
+  void save();
+
+  QNetworkAccessManager *mpNetworkAccessManager = 0;
+  QList<CloudAccount *> mAccounts;
+  bool mLoaded = false;
+};
+
+#endif // CLOUDACCOUNT_H

--- a/OMEdit/OMEditLIB/Cloud/CloudBrowserDialog.cpp
+++ b/OMEdit/OMEditLIB/Cloud/CloudBrowserDialog.cpp
@@ -1,0 +1,284 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#include "Cloud/CloudBrowserDialog.h"
+#include "Cloud/CloudAccount.h"
+#include "Cloud/CloudProvider.h"
+#include "Util/Helper.h"
+
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QPushButton>
+#include <QTreeWidget>
+#include <QInputDialog>
+#include <QMenu>
+#include <QVBoxLayout>
+
+namespace {
+
+// Marks a folder whose children have not been listed yet.
+const int kFolderIdRole = Qt::UserRole;
+const int kLoadedRole = Qt::UserRole + 1;
+const int kIsFolderRole = Qt::UserRole + 2;
+
+} // namespace
+
+CloudBrowserDialog::CloudBrowserDialog(Mode mode, QWidget *pParent)
+  : QDialog(pParent), mMode(mode)
+{
+  setWindowTitle(mode == OpenFolder ? tr("%1 - Open from Cloud Storage").arg(Helper::applicationName)
+                                    : tr("%1 - Save to Cloud Storage").arg(Helper::applicationName));
+  setMinimumSize(520, 420);
+
+  mpAccountComboBox = new QComboBox;
+  const QList<CloudAccount *> accounts = CloudAccountManager::instance()->accounts();
+  for (CloudAccount *pAccount : accounts) {
+    mpAccountComboBox->addItem(QString("%1 - %2").arg(cloudProviderDisplayName(pAccount->kind()),
+                                                      pAccount->displayName()),
+                               pAccount->key());
+  }
+  connect(mpAccountComboBox, SIGNAL(currentIndexChanged(int)), SLOT(accountChanged()));
+
+  mpTreeWidget = new QTreeWidget;
+  mpTreeWidget->setHeaderLabels(QStringList() << tr("Folder"));
+  mpTreeWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+  // A new folder is made on demand from here, rather than every save being forced
+  // to invent one.
+  mpTreeWidget->setContextMenuPolicy(Qt::CustomContextMenu);
+  connect(mpTreeWidget, SIGNAL(customContextMenuRequested(QPoint)), SLOT(showContextMenu(QPoint)));
+  connect(mpTreeWidget, SIGNAL(itemExpanded(QTreeWidgetItem*)), SLOT(itemExpanded(QTreeWidgetItem*)));
+  connect(mpTreeWidget, SIGNAL(itemSelectionChanged()), SLOT(selectionChanged()));
+
+  mpStatusLabel = new QLabel;
+  mpStatusLabel->setWordWrap(true);
+
+  mpButtonBox = new QDialogButtonBox(Qt::Horizontal);
+  mpOkButton = new QPushButton(mode == OpenFolder ? tr("Open") : Helper::save);
+  mpOkButton->setEnabled(false);
+  connect(mpOkButton, SIGNAL(clicked()), SLOT(accept()));
+  QPushButton *pCancelButton = new QPushButton(Helper::cancel);
+  connect(pCancelButton, SIGNAL(clicked()), SLOT(reject()));
+  mpButtonBox->addButton(mpOkButton, QDialogButtonBox::ActionRole);
+  mpButtonBox->addButton(pCancelButton, QDialogButtonBox::ActionRole);
+
+  QVBoxLayout *pMainLayout = new QVBoxLayout;
+  pMainLayout->addWidget(new QLabel(tr("Account:")));
+  pMainLayout->addWidget(mpAccountComboBox);
+  pMainLayout->addWidget(new QLabel(mode == OpenFolder
+                                       ? tr("Choose a folder or a file to open:")
+                                       : tr("Choose the folder to save into (right-click for a new folder):")));
+  pMainLayout->addWidget(mpTreeWidget);
+  pMainLayout->addWidget(mpStatusLabel);
+  pMainLayout->addWidget(mpButtonBox);
+  setLayout(pMainLayout);
+
+  if (accounts.isEmpty()) {
+    mpStatusLabel->setText(tr("No cloud accounts yet. Add one on the Cloud Storage page of the options dialog."));
+  } else {
+    loadRoot();
+  }
+}
+
+CloudAccount *CloudBrowserDialog::selectedAccount() const
+{
+  if (mpAccountComboBox->currentIndex() < 0) {
+    return 0;
+  }
+  return CloudAccountManager::instance()->account(mpAccountComboBox->currentData().toString());
+}
+
+void CloudBrowserDialog::setBusy(bool busy, const QString &message)
+{
+  mPendingRequests += busy ? 1 : -1;
+  if (mPendingRequests < 0) {
+    mPendingRequests = 0;
+  }
+  mpStatusLabel->setText(message);
+  mpAccountComboBox->setEnabled(mPendingRequests == 0);
+}
+
+void CloudBrowserDialog::accountChanged()
+{
+  mpTreeWidget->clear();
+  mSelectedFolderId.clear();
+  mSelectedFolderName.clear();
+  selectionChanged();
+  loadRoot();
+}
+
+void CloudBrowserDialog::loadRoot()
+{
+  CloudAccount *pAccount = selectedAccount();
+  if (!pAccount) {
+    return;
+  }
+  setBusy(true, tr("Opening %1...").arg(cloudProviderDisplayName(pAccount->kind())));
+  CloudReply *pReply = pAccount->provider()->appRootFolder();
+  connect(pReply, &CloudReply::finished, this, [this, pReply]() {
+    setBusy(false);
+    if (pReply->error().isError()) {
+      mpStatusLabel->setText(tr("Could not open the cloud folder: %1").arg(pReply->error().message));
+      return;
+    }
+    QTreeWidgetItem *pRoot = new QTreeWidgetItem(mpTreeWidget);
+    pRoot->setText(0, pReply->item().name);
+    pRoot->setData(0, kFolderIdRole, pReply->item().id);
+    pRoot->setData(0, kLoadedRole, false);
+    pRoot->setData(0, kIsFolderRole, true);
+    // A placeholder child makes the item expandable before anything is listed.
+    new QTreeWidgetItem(pRoot);
+    pRoot->setExpanded(true);
+    mpTreeWidget->setCurrentItem(pRoot);
+  });
+}
+
+void CloudBrowserDialog::itemExpanded(QTreeWidgetItem *pItem)
+{
+  if (pItem->data(0, kLoadedRole).toBool()) {
+    return;
+  }
+  listInto(pItem, pItem->data(0, kFolderIdRole).toString());
+}
+
+void CloudBrowserDialog::listInto(QTreeWidgetItem *pItem, const QString &folderId)
+{
+  CloudAccount *pAccount = selectedAccount();
+  if (!pAccount || folderId.isEmpty()) {
+    return;
+  }
+  pItem->setData(0, kLoadedRole, true);
+  setBusy(true, tr("Listing %1...").arg(pItem->text(0)));
+  CloudReply *pReply = pAccount->provider()->listFolder(folderId);
+  connect(pReply, &CloudReply::finished, this, [this, pReply, pItem]() {
+    setBusy(false);
+    if (pReply->error().isError()) {
+      pItem->setData(0, kLoadedRole, false);
+      mpStatusLabel->setText(tr("Could not list the folder: %1").arg(pReply->error().message));
+      return;
+    }
+    // Drop the placeholder now that the real children are known.
+    qDeleteAll(pItem->takeChildren());
+    // Files are shown as well as folders: hiding them made a file that had just
+    // been saved look as though it were not there.
+    const QList<RemoteItem> items = pReply->items();
+    for (const RemoteItem &item : items) {
+      QTreeWidgetItem *pChild = new QTreeWidgetItem(pItem);
+      pChild->setText(0, item.name);
+      pChild->setData(0, kFolderIdRole, item.id);
+      pChild->setData(0, kIsFolderRole, item.isFolder);
+      pChild->setData(0, kLoadedRole, !item.isFolder);
+      if (item.isFolder) {
+        new QTreeWidgetItem(pChild);
+      }
+    }
+  });
+}
+
+void CloudBrowserDialog::selectionChanged()
+{
+  QTreeWidgetItem *pItem = mpTreeWidget->currentItem();
+  mSelectedFolderId.clear();
+  mSelectedFolderName.clear();
+  mSelectedFileName.clear();
+  if (!pItem) {
+    mpOkButton->setEnabled(false);
+    return;
+  }
+  const bool isFolder = pItem->data(0, kIsFolderRole).toBool();
+  if (isFolder) {
+    mSelectedFolderId = pItem->data(0, kFolderIdRole).toString();
+    mSelectedFolderName = pItem->text(0);
+  } else if (pItem->parent()) {
+    // A file is opened by mounting the folder that holds it.
+    mSelectedFolderId = pItem->parent()->data(0, kFolderIdRole).toString();
+    mSelectedFolderName = pItem->parent()->text(0);
+    mSelectedFileName = pItem->text(0);
+  }
+  // Saving needs somewhere to put things, so only a folder will do there.
+  const bool usable = !mSelectedFolderId.isEmpty() && (mMode == OpenFolder || mSelectedFileName.isEmpty());
+  mpOkButton->setEnabled(usable);
+}
+
+void CloudBrowserDialog::showContextMenu(const QPoint &position)
+{
+  if (!mpTreeWidget->itemAt(position)) {
+    return;
+  }
+  QMenu menu(this);
+  QAction *pNewFolderAction = menu.addAction(tr("New Folder..."));
+  connect(pNewFolderAction, SIGNAL(triggered()), SLOT(createFolder()));
+  menu.exec(mpTreeWidget->viewport()->mapToGlobal(position));
+}
+
+void CloudBrowserDialog::createFolder()
+{
+  QTreeWidgetItem *pParent = mpTreeWidget->currentItem();
+  CloudAccount *pAccount = selectedAccount();
+  if (!pParent || !pAccount) {
+    return;
+  }
+  const QString parentId = pParent->data(0, kFolderIdRole).toString();
+
+  // open(), not getText(): a modal exec() here would park the main thread and the
+  // reply to the create request would never be delivered. See MainWindow::openFromCloud.
+  QInputDialog *pPrompt = new QInputDialog(this);
+  pPrompt->setAttribute(Qt::WA_DeleteOnClose);
+  pPrompt->setWindowTitle(tr("New Folder"));
+  pPrompt->setLabelText(tr("Folder name:"));
+  pPrompt->setInputMode(QInputDialog::TextInput);
+  connect(pPrompt, &QInputDialog::textValueSelected, this, [this, pAccount, parentId, pParent](const QString &name) {
+    const QString trimmed = name.trimmed();
+    if (trimmed.isEmpty()) {
+      return;
+    }
+    setBusy(true, tr("Creating %1...").arg(trimmed));
+    CloudReply *pReply = pAccount->provider()->createFolder(parentId, trimmed);
+    connect(pReply, &CloudReply::finished, this, [this, pReply, pParent]() {
+      setBusy(false);
+      if (pReply->error().isError()) {
+        mpStatusLabel->setText(tr("Could not create the folder: %1").arg(pReply->error().message));
+        return;
+      }
+      QTreeWidgetItem *pChild = new QTreeWidgetItem(pParent);
+      pChild->setText(0, pReply->item().name);
+      pChild->setData(0, kFolderIdRole, pReply->item().id);
+      pChild->setData(0, kLoadedRole, true);
+      pParent->setExpanded(true);
+      mpTreeWidget->setCurrentItem(pChild);
+    });
+  });
+  pPrompt->open();
+}

--- a/OMEdit/OMEditLIB/Cloud/CloudBrowserDialog.h
+++ b/OMEdit/OMEditLIB/Cloud/CloudBrowserDialog.h
@@ -1,0 +1,103 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifndef CLOUDBROWSERDIALOG_H
+#define CLOUDBROWSERDIALOG_H
+
+#include "Cloud/CloudTypes.h"
+
+#include <QDialog>
+#include <QString>
+
+class CloudAccount;
+class QComboBox;
+class QDialogButtonBox;
+class QLabel;
+class QPushButton;
+class QTreeWidget;
+class QTreeWidgetItem;
+
+/*!
+ * \brief Browse the folders of a cloud account and pick one.
+ *
+ * The tree starts at the application's own folder, which under drive.file is all
+ * OMEdit can see. Children are listed when a folder is first expanded.
+ */
+class CloudBrowserDialog : public QDialog
+{
+  Q_OBJECT
+public:
+  enum Mode {
+    //! Pick an existing folder to open as a package.
+    OpenFolder,
+    //! Pick the folder to save into. A new one can be made from the context menu,
+    //! rather than being forced on every save.
+    SaveFolder
+  };
+
+  CloudBrowserDialog(Mode mode, QWidget *pParent = 0);
+
+  CloudAccount *selectedAccount() const;
+  //! The folder to mount: the selection itself, or its parent when a file is picked.
+  QString selectedFolderId() const { return mSelectedFolderId; }
+  QString selectedFolderName() const { return mSelectedFolderName; }
+  //! Set when a file is selected rather than a folder, so it can be opened directly.
+  QString selectedFileName() const { return mSelectedFileName; }
+
+private slots:
+  void accountChanged();
+  void itemExpanded(QTreeWidgetItem *pItem);
+  void selectionChanged();
+  void showContextMenu(const QPoint &position);
+  void createFolder();
+
+private:
+  void loadRoot();
+  void listInto(QTreeWidgetItem *pItem, const QString &folderId);
+  void setBusy(bool busy, const QString &message = QString());
+
+  Mode mMode;
+  QComboBox *mpAccountComboBox;
+  QTreeWidget *mpTreeWidget;
+  QLabel *mpStatusLabel;
+  QDialogButtonBox *mpButtonBox;
+  QPushButton *mpOkButton;
+  QString mSelectedFolderId;
+  QString mSelectedFolderName;
+  QString mSelectedFileName;
+  int mPendingRequests = 0;
+};
+
+#endif // CLOUDBROWSERDIALOG_H

--- a/OMEdit/OMEditLIB/Cloud/CloudCache.cpp
+++ b/OMEdit/OMEditLIB/Cloud/CloudCache.cpp
@@ -1,0 +1,62 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+// Native side: the working copy is a real directory and survives on its own. The
+// web target implements the same functions over IndexedDB in
+// OMEditGUI/wasm/cloud_cache_idb.cpp.
+
+#if !defined(__EMSCRIPTEN__)
+
+#include "Cloud/CloudCache.h"
+
+#include <QTimer>
+
+bool CloudCache::isAvailable()
+{
+  return false;
+}
+
+void CloudCache::save(const CloudMount &) {}
+
+void CloudCache::restore(const CloudMount &, const std::function<void(int)> &done)
+{
+  if (done) {
+    QTimer::singleShot(0, [done]() { done(0); });
+  }
+}
+
+void CloudCache::forget(const CloudMount &) {}
+
+#endif // !__EMSCRIPTEN__

--- a/OMEdit/OMEditLIB/Cloud/CloudCache.h
+++ b/OMEdit/OMEditLIB/Cloud/CloudCache.h
@@ -1,0 +1,66 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifndef CLOUDCACHE_H
+#define CLOUDCACHE_H
+
+#include "Cloud/CloudMount.h"
+
+#include <functional>
+
+/*!
+ * \brief Keeps a mount's working copy across a restart of the application.
+ *
+ * A no-op natively, where the working copy is a real directory. In the browser it
+ * is in memory, so without this every reload re-downloads the package. IndexedDB
+ * rather than PersistentStorage's localStorage: package contents are far larger,
+ * and nothing here runs during startup, so waiting for the database is fine.
+ */
+namespace CloudCache
+{
+  bool isAvailable();
+
+  //! Mirror the working copy. Cheap enough to call after every save.
+  void save(const CloudMount &mount);
+
+  //! Puts the cache back and reports how many files arrived. done() is always
+  //! invoked from the event loop, never inside the caller's frame.
+  void restore(const CloudMount &mount, const std::function<void(int)> &done);
+
+  //! Forget a mount's contents; for an unmount.
+  void forget(const CloudMount &mount);
+}
+
+#endif // CLOUDCACHE_H

--- a/OMEdit/OMEditLIB/Cloud/CloudConfig.cpp
+++ b/OMEdit/OMEditLIB/Cloud/CloudConfig.cpp
@@ -1,0 +1,234 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#include "Cloud/CloudConfig.h"
+#include "Util/PersistentStorage.h"
+#include "Util/Utilities.h"
+
+#include <QEventLoop>
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QSettings>
+#include <QTimer>
+
+#if defined(__EMSCRIPTEN__)
+#include <emscripten.h>
+#include <emscripten/em_js.h>
+#include <cstdlib>
+
+// Resolved against the page, not the origin root: the file is staged beside the
+// application so that a versioned deployment carries the configuration it was
+// built with, and a relative QUrl has no scheme for QNetworkAccessManager to use.
+EM_JS(char *, omedit_cloud_config_url, (), {
+  try {
+    return stringToNewUTF8(new URL("cloud_config.json", location.href).href);
+  } catch (e) {
+    return stringToNewUTF8("");
+  }
+});
+
+// Synchronous on purpose. A nested QEventLoop waiting on a QNetworkReply is the
+// one thing that must not happen on this thread - it swallows other replies and
+// can unwind Asyncify from under a callback - whereas a synchronous XHR simply
+// blocks, involving neither. The file is a few hundred bytes from our own origin.
+EM_JS(char *, omedit_fetch_text_sync, (const char *url), {
+  try {
+    const request = new XMLHttpRequest();
+    request.open("GET", UTF8ToString(url), false);
+    request.send();
+    if (request.status >= 200 && request.status < 300) {
+      return stringToNewUTF8(request.responseText);
+    }
+  } catch (e) {
+    console.warn("[OMEdit] could not read cloud_config.json", e);
+  }
+  return stringToNewUTF8("");
+});
+#endif
+
+namespace {
+
+const char *const kConfigFileName = "cloud_config.json";
+
+// Endpoints are part of the protocol, not of a deployment, so they are the one
+// thing here that is compiled in.
+struct ProviderEndpoints
+{
+  const char *authorizationUrl;
+  const char *tokenUrl;
+  const char *scope;
+  const char *extraAuthorizationParameters; // comma separated
+};
+
+const ProviderEndpoints kGoogle = {
+  "https://accounts.google.com/o/oauth2/v2/auth",
+  "https://oauth2.googleapis.com/token",
+  // drive.file keeps this a non-sensitive scope: no Google app verification, and
+  // the application only ever sees what it created or the user handed it.
+  "https://www.googleapis.com/auth/drive.file",
+  // access_type=offline is what makes Google return a refresh token at all, and
+  // it only returns one on a consent screen the user actually saw.
+  "access_type=offline,prompt=consent,include_granted_scopes=true"
+};
+
+const ProviderEndpoints kMicrosoft = {
+  "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+  "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+  "offline_access User.Read Files.ReadWrite",
+  ""
+};
+
+const ProviderEndpoints &endpoints(CloudProviderKind kind)
+{
+  return kind == CloudProviderKind::GoogleDrive ? kGoogle : kMicrosoft;
+}
+
+int providerIndex(CloudProviderKind kind)
+{
+  return kind == CloudProviderKind::GoogleDrive ? 0 : 1;
+}
+
+CloudClientRegistration registrationFromJson(const QJsonObject &object)
+{
+  CloudClientRegistration registration;
+  registration.clientId = object.value(QStringLiteral("clientId")).toString();
+  registration.clientSecret = object.value(QStringLiteral("clientSecret")).toString();
+  registration.fullDriveScope = object.value(QStringLiteral("fullDriveScope")).toBool(false);
+  registration.redirectUri = object.value(QStringLiteral("redirectUri")).toString();
+  return registration;
+}
+
+} // namespace
+
+CloudConfig *CloudConfig::instance()
+{
+  static CloudConfig config;
+  return &config;
+}
+
+QString CloudConfig::settingsKey(CloudProviderKind kind, const QString &field)
+{
+  return QStringLiteral("cloud/%1/%2").arg(cloudProviderKindToString(kind), field);
+}
+
+void CloudConfig::ensureLoaded(QNetworkAccessManager *pNetworkAccessManager)
+{
+  if (mLoaded) {
+    return;
+  }
+  mLoaded = true;
+
+  QByteArray contents;
+#if defined(__EMSCRIPTEN__)
+  // Served next to the application, so a relative URL reaches it wherever the
+  // deployment is rooted.
+  Q_UNUSED(pNetworkAccessManager)
+  char *rawUrl = omedit_cloud_config_url();
+  const QString configUrl = QString::fromUtf8(rawUrl);
+  free(rawUrl);
+  if (!configUrl.isEmpty()) {
+    char *rawContents = omedit_fetch_text_sync(configUrl.toUtf8().constData());
+    contents = QByteArray(rawContents);
+    free(rawContents);
+  }
+#else
+  Q_UNUSED(pNetworkAccessManager)
+  QFile file(PersistentStorage::root() + QLatin1Char('/') + QLatin1String(kConfigFileName));
+  if (file.open(QIODevice::ReadOnly)) {
+    contents = file.readAll();
+  }
+#endif
+  if (contents.isEmpty()) {
+    return;
+  }
+  const QJsonObject root = QJsonDocument::fromJson(contents).object();
+  mDeploymentRegistrations[providerIndex(CloudProviderKind::GoogleDrive)] =
+      registrationFromJson(root.value(QStringLiteral("googledrive")).toObject());
+  mDeploymentRegistrations[providerIndex(CloudProviderKind::OneDrive)] =
+      registrationFromJson(root.value(QStringLiteral("onedrive")).toObject());
+}
+
+CloudClientRegistration CloudConfig::registration(CloudProviderKind kind) const
+{
+  QSettings *pSettings = Utilities::getApplicationSettings();
+  CloudClientRegistration registration = mDeploymentRegistrations[providerIndex(kind)];
+  const QString clientId = pSettings->value(settingsKey(kind, QStringLiteral("clientId"))).toString();
+  if (!clientId.isEmpty()) {
+    registration.clientId = clientId;
+    // A user-supplied id comes with its own secret, or none; the deployment's
+    // secret belongs to a different application and must not be paired with it.
+    registration.clientSecret = pSettings->value(settingsKey(kind, QStringLiteral("clientSecret"))).toString();
+    registration.redirectUri = pSettings->value(settingsKey(kind, QStringLiteral("redirectUri"))).toString();
+  }
+  if (pSettings->contains(settingsKey(kind, QStringLiteral("fullDriveScope")))) {
+    registration.fullDriveScope = pSettings->value(settingsKey(kind, QStringLiteral("fullDriveScope"))).toBool();
+  }
+  return registration;
+}
+
+void CloudConfig::setRegistration(CloudProviderKind kind, const CloudClientRegistration &registration)
+{
+  QSettings *pSettings = Utilities::getApplicationSettings();
+  pSettings->setValue(settingsKey(kind, QStringLiteral("clientId")), registration.clientId);
+  pSettings->setValue(settingsKey(kind, QStringLiteral("clientSecret")), registration.clientSecret);
+  pSettings->setValue(settingsKey(kind, QStringLiteral("fullDriveScope")), registration.fullDriveScope);
+  pSettings->setValue(settingsKey(kind, QStringLiteral("redirectUri")), registration.redirectUri);
+}
+
+OAuth2Config CloudConfig::oauthConfig(CloudProviderKind kind) const
+{
+  const ProviderEndpoints &provider = endpoints(kind);
+  const CloudClientRegistration client = registration(kind);
+
+  OAuth2Config config;
+  config.authorizationUrl = QLatin1String(provider.authorizationUrl);
+  config.tokenUrl = QLatin1String(provider.tokenUrl);
+  config.clientId = client.clientId;
+  config.clientSecret = client.clientSecret;
+  config.redirectUri = client.redirectUri;
+  config.scope = QLatin1String(provider.scope);
+  if (kind == CloudProviderKind::GoogleDrive && client.fullDriveScope) {
+    config.scope = QStringLiteral("https://www.googleapis.com/auth/drive");
+  }
+  const QString extra = QLatin1String(provider.extraAuthorizationParameters);
+  if (!extra.isEmpty()) {
+    config.extraAuthorizationParameters = extra.split(QLatin1Char(','), Qt::SkipEmptyParts);
+  }
+  return config;
+}

--- a/OMEdit/OMEditLIB/Cloud/CloudConfig.h
+++ b/OMEdit/OMEditLIB/Cloud/CloudConfig.h
@@ -1,0 +1,92 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifndef CLOUDCONFIG_H
+#define CLOUDCONFIG_H
+
+#include "Cloud/CloudTypes.h"
+#include "Cloud/OAuth2Client.h"
+
+#include <QString>
+
+class QNetworkAccessManager;
+
+//! What a deployment has to supply for one service before it can be used.
+struct CloudClientRegistration
+{
+  QString clientId;
+  //! Google rejects a PKCE exchange without one even for a public client, so it
+  //! is deployment configuration and not confidential. Microsoft needs none.
+  QString clientSecret;
+  //! Full Drive access instead of drive.file, for a deployment that registered
+  //! and verified its own client with Google. Ignored for OneDrive.
+  bool fullDriveScope = false;
+  //! Overrides the default /oauth-callback.html at the origin root, which is one
+  //! registered URI for every versioned path under it (no wildcards are allowed).
+  QString redirectUri;
+
+  bool isConfigured() const { return !clientId.isEmpty(); }
+};
+
+/*!
+ * \brief Which OAuth applications this installation talks to.
+ *
+ * Never compiled in: a client id identifies the deployment. Settings first, then
+ * cloud_config.json, then nothing - which reports itself as not set up.
+ */
+class CloudConfig
+{
+public:
+  static CloudConfig *instance();
+
+  //! Called from user-initiated actions, never during startup: on the web target
+  //! the first call blocks briefly while cloud_config.json is fetched.
+  void ensureLoaded(QNetworkAccessManager *pNetworkAccessManager);
+
+  CloudClientRegistration registration(CloudProviderKind kind) const;
+  void setRegistration(CloudProviderKind kind, const CloudClientRegistration &registration);
+
+  //! Endpoints, scopes and the registration, ready for OAuth2Client.
+  OAuth2Config oauthConfig(CloudProviderKind kind) const;
+
+private:
+  CloudConfig() = default;
+  static QString settingsKey(CloudProviderKind kind, const QString &field);
+
+  CloudClientRegistration mDeploymentRegistrations[2];
+  bool mLoaded = false;
+};
+
+#endif // CLOUDCONFIG_H

--- a/OMEdit/OMEditLIB/Cloud/CloudConflictDialog.cpp
+++ b/OMEdit/OMEditLIB/Cloud/CloudConflictDialog.cpp
@@ -1,0 +1,156 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#include "Cloud/CloudConflictDialog.h"
+#include "Cloud/CloudSyncEngine.h"
+#include "Util/Helper.h"
+
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QHeaderView>
+#include <QLabel>
+#include <QPushButton>
+#include <QTreeWidget>
+#include <QVBoxLayout>
+
+namespace {
+
+QString describe(SyncAction::ConflictKind kind)
+{
+  switch (kind) {
+    case SyncAction::BothChanged:
+      return CloudConflictDialog::tr("Changed here and in the cloud");
+    case SyncAction::BothCreated:
+      return CloudConflictDialog::tr("Created here and in the cloud");
+    case SyncAction::LocalDeletedRemoteChanged:
+      return CloudConflictDialog::tr("Deleted here, changed in the cloud");
+    case SyncAction::LocalChangedRemoteDeleted:
+      return CloudConflictDialog::tr("Changed here, deleted in the cloud");
+    case SyncAction::NoConflict:
+      break;
+  }
+  return QString();
+}
+
+void fillChoices(QComboBox *pComboBox, SyncAction::ConflictKind kind)
+{
+  const bool localGone = kind == SyncAction::LocalDeletedRemoteChanged;
+  const bool remoteGone = kind == SyncAction::LocalChangedRemoteDeleted;
+  pComboBox->addItem(localGone ? CloudConflictDialog::tr("Delete it in the cloud too")
+                               : CloudConflictDialog::tr("Keep my version"),
+                     CloudSyncEngine::KeepLocal);
+  pComboBox->addItem(remoteGone ? CloudConflictDialog::tr("Delete my copy too")
+                                : CloudConflictDialog::tr("Take the cloud version"),
+                     CloudSyncEngine::TakeRemote);
+  pComboBox->addItem(CloudConflictDialog::tr("Keep both"), CloudSyncEngine::KeepBoth);
+  pComboBox->setCurrentIndex(pComboBox->findData(CloudSyncEngine::KeepBoth));
+}
+
+} // namespace
+
+CloudConflictDialog::CloudConflictDialog(const QString &remoteName, const QList<SyncAction> &conflicts,
+                                         QWidget *pParent)
+  : QDialog(pParent)
+{
+  setWindowTitle(QString("%1 - %2").arg(Helper::applicationName, tr("Synchronisation Conflicts")));
+  setAttribute(Qt::WA_DeleteOnClose);
+  resize(650, 380);
+
+  QLabel *pHeadingLabel =
+      new QLabel(tr("These files in <b>%1</b> changed both here and in the cloud since the last synchronisation. "
+                    "Keeping both writes the cloud version to the original name and yours beside it.")
+                     .arg(remoteName));
+  pHeadingLabel->setWordWrap(true);
+
+  mpTreeWidget = new QTreeWidget;
+  mpTreeWidget->setColumnCount(3);
+  mpTreeWidget->setHeaderLabels(QStringList() << tr("File") << tr("What happened") << tr("What to do"));
+  mpTreeWidget->setRootIsDecorated(false);
+  mpTreeWidget->header()->setSectionResizeMode(0, QHeaderView::Stretch);
+  for (const SyncAction &conflict : conflicts) {
+    QTreeWidgetItem *pItem = new QTreeWidgetItem(mpTreeWidget);
+    pItem->setText(0, conflict.relativePath);
+    pItem->setText(1, describe(conflict.conflict));
+    QComboBox *pComboBox = new QComboBox;
+    fillChoices(pComboBox, conflict.conflict);
+    mpTreeWidget->setItemWidget(pItem, 2, pComboBox);
+    mChoices.insert(conflict.relativePath, pComboBox);
+  }
+  mpTreeWidget->resizeColumnToContents(1);
+
+  QPushButton *pKeepMineButton = new QPushButton(tr("Keep Mine For All"));
+  connect(pKeepMineButton, &QPushButton::clicked, this, [this]() { applyToAll(CloudSyncEngine::KeepLocal); });
+  QPushButton *pTakeCloudButton = new QPushButton(tr("Take Cloud For All"));
+  connect(pTakeCloudButton, &QPushButton::clicked, this, [this]() { applyToAll(CloudSyncEngine::TakeRemote); });
+  QPushButton *pKeepBothButton = new QPushButton(tr("Keep Both For All"));
+  connect(pKeepBothButton, &QPushButton::clicked, this, [this]() { applyToAll(CloudSyncEngine::KeepBoth); });
+
+  QHBoxLayout *pAllLayout = new QHBoxLayout;
+  pAllLayout->addWidget(pKeepMineButton);
+  pAllLayout->addWidget(pTakeCloudButton);
+  pAllLayout->addWidget(pKeepBothButton);
+  pAllLayout->addStretch();
+
+  mpButtonBox = new QDialogButtonBox(QDialogButtonBox::Cancel);
+  mpButtonBox->addButton(tr("Synchronise"), QDialogButtonBox::AcceptRole);
+  connect(mpButtonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+  connect(mpButtonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+  QVBoxLayout *pMainLayout = new QVBoxLayout;
+  pMainLayout->addWidget(pHeadingLabel);
+  pMainLayout->addWidget(mpTreeWidget);
+  pMainLayout->addLayout(pAllLayout);
+  pMainLayout->addWidget(mpButtonBox);
+  setLayout(pMainLayout);
+}
+
+void CloudConflictDialog::applyToAll(int resolution)
+{
+  for (QComboBox *pComboBox : std::as_const(mChoices)) {
+    const int index = pComboBox->findData(resolution);
+    if (index >= 0) {
+      pComboBox->setCurrentIndex(index);
+    }
+  }
+}
+
+QHash<QString, int> CloudConflictDialog::resolutions() const
+{
+  QHash<QString, int> chosen;
+  for (auto it = mChoices.constBegin(); it != mChoices.constEnd(); ++it) {
+    chosen.insert(it.key(), it.value()->currentData().toInt());
+  }
+  return chosen;
+}

--- a/OMEdit/OMEditLIB/Cloud/CloudConflictDialog.h
+++ b/OMEdit/OMEditLIB/Cloud/CloudConflictDialog.h
@@ -1,0 +1,75 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifndef CLOUDCONFLICTDIALOG_H
+#define CLOUDCONFLICTDIALOG_H
+
+#include "Cloud/CloudManifest.h"
+
+#include <QDialog>
+#include <QHash>
+#include <QList>
+#include <QString>
+
+class QComboBox;
+class QDialogButtonBox;
+class QTreeWidget;
+
+/*!
+ * \brief Asks what to do with each file that changed on both sides.
+ *
+ * Three-way: the sync engine has already established that the local copy and the
+ * remote one both moved away from the last synced state, so there is no answer
+ * that is right by construction and the user picks per file. Keeping both is the
+ * default because it is the only choice that discards nothing.
+ */
+class CloudConflictDialog : public QDialog
+{
+  Q_OBJECT
+public:
+  CloudConflictDialog(const QString &remoteName, const QList<SyncAction> &conflicts, QWidget *pParent = 0);
+
+  //! Relative path to a CloudSyncEngine::Resolution.
+  QHash<QString, int> resolutions() const;
+
+private:
+  void applyToAll(int resolution);
+
+  QTreeWidget *mpTreeWidget;
+  QDialogButtonBox *mpButtonBox;
+  QHash<QString, QComboBox *> mChoices;
+};
+
+#endif // CLOUDCONFLICTDIALOG_H

--- a/OMEdit/OMEditLIB/Cloud/CloudManifest.cpp
+++ b/OMEdit/OMEditLIB/Cloud/CloudManifest.cpp
@@ -1,0 +1,428 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#include "Cloud/CloudManifest.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSaveFile>
+#include <QSet>
+
+namespace {
+
+const int kManifestVersion = 1;
+
+// A sync that removes this much of a package is worth a second look: either the
+// user really did reorganise it, or the working copy is not what we think it is.
+const int kDeletionCountThreshold = 5;
+const double kDeletionFractionThreshold = 0.25;
+
+ManifestEntry entryFromJson(const QJsonObject &object)
+{
+  ManifestEntry entry;
+  entry.relativePath = object.value(QStringLiteral("path")).toString();
+  entry.remoteId = object.value(QStringLiteral("id")).toString();
+  entry.remoteRevision = object.value(QStringLiteral("revision")).toString();
+  entry.contentHash = QByteArray::fromHex(object.value(QStringLiteral("sha256")).toString().toLatin1());
+  entry.size = qint64(object.value(QStringLiteral("size")).toDouble(0));
+  entry.isFolder = object.value(QStringLiteral("folder")).toBool(false);
+  return entry;
+}
+
+QJsonObject entryToJson(const ManifestEntry &entry)
+{
+  QJsonObject object;
+  object.insert(QStringLiteral("path"), entry.relativePath);
+  object.insert(QStringLiteral("id"), entry.remoteId);
+  object.insert(QStringLiteral("revision"), entry.remoteRevision);
+  object.insert(QStringLiteral("sha256"), QString::fromLatin1(entry.contentHash.toHex()));
+  object.insert(QStringLiteral("size"), entry.size);
+  object.insert(QStringLiteral("folder"), entry.isFolder);
+  return object;
+}
+
+//! True if any path in the set lies under dir.
+bool hasDescendant(const QString &dir, const QList<QString> &paths)
+{
+  const QString prefix = dir + QLatin1Char('/');
+  for (const QString &path : paths) {
+    if (path.startsWith(prefix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace
+
+int SyncPlan::count(SyncAction::Kind kind) const
+{
+  int total = 0;
+  for (const SyncAction &action : actions) {
+    if (action.kind == kind) {
+      ++total;
+    }
+  }
+  return total;
+}
+
+bool SyncPlan::hasConflicts() const
+{
+  return count(SyncAction::Conflict) > 0;
+}
+
+QList<SyncAction> SyncPlan::conflicts() const
+{
+  QList<SyncAction> result;
+  for (const SyncAction &action : actions) {
+    if (action.kind == SyncAction::Conflict) {
+      result << action;
+    }
+  }
+  return result;
+}
+
+bool SyncPlan::needsDeletionConfirmation(int manifestFileCount) const
+{
+  const int deletions = count(SyncAction::DeleteRemote);
+  if (deletions == 0) {
+    return false;
+  }
+  return deletions > kDeletionCountThreshold
+         || (manifestFileCount > 0 && double(deletions) / double(manifestFileCount) > kDeletionFractionThreshold);
+}
+
+int CloudManifest::fileCount() const
+{
+  int total = 0;
+  for (const ManifestEntry &entry : entries) {
+    if (!entry.isFolder) {
+      ++total;
+    }
+  }
+  return total;
+}
+
+bool CloudManifest::load(const QString &path)
+{
+  QFile file(path);
+  if (!file.open(QIODevice::ReadOnly)) {
+    return false;
+  }
+  const QJsonObject root = QJsonDocument::fromJson(file.readAll()).object();
+  if (root.value(QStringLiteral("version")).toInt() != kManifestVersion) {
+    return false;
+  }
+  remoteRootId = root.value(QStringLiteral("remoteRootId")).toString();
+  deltaToken = root.value(QStringLiteral("deltaToken")).toString();
+  // Deliberately not read back: the manifest persists in browser storage while
+  // the working copy does not, so a stored "complete" would license deleting
+  // every file in the remote folder. It is earned again each run.
+  workingCopyComplete = false;
+  entries.clear();
+  const QJsonArray stored = root.value(QStringLiteral("entries")).toArray();
+  for (const QJsonValue &value : stored) {
+    const ManifestEntry entry = entryFromJson(value.toObject());
+    if (!entry.relativePath.isEmpty()) {
+      entries.insert(entry.relativePath, entry);
+    }
+  }
+  return true;
+}
+
+bool CloudManifest::save(const QString &path) const
+{
+  QJsonArray stored;
+  for (const ManifestEntry &entry : entries) {
+    stored.append(entryToJson(entry));
+  }
+  QJsonObject root;
+  root.insert(QStringLiteral("version"), kManifestVersion);
+  root.insert(QStringLiteral("remoteRootId"), remoteRootId);
+  root.insert(QStringLiteral("deltaToken"), deltaToken);
+  root.insert(QStringLiteral("workingCopyComplete"), workingCopyComplete);
+  root.insert(QStringLiteral("entries"), stored);
+
+  QDir().mkpath(QFileInfo(path).absolutePath());
+  QSaveFile file(path);
+  if (!file.open(QIODevice::WriteOnly)) {
+    return false;
+  }
+  file.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
+  return file.commit();
+}
+
+bool isUsableLocalName(const QString &name, QString *reason)
+{
+  if (name.isEmpty()) {
+    *reason = QStringLiteral("the name is empty");
+    return false;
+  }
+  if (name == QLatin1String(".") || name == QLatin1String("..")) {
+    *reason = QStringLiteral("the name is a directory reference");
+    return false;
+  }
+  if (name.contains(QLatin1Char('/')) || name.contains(QLatin1Char('\\'))) {
+    *reason = QStringLiteral("the name contains a path separator");
+    return false;
+  }
+#if defined(Q_OS_WIN)
+  // Reserved on Windows however the file is opened, and a trailing dot or space
+  // is silently dropped by the filesystem, which would break the round trip.
+  static const QStringList reserved = QStringList()
+      << QStringLiteral("CON") << QStringLiteral("PRN") << QStringLiteral("AUX") << QStringLiteral("NUL")
+      << QStringLiteral("COM1") << QStringLiteral("COM2") << QStringLiteral("COM3") << QStringLiteral("COM4")
+      << QStringLiteral("COM5") << QStringLiteral("COM6") << QStringLiteral("COM7") << QStringLiteral("COM8")
+      << QStringLiteral("COM9") << QStringLiteral("LPT1") << QStringLiteral("LPT2") << QStringLiteral("LPT3")
+      << QStringLiteral("LPT4") << QStringLiteral("LPT5") << QStringLiteral("LPT6") << QStringLiteral("LPT7")
+      << QStringLiteral("LPT8") << QStringLiteral("LPT9");
+  const QString stem = name.section(QLatin1Char('.'), 0, 0).toUpper();
+  if (reserved.contains(stem)) {
+    *reason = QStringLiteral("the name is reserved by Windows");
+    return false;
+  }
+  if (name.endsWith(QLatin1Char('.')) || name.endsWith(QLatin1Char(' '))) {
+    *reason = QStringLiteral("the name ends with a dot or a space");
+    return false;
+  }
+  static const QString illegal = QStringLiteral("<>:\"|?*");
+  for (const QChar &character : name) {
+    if (illegal.contains(character) || character.unicode() < 32) {
+      *reason = QStringLiteral("the name contains a character Windows does not allow in a file name");
+      return false;
+    }
+  }
+#else
+  for (const QChar &character : name) {
+    if (character.unicode() == 0) {
+      *reason = QStringLiteral("the name contains a null character");
+      return false;
+    }
+  }
+#endif
+  return true;
+}
+
+SyncPlan planSync(const CloudManifest &manifest, const QMap<QString, LocalEntry> &local,
+                  const QMap<QString, RemoteEntry> &remote)
+{
+  SyncPlan plan;
+
+  QSet<QString> paths;
+  for (auto it = manifest.entries.constBegin(); it != manifest.entries.constEnd(); ++it) {
+    paths.insert(it.key());
+  }
+  for (auto it = local.constBegin(); it != local.constEnd(); ++it) {
+    paths.insert(it.key());
+  }
+  for (auto it = remote.constBegin(); it != remote.constEnd(); ++it) {
+    paths.insert(it.key());
+  }
+
+  // Sorted so a parent folder is always acted on before its children, and so the
+  // plan reads in an order a person can follow.
+  QList<QString> sorted = paths.values();
+  std::sort(sorted.begin(), sorted.end());
+
+  QList<QString> remotePaths = remote.keys();
+  QList<QString> deletedRemotePaths;
+
+  for (const QString &path : std::as_const(sorted)) {
+    const bool inManifest = manifest.entries.contains(path);
+    const bool inLocal = local.contains(path);
+    const bool inRemote = remote.contains(path);
+    const ManifestEntry manifestEntry = manifest.entries.value(path);
+    const LocalEntry localEntry = local.value(path);
+    const RemoteEntry remoteEntry = remote.value(path);
+
+    SyncAction action;
+    action.relativePath = path;
+    action.remoteId = inRemote ? remoteEntry.remoteId : manifestEntry.remoteId;
+    action.expectedRevision = manifestEntry.remoteRevision;
+    action.isFolder = (inLocal && localEntry.isFolder) || (inRemote && remoteEntry.isFolder)
+                      || (inManifest && manifestEntry.isFolder);
+
+    // Folders carry no contents of their own, so they only ever need creating or,
+    // once everything under them has gone, removing.
+    if (action.isFolder) {
+      if (inLocal && !inRemote) {
+        // Only a folder that never reached the remote needs creating there; one
+        // the manifest knows was removed remotely goes away with its files.
+        if (!inManifest) {
+          action.kind = SyncAction::CreateRemoteFolder;
+          plan.actions << action;
+        }
+      } else if (!inLocal && inRemote) {
+        // A folder the manifest knows, missing locally, is a local deletion - and
+        // the pass at the end decides whether it may go. Recreating it here would
+        // contradict that. While the working copy is unverified, missing means
+        // "not restored yet", so it is created rather than deleted.
+        if (!inManifest || !manifest.workingCopyComplete) {
+          action.kind = SyncAction::CreateLocalFolder;
+          plan.actions << action;
+        }
+      } else if (inManifest && !inLocal && !inRemote) {
+        action.kind = SyncAction::DropManifestEntry;
+        plan.actions << action;
+      }
+      continue;
+    }
+
+    if (!inManifest) {
+      if (inLocal && !inRemote) {
+        action.kind = SyncAction::UploadNew;
+      } else if (!inLocal && inRemote) {
+        action.kind = SyncAction::DownloadNew;
+      } else if (inLocal && inRemote) {
+        // No common ancestor. Identical bytes are not a conflict, just something
+        // to record; anything else is for the user to settle.
+        if (!localEntry.providerHash.isEmpty()
+            && localEntry.providerHash == remoteEntry.contentHash.toLatin1()) {
+          action.kind = SyncAction::AdoptIdentical;
+        } else {
+          action.kind = SyncAction::Conflict;
+          action.conflict = SyncAction::BothCreated;
+        }
+      } else {
+        continue;
+      }
+      plan.actions << action;
+      continue;
+    }
+
+    const bool localChanged = inLocal && localEntry.contentHash != manifestEntry.contentHash;
+    const bool remoteChanged = inRemote && remoteEntry.remoteRevision != manifestEntry.remoteRevision;
+
+    if (inLocal && inRemote) {
+      if (!localChanged && !remoteChanged) {
+        continue;
+      }
+      if (localChanged && !remoteChanged) {
+        action.kind = SyncAction::UpdateRemote;
+      } else if (!localChanged && remoteChanged) {
+        action.kind = SyncAction::DownloadUpdate;
+      } else if (!localEntry.providerHash.isEmpty()
+                 && localEntry.providerHash == remoteEntry.contentHash.toLatin1()) {
+        // Both moved, but to the same bytes - nothing to reconcile.
+        action.kind = SyncAction::AdoptIdentical;
+      } else {
+        action.kind = SyncAction::Conflict;
+        action.conflict = SyncAction::BothChanged;
+      }
+      plan.actions << action;
+      continue;
+    }
+
+    if (!inLocal && inRemote) {
+      // On a working copy that was never fully restored, missing means "not here
+      // yet", not "deleted" - so fetch it back. Skipping instead left the copy
+      // permanently empty: on the web target it is wiped by every reload, so the
+      // files could never come back and reopening a mount produced nothing.
+      // Fetching cannot lose anything, so it applies whether or not the remote
+      // moved on in the meantime.
+      if (!manifest.workingCopyComplete) {
+        action.kind = SyncAction::DownloadNew;
+        plan.actions << action;
+        continue;
+      }
+      if (remoteChanged) {
+        // Deleting now would throw away an edit made elsewhere.
+        action.kind = SyncAction::Conflict;
+        action.conflict = SyncAction::LocalDeletedRemoteChanged;
+        plan.actions << action;
+        continue;
+      }
+      action.kind = SyncAction::DeleteRemote;
+      deletedRemotePaths << path;
+      plan.actions << action;
+      continue;
+    }
+
+    if (inLocal && !inRemote) {
+      if (localChanged) {
+        action.kind = SyncAction::Conflict;
+        action.conflict = SyncAction::LocalChangedRemoteDeleted;
+      } else {
+        action.kind = SyncAction::DeleteLocal;
+      }
+      plan.actions << action;
+      continue;
+    }
+
+    // Gone from both sides.
+    action.kind = SyncAction::DropManifestEntry;
+    plan.actions << action;
+  }
+
+  // A folder may only be removed once nothing is left under it. Deepest first, so
+  // that removing A/B lets A go too; anything the remote still holds there - a
+  // file someone else added, or one this plan is keeping - means the folder stays.
+  if (manifest.workingCopyComplete) {
+    QSet<QString> deleted(deletedRemotePaths.constBegin(), deletedRemotePaths.constEnd());
+    QList<QString> folders;
+    for (const QString &path : std::as_const(sorted)) {
+      if (manifest.entries.value(path).isFolder && !local.contains(path) && remote.contains(path)) {
+        folders << path;
+      }
+    }
+    std::sort(folders.begin(), folders.end(), std::greater<QString>());
+    for (const QString &path : std::as_const(folders)) {
+      QList<QString> survivors;
+      for (const QString &remotePath : std::as_const(remotePaths)) {
+        if (!deleted.contains(remotePath)) {
+          survivors << remotePath;
+        }
+      }
+      if (hasDescendant(path, survivors)) {
+        plan.skipped << path;
+        continue;
+      }
+      SyncAction action;
+      action.kind = SyncAction::DeleteRemote;
+      action.relativePath = path;
+      action.remoteId = remote.value(path).remoteId;
+      action.expectedRevision = manifest.entries.value(path).remoteRevision;
+      action.isFolder = true;
+      plan.actions << action;
+      deleted.insert(path);
+    }
+  }
+
+  return plan;
+}

--- a/OMEdit/OMEditLIB/Cloud/CloudManifest.h
+++ b/OMEdit/OMEditLIB/Cloud/CloudManifest.h
@@ -1,0 +1,184 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifndef CLOUDMANIFEST_H
+#define CLOUDMANIFEST_H
+
+#include <QByteArray>
+#include <QList>
+#include <QMap>
+#include <QString>
+#include <QStringList>
+
+/*!
+ * \brief What one file looked like the last time it was in sync.
+ *
+ * The common ancestor of the three-way comparison: without it there is no
+ * telling "the user deleted this" from "this has not arrived yet".
+ */
+struct ManifestEntry
+{
+  QString relativePath;
+  QString remoteId;
+  QString remoteRevision;
+  //! SHA-256 of the bytes at the last sync, so a local edit is detectable
+  //! without trusting timestamps.
+  QByteArray contentHash;
+  qint64 size = 0;
+  bool isFolder = false;
+};
+
+//! The working copy as it is right now.
+struct LocalEntry
+{
+  QString relativePath;
+  QByteArray contentHash;
+  //! Only filled for a provider that publishes a comparable hash (Drive's MD5),
+  //! and only used to spot that both sides were changed to the same bytes.
+  QByteArray providerHash;
+  qint64 size = 0;
+  bool isFolder = false;
+};
+
+//! The remote tree as it is right now, keyed by the same relative paths.
+struct RemoteEntry
+{
+  QString relativePath;
+  QString remoteId;
+  QString remoteRevision;
+  QString contentHash;
+  qint64 size = 0;
+  bool isFolder = false;
+};
+
+/*!
+ * \brief One thing the sync has to do. A Conflict is carried to the user and the
+ * engine re-plans with their answer; nothing here discards anybody's bytes.
+ */
+struct SyncAction
+{
+  enum Kind {
+    UploadNew,
+    UpdateRemote,
+    DownloadNew,
+    DownloadUpdate,
+    DeleteRemote,
+    DeleteLocal,
+    CreateRemoteFolder,
+    CreateLocalFolder,
+    //! Both sides already agree; record it and move on.
+    AdoptIdentical,
+    //! Gone from both sides; only the manifest still mentions it.
+    DropManifestEntry,
+    Conflict
+  };
+
+  enum ConflictKind {
+    NoConflict,
+    //! Changed on both sides since the last sync.
+    BothChanged,
+    //! Appeared on both sides with no common ancestor.
+    BothCreated,
+    //! Deleted here, changed there - deleting would discard their edit.
+    LocalDeletedRemoteChanged,
+    //! Changed here, deleted there - deleting would discard our edit.
+    LocalChangedRemoteDeleted
+  };
+
+  Kind kind = AdoptIdentical;
+  ConflictKind conflict = NoConflict;
+  QString relativePath;
+  QString remoteId;
+  //! The revision the write is allowed to overwrite; empty means unguarded, which
+  //! only happens once the user has resolved a conflict.
+  QString expectedRevision;
+  bool isFolder = false;
+};
+
+/*!
+ * \brief The work of one synchronisation, and what it would cost.
+ */
+struct SyncPlan
+{
+  QList<SyncAction> actions;
+  //! Paths the remote holds that cannot be represented locally, or that collide.
+  QStringList skipped;
+
+  int count(SyncAction::Kind kind) const;
+  bool hasConflicts() const;
+  QList<SyncAction> conflicts() const;
+
+  //! True when enough is being deleted to want a second look. Removing most of a
+  //! package is either a reorganisation or a bug, and only the user can tell.
+  bool needsDeletionConfirmation(int manifestFileCount) const;
+};
+
+/*!
+ * \brief The last synced state of one mounted folder.
+ */
+class CloudManifest
+{
+public:
+  QMap<QString, ManifestEntry> entries;
+  QString remoteRootId;
+  //! Where the next changes() call resumes from.
+  QString deltaToken;
+  /*!
+   * \brief Whether a file missing from the working copy means it was deleted.
+   * False when the working copy holds none of what the manifest lists - what a
+   * reload leaves behind on the web target - and then nothing is deleted.
+   */
+  bool workingCopyComplete = false;
+
+  bool load(const QString &path);
+  //! Written through a temporary file, so an interrupted write cannot truncate it.
+  bool save(const QString &path) const;
+
+  int fileCount() const;
+};
+
+/*!
+ * \brief Decide what to do, comparing the last synced state with both sides.
+ *
+ * Pure, so every case is testable. Anything ambiguous becomes a Conflict rather
+ * than a guess, and a deletion needs workingCopyComplete.
+ */
+SyncPlan planSync(const CloudManifest &manifest, const QMap<QString, LocalEntry> &local,
+                  const QMap<QString, RemoteEntry> &remote);
+
+//! Rejects a remote name that cannot be part of a local path on this platform.
+bool isUsableLocalName(const QString &name, QString *reason);
+
+#endif // CLOUDMANIFEST_H

--- a/OMEdit/OMEditLIB/Cloud/CloudMount.cpp
+++ b/OMEdit/OMEditLIB/Cloud/CloudMount.cpp
@@ -1,0 +1,270 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#include "Cloud/CloudMount.h"
+#include "Cloud/CloudCache.h"
+#include "Cloud/CloudTypes.h"
+#include "Util/PersistentStorage.h"
+
+#include <QCryptographicHash>
+#include <QDir>
+#include <QFileInfo>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSaveFile>
+
+namespace {
+
+const char *const kMountsFileName = "cloud-mounts.json";
+
+QString mountsFilePath()
+{
+  return CloudMountManager::manifestRoot() + QLatin1Char('/') + QLatin1String(kMountsFileName);
+}
+
+//! A folder name that is safe on every platform and stable across restarts.
+QString makeMountId(const QString &accountKey, const QString &remoteRootId)
+{
+  const QByteArray digest =
+      QCryptographicHash::hash((accountKey + QLatin1Char('/') + remoteRootId).toUtf8(), QCryptographicHash::Sha1);
+  return QString::fromLatin1(digest.toHex().left(16));
+}
+
+/*!
+ * \brief A remote name reduced to something usable as a directory name.
+ * Only for the working copy's own folder - the files inside keep their real
+ * names, and one that cannot be represented locally is reported rather than
+ * mangled (see isUsableLocalName).
+ */
+QString sanitiseFolderName(const QString &name)
+{
+  QString safe;
+  for (const QChar &character : name) {
+    safe += (character.isLetterOrNumber() || character == QLatin1Char('.') || character == QLatin1Char('-')
+             || character == QLatin1Char('_'))
+                ? character
+                : QLatin1Char('_');
+  }
+  safe = safe.trimmed();
+  return safe.isEmpty() ? QStringLiteral("package") : safe;
+}
+
+} // namespace
+
+QString CloudMount::manifestPath() const
+{
+  return CloudMountManager::manifestRoot() + QStringLiteral("/manifest-") + mountId + QStringLiteral(".json");
+}
+
+CloudMountManager *CloudMountManager::instance()
+{
+  static CloudMountManager manager;
+  return &manager;
+}
+
+QString CloudMountManager::workingCopyRoot()
+{
+#if defined(__EMSCRIPTEN__)
+  // In the omc worker's filesystem, so that omc reads the same bytes the GUI
+  // writes. Deliberately not under /persist, which is the page's own tree.
+  return QStringLiteral("/cloud");
+#else
+  return PersistentStorage::root() + QStringLiteral("/cloud");
+#endif
+}
+
+QString CloudMountManager::manifestRoot()
+{
+  // Always page-local and persisted: on the web target the working copy is
+  // volatile, and a manifest that vanished with it could not tell a lost restore
+  // from a deliberate deletion.
+  return PersistentStorage::root();
+}
+
+void CloudMountManager::load()
+{
+  if (mLoaded) {
+    return;
+  }
+  mLoaded = true;
+  QFile file(mountsFilePath());
+  if (!file.open(QIODevice::ReadOnly)) {
+    return;
+  }
+  const QJsonArray stored = QJsonDocument::fromJson(file.readAll()).array();
+  for (const QJsonValue &value : stored) {
+    const QJsonObject object = value.toObject();
+    CloudMount mount;
+    mount.mountId = object.value(QStringLiteral("mountId")).toString();
+    mount.accountKey = object.value(QStringLiteral("accountKey")).toString();
+    mount.remoteRootId = object.value(QStringLiteral("remoteRootId")).toString();
+    mount.remoteName = object.value(QStringLiteral("remoteName")).toString();
+    mount.localRoot = object.value(QStringLiteral("localRoot")).toString();
+    mount.autoPush = object.value(QStringLiteral("autoPush")).toBool(true);
+    if (mount.isValid()) {
+      mMounts << mount;
+    }
+  }
+}
+
+void CloudMountManager::save()
+{
+  QJsonArray stored;
+  for (const CloudMount &mount : std::as_const(mMounts)) {
+    QJsonObject object;
+    object.insert(QStringLiteral("mountId"), mount.mountId);
+    object.insert(QStringLiteral("accountKey"), mount.accountKey);
+    object.insert(QStringLiteral("remoteRootId"), mount.remoteRootId);
+    object.insert(QStringLiteral("remoteName"), mount.remoteName);
+    object.insert(QStringLiteral("localRoot"), mount.localRoot);
+    object.insert(QStringLiteral("autoPush"), mount.autoPush);
+    stored.append(object);
+  }
+  QDir().mkpath(manifestRoot());
+  QSaveFile file(mountsFilePath());
+  if (file.open(QIODevice::WriteOnly)) {
+    file.write(QJsonDocument(stored).toJson(QJsonDocument::Indented));
+    file.commit();
+  }
+  PersistentStorage::scheduleSnapshot();
+  emit mountsChanged();
+}
+
+QList<CloudMount> CloudMountManager::mounts()
+{
+  load();
+  return mMounts;
+}
+
+CloudMount CloudMountManager::mount(const QString &mountId)
+{
+  load();
+  for (const CloudMount &mount : std::as_const(mMounts)) {
+    if (mount.mountId == mountId) {
+      return mount;
+    }
+  }
+  return CloudMount();
+}
+
+CloudMount CloudMountManager::mountForPath(const QString &path)
+{
+  load();
+  const QString cleaned = QDir::cleanPath(path);
+  for (const CloudMount &mount : std::as_const(mMounts)) {
+    const QString root = QDir::cleanPath(mount.localRoot);
+    if (cleaned == root || cleaned.startsWith(root + QLatin1Char('/'))) {
+      return mount;
+    }
+  }
+  return CloudMount();
+}
+
+CloudMount CloudMountManager::addMount(const QString &accountKey, const QString &remoteRootId,
+                                       const QString &remoteName)
+{
+  load();
+  const QString mountId = makeMountId(accountKey, remoteRootId);
+  for (const CloudMount &existing : std::as_const(mMounts)) {
+    if (existing.mountId == mountId) {
+      return existing;
+    }
+  }
+  CloudMount mount;
+  mount.mountId = mountId;
+  mount.accountKey = accountKey;
+  mount.remoteRootId = remoteRootId;
+  mount.remoteName = remoteName;
+  // The mount id keeps two folders of the same name apart.
+  mount.localRoot = QStringLiteral("%1/%2-%3").arg(workingCopyRoot(), sanitiseFolderName(remoteName), mountId);
+  mMounts << mount;
+  save();
+  return mount;
+}
+
+void CloudMountManager::removeMount(const QString &mountId)
+{
+  load();
+  for (int i = 0; i < mMounts.size(); ++i) {
+    if (mMounts.at(i).mountId != mountId) {
+      continue;
+    }
+    const CloudMount mount = mMounts.takeAt(i);
+    // The working copy, its cache and the manifest go; nothing is touched remotely.
+    QDir(mount.localRoot).removeRecursively();
+    QFile::remove(mount.manifestPath());
+    CloudCache::forget(mount);
+    save();
+    return;
+  }
+}
+
+void CloudMountManager::updateMount(const CloudMount &mount)
+{
+  load();
+  for (int i = 0; i < mMounts.size(); ++i) {
+    if (mMounts.at(i).mountId == mount.mountId) {
+      mMounts[i] = mount;
+      save();
+      return;
+    }
+  }
+}
+
+bool isInsideCloudMount(const QString &path)
+{
+  return CloudMountManager::instance()->mountForPath(path).isValid();
+}
+
+#if defined(__EMSCRIPTEN__)
+// Defined in OMEditLIB/OMC/OMCProxy.cpp; the omc worker's directory listing.
+QStringList omcWorkerListDir(const char *path);
+#endif
+
+QStringList cloudListDirectory(const QString &path)
+{
+#if defined(__EMSCRIPTEN__)
+  return omcWorkerListDir(path.toUtf8().constData());
+#else
+  QStringList names;
+  const QFileInfoList entries = QDir(path).entryInfoList(QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot);
+  for (const QFileInfo &info : entries) {
+    names << (info.isDir() ? info.fileName() + QLatin1Char('/') : info.fileName());
+  }
+  return names;
+#endif
+}

--- a/OMEdit/OMEditLIB/Cloud/CloudMount.h
+++ b/OMEdit/OMEditLIB/Cloud/CloudMount.h
@@ -1,0 +1,116 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifndef CLOUDMOUNT_H
+#define CLOUDMOUNT_H
+
+#include "Cloud/CloudTypes.h"
+
+#include <QList>
+#include <QObject>
+#include <QString>
+
+/*!
+ * \brief A remote folder made available as an ordinary local path.
+ *
+ * Nothing downstream knows it came from a cloud service. Natively the working
+ * copy is a real directory; on the web target it is in the omc worker's
+ * filesystem, which the QAbstractFileEngine makes look the same to QFile.
+ */
+struct CloudMount
+{
+  QString mountId;
+  QString accountKey;
+  QString remoteRootId;
+  //! What the folder is called remotely; shown in the library tree and dialogs.
+  QString remoteName;
+  QString localRoot;
+  //! Push after every successful save, rather than only when asked.
+  bool autoPush = true;
+
+  bool isValid() const { return !mountId.isEmpty() && !localRoot.isEmpty(); }
+  //! Outside the working copy: deleting that must not take the sync state with
+  //! it, and the manifest must never be uploaded as part of the package.
+  QString manifestPath() const;
+};
+
+/*!
+ * \brief The mounts this installation knows about, remembered across restarts.
+ */
+class CloudMountManager : public QObject
+{
+  Q_OBJECT
+public:
+  static CloudMountManager *instance();
+
+  //! Root of every working copy. "/cloud" on the web target.
+  static QString workingCopyRoot();
+  static QString manifestRoot();
+
+  QList<CloudMount> mounts();
+  CloudMount mount(const QString &mountId);
+
+  //! The mount a path belongs to, or an invalid mount.
+  CloudMount mountForPath(const QString &path);
+
+  CloudMount addMount(const QString &accountKey, const QString &remoteRootId, const QString &remoteName);
+  void removeMount(const QString &mountId);
+  void updateMount(const CloudMount &mount);
+
+signals:
+  void mountsChanged();
+
+private:
+  CloudMountManager() = default;
+  void load();
+  void save();
+
+  QList<CloudMount> mMounts;
+  bool mLoaded = false;
+};
+
+//! True when path lies inside a mounted cloud folder. On the web target this is
+//! what decides whether a saved file is also handed to the user as a download.
+bool isInsideCloudMount(const QString &path);
+
+/*!
+ * \brief The immediate children of a directory, directories marked by a trailing '/'.
+ *
+ * Not QDir on the web target: it enumerates nothing through the worker-VFS
+ * QAbstractFileEngine, even for a directory whose files read back correctly.
+ */
+QStringList cloudListDirectory(const QString &path);
+
+#endif // CLOUDMOUNT_H

--- a/OMEdit/OMEditLIB/Cloud/CloudProvider.cpp
+++ b/OMEdit/OMEditLIB/Cloud/CloudProvider.cpp
@@ -1,0 +1,162 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#include "Cloud/CloudProvider.h"
+#include "Cloud/OAuth2Client.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QTimer>
+
+void CloudReply::abort()
+{
+  if (mFinished || mAborted) {
+    return;
+  }
+  mAborted = true;
+  if (mpNetworkReply) {
+    mpNetworkReply->abort();
+  } else {
+    finish(CloudError(CloudError::Cancelled, tr("Cancelled.")));
+  }
+}
+
+void CloudReply::finish(const CloudError &error)
+{
+  if (mFinished) {
+    return;
+  }
+  mFinished = true;
+  mError = mAborted && !error.isError() ? CloudError(CloudError::Cancelled, tr("Cancelled.")) : error;
+  // Never synchronous: an operation can finish before the call that started it
+  // returns, and the caller connects to finished() only afterwards.
+  QMetaObject::invokeMethod(this, [this]() {
+    emit finished();
+    deleteLater();
+  }, Qt::QueuedConnection);
+}
+
+void CloudReply::trackNetworkReply(QNetworkReply *pNetworkReply)
+{
+  mpNetworkReply = pNetworkReply;
+  connect(pNetworkReply, &QNetworkReply::downloadProgress, this, &CloudReply::progress);
+  connect(pNetworkReply, &QNetworkReply::uploadProgress, this, &CloudReply::progress);
+}
+
+CloudProvider::CloudProvider(OAuth2Client *pOAuth2Client, QNetworkAccessManager *pNetworkAccessManager, QObject *pParent)
+  : QObject(pParent), mpOAuth2Client(pOAuth2Client), mpNetworkAccessManager(pNetworkAccessManager)
+{
+}
+
+CloudReply *CloudProvider::send(const QNetworkRequest &request, const QByteArray &verb, const QByteArray &body,
+                                const std::function<void(CloudReply *, const QByteArray &)> &parse)
+{
+  CloudReply *pReply = new CloudReply(this);
+  dispatch(pReply, request, verb, body, parse, false);
+  return pReply;
+}
+
+void CloudProvider::dispatch(CloudReply *pReply, const QNetworkRequest &request, const QByteArray &verb,
+                             const QByteArray &body, const std::function<void(CloudReply *, const QByteArray &)> &parse,
+                             bool isRetry)
+{
+  mpOAuth2Client->withAccessToken(pReply, [this, pReply, request, verb, body, parse, isRetry](const CloudError &tokenError) {
+    if (tokenError.isError()) {
+      pReply->finish(tokenError);
+      return;
+    }
+    QNetworkRequest authorized(request);
+    authorized.setRawHeader("Authorization", "Bearer " + mpOAuth2Client->accessToken().toUtf8());
+    cloudLog(QStringLiteral("cloud %1 %2").arg(QString::fromUtf8(verb), authorized.url().toString()));
+    QNetworkReply *pNetworkReply = mpNetworkAccessManager->sendCustomRequest(authorized, verb, body);
+    pReply->trackNetworkReply(pNetworkReply);
+    // emscripten fetch has no timeout of its own.
+    QTimer *pTimeout = new QTimer(pNetworkReply);
+    pTimeout->setSingleShot(true);
+    connect(pTimeout, &QTimer::timeout, pNetworkReply, [pNetworkReply]() {
+      cloudLog(QStringLiteral("cloud request timed out %1").arg(pNetworkReply->url().toString()));
+      pNetworkReply->abort();
+    });
+    pTimeout->start(60000);
+    connect(pNetworkReply, &QNetworkReply::finished, pReply,
+            [this, pReply, pNetworkReply, request, verb, body, parse, isRetry]() {
+      pNetworkReply->deleteLater();
+      const int status = pNetworkReply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+      const QByteArray payload = pNetworkReply->readAll();
+      cloudLog(QStringLiteral("cloud <- %1 qt error %2 bytes %3")
+                   .arg(status).arg(int(pNetworkReply->error())).arg(payload.size()));
+      if (pNetworkReply->error() == QNetworkReply::OperationCanceledError) {
+        pReply->finish(CloudError(CloudError::Cancelled, tr("Cancelled.")));
+        return;
+      }
+      // Expired or revoked between the check and the service reading it.
+      if (status == 401 && !isRetry) {
+        mpOAuth2Client->setTokens(mpOAuth2Client->refreshToken(), QString(), QDateTime());
+        dispatch(pReply, request, verb, body, parse, true);
+        return;
+      }
+      if (status < 200 || status >= 300) {
+        pReply->finish(classifyError(status, payload, pNetworkReply->errorString()));
+        return;
+      }
+      if (pNetworkReply->error() != QNetworkReply::NoError) {
+        pReply->finish(CloudError(CloudError::Network, pNetworkReply->errorString()));
+        return;
+      }
+      if (parse) {
+        parse(pReply, payload);
+      }
+      pReply->finish(CloudError());
+    });
+  });
+}
+
+/*!
+ * \brief Turn an error response into a CloudError.
+ * Both services wrap the reason in {"error": {"message": ...}}; a provider
+ * overrides this where the status alone is ambiguous, as Drive's 403 is.
+ */
+CloudError CloudProvider::classifyError(int status, const QByteArray &payload, const QString &fallback) const
+{
+  const QJsonObject error = QJsonDocument::fromJson(payload).object().value(QStringLiteral("error")).toObject();
+  QString message = error.value(QStringLiteral("message")).toString();
+  if (message.isEmpty()) {
+    message = fallback;
+  }
+  return CloudError::fromHttpStatus(status, message);
+}

--- a/OMEdit/OMEditLIB/Cloud/CloudProvider.h
+++ b/OMEdit/OMEditLIB/Cloud/CloudProvider.h
@@ -1,0 +1,161 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifndef CLOUDPROVIDER_H
+#define CLOUDPROVIDER_H
+
+#include "Cloud/CloudTypes.h"
+
+#include <QByteArray>
+
+#include <functional>
+#include <QList>
+#include <QObject>
+#include <QPointer>
+#include <QString>
+
+class OAuth2Client;
+class QNetworkAccessManager;
+class QNetworkReply;
+class QNetworkRequest;
+
+/*!
+ * \brief One in-flight cloud operation.
+ *
+ * Emits finished() exactly once and then deletes itself, so hold one across
+ * anything else with a QPointer.
+ */
+class CloudReply : public QObject
+{
+  Q_OBJECT
+public:
+  explicit CloudReply(QObject *pParent = 0) : QObject(pParent) {}
+
+  bool isFinished() const { return mFinished; }
+  CloudError error() const { return mError; }
+
+  QList<RemoteItem> items() const { return mItems; }
+  RemoteItem item() const { return mItem; }
+  QByteArray data() const { return mData; }
+  //! Where the next changes() call should resume from.
+  QString deltaToken() const { return mDeltaToken; }
+  //! Ids the service reported as removed since the delta token.
+  QStringList removedIds() const { return mRemovedIds; }
+
+  void abort();
+
+  //! Called by the provider; public so a provider can compose replies.
+  void finish(const CloudError &error);
+  void setItems(const QList<RemoteItem> &items) { mItems = items; }
+  void setItem(const RemoteItem &item) { mItem = item; }
+  void setData(const QByteArray &data) { mData = data; }
+  void setDeltaToken(const QString &token) { mDeltaToken = token; }
+  void setRemovedIds(const QStringList &ids) { mRemovedIds = ids; }
+  void trackNetworkReply(QNetworkReply *pNetworkReply);
+  //! For an operation that needs several round trips before it can report.
+  static CloudReply *pending(QObject *pParent) { return new CloudReply(pParent); }
+
+signals:
+  void finished();
+  void progress(qint64 done, qint64 total);
+
+private:
+  bool mFinished = false;
+  bool mAborted = false;
+  CloudError mError;
+  QList<RemoteItem> mItems;
+  RemoteItem mItem;
+  QByteArray mData;
+  QString mDeltaToken;
+  QStringList mRemovedIds;
+  QPointer<QNetworkReply> mpNetworkReply;
+};
+
+/*!
+ * \brief A file service, reduced to what a Modelica package needs.
+ *
+ * Path-free by design: the sync engine owns the path-to-id mapping, since Drive
+ * has no paths and allows two children of one folder to share a name. Deletion is
+ * always to the service's trash, never permanent.
+ */
+class CloudProvider : public QObject
+{
+  Q_OBJECT
+public:
+  CloudProvider(OAuth2Client *pOAuth2Client, QNetworkAccessManager *pNetworkAccessManager, QObject *pParent = 0);
+
+  virtual CloudProviderKind kind() const = 0;
+
+  //! The signed-in user, for showing which account this is.
+  virtual CloudReply *userInfo() = 0;
+
+  //! The folder this application works in, created on first use. With Drive's
+  //! drive.file scope it can only see what it created, so everything lives here.
+  virtual CloudReply *appRootFolder() = 0;
+
+  virtual CloudReply *listFolder(const QString &folderId) = 0;
+  virtual CloudReply *metadata(const QString &itemId) = 0;
+  virtual CloudReply *download(const QString &fileId) = 0;
+  virtual CloudReply *createFolder(const QString &parentId, const QString &name) = 0;
+  virtual CloudReply *uploadNew(const QString &parentId, const QString &name, const QByteArray &contents) = 0;
+
+  //! Overwrite, but only if the file still has the revision we last saw. Empty
+  //! means unguarded, which only happens after the user resolved a conflict.
+  virtual CloudReply *uploadUpdate(const QString &fileId, const QByteArray &contents, const QString &expectedRevision) = 0;
+
+  virtual CloudReply *trashItem(const QString &itemId, const QString &expectedRevision) = 0;
+
+  //! A token marking "now", to hand to changes() later.
+  virtual CloudReply *currentDeltaToken(const QString &rootId) = 0;
+  virtual CloudReply *changes(const QString &rootId, const QString &deltaToken) = 0;
+
+protected:
+  //! Send a request with a fresh access token, retrying once on a 401. parse()
+  //! turns a successful payload into the reply's result.
+  CloudReply *send(const QNetworkRequest &request, const QByteArray &verb, const QByteArray &body,
+                   const std::function<void(CloudReply *, const QByteArray &)> &parse);
+
+  //! Status alone is ambiguous on Drive, where 403 covers rate limiting too.
+  virtual CloudError classifyError(int status, const QByteArray &payload, const QString &fallback) const;
+
+  OAuth2Client *mpOAuth2Client;
+  QNetworkAccessManager *mpNetworkAccessManager;
+
+private:
+  void dispatch(CloudReply *pReply, const QNetworkRequest &request, const QByteArray &verb, const QByteArray &body,
+                const std::function<void(CloudReply *, const QByteArray &)> &parse, bool isRetry);
+};
+
+#endif // CLOUDPROVIDER_H

--- a/OMEdit/OMEditLIB/Cloud/CloudSyncEngine.cpp
+++ b/OMEdit/OMEditLIB/Cloud/CloudSyncEngine.cpp
@@ -1,0 +1,578 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#include "Cloud/CloudSyncEngine.h"
+#include "Cloud/CloudProvider.h"
+#include "Cloud/CloudTypes.h"
+
+#include <QCryptographicHash>
+#include <QDateTime>
+#include <QDir>
+#include <QDirIterator>
+#include <QFile>
+#include <QFileInfo>
+
+namespace {
+
+//! Rank of an action in the execution order. See the class comment: uploads must
+//! be recorded before any deletion is issued.
+int phaseOf(const SyncAction &action)
+{
+  switch (action.kind) {
+    case SyncAction::CreateLocalFolder:  return 0;
+    case SyncAction::DownloadNew:
+    case SyncAction::DownloadUpdate:     return 1;
+    case SyncAction::CreateRemoteFolder: return 2;
+    case SyncAction::UploadNew:
+    case SyncAction::UpdateRemote:       return 3;
+    case SyncAction::AdoptIdentical:     return 4;
+    case SyncAction::DeleteRemote:       return 5;
+    case SyncAction::DeleteLocal:        return 6;
+    case SyncAction::DropManifestEntry:  return 7;
+    case SyncAction::Conflict:           return 8;
+  }
+  return 8;
+}
+
+QByteArray hashOf(const QByteArray &contents)
+{
+  return QCryptographicHash::hash(contents, QCryptographicHash::Sha256);
+}
+
+//! Anything whose path has a dot-component: .git and friends are not part of a
+//! Modelica package and must not be pushed to somebody's Drive.
+bool isHiddenPath(const QString &relativePath)
+{
+  const QStringList components = relativePath.split(QLatin1Char('/'), Qt::SkipEmptyParts);
+  for (const QString &component : components) {
+    if (component.startsWith(QLatin1Char('.'))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+QString conflictCopyName(const QString &relativePath)
+{
+  const QString stamp = QDateTime::currentDateTime().toString(QStringLiteral("yyyy-MM-dd-hhmmss"));
+  const int dot = relativePath.lastIndexOf(QLatin1Char('.'));
+  const int slash = relativePath.lastIndexOf(QLatin1Char('/'));
+  if (dot > slash) {
+    return QStringLiteral("%1.conflict-%2%3").arg(relativePath.left(dot), stamp, relativePath.mid(dot));
+  }
+  return QStringLiteral("%1.conflict-%2").arg(relativePath, stamp);
+}
+
+} // namespace
+
+CloudSyncEngine::CloudSyncEngine(const CloudMount &mount, CloudProvider *pProvider, QObject *pParent)
+  : QObject(pParent), mMount(mount), mpProvider(pProvider)
+{
+}
+
+QString CloudSyncEngine::absolutePath(const QString &relativePath) const
+{
+  return mMount.localRoot + QLatin1Char('/') + relativePath;
+}
+
+QString CloudSyncEngine::parentRemoteId(const QString &relativePath) const
+{
+  const int slash = relativePath.lastIndexOf(QLatin1Char('/'));
+  if (slash < 0) {
+    return mMount.remoteRootId;
+  }
+  return mRemoteIdByPath.value(relativePath.left(slash), mMount.remoteRootId);
+}
+
+void CloudSyncEngine::start()
+{
+  mManifest.load(mMount.manifestPath());
+  mManifest.remoteRootId = mMount.remoteRootId;
+  mLocal.clear();
+  mRemote.clear();
+  mRemoteIdByPath.clear();
+  mSkipped.clear();
+  mCancelled = false;
+  mManifestSavedBeforeDeletions = false;
+  mDone = 0;
+
+  scanLocal();
+  // A working copy that has lost every file the manifest lists was not restored;
+  // one missing some of them has had files deleted. Only when nothing is left are
+  // the two indistinguishable, and there the safe reading is "not restored".
+  int expected = 0;
+  int present = 0;
+  for (auto it = mManifest.entries.constBegin(); it != mManifest.entries.constEnd(); ++it) {
+    if (it.value().isFolder) {
+      continue;
+    }
+    ++expected;
+    if (mLocal.contains(it.key())) {
+      ++present;
+    }
+  }
+  mManifest.workingCopyComplete = expected == 0 || present > 0;
+  cloudLog(QStringLiteral("sync %1: %2 local entries under %3, working copy complete: %4")
+               .arg(mMount.remoteName).arg(mLocal.size()).arg(mMount.localRoot)
+               .arg(mManifest.workingCopyComplete ? QStringLiteral("yes") : QStringLiteral("no")));
+
+  mRemoteIdByPath.insert(QString(), mMount.remoteRootId);
+  mPendingListings = 0;
+  mListingFailed = false;
+  emit progress(0, 0, tr("Looking at %1...").arg(mMount.remoteName));
+  listRemoteFrom(mMount.remoteRootId, QString());
+}
+
+void CloudSyncEngine::scanLocal()
+{
+  scanLocalInto(QDir::cleanPath(mMount.localRoot), QString());
+}
+
+/*!
+ * \brief Walk the working copy one directory at a time. QDirIterator is not an
+ * option: it enumerates nothing through the worker-VFS QAbstractFileEngine.
+ */
+void CloudSyncEngine::scanLocalInto(const QString &directory, const QString &prefix)
+{
+  const QStringList names = cloudListDirectory(directory);
+  for (const QString &raw : names) {
+    const bool isFolder = raw.endsWith(QLatin1Char('/'));
+    const QString name = isFolder ? raw.left(raw.size() - 1) : raw;
+    if (name.isEmpty()) {
+      continue;
+    }
+    const QString relativePath = prefix.isEmpty() ? name : prefix + QLatin1Char('/') + name;
+    if (isHiddenPath(relativePath)) {
+      continue;
+    }
+    LocalEntry entry;
+    entry.relativePath = relativePath;
+    entry.isFolder = isFolder;
+    if (isFolder) {
+      mLocal.insert(relativePath, entry);
+      scanLocalInto(directory + QLatin1Char('/') + name, relativePath);
+      continue;
+    }
+    QFile file(directory + QLatin1Char('/') + name);
+    if (!file.open(QIODevice::ReadOnly)) {
+      continue;
+    }
+    const QByteArray contents = file.readAll();
+    entry.contentHash = hashOf(contents);
+    entry.size = contents.size();
+    // Drive's MD5 is what lets both sides changing to the same bytes be
+    // recognised instead of reported as a conflict.
+    if (mpProvider && mpProvider->kind() == CloudProviderKind::GoogleDrive) {
+      entry.providerHash = QCryptographicHash::hash(contents, QCryptographicHash::Md5).toHex();
+    }
+    mLocal.insert(relativePath, entry);
+  }
+}
+
+void CloudSyncEngine::listRemoteFrom(const QString &folderId, const QString &prefix)
+{
+  ++mPendingListings;
+  CloudReply *pReply = mpProvider->listFolder(folderId);
+  connect(pReply, &CloudReply::finished, this, [this, pReply, prefix]() {
+    --mPendingListings;
+    if (pReply->error().isError()) {
+      if (!mListingFailed) {
+        mListingFailed = true;
+        mListingError = pReply->error();
+      }
+      remoteListingDone();
+      return;
+    }
+    // Drive allows two children of one folder to share a name; a path-based sync
+    // cannot choose between them, so both are reported and neither is used.
+    QHash<QString, int> nameCounts;
+    const QList<RemoteItem> items = pReply->items();
+    for (const RemoteItem &item : items) {
+      nameCounts[item.name] += 1;
+    }
+    for (const RemoteItem &item : items) {
+      QString reason;
+      if (nameCounts.value(item.name) > 1) {
+        mSkipped << tr("%1: the folder holds more than one entry with this name").arg(item.name);
+        continue;
+      }
+      if (!isUsableLocalName(item.name, &reason)) {
+        mSkipped << tr("%1: %2").arg(item.name, reason);
+        continue;
+      }
+      const QString relativePath = prefix.isEmpty() ? item.name : prefix + QLatin1Char('/') + item.name;
+      RemoteEntry entry;
+      entry.relativePath = relativePath;
+      entry.remoteId = item.id;
+      entry.remoteRevision = item.revision;
+      entry.contentHash = item.contentHash;
+      entry.size = item.size;
+      entry.isFolder = item.isFolder;
+      mRemote.insert(relativePath, entry);
+      mRemoteIdByPath.insert(relativePath, item.id);
+      if (item.isFolder && !mCancelled) {
+        listRemoteFrom(item.id, relativePath);
+      }
+    }
+    remoteListingDone();
+  });
+}
+
+void CloudSyncEngine::remoteListingDone()
+{
+  if (mPendingListings > 0) {
+    return;
+  }
+  if (mListingFailed) {
+    finish(mListingError);
+    return;
+  }
+  if (mCancelled) {
+    finish(CloudError(CloudError::Cancelled, tr("Cancelled.")));
+    return;
+  }
+  if (!mSkipped.isEmpty()) {
+    emit skipped(mSkipped);
+  }
+  planAndProceed();
+}
+
+void CloudSyncEngine::planAndProceed()
+{
+  mPlan = planSync(mManifest, mLocal, mRemote);
+
+  // Fold in whatever the user chose for the conflicts reported last time round.
+  if (!mResolutions.isEmpty()) {
+    QList<SyncAction> resolved;
+    for (SyncAction action : std::as_const(mPlan.actions)) {
+      if (action.kind != SyncAction::Conflict || !mResolutions.contains(action.relativePath)) {
+        resolved << action;
+        continue;
+      }
+      const Resolution resolution = Resolution(mResolutions.value(action.relativePath));
+      const bool remoteExists = mRemote.contains(action.relativePath);
+      const bool localExists = mLocal.contains(action.relativePath);
+      if (resolution == KeepBoth && localExists) {
+        // Move ours aside so the remote version can land at the real path. Only
+        // once: a re-plan must not rename the copy it made last time.
+        if (!mConflictCopies.contains(action.relativePath)) {
+          const QString copy = conflictCopyName(action.relativePath);
+          if (QFile::rename(absolutePath(action.relativePath), absolutePath(copy))) {
+            mConflictCopies.insert(action.relativePath, copy);
+          }
+        }
+        if (mConflictCopies.contains(action.relativePath)) {
+          SyncAction upload;
+          upload.kind = SyncAction::UploadNew;
+          upload.relativePath = mConflictCopies.value(action.relativePath);
+          resolved << upload;
+        }
+      }
+      if (resolution == KeepLocal) {
+        SyncAction push;
+        push.relativePath = action.relativePath;
+        push.remoteId = action.remoteId;
+        // Deliberately unguarded: the user has just been shown the other version
+        // and asked for theirs to win.
+        push.expectedRevision.clear();
+        if (!localExists) {
+          // "Mine" is a deletion, so keeping it means removing the remote.
+          push.kind = SyncAction::DeleteRemote;
+        } else {
+          push.kind = remoteExists ? SyncAction::UpdateRemote : SyncAction::UploadNew;
+        }
+        resolved << push;
+      } else {
+        SyncAction take;
+        take.relativePath = action.relativePath;
+        take.remoteId = action.remoteId;
+        take.kind = remoteExists ? SyncAction::DownloadUpdate : SyncAction::DeleteLocal;
+        resolved << take;
+      }
+    }
+    mPlan.actions = resolved;
+  }
+
+  if (mPlan.hasConflicts()) {
+    emit conflictsDetected(mPlan.conflicts());
+    return;
+  }
+  if (!mDeletionsConfirmed && mPlan.needsDeletionConfirmation(mManifest.fileCount())) {
+    QList<SyncAction> deletions;
+    for (const SyncAction &action : std::as_const(mPlan.actions)) {
+      if (action.kind == SyncAction::DeleteRemote) {
+        deletions << action;
+      }
+    }
+    emit deletionsNeedConfirmation(deletions);
+    return;
+  }
+
+  cloudLog(QStringLiteral("sync plan: %1 actions (%2 uploads, %3 downloads, %4 remote deletes), %5 remote entries")
+               .arg(mPlan.actions.size())
+               .arg(mPlan.count(SyncAction::UploadNew) + mPlan.count(SyncAction::UpdateRemote))
+               .arg(mPlan.count(SyncAction::DownloadNew) + mPlan.count(SyncAction::DownloadUpdate))
+               .arg(mPlan.count(SyncAction::DeleteRemote))
+               .arg(mRemote.size()));
+  mQueue = mPlan.actions;
+  std::stable_sort(mQueue.begin(), mQueue.end(),
+                   [](const SyncAction &a, const SyncAction &b) { return phaseOf(a) < phaseOf(b); });
+  mTotal = mQueue.size();
+  mDone = 0;
+  if (mQueue.isEmpty()) {
+    // Still worth recording: the working copy has now been seen in full.
+    mManifest.workingCopyComplete = true;
+    mManifest.save(mMount.manifestPath());
+    finish(CloudError());
+    return;
+  }
+  runNext();
+}
+
+void CloudSyncEngine::applyResolutions(const QHash<QString, int> &resolutions)
+{
+  // Merged, not replaced: a later round only carries the conflicts still open.
+  for (auto it = resolutions.constBegin(); it != resolutions.constEnd(); ++it) {
+    mResolutions.insert(it.key(), it.value());
+  }
+  planAndProceed();
+}
+
+void CloudSyncEngine::confirmDeletions(bool proceed)
+{
+  if (!proceed) {
+    finish(CloudError(CloudError::Cancelled, tr("Synchronisation cancelled; nothing was changed.")));
+    return;
+  }
+  mDeletionsConfirmed = true;
+  planAndProceed();
+}
+
+void CloudSyncEngine::cancel()
+{
+  mCancelled = true;
+  if (mpCurrentReply && !mpCurrentReply->isFinished()) {
+    mpCurrentReply->abort();
+    return;
+  }
+  if (mPendingListings == 0) {
+    // Cancelled while waiting for an answer: nothing is in flight to unwind, so
+    // the run has to end here or it never ends at all.
+    finish(CloudError(CloudError::Cancelled, tr("Cancelled.")));
+  }
+}
+
+void CloudSyncEngine::recordFromItem(const QString &relativePath, const RemoteItem &item, const QByteArray &contentHash)
+{
+  ManifestEntry entry;
+  entry.relativePath = relativePath;
+  entry.remoteId = item.id;
+  entry.remoteRevision = item.revision;
+  entry.contentHash = contentHash;
+  entry.size = item.size;
+  entry.isFolder = item.isFolder;
+  mManifest.entries.insert(relativePath, entry);
+  if (!item.id.isEmpty()) {
+    mRemoteIdByPath.insert(relativePath, item.id);
+  }
+}
+
+void CloudSyncEngine::runNext()
+{
+  if (mCancelled) {
+    finish(CloudError(CloudError::Cancelled, tr("Cancelled.")));
+    return;
+  }
+  if (mQueue.isEmpty()) {
+    mManifest.workingCopyComplete = true;
+    // Where the next run resumes from, so a restart revalidates cheaply.
+    CloudReply *pToken = mpProvider->currentDeltaToken(mMount.remoteRootId);
+    mpCurrentReply = pToken;
+    connect(pToken, &CloudReply::finished, this, [this, pToken]() {
+      if (!pToken->error().isError()) {
+        mManifest.deltaToken = pToken->deltaToken();
+      }
+      mManifest.save(mMount.manifestPath());
+      finish(CloudError());
+    });
+    return;
+  }
+
+  const SyncAction action = mQueue.takeFirst();
+  // The one ordering rule that matters: everything uploaded is on record before
+  // the first deletion goes out.
+  if (!mManifestSavedBeforeDeletions && phaseOf(action) >= 5) {
+    mManifestSavedBeforeDeletions = true;
+    mManifest.save(mMount.manifestPath());
+  }
+  emit progress(mDone++, mTotal, action.relativePath);
+
+  switch (action.kind) {
+    case SyncAction::CreateLocalFolder: {
+      QDir().mkpath(absolutePath(action.relativePath));
+      ManifestEntry entry;
+      entry.relativePath = action.relativePath;
+      entry.remoteId = action.remoteId;
+      entry.remoteRevision = mRemote.value(action.relativePath).remoteRevision;
+      entry.isFolder = true;
+      mManifest.entries.insert(action.relativePath, entry);
+      runNext();
+      return;
+    }
+    case SyncAction::DownloadNew:
+    case SyncAction::DownloadUpdate: {
+      CloudReply *pReply = mpProvider->download(action.remoteId);
+      mpCurrentReply = pReply;
+      connect(pReply, &CloudReply::finished, this, [this, pReply, action]() {
+        if (pReply->error().isError()) {
+          finish(pReply->error());
+          return;
+        }
+        const QString path = absolutePath(action.relativePath);
+        QDir().mkpath(QFileInfo(path).absolutePath());
+        QFile file(path);
+        if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+          finish(CloudError(CloudError::Provider, tr("Could not write %1.").arg(path)));
+          return;
+        }
+        const QByteArray contents = pReply->data();
+        file.write(contents);
+        file.close();
+        RemoteItem item;
+        item.id = action.remoteId;
+        item.revision = mRemote.value(action.relativePath).remoteRevision;
+        item.size = contents.size();
+        recordFromItem(action.relativePath, item, hashOf(contents));
+        runNext();
+      });
+      return;
+    }
+    case SyncAction::CreateRemoteFolder: {
+      const QString name = action.relativePath.section(QLatin1Char('/'), -1);
+      CloudReply *pReply = mpProvider->createFolder(parentRemoteId(action.relativePath), name);
+      mpCurrentReply = pReply;
+      connect(pReply, &CloudReply::finished, this, [this, pReply, action]() {
+        if (pReply->error().isError()) {
+          finish(pReply->error());
+          return;
+        }
+        recordFromItem(action.relativePath, pReply->item(), QByteArray());
+        runNext();
+      });
+      return;
+    }
+    case SyncAction::UploadNew:
+    case SyncAction::UpdateRemote: {
+      QFile file(absolutePath(action.relativePath));
+      if (!file.open(QIODevice::ReadOnly)) {
+        // Vanished between the scan and now; the next run will see it properly.
+        runNext();
+        return;
+      }
+      const QByteArray contents = file.readAll();
+      file.close();
+      CloudReply *pReply =
+          action.kind == SyncAction::UploadNew
+              ? mpProvider->uploadNew(parentRemoteId(action.relativePath),
+                                      action.relativePath.section(QLatin1Char('/'), -1), contents)
+              : mpProvider->uploadUpdate(action.remoteId, contents, action.expectedRevision);
+      mpCurrentReply = pReply;
+      connect(pReply, &CloudReply::finished, this, [this, pReply, action, contents]() {
+        if (pReply->error().isError()) {
+          finish(pReply->error());
+          return;
+        }
+        recordFromItem(action.relativePath, pReply->item(), hashOf(contents));
+        runNext();
+      });
+      return;
+    }
+    case SyncAction::AdoptIdentical: {
+      RemoteItem item;
+      item.id = action.remoteId;
+      item.revision = mRemote.value(action.relativePath).remoteRevision;
+      recordFromItem(action.relativePath, item, mLocal.value(action.relativePath).contentHash);
+      runNext();
+      return;
+    }
+    case SyncAction::DeleteRemote: {
+      CloudReply *pReply = mpProvider->trashItem(action.remoteId, action.expectedRevision);
+      mpCurrentReply = pReply;
+      connect(pReply, &CloudReply::finished, this, [this, pReply, action]() {
+        if (pReply->error().isError()) {
+          finish(pReply->error());
+          return;
+        }
+        // Only now, with the removal confirmed, does the entry go.
+        mManifest.entries.remove(action.relativePath);
+        runNext();
+      });
+      return;
+    }
+    case SyncAction::DeleteLocal: {
+      const QString path = absolutePath(action.relativePath);
+      if (action.isFolder) {
+        QDir(path).removeRecursively();
+      } else {
+        QFile::remove(path);
+      }
+      mManifest.entries.remove(action.relativePath);
+      runNext();
+      return;
+    }
+    case SyncAction::DropManifestEntry: {
+      mManifest.entries.remove(action.relativePath);
+      runNext();
+      return;
+    }
+    case SyncAction::Conflict:
+      // Unresolved conflicts never reach the queue.
+      runNext();
+      return;
+  }
+}
+
+void CloudSyncEngine::finish(const CloudError &error)
+{
+  if (mFinished) {
+    return;
+  }
+  mFinished = true;
+  // Also on the way out of a failure: without this the next run sees everything
+  // uploaded before it as created on both sides, with no common ancestor.
+  mManifest.save(mMount.manifestPath());
+  emit progress(mTotal, mTotal, QString());
+  emit finished(error);
+}

--- a/OMEdit/OMEditLIB/Cloud/CloudSyncEngine.cpp
+++ b/OMEdit/OMEditLIB/Cloud/CloudSyncEngine.cpp
@@ -520,10 +520,13 @@ void CloudSyncEngine::runNext()
       return;
     }
     case SyncAction::AdoptIdentical: {
+      const LocalEntry local = mLocal.value(action.relativePath);
       RemoteItem item;
       item.id = action.remoteId;
       item.revision = mRemote.value(action.relativePath).remoteRevision;
-      recordFromItem(action.relativePath, item, mLocal.value(action.relativePath).contentHash);
+      item.size = local.size;
+      item.isFolder = action.isFolder;
+      recordFromItem(action.relativePath, item, local.contentHash);
       runNext();
       return;
     }

--- a/OMEdit/OMEditLIB/Cloud/CloudSyncEngine.h
+++ b/OMEdit/OMEditLIB/Cloud/CloudSyncEngine.h
@@ -1,0 +1,137 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifndef CLOUDSYNCENGINE_H
+#define CLOUDSYNCENGINE_H
+
+#include "Cloud/CloudManifest.h"
+#include "Cloud/CloudMount.h"
+#include "Cloud/CloudTypes.h"
+
+#include <QHash>
+#include <QList>
+#include <QObject>
+#include <QPointer>
+
+class CloudProvider;
+class CloudReply;
+
+/*!
+ * \brief Runs one synchronisation of a mounted folder.
+ *
+ * planSync() decides what to do; this carries it out in an order that cannot lose
+ * data on an interruption:
+ *
+ *   local folders -> downloads -> remote folders -> uploads
+ *   -> SAVE MANIFEST -> remote deletions -> local deletions -> SAVE MANIFEST
+ *
+ * An entry is dropped only once its remote deletion is confirmed, so an
+ * interrupted run leaves a file looking new, never deleted. Conflicts and large
+ * deletions are reported, not decided here.
+ */
+class CloudSyncEngine : public QObject
+{
+  Q_OBJECT
+public:
+  //! What to do with one conflicting path. Every value keeps the bytes.
+  enum Resolution {
+    KeepLocal,
+    TakeRemote,
+    //! Keep the remote version at the original path and the local one beside it.
+    KeepBoth
+  };
+
+  CloudSyncEngine(const CloudMount &mount, CloudProvider *pProvider, QObject *pParent = 0);
+
+  void start();
+  //! Continue after conflictsDetected(), keyed by relative path.
+  void applyResolutions(const QHash<QString, int> &resolutions);
+  //! Continue (or abandon) after deletionsNeedConfirmation().
+  void confirmDeletions(bool proceed);
+  void cancel();
+
+  const CloudManifest &manifest() const { return mManifest; }
+
+signals:
+  void progress(int done, int total, const QString &description);
+  void conflictsDetected(const QList<SyncAction> &conflicts);
+  //! More deletions than looks routine; the user sees them listed before any run.
+  void deletionsNeedConfirmation(const QList<SyncAction> &deletions);
+  //! Remote entries that could not be represented locally, with the reason.
+  void skipped(const QStringList &descriptions);
+  void finished(const CloudError &error);
+
+private:
+  void scanLocal();
+  void scanLocalInto(const QString &directory, const QString &prefix);
+  void listRemoteFrom(const QString &folderId, const QString &prefix);
+  void remoteListingDone();
+  void planAndProceed();
+  void runNext();
+  void finish(const CloudError &error);
+  void recordFromItem(const QString &relativePath, const RemoteItem &item, const QByteArray &contentHash);
+  QString absolutePath(const QString &relativePath) const;
+  QString parentRemoteId(const QString &relativePath) const;
+
+  CloudMount mMount;
+  CloudProvider *mpProvider;
+  CloudManifest mManifest;
+
+  QMap<QString, LocalEntry> mLocal;
+  QMap<QString, RemoteEntry> mRemote;
+  QHash<QString, QString> mRemoteIdByPath;
+  QStringList mSkipped;
+
+  SyncPlan mPlan;
+  QList<SyncAction> mQueue;
+  int mTotal = 0;
+  int mDone = 0;
+  //! Set once the queue crosses from uploads into deletions.
+  bool mManifestSavedBeforeDeletions = false;
+
+  QHash<QString, int> mResolutions;
+  //! Where a KeepBoth answer moved the local version, so a re-plan reuses it.
+  QHash<QString, QString> mConflictCopies;
+  bool mDeletionsConfirmed = false;
+  bool mCancelled = false;
+  bool mFinished = false;
+  //! Outstanding recursive folder listings.
+  int mPendingListings = 0;
+  bool mListingFailed = false;
+  CloudError mListingError;
+  QPointer<CloudReply> mpCurrentReply;
+};
+
+#endif // CLOUDSYNCENGINE_H

--- a/OMEdit/OMEditLIB/Cloud/CloudTypes.cpp
+++ b/OMEdit/OMEditLIB/Cloud/CloudTypes.cpp
@@ -1,0 +1,113 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#include "Cloud/CloudTypes.h"
+
+#include <QCoreApplication>
+#include <QDebug>
+
+#if defined(__EMSCRIPTEN__)
+#include <emscripten.h>
+#include <emscripten/em_js.h>
+
+EM_JS(void, omedit_cloud_log, (const char *message), {
+  console.log("[OMEdit]", UTF8ToString(message));
+});
+#endif
+
+void cloudLog(const QString &message)
+{
+#if defined(__EMSCRIPTEN__)
+  omedit_cloud_log(message.toUtf8().constData());
+#else
+  qDebug().noquote() << "[OMEdit]" << message;
+#endif
+}
+
+QString cloudProviderKindToString(CloudProviderKind kind)
+{
+  switch (kind) {
+    case CloudProviderKind::GoogleDrive: return QStringLiteral("googledrive");
+    case CloudProviderKind::OneDrive:    return QStringLiteral("onedrive");
+  }
+  return QString();
+}
+
+bool cloudProviderKindFromString(const QString &text, CloudProviderKind *kind)
+{
+  if (text == QLatin1String("googledrive")) {
+    *kind = CloudProviderKind::GoogleDrive;
+    return true;
+  }
+  if (text == QLatin1String("onedrive")) {
+    *kind = CloudProviderKind::OneDrive;
+    return true;
+  }
+  return false;
+}
+
+QString cloudProviderDisplayName(CloudProviderKind kind)
+{
+  switch (kind) {
+    case CloudProviderKind::GoogleDrive:
+      return QCoreApplication::translate("Cloud", "Google Drive");
+    case CloudProviderKind::OneDrive:
+      return QCoreApplication::translate("Cloud", "OneDrive");
+  }
+  return QString();
+}
+
+CloudError CloudError::fromHttpStatus(int status, const QString &message)
+{
+  Code code = Provider;
+  switch (status) {
+    case 401: code = Auth; break;
+    // Not Auth: Drive also returns 403 for rate limiting and for a plain
+    // permission denial, and treating those as "sign in again" would loop.
+    // The provider refines it from the error body.
+    case 403: code = Provider; break;
+    case 404: code = NotFound; break;
+    // 412 is our own If-Match precondition; 409 is a name/parent clash.
+    case 409:
+    case 412: code = Conflict; break;
+    case 429: code = RateLimited; break;
+    default:
+      if (status >= 500) {
+        code = Network;
+      }
+      break;
+  }
+  return CloudError(code, message, status);
+}

--- a/OMEdit/OMEditLIB/Cloud/CloudTypes.h
+++ b/OMEdit/OMEditLIB/Cloud/CloudTypes.h
@@ -1,0 +1,111 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifndef CLOUDTYPES_H
+#define CLOUDTYPES_H
+
+#include <QDateTime>
+#include <QMetaType>
+#include <QString>
+
+//! Which service an account belongs to.
+enum class CloudProviderKind {
+  GoogleDrive,
+  OneDrive
+};
+
+//! Diagnostics; reaches the browser console, which qInfo does not.
+void cloudLog(const QString &message);
+
+QString cloudProviderKindToString(CloudProviderKind kind);
+bool cloudProviderKindFromString(const QString &text, CloudProviderKind *kind);
+QString cloudProviderDisplayName(CloudProviderKind kind);
+
+/*!
+ * \brief One file or folder as the service describes it.
+ *
+ * revision changes on every write (Drive's headRevisionId, Graph's cTag) and is
+ * what the sync engine compares against the manifest. contentHash is stronger
+ * where it exists, but both services omit it often enough not to rely on it.
+ */
+struct RemoteItem
+{
+  QString id;
+  QString name;
+  QString parentId;
+  bool isFolder = false;
+  qint64 size = -1;
+  QDateTime modified;
+  QString revision;
+  QString contentHash;
+
+  bool isValid() const { return !id.isEmpty(); }
+};
+
+/*!
+ * \brief A failure worth telling the user about, or reacting to. Auth means the
+ * user has to sign in again; Conflict is a failed precondition on a write, which
+ * the sync engine turns into a conflict rather than an error.
+ */
+struct CloudError
+{
+  enum Code {
+    NoError,
+    Network,
+    Auth,
+    NotFound,
+    Conflict,
+    RateLimited,
+    Protocol,
+    Cancelled,
+    Provider
+  };
+
+  Code code = NoError;
+  QString message;
+  int httpStatus = 0;
+
+  CloudError() = default;
+  CloudError(Code errorCode, const QString &errorMessage, int status = 0)
+    : code(errorCode), message(errorMessage), httpStatus(status) {}
+
+  bool isError() const { return code != NoError; }
+  static CloudError fromHttpStatus(int status, const QString &message);
+};
+
+Q_DECLARE_METATYPE(RemoteItem)
+Q_DECLARE_METATYPE(CloudError)
+
+#endif // CLOUDTYPES_H

--- a/OMEdit/OMEditLIB/Cloud/GoogleDriveProvider.cpp
+++ b/OMEdit/OMEditLIB/Cloud/GoogleDriveProvider.cpp
@@ -1,0 +1,539 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#include "Cloud/GoogleDriveProvider.h"
+#include "Cloud/OAuth2Client.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QUrlQuery>
+
+namespace {
+
+const char *const kApiBase = "https://www.googleapis.com/drive/v3";
+const char *const kUploadBase = "https://www.googleapis.com/upload/drive/v3";
+const char *const kFolderMimeType = "application/vnd.google-apps.folder";
+const char *const kAppFolderName = "OpenModelica";
+
+// Everything the sync engine needs, and nothing else: Drive charges for wide
+// field masks in latency.
+const char *const kItemFields = "id,name,mimeType,size,modifiedTime,md5Checksum,headRevisionId,parents,trashed";
+
+// Above this a single request is a bad idea, so the upload becomes resumable.
+const qint64 kResumableThreshold = 5 * 1024 * 1024;
+
+QString quoteForQuery(const QString &value)
+{
+  QString escaped = value;
+  escaped.replace(QLatin1Char('\\'), QLatin1String("\\\\"));
+  escaped.replace(QLatin1Char('\''), QLatin1String("\\'"));
+  return escaped;
+}
+
+RemoteItem itemFromJson(const QJsonObject &object)
+{
+  RemoteItem item;
+  item.id = object.value(QStringLiteral("id")).toString();
+  item.name = object.value(QStringLiteral("name")).toString();
+  item.isFolder = object.value(QStringLiteral("mimeType")).toString() == QLatin1String(kFolderMimeType);
+  item.size = object.value(QStringLiteral("size")).toString(QStringLiteral("-1")).toLongLong();
+  item.modified = QDateTime::fromString(object.value(QStringLiteral("modifiedTime")).toString(), Qt::ISODateWithMs);
+  item.contentHash = object.value(QStringLiteral("md5Checksum")).toString();
+  // A folder has no revision of its own; its identity is enough.
+  item.revision = object.value(QStringLiteral("headRevisionId")).toString();
+  const QJsonArray parents = object.value(QStringLiteral("parents")).toArray();
+  if (!parents.isEmpty()) {
+    item.parentId = parents.first().toString();
+  }
+  return item;
+}
+
+QNetworkRequest jsonRequest(const QUrl &url)
+{
+  QNetworkRequest request(url);
+  request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/json"));
+  return request;
+}
+
+} // namespace
+
+GoogleDriveProvider::GoogleDriveProvider(OAuth2Client *pOAuth2Client, QNetworkAccessManager *pNetworkAccessManager,
+                                         QObject *pParent)
+  : CloudProvider(pOAuth2Client, pNetworkAccessManager, pParent)
+{
+}
+
+CloudError GoogleDriveProvider::classifyError(int status, const QByteArray &payload, const QString &fallback) const
+{
+  CloudError error = CloudProvider::classifyError(status, payload, fallback);
+  if (status != 403) {
+    return error;
+  }
+  // Drive overloads 403: a quota or rate problem is worth retrying, a permission
+  // problem is not, and neither is a reason to make the user sign in again.
+  const QJsonArray errors = QJsonDocument::fromJson(payload)
+                                .object()
+                                .value(QStringLiteral("error"))
+                                .toObject()
+                                .value(QStringLiteral("errors"))
+                                .toArray();
+  for (const QJsonValue &value : errors) {
+    const QString reason = value.toObject().value(QStringLiteral("reason")).toString();
+    if (reason == QLatin1String("rateLimitExceeded") || reason == QLatin1String("userRateLimitExceeded")) {
+      error.code = CloudError::RateLimited;
+      return error;
+    }
+  }
+  return error;
+}
+
+CloudReply *GoogleDriveProvider::userInfo()
+{
+  // Drive's about endpoint, not oauth2/v3/userinfo: that one needs the
+  // openid/email/profile scopes, which drive.file exists to avoid asking for.
+  QUrl url(QStringLiteral("%1/about").arg(QLatin1String(kApiBase)));
+  QUrlQuery query;
+  query.addQueryItem(QStringLiteral("fields"), QStringLiteral("user(displayName,emailAddress,permissionId)"));
+  url.setQuery(query);
+  return send(QNetworkRequest(url), "GET", QByteArray(), [](CloudReply *pReply, const QByteArray &payload) {
+    const QJsonObject user = QJsonDocument::fromJson(payload).object().value(QStringLiteral("user")).toObject();
+    const QString email = user.value(QStringLiteral("emailAddress")).toString();
+    const QString permissionId = user.value(QStringLiteral("permissionId")).toString();
+    RemoteItem account;
+    // Whichever identifiers this scope actually yields; the account key only has
+    // to be stable, and the name only has to be recognisable.
+    account.id = permissionId.isEmpty() ? email : permissionId;
+    account.name = email.isEmpty() ? user.value(QStringLiteral("displayName")).toString() : email;
+    pReply->setItem(account);
+  });
+}
+
+CloudReply *GoogleDriveProvider::appRootFolder()
+{
+  if (!mAppRootId.isEmpty()) {
+    CloudReply *pReply = CloudReply::pending(this);
+    RemoteItem item;
+    item.id = mAppRootId;
+    item.name = QLatin1String(kAppFolderName);
+    item.isFolder = true;
+    pReply->setItem(item);
+    pReply->finish(CloudError());
+    return pReply;
+  }
+
+  CloudReply *pOuter = CloudReply::pending(this);
+  QUrlQuery query;
+  query.addQueryItem(QStringLiteral("q"), QStringLiteral("name='%1' and mimeType='%2' and trashed=false and 'root' in parents")
+                                              .arg(QLatin1String(kAppFolderName), QLatin1String(kFolderMimeType)));
+  query.addQueryItem(QStringLiteral("fields"), QStringLiteral("files(%1)").arg(QLatin1String(kItemFields)));
+  QUrl url(QStringLiteral("%1/files").arg(QLatin1String(kApiBase)));
+  url.setQuery(query);
+
+  CloudReply *pSearch = send(QNetworkRequest(url), "GET", QByteArray(), [](CloudReply *pReply, const QByteArray &payload) {
+    const QJsonArray files = QJsonDocument::fromJson(payload).object().value(QStringLiteral("files")).toArray();
+    if (!files.isEmpty()) {
+      pReply->setItem(itemFromJson(files.first().toObject()));
+    }
+  });
+  connect(pSearch, &CloudReply::finished, pOuter, [this, pOuter, pSearch]() {
+    if (pSearch->error().isError()) {
+      pOuter->finish(pSearch->error());
+      return;
+    }
+    if (pSearch->item().isValid()) {
+      mAppRootId = pSearch->item().id;
+      pOuter->setItem(pSearch->item());
+      pOuter->finish(CloudError());
+      return;
+    }
+    // First run for this account: make the folder the application works in.
+    cloudLog(QStringLiteral("no application folder yet; creating it"));
+    CloudReply *pCreate = createFolder(QStringLiteral("root"), QLatin1String(kAppFolderName));
+    connect(pCreate, &CloudReply::finished, pOuter, [this, pOuter, pCreate]() {
+      if (!pCreate->error().isError()) {
+        mAppRootId = pCreate->item().id;
+      }
+      pOuter->setItem(pCreate->item());
+      pOuter->finish(pCreate->error());
+    });
+  });
+  return pOuter;
+}
+
+CloudReply *GoogleDriveProvider::listFolder(const QString &folderId)
+{
+  CloudReply *pReply = CloudReply::pending(this);
+  listPage(pReply, folderId, QString(), QList<RemoteItem>());
+  return pReply;
+}
+
+void GoogleDriveProvider::listPage(CloudReply *pReply, const QString &folderId, const QString &pageToken,
+                                   const QList<RemoteItem> &sofar)
+{
+  QUrlQuery query;
+  query.addQueryItem(QStringLiteral("q"), QStringLiteral("'%1' in parents and trashed=false").arg(quoteForQuery(folderId)));
+  query.addQueryItem(QStringLiteral("fields"), QStringLiteral("nextPageToken,files(%1)").arg(QLatin1String(kItemFields)));
+  query.addQueryItem(QStringLiteral("pageSize"), QStringLiteral("1000"));
+  query.addQueryItem(QStringLiteral("spaces"), QStringLiteral("drive"));
+  if (!pageToken.isEmpty()) {
+    query.addQueryItem(QStringLiteral("pageToken"), pageToken);
+  }
+  QUrl url(QStringLiteral("%1/files").arg(QLatin1String(kApiBase)));
+  url.setQuery(query);
+
+  CloudReply *pPage = send(QNetworkRequest(url), "GET", QByteArray(), [](CloudReply *pInner, const QByteArray &payload) {
+    const QJsonObject object = QJsonDocument::fromJson(payload).object();
+    QList<RemoteItem> items;
+    const QJsonArray files = object.value(QStringLiteral("files")).toArray();
+    for (const QJsonValue &value : files) {
+      items << itemFromJson(value.toObject());
+    }
+    pInner->setItems(items);
+    pInner->setDeltaToken(object.value(QStringLiteral("nextPageToken")).toString());
+  });
+  connect(pPage, &CloudReply::finished, pReply, [this, pReply, pPage, folderId, sofar]() {
+    if (pPage->error().isError()) {
+      pReply->finish(pPage->error());
+      return;
+    }
+    QList<RemoteItem> items = sofar;
+    items << pPage->items();
+    const QString next = pPage->deltaToken();
+    if (next.isEmpty()) {
+      pReply->setItems(items);
+      pReply->finish(CloudError());
+      return;
+    }
+    listPage(pReply, folderId, next, items);
+  });
+}
+
+CloudReply *GoogleDriveProvider::metadata(const QString &itemId)
+{
+  QUrl url(QStringLiteral("%1/files/%2").arg(QLatin1String(kApiBase), itemId));
+  QUrlQuery query;
+  query.addQueryItem(QStringLiteral("fields"), QLatin1String(kItemFields));
+  url.setQuery(query);
+  return send(QNetworkRequest(url), "GET", QByteArray(), [](CloudReply *pReply, const QByteArray &payload) {
+    pReply->setItem(itemFromJson(QJsonDocument::fromJson(payload).object()));
+  });
+}
+
+CloudReply *GoogleDriveProvider::download(const QString &fileId)
+{
+  QUrl url(QStringLiteral("%1/files/%2").arg(QLatin1String(kApiBase), fileId));
+  QUrlQuery query;
+  query.addQueryItem(QStringLiteral("alt"), QStringLiteral("media"));
+  url.setQuery(query);
+  return send(QNetworkRequest(url), "GET", QByteArray(), [](CloudReply *pReply, const QByteArray &payload) {
+    pReply->setData(payload);
+  });
+}
+
+CloudReply *GoogleDriveProvider::createFolder(const QString &parentId, const QString &name)
+{
+  QJsonObject fileMetadata;
+  fileMetadata.insert(QStringLiteral("name"), name);
+  fileMetadata.insert(QStringLiteral("mimeType"), QLatin1String(kFolderMimeType));
+  fileMetadata.insert(QStringLiteral("parents"), QJsonArray() << parentId);
+
+  QUrl url(QStringLiteral("%1/files").arg(QLatin1String(kApiBase)));
+  QUrlQuery query;
+  query.addQueryItem(QStringLiteral("fields"), QLatin1String(kItemFields));
+  url.setQuery(query);
+  return send(jsonRequest(url), "POST", QJsonDocument(fileMetadata).toJson(QJsonDocument::Compact),
+              [](CloudReply *pReply, const QByteArray &payload) {
+    pReply->setItem(itemFromJson(QJsonDocument::fromJson(payload).object()));
+  });
+}
+
+CloudReply *GoogleDriveProvider::uploadNew(const QString &parentId, const QString &name, const QByteArray &contents)
+{
+  if (contents.size() >= kResumableThreshold) {
+    CloudReply *pReply = CloudReply::pending(this);
+    startResumableUpload(pReply, QString(), parentId, name, contents);
+    return pReply;
+  }
+
+  QJsonObject fileMetadata;
+  fileMetadata.insert(QStringLiteral("name"), name);
+  fileMetadata.insert(QStringLiteral("parents"), QJsonArray() << parentId);
+
+  // multipart/related: the metadata and the bytes in one request.
+  const QByteArray boundary = "omedit-" + QByteArray::number(QDateTime::currentMSecsSinceEpoch(), 16);
+  QByteArray body;
+  body += "--" + boundary + "\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n";
+  body += QJsonDocument(fileMetadata).toJson(QJsonDocument::Compact);
+  body += "\r\n--" + boundary + "\r\nContent-Type: application/octet-stream\r\n\r\n";
+  body += contents;
+  body += "\r\n--" + boundary + "--\r\n";
+
+  QUrl url(QStringLiteral("%1/files").arg(QLatin1String(kUploadBase)));
+  QUrlQuery query;
+  query.addQueryItem(QStringLiteral("uploadType"), QStringLiteral("multipart"));
+  query.addQueryItem(QStringLiteral("fields"), QLatin1String(kItemFields));
+  url.setQuery(query);
+
+  QNetworkRequest request(url);
+  request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("multipart/related; boundary=%1").arg(QString::fromLatin1(boundary)));
+  return send(request, "POST", body, [](CloudReply *pReply, const QByteArray &payload) {
+    pReply->setItem(itemFromJson(QJsonDocument::fromJson(payload).object()));
+  });
+}
+
+CloudReply *GoogleDriveProvider::uploadUpdate(const QString &fileId, const QByteArray &contents,
+                                              const QString &expectedRevision)
+{
+  CloudReply *pReply = CloudReply::pending(this);
+  if (expectedRevision.isEmpty()) {
+    putContents(pReply, fileId, contents);
+    return pReply;
+  }
+  // Drive v3 offers no conditional write, so the revision is checked first. The
+  // gap is real; the next pass closes it and the trash makes a lost race
+  // recoverable.
+  CloudReply *pCheck = metadata(fileId);
+  connect(pCheck, &CloudReply::finished, pReply, [this, pReply, pCheck, fileId, contents, expectedRevision]() {
+    if (pCheck->error().isError()) {
+      pReply->finish(pCheck->error());
+      return;
+    }
+    if (pCheck->item().revision != expectedRevision) {
+      pReply->setItem(pCheck->item());
+      pReply->finish(CloudError(CloudError::Conflict, tr("The file changed in Google Drive since it was last synchronised.")));
+      return;
+    }
+    putContents(pReply, fileId, contents);
+  });
+  return pReply;
+}
+
+void GoogleDriveProvider::putContents(CloudReply *pReply, const QString &fileId, const QByteArray &contents)
+{
+  if (contents.size() >= kResumableThreshold) {
+    startResumableUpload(pReply, fileId, QString(), QString(), contents);
+    return;
+  }
+  QUrl url(QStringLiteral("%1/files/%2").arg(QLatin1String(kUploadBase), fileId));
+  QUrlQuery query;
+  query.addQueryItem(QStringLiteral("uploadType"), QStringLiteral("media"));
+  query.addQueryItem(QStringLiteral("fields"), QLatin1String(kItemFields));
+  url.setQuery(query);
+
+  QNetworkRequest request(url);
+  request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/octet-stream"));
+  CloudReply *pUpload = send(request, "PATCH", contents, [](CloudReply *pInner, const QByteArray &payload) {
+    pInner->setItem(itemFromJson(QJsonDocument::fromJson(payload).object()));
+  });
+  connect(pUpload, &CloudReply::progress, pReply, &CloudReply::progress);
+  connect(pUpload, &CloudReply::finished, pReply, [pReply, pUpload]() {
+    pReply->setItem(pUpload->item());
+    pReply->finish(pUpload->error());
+  });
+}
+
+/*!
+ * \brief Two-step upload for a file too big to push in one request. The first
+ * request returns a one-off URL in Location; the bytes then go there.
+ */
+void GoogleDriveProvider::startResumableUpload(CloudReply *pReply, const QString &fileId, const QString &parentId,
+                                               const QString &name, const QByteArray &contents)
+{
+  QJsonObject fileMetadata;
+  if (fileId.isEmpty()) {
+    fileMetadata.insert(QStringLiteral("name"), name);
+    fileMetadata.insert(QStringLiteral("parents"), QJsonArray() << parentId);
+  }
+  QUrl url(fileId.isEmpty() ? QStringLiteral("%1/files").arg(QLatin1String(kUploadBase))
+                            : QStringLiteral("%1/files/%2").arg(QLatin1String(kUploadBase), fileId));
+  QUrlQuery query;
+  query.addQueryItem(QStringLiteral("uploadType"), QStringLiteral("resumable"));
+  query.addQueryItem(QStringLiteral("fields"), QLatin1String(kItemFields));
+  url.setQuery(query);
+
+  QNetworkRequest request = jsonRequest(url);
+  request.setRawHeader("X-Upload-Content-Type", "application/octet-stream");
+  request.setRawHeader("X-Upload-Content-Length", QByteArray::number(static_cast<qlonglong>(contents.size())));
+
+  // The session URL only comes back in a header, which send()'s parse hook does
+  // not see, so this one request is made directly.
+  mpOAuth2Client->withAccessToken(pReply, [this, pReply, request, fileMetadata, contents, fileId](const CloudError &tokenError) {
+    if (tokenError.isError()) {
+      pReply->finish(tokenError);
+      return;
+    }
+    QNetworkRequest authorized(request);
+    authorized.setRawHeader("Authorization", "Bearer " + mpOAuth2Client->accessToken().toUtf8());
+    QNetworkReply *pStart = mpNetworkAccessManager->sendCustomRequest(
+        authorized, fileId.isEmpty() ? "POST" : "PATCH", QJsonDocument(fileMetadata).toJson(QJsonDocument::Compact));
+    connect(pStart, &QNetworkReply::finished, pReply, [this, pReply, pStart, contents]() {
+      pStart->deleteLater();
+      const int status = pStart->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+      const QUrl sessionUrl(QString::fromUtf8(pStart->rawHeader("Location")));
+      if (status < 200 || status >= 300 || sessionUrl.isEmpty()) {
+        pReply->finish(classifyError(status, pStart->readAll(), pStart->errorString()));
+        return;
+      }
+      QNetworkRequest put(sessionUrl);
+      put.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/octet-stream"));
+      // The session URL carries its own authorization; Google documents the
+      // bearer token as not required here.
+      QNetworkReply *pPut = mpNetworkAccessManager->put(put, contents);
+      pReply->trackNetworkReply(pPut);
+      connect(pPut, &QNetworkReply::finished, pReply, [this, pReply, pPut]() {
+        pPut->deleteLater();
+        const int putStatus = pPut->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        const QByteArray payload = pPut->readAll();
+        if (putStatus < 200 || putStatus >= 300) {
+          pReply->finish(classifyError(putStatus, payload, pPut->errorString()));
+          return;
+        }
+        pReply->setItem(itemFromJson(QJsonDocument::fromJson(payload).object()));
+        pReply->finish(CloudError());
+      });
+    });
+  });
+}
+
+CloudReply *GoogleDriveProvider::trashItem(const QString &itemId, const QString &expectedRevision)
+{
+  QJsonObject patch;
+  patch.insert(QStringLiteral("trashed"), true);
+  QUrl url(QStringLiteral("%1/files/%2").arg(QLatin1String(kApiBase), itemId));
+
+  auto issueTrash = [this, url, patch](CloudReply *pOuter) {
+    CloudReply *pTrash = send(jsonRequest(url), "PATCH", QJsonDocument(patch).toJson(QJsonDocument::Compact), 0);
+    connect(pTrash, &CloudReply::finished, pOuter, [pOuter, pTrash]() { pOuter->finish(pTrash->error()); });
+  };
+
+  CloudReply *pReply = CloudReply::pending(this);
+  if (expectedRevision.isEmpty()) {
+    issueTrash(pReply);
+    return pReply;
+  }
+  CloudReply *pCheck = metadata(itemId);
+  connect(pCheck, &CloudReply::finished, pReply, [pReply, pCheck, expectedRevision, issueTrash]() {
+    if (pCheck->error().isError()) {
+      pReply->finish(pCheck->error());
+      return;
+    }
+    if (pCheck->item().revision != expectedRevision) {
+      pReply->setItem(pCheck->item());
+      pReply->finish(CloudError(CloudError::Conflict, tr("The file changed in Google Drive since it was last synchronised.")));
+      return;
+    }
+    issueTrash(pReply);
+  });
+  return pReply;
+}
+
+CloudReply *GoogleDriveProvider::currentDeltaToken(const QString &rootId)
+{
+  Q_UNUSED(rootId)
+  QUrl url(QStringLiteral("%1/changes/startPageToken").arg(QLatin1String(kApiBase)));
+  return send(QNetworkRequest(url), "GET", QByteArray(), [](CloudReply *pReply, const QByteArray &payload) {
+    pReply->setDeltaToken(QJsonDocument::fromJson(payload).object().value(QStringLiteral("startPageToken")).toString());
+  });
+}
+
+CloudReply *GoogleDriveProvider::changes(const QString &rootId, const QString &deltaToken)
+{
+  // Drive reports changes per account rather than per folder; the sync engine
+  // only looks at the ids its manifest knows, so the extra noise is harmless.
+  Q_UNUSED(rootId)
+  CloudReply *pReply = CloudReply::pending(this);
+  changesPage(pReply, deltaToken, QList<RemoteItem>(), QStringList());
+  return pReply;
+}
+
+void GoogleDriveProvider::changesPage(CloudReply *pReply, const QString &pageToken, const QList<RemoteItem> &sofar,
+                                      const QStringList &removed)
+{
+  QUrlQuery query;
+  query.addQueryItem(QStringLiteral("pageToken"), pageToken);
+  query.addQueryItem(QStringLiteral("pageSize"), QStringLiteral("1000"));
+  query.addQueryItem(QStringLiteral("spaces"), QStringLiteral("drive"));
+  query.addQueryItem(QStringLiteral("fields"),
+                     QStringLiteral("nextPageToken,newStartPageToken,changes(fileId,removed,file(%1))")
+                         .arg(QLatin1String(kItemFields)));
+  QUrl url(QStringLiteral("%1/changes").arg(QLatin1String(kApiBase)));
+  url.setQuery(query);
+
+  CloudReply *pPage = send(QNetworkRequest(url), "GET", QByteArray(), [](CloudReply *pInner, const QByteArray &payload) {
+    const QJsonObject object = QJsonDocument::fromJson(payload).object();
+    QList<RemoteItem> items;
+    QStringList removedIds;
+    const QJsonArray changes = object.value(QStringLiteral("changes")).toArray();
+    for (const QJsonValue &value : changes) {
+      const QJsonObject change = value.toObject();
+      const QJsonObject file = change.value(QStringLiteral("file")).toObject();
+      // "removed" covers a delete; a file moved to the trash is still reported as
+      // a normal change, so trashed has to be read as removal too.
+      if (change.value(QStringLiteral("removed")).toBool() || file.value(QStringLiteral("trashed")).toBool()) {
+        removedIds << change.value(QStringLiteral("fileId")).toString();
+      } else if (!file.isEmpty()) {
+        items << itemFromJson(file);
+      }
+    }
+    pInner->setItems(items);
+    pInner->setRemovedIds(removedIds);
+    pInner->setDeltaToken(object.value(QStringLiteral("nextPageToken")).toString());
+    pInner->setData(object.value(QStringLiteral("newStartPageToken")).toString().toUtf8());
+  });
+  connect(pPage, &CloudReply::finished, pReply, [this, pReply, pPage, sofar, removed]() {
+    if (pPage->error().isError()) {
+      pReply->finish(pPage->error());
+      return;
+    }
+    QList<RemoteItem> items = sofar;
+    items << pPage->items();
+    QStringList removedIds = removed;
+    removedIds << pPage->removedIds();
+    const QString next = pPage->deltaToken();
+    if (!next.isEmpty()) {
+      changesPage(pReply, next, items, removedIds);
+      return;
+    }
+    pReply->setItems(items);
+    pReply->setRemovedIds(removedIds);
+    // The last page carries the token the next run resumes from.
+    pReply->setDeltaToken(QString::fromUtf8(pPage->data()));
+    pReply->finish(CloudError());
+  });
+}

--- a/OMEdit/OMEditLIB/Cloud/GoogleDriveProvider.h
+++ b/OMEdit/OMEditLIB/Cloud/GoogleDriveProvider.h
@@ -1,0 +1,83 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifndef GOOGLEDRIVEPROVIDER_H
+#define GOOGLEDRIVEPROVIDER_H
+
+#include "Cloud/CloudProvider.h"
+
+/*!
+ * \brief Google Drive, over the v3 REST API.
+ *
+ * The drive.file scope only sees what the application created, which is what
+ * keeps it non-sensitive (no Google app verification) and why everything lives
+ * under one folder. Drive v3 has no conditional writes - no If-Match, no ETag on
+ * files - so a guarded update is read-revision-then-write and is not atomic.
+ */
+class GoogleDriveProvider : public CloudProvider
+{
+  Q_OBJECT
+public:
+  GoogleDriveProvider(OAuth2Client *pOAuth2Client, QNetworkAccessManager *pNetworkAccessManager, QObject *pParent = 0);
+
+  CloudProviderKind kind() const override { return CloudProviderKind::GoogleDrive; }
+
+  CloudReply *userInfo() override;
+  CloudReply *appRootFolder() override;
+  CloudReply *listFolder(const QString &folderId) override;
+  CloudReply *metadata(const QString &itemId) override;
+  CloudReply *download(const QString &fileId) override;
+  CloudReply *createFolder(const QString &parentId, const QString &name) override;
+  CloudReply *uploadNew(const QString &parentId, const QString &name, const QByteArray &contents) override;
+  CloudReply *uploadUpdate(const QString &fileId, const QByteArray &contents, const QString &expectedRevision) override;
+  CloudReply *trashItem(const QString &itemId, const QString &expectedRevision) override;
+  CloudReply *currentDeltaToken(const QString &rootId) override;
+  CloudReply *changes(const QString &rootId, const QString &deltaToken) override;
+
+protected:
+  CloudError classifyError(int status, const QByteArray &payload, const QString &fallback) const override;
+
+private:
+  void listPage(CloudReply *pReply, const QString &folderId, const QString &pageToken, const QList<RemoteItem> &sofar);
+  void changesPage(CloudReply *pReply, const QString &pageToken, const QList<RemoteItem> &sofar,
+                   const QStringList &removed);
+  void putContents(CloudReply *pReply, const QString &fileId, const QByteArray &contents);
+  void startResumableUpload(CloudReply *pReply, const QString &fileId, const QString &parentId, const QString &name,
+                            const QByteArray &contents);
+
+  QString mAppRootId;
+};
+
+#endif // GOOGLEDRIVEPROVIDER_H

--- a/OMEdit/OMEditLIB/Cloud/OAuth2Client.cpp
+++ b/OMEdit/OMEditLIB/Cloud/OAuth2Client.cpp
@@ -1,0 +1,284 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#include "Cloud/OAuth2Client.h"
+#include "Cloud/OAuth2Redirect.h"
+
+#include <QCryptographicHash>
+#include <memory>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QDebug>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QRandomGenerator>
+#include <QUrl>
+#include <QTimer>
+#include <QUrlQuery>
+
+namespace {
+
+//! base64url without padding, as RFC 7636 wants it.
+QString base64Url(const QByteArray &bytes)
+{
+  return QString::fromLatin1(bytes.toBase64(QByteArray::Base64UrlEncoding | QByteArray::OmitTrailingEquals));
+}
+
+QString randomToken(int bytes)
+{
+  QByteArray raw(bytes, Qt::Uninitialized);
+  QRandomGenerator::system()->generate(raw.begin(), raw.end());
+  return base64Url(raw);
+}
+
+//! The access token is treated as expired a minute early, so a request that is
+//! about to be sent does not race the expiry.
+const int kExpirySlackSeconds = 60;
+
+} // namespace
+
+OAuth2Client::OAuth2Client(const OAuth2Config &config, QNetworkAccessManager *pNetworkAccessManager, QObject *pParent)
+  : QObject(pParent), mConfig(config), mpNetworkAccessManager(pNetworkAccessManager)
+{
+}
+
+QString OAuth2Client::generateCodeVerifier()
+{
+  return randomToken(32);
+}
+
+QString OAuth2Client::codeChallenge(const QString &verifier)
+{
+  return base64Url(QCryptographicHash::hash(verifier.toLatin1(), QCryptographicHash::Sha256));
+}
+
+void OAuth2Client::setTokens(const QString &refreshToken, const QString &accessToken, const QDateTime &accessExpiry)
+{
+  mRefreshToken = refreshToken;
+  mAccessToken = accessToken;
+  mAccessExpiry = accessExpiry;
+}
+
+bool OAuth2Client::hasUsableAccessToken() const
+{
+  return !mAccessToken.isEmpty() && mAccessExpiry.isValid()
+         && QDateTime::currentDateTimeUtc().addSecs(kExpirySlackSeconds) < mAccessExpiry;
+}
+
+void OAuth2Client::signOut()
+{
+  mAccessToken.clear();
+  mRefreshToken.clear();
+  mAccessExpiry = QDateTime();
+  emit tokensChanged();
+}
+
+void OAuth2Client::ensureAccessToken(bool allowInteractive)
+{
+  if (hasUsableAccessToken()) {
+    emit ready();
+    return;
+  }
+  if (mBusy) {
+    // The in-flight attempt emits for everyone waiting. Bounded: both the token
+    // request and the browser sign-in have timeouts, so this cannot wedge.
+    return;
+  }
+  mAllowInteractive = allowInteractive;
+  if (!mRefreshToken.isEmpty()) {
+    mBusy = true;
+    exchange(QStringLiteral("refresh_token"), QStringList() << QStringLiteral("refresh_token=%1").arg(QString::fromUtf8(QUrl::toPercentEncoding(mRefreshToken))), false);
+    return;
+  }
+  if (!allowInteractive) {
+    emit failed(CloudError(CloudError::Auth, tr("Not signed in.")));
+    return;
+  }
+  mBusy = true;
+  startInteractive();
+}
+
+void OAuth2Client::withAccessToken(QObject *pContext, const std::function<void(const CloudError &)> &callback)
+{
+  // ready() and failed() are broadcast to everyone waiting on the same renewal,
+  // so the shared flag keeps this particular caller to a single delivery.
+  auto delivered = std::make_shared<bool>(false);
+  auto deliver = [delivered, callback](const CloudError &error) {
+    if (*delivered) {
+      return;
+    }
+    *delivered = true;
+    callback(error);
+  };
+  connect(this, &OAuth2Client::ready, pContext, [deliver]() { deliver(CloudError()); });
+  connect(this, &OAuth2Client::failed, pContext, [deliver](const CloudError &error) { deliver(error); });
+  ensureAccessToken();
+}
+
+void OAuth2Client::startInteractive()
+{
+  OAuth2Redirect *pRedirect = OAuth2Redirect::create(mConfig.redirectUri, this);
+  const QString redirectUri = pRedirect->redirectUri();
+  if (redirectUri.isEmpty()) {
+    mBusy = false;
+    pRedirect->deleteLater();
+    emit failed(CloudError(CloudError::Auth, tr("Could not set up the sign-in redirect.")));
+    return;
+  }
+  mConfig.redirectUri = redirectUri;
+  mCodeVerifier = generateCodeVerifier();
+  mState = randomToken(16);
+
+  QUrlQuery query;
+  query.addQueryItem(QStringLiteral("response_type"), QStringLiteral("code"));
+  query.addQueryItem(QStringLiteral("client_id"), mConfig.clientId);
+  query.addQueryItem(QStringLiteral("redirect_uri"), redirectUri);
+  query.addQueryItem(QStringLiteral("scope"), mConfig.scope);
+  query.addQueryItem(QStringLiteral("state"), mState);
+  query.addQueryItem(QStringLiteral("code_challenge"), codeChallenge(mCodeVerifier));
+  query.addQueryItem(QStringLiteral("code_challenge_method"), QStringLiteral("S256"));
+  for (const QString &parameter : std::as_const(mConfig.extraAuthorizationParameters)) {
+    const int equals = parameter.indexOf(QLatin1Char('='));
+    if (equals > 0) {
+      query.addQueryItem(parameter.left(equals), parameter.mid(equals + 1));
+    }
+  }
+  QUrl url(mConfig.authorizationUrl);
+  url.setQuery(query);
+
+  emit phaseChanged(tr("Waiting for you to sign in with the browser..."));
+  connect(pRedirect, &OAuth2Redirect::finished, this, &OAuth2Client::onRedirectFinished);
+  connect(pRedirect, &OAuth2Redirect::finished, pRedirect, &QObject::deleteLater);
+  // Whatever happens next - including the browser refusing to open - arrives as
+  // finished(), so there is nothing to report here.
+  pRedirect->start(url, mState);
+}
+
+void OAuth2Client::onRedirectFinished(const QString &code, const QString &state, const QString &error)
+{
+  if (!error.isEmpty()) {
+    mBusy = false;
+    emit failed(CloudError(CloudError::Auth, error));
+    return;
+  }
+  // A mismatched state means the response is not the one this flow asked for.
+  if (state != mState) {
+    mBusy = false;
+    emit failed(CloudError(CloudError::Auth, tr("The sign-in response did not match the request.")));
+    return;
+  }
+  emit phaseChanged(tr("Exchanging the authorization code..."));
+  QStringList parameters;
+  parameters << QStringLiteral("code=%1").arg(QString::fromUtf8(QUrl::toPercentEncoding(code)));
+  parameters << QStringLiteral("redirect_uri=%1").arg(QString::fromUtf8(QUrl::toPercentEncoding(mConfig.redirectUri)));
+  parameters << QStringLiteral("code_verifier=%1").arg(mCodeVerifier);
+  exchange(QStringLiteral("authorization_code"), parameters, true);
+}
+
+void OAuth2Client::exchange(const QString &grantType, const QStringList &parameters, bool interactive)
+{
+  QStringList body;
+  body << QStringLiteral("grant_type=%1").arg(grantType);
+  body << QStringLiteral("client_id=%1").arg(QString::fromUtf8(QUrl::toPercentEncoding(mConfig.clientId)));
+  if (!mConfig.clientSecret.isEmpty()) {
+    body << QStringLiteral("client_secret=%1").arg(QString::fromUtf8(QUrl::toPercentEncoding(mConfig.clientSecret)));
+  }
+  body << parameters;
+
+  QNetworkRequest request((QUrl(mConfig.tokenUrl)));
+  request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/x-www-form-urlencoded"));
+  cloudLog(QStringLiteral("token request -> %1 grant %2").arg(mConfig.tokenUrl, grantType));
+  QNetworkReply *pReply = mpNetworkAccessManager->post(request, body.join(QLatin1Char('&')).toUtf8());
+  // A request that never completes would leave the dialog waiting for ever; on
+  // wasm the transport is emscripten fetch, which has no timeout of its own.
+  QTimer *pTimeout = new QTimer(pReply);
+  pTimeout->setSingleShot(true);
+  connect(pTimeout, &QTimer::timeout, pReply, [pReply]() {
+    cloudLog(QStringLiteral("token request timed out"));
+    pReply->abort();
+  });
+  pTimeout->start(30000);
+  connect(pReply, &QNetworkReply::errorOccurred, this, [](QNetworkReply::NetworkError error) {
+    cloudLog(QStringLiteral("token request error %1").arg(int(error)));
+  });
+  connect(pReply, &QNetworkReply::finished, this, [this, pReply, interactive]() {
+    pReply->deleteLater();
+    const QByteArray payload = pReply->readAll();
+    const int status = pReply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    const QString transportError = pReply->errorString();
+    const bool requestFailed = pReply->error() != QNetworkReply::NoError || status < 200 || status >= 300;
+    cloudLog(QStringLiteral("token response status %1 qt error %2").arg(status).arg(int(pReply->error())));
+    // Everything below runs application code - storing the refresh token, sending
+    // the next request - and none of it may run inside the network callback: that
+    // is a JS->wasm frame, and anything that waits there unwinds Asyncify from
+    // under the browser and wedges the runtime. Hand it to the event loop first.
+    QTimer::singleShot(0, this, [this, payload, status, transportError, requestFailed, interactive]() {
+      mBusy = false;
+      const QJsonObject object = QJsonDocument::fromJson(payload).object();
+      if (requestFailed) {
+        const QString description = object.value(QStringLiteral("error_description")).toString(
+            object.value(QStringLiteral("error")).toString(transportError));
+        // A refresh token can be revoked or simply expire. The account then has to
+        // be signed in again - but not from here: opening the sign-in window
+        // outside a user gesture is blocked by the browser, and the user would see
+        // nothing happen at all. Report it and let them start the sign-in.
+        if (!interactive) {
+          mRefreshToken.clear();
+          emit tokensChanged();
+          emit failed(CloudError(CloudError::Auth, tr("The saved sign-in is no longer valid. Sign in again.")));
+          return;
+        }
+        emit failed(CloudError(CloudError::Auth, description, status));
+        return;
+      }
+      mAccessToken = object.value(QStringLiteral("access_token")).toString();
+      const int expiresIn = object.value(QStringLiteral("expires_in")).toInt(3600);
+      mAccessExpiry = QDateTime::currentDateTimeUtc().addSecs(expiresIn);
+      // Only replace the refresh token when the service sent a new one: a refresh
+      // response usually omits it, and Microsoft rotates it on every use.
+      const QString newRefreshToken = object.value(QStringLiteral("refresh_token")).toString();
+      if (!newRefreshToken.isEmpty()) {
+        mRefreshToken = newRefreshToken;
+      }
+      if (mAccessToken.isEmpty()) {
+        emit failed(CloudError(CloudError::Protocol, tr("The service returned no access token.")));
+        return;
+      }
+      emit tokensChanged();
+      emit ready();
+    });
+  });
+}

--- a/OMEdit/OMEditLIB/Cloud/OAuth2Client.h
+++ b/OMEdit/OMEditLIB/Cloud/OAuth2Client.h
@@ -1,0 +1,127 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifndef OAUTH2CLIENT_H
+#define OAUTH2CLIENT_H
+
+#include "Cloud/CloudTypes.h"
+
+#include <QDateTime>
+#include <QObject>
+
+#include <functional>
+#include <QString>
+#include <QStringList>
+
+class QNetworkAccessManager;
+
+//! Endpoints and registration of one OAuth 2.0 application.
+struct OAuth2Config
+{
+  QString authorizationUrl;
+  QString tokenUrl;
+  QString clientId;
+  //! Only Google needs one, and only because its token endpoint rejects a PKCE
+  //! exchange without it. Deployment configuration, not a confidential value.
+  QString clientSecret;
+  QString scope;
+  QString redirectUri;
+  //! "access_type=offline", "prompt=consent", ... appended to the authorization URL.
+  QStringList extraAuthorizationParameters;
+};
+
+/*!
+ * \brief Authorization code flow with PKCE, for a public client.
+ *
+ * Not QtNetworkAuth: that module is in neither Qt kit here. The interactive half
+ * differs completely between the two platforms and lives behind OAuth2Redirect.
+ */
+class OAuth2Client : public QObject
+{
+  Q_OBJECT
+public:
+  OAuth2Client(const OAuth2Config &config, QNetworkAccessManager *pNetworkAccessManager, QObject *pParent = 0);
+
+  const OAuth2Config &config() const { return mConfig; }
+
+  //! Restore a previous sign-in. An expired access token is fine: it gets refreshed.
+  void setTokens(const QString &refreshToken, const QString &accessToken, const QDateTime &accessExpiry);
+  QString refreshToken() const { return mRefreshToken; }
+  QString accessToken() const { return mAccessToken; }
+  QDateTime accessExpiry() const { return mAccessExpiry; }
+  bool isSignedIn() const { return !mRefreshToken.isEmpty() || hasUsableAccessToken(); }
+
+  //! Makes accessToken() usable, then emits ready(). Refreshes silently where it
+  //! can; the interactive flow is the fallback.
+  void ensureAccessToken(bool allowInteractive = true);
+
+  //! Runs callback once, when a token is available or getting one failed. Tied
+  //! to pContext's lifetime, so an abandoned request leaves nothing dangling.
+  void withAccessToken(QObject *pContext, const std::function<void(const CloudError &)> &callback);
+
+  //! Forget the tokens. Does not revoke them at the service.
+  void signOut();
+
+  static QString generateCodeVerifier();
+  static QString codeChallenge(const QString &verifier);
+
+signals:
+  //! Coarse progress, for a dialog that would otherwise just say "signing in".
+  void phaseChanged(const QString &description);
+  void ready();
+  void failed(const CloudError &error);
+  //! The refresh token changed and should be written back to the secret store.
+  void tokensChanged();
+
+private slots:
+  void onRedirectFinished(const QString &code, const QString &state, const QString &error);
+
+private:
+  bool hasUsableAccessToken() const;
+  void startInteractive();
+  void exchange(const QString &grantType, const QStringList &parameters, bool interactive);
+
+  OAuth2Config mConfig;
+  QNetworkAccessManager *mpNetworkAccessManager;
+  QString mAccessToken;
+  QString mRefreshToken;
+  QDateTime mAccessExpiry;
+  QString mCodeVerifier;
+  QString mState;
+  bool mBusy = false;
+  bool mAllowInteractive = true;
+};
+
+#endif // OAUTH2CLIENT_H

--- a/OMEdit/OMEditLIB/Cloud/OAuth2Redirect.h
+++ b/OMEdit/OMEditLIB/Cloud/OAuth2Redirect.h
@@ -1,0 +1,76 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifndef OAUTH2REDIRECT_H
+#define OAUTH2REDIRECT_H
+
+#include <QObject>
+#include <QString>
+#include <QUrl>
+
+/*!
+ * \brief Shows the user the authorization page and brings the code back.
+ *
+ * Desktop opens the system browser and catches the redirect on a loopback
+ * socket. The browser build opens a popup that returns to a callback page of our
+ * own origin; COOP: same-origin severs the popup's opener in both directions, so
+ * the code travels back over a BroadcastChannel rather than postMessage.
+ */
+class OAuth2Redirect : public QObject
+{
+  Q_OBJECT
+public:
+  explicit OAuth2Redirect(QObject *pParent = 0) : QObject(pParent) {}
+
+  //! The platform's implementation; the caller takes ownership. configuredUri is
+  //! ignored on desktop, whose port is only known once bound.
+  static OAuth2Redirect *create(const QString &configuredUri, QObject *pParent = 0);
+
+  //! Empty if the listener could not be set up. On desktop this reserves the
+  //! loopback port, so nothing else knows the URI until this has been called.
+  virtual QString redirectUri() = 0;
+
+  //! The return value only says whether a browser window was launched; the
+  //! outcome, failures included, always arrives as finished().
+  virtual bool start(const QUrl &authorizationUrl, const QString &state) = 0;
+  virtual void cancel() = 0;
+
+signals:
+  //! One of code or error is set; state is echoed back for checking. Emitted
+  //! exactly once per start(), cancellation included, so nobody waits forever.
+  void finished(const QString &code, const QString &state, const QString &error);
+};
+
+#endif // OAUTH2REDIRECT_H

--- a/OMEdit/OMEditLIB/Cloud/OAuth2RedirectLoopback.cpp
+++ b/OMEdit/OMEditLIB/Cloud/OAuth2RedirectLoopback.cpp
@@ -1,0 +1,166 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+// Desktop half of OAuth2Redirect: the system browser plus a loopback listener.
+// Both services allow a http://127.0.0.1:<any port> redirect for a public client,
+// which is what lets this work without registering a fixed port.
+
+#if !defined(__EMSCRIPTEN__)
+
+#include "Cloud/OAuth2Redirect.h"
+
+#include <QDesktopServices>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QTimer>
+#include <QUrlQuery>
+
+namespace {
+
+// Long enough for the user to find the browser window, sign in and consent.
+const int kTimeoutMs = 5 * 60 * 1000;
+
+const char *const kResponsePage =
+    "HTTP/1.1 200 OK\r\n"
+    "Content-Type: text/html; charset=utf-8\r\n"
+    "Connection: close\r\n"
+    "\r\n"
+    "<!doctype html><html><head><meta charset=\"utf-8\"><title>OMEdit</title></head>"
+    "<body style=\"font-family:sans-serif;padding:2em\">"
+    "<h2>OMEdit is signed in</h2><p>You can close this tab and go back to OMEdit.</p>"
+    "</body></html>";
+
+class LoopbackRedirect : public OAuth2Redirect
+{
+public:
+  explicit LoopbackRedirect(QObject *pParent) : OAuth2Redirect(pParent)
+  {
+    mpServer = new QTcpServer(this);
+    connect(mpServer, &QTcpServer::newConnection, this, &LoopbackRedirect::onConnection);
+    mpTimeout = new QTimer(this);
+    mpTimeout->setSingleShot(true);
+    mpTimeout->setInterval(kTimeoutMs);
+    connect(mpTimeout, &QTimer::timeout, this, [this]() {
+      settle(QString(), QString(), tr("Timed out waiting for the sign-in to finish."));
+    });
+  }
+
+  QString redirectUri() override
+  {
+    if (!mpServer->isListening() && !mpServer->listen(QHostAddress::LocalHost, 0)) {
+      return QString();
+    }
+    return QStringLiteral("http://127.0.0.1:%1/").arg(mpServer->serverPort());
+  }
+
+  bool start(const QUrl &authorizationUrl, const QString &state) override
+  {
+    // The loopback listener echoes back whatever the service sends; the client
+    // does the checking.
+    Q_UNUSED(state)
+    if (redirectUri().isEmpty()) {
+      return false;
+    }
+    mpTimeout->start();
+    if (!QDesktopServices::openUrl(authorizationUrl)) {
+      settle(QString(), QString(), tr("Could not open a web browser for signing in."));
+      return false;
+    }
+    return true;
+  }
+
+  void cancel() override { settle(QString(), QString(), tr("Sign-in was cancelled.")); }
+
+private:
+  void onConnection()
+  {
+    QTcpSocket *pSocket = mpServer->nextPendingConnection();
+    if (!pSocket) {
+      return;
+    }
+    connect(pSocket, &QTcpSocket::readyRead, this, [this, pSocket]() {
+      mRequest += pSocket->readAll();
+      // The request line is all that is needed and it ends at the first newline.
+      const int end = mRequest.indexOf('\n');
+      if (end < 0) {
+        return;
+      }
+      const QByteArray line = mRequest.left(end).trimmed();
+      pSocket->write(kResponsePage);
+      pSocket->disconnectFromHost();
+      // "GET /?code=...&state=... HTTP/1.1"
+      const QList<QByteArray> parts = line.split(' ');
+      if (parts.size() < 2) {
+        settle(QString(), QString(), tr("The sign-in redirect could not be read."));
+        return;
+      }
+      const QUrlQuery query(QUrl(QString::fromUtf8(parts.at(1))).query());
+      const QString error = query.queryItemValue(QStringLiteral("error"), QUrl::FullyDecoded);
+      settle(query.queryItemValue(QStringLiteral("code"), QUrl::FullyDecoded),
+             query.queryItemValue(QStringLiteral("state"), QUrl::FullyDecoded),
+             error.isEmpty() ? QString() : tr("The service refused the sign-in: %1").arg(error));
+    });
+    connect(pSocket, &QTcpSocket::disconnected, pSocket, &QObject::deleteLater);
+  }
+
+  //! Emit finished() exactly once, however the flow ends.
+  void settle(const QString &code, const QString &state, const QString &error)
+  {
+    if (mSettled) {
+      return;
+    }
+    mSettled = true;
+    mpTimeout->stop();
+    mpServer->close();
+    emit finished(code, state, error.isEmpty() && code.isEmpty() ? tr("No authorization code was returned.") : error);
+  }
+
+  QTcpServer *mpServer;
+  QTimer *mpTimeout;
+  QByteArray mRequest;
+  bool mSettled = false;
+};
+
+} // namespace
+
+OAuth2Redirect *OAuth2Redirect::create(const QString &configuredUri, QObject *pParent)
+{
+  // Ignored on purpose: the loopback port is only known once the socket is bound,
+  // and both services accept http://127.0.0.1 on any port for a public client.
+  Q_UNUSED(configuredUri)
+  return new LoopbackRedirect(pParent);
+}
+
+#endif // !__EMSCRIPTEN__

--- a/OMEdit/OMEditLIB/Cloud/OAuth2RedirectLoopback.cpp
+++ b/OMEdit/OMEditLIB/Cloud/OAuth2RedirectLoopback.cpp
@@ -42,6 +42,7 @@
 #include "Cloud/OAuth2Redirect.h"
 
 #include <QDesktopServices>
+#include <QHash>
 #include <QTcpServer>
 #include <QTcpSocket>
 #include <QTimer>
@@ -111,13 +112,16 @@ private:
       return;
     }
     connect(pSocket, &QTcpSocket::readyRead, this, [this, pSocket]() {
-      mRequest += pSocket->readAll();
+      // A browser may have several connections open at once, so each buffers on its own.
+      QByteArray &buffer = mRequests[pSocket];
+      buffer += pSocket->readAll();
       // The request line is all that is needed and it ends at the first newline.
-      const int end = mRequest.indexOf('\n');
+      const int end = buffer.indexOf('\n');
       if (end < 0) {
         return;
       }
-      const QByteArray line = mRequest.left(end).trimmed();
+      const QByteArray line = buffer.left(end).trimmed();
+      mRequests.remove(pSocket);
       pSocket->write(kResponsePage);
       pSocket->disconnectFromHost();
       // "GET /?code=...&state=... HTTP/1.1"
@@ -132,7 +136,10 @@ private:
              query.queryItemValue(QStringLiteral("state"), QUrl::FullyDecoded),
              error.isEmpty() ? QString() : tr("The service refused the sign-in: %1").arg(error));
     });
-    connect(pSocket, &QTcpSocket::disconnected, pSocket, &QObject::deleteLater);
+    connect(pSocket, &QTcpSocket::disconnected, this, [this, pSocket]() {
+      mRequests.remove(pSocket);
+      pSocket->deleteLater();
+    });
   }
 
   //! Emit finished() exactly once, however the flow ends.
@@ -149,7 +156,7 @@ private:
 
   QTcpServer *mpServer;
   QTimer *mpTimeout;
-  QByteArray mRequest;
+  QHash<QTcpSocket*, QByteArray> mRequests;
   bool mSettled = false;
 };
 

--- a/OMEdit/OMEditLIB/Cloud/OneDriveProvider.cpp
+++ b/OMEdit/OMEditLIB/Cloud/OneDriveProvider.cpp
@@ -1,0 +1,465 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#include "Cloud/OneDriveProvider.h"
+#include "Cloud/OAuth2Client.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QUrlQuery>
+
+namespace {
+
+const char *const kGraphBase = "https://graph.microsoft.com/v1.0";
+const char *const kAppFolderName = "OpenModelica";
+
+const char *const kItemSelect = "id,name,size,lastModifiedDateTime,eTag,cTag,file,folder,parentReference";
+
+// Graph's own limit for a plain content PUT; anything larger needs a session.
+const qint64 kUploadSessionThreshold = 4 * 1024 * 1024;
+
+RemoteItem itemFromJson(const QJsonObject &object)
+{
+  RemoteItem item;
+  item.id = object.value(QStringLiteral("id")).toString();
+  item.name = object.value(QStringLiteral("name")).toString();
+  item.isFolder = object.contains(QStringLiteral("folder"));
+  // toDouble, not the Qt 6 only toInteger; a size is exact as a double.
+  item.size = qint64(object.value(QStringLiteral("size")).toDouble(-1));
+  item.modified = QDateTime::fromString(object.value(QStringLiteral("lastModifiedDateTime")).toString(), Qt::ISODateWithMs);
+  item.parentId = object.value(QStringLiteral("parentReference")).toObject().value(QStringLiteral("id")).toString();
+  // cTag changes only when the contents change; eTag also moves on a metadata
+  // edit, so cTag is the better "did the file change" signal where it exists.
+  const QString cTag = object.value(QStringLiteral("cTag")).toString();
+  item.revision = cTag.isEmpty() ? object.value(QStringLiteral("eTag")).toString() : cTag;
+  const QJsonObject hashes = object.value(QStringLiteral("file")).toObject().value(QStringLiteral("hashes")).toObject();
+  item.contentHash = hashes.value(QStringLiteral("quickXorHash")).toString(
+      hashes.value(QStringLiteral("sha256Hash")).toString());
+  return item;
+}
+
+QNetworkRequest jsonRequest(const QUrl &url)
+{
+  QNetworkRequest request(url);
+  request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/json"));
+  return request;
+}
+
+//! Graph puts a name into the path; a Modelica class name never needs more, but
+//! a colon would end the addressing segment, so it is encoded regardless.
+QString encodePathSegment(const QString &name)
+{
+  return QString::fromUtf8(QUrl::toPercentEncoding(name));
+}
+
+QUrl itemUrl(const QString &itemId, const QString &suffix = QString())
+{
+  QUrl url(QStringLiteral("%1/me/drive/items/%2%3").arg(QLatin1String(kGraphBase), itemId, suffix));
+  return url;
+}
+
+} // namespace
+
+OneDriveProvider::OneDriveProvider(OAuth2Client *pOAuth2Client, QNetworkAccessManager *pNetworkAccessManager,
+                                   QObject *pParent)
+  : CloudProvider(pOAuth2Client, pNetworkAccessManager, pParent)
+{
+}
+
+CloudReply *OneDriveProvider::userInfo()
+{
+  QUrl url(QStringLiteral("%1/me").arg(QLatin1String(kGraphBase)));
+  return send(QNetworkRequest(url), "GET", QByteArray(), [](CloudReply *pReply, const QByteArray &payload) {
+    const QJsonObject object = QJsonDocument::fromJson(payload).object();
+    RemoteItem account;
+    account.id = object.value(QStringLiteral("id")).toString();
+    account.name = object.value(QStringLiteral("mail")).toString(
+        object.value(QStringLiteral("userPrincipalName")).toString());
+    pReply->setItem(account);
+  });
+}
+
+CloudReply *OneDriveProvider::appRootFolder()
+{
+  if (!mAppRootId.isEmpty()) {
+    CloudReply *pReply = CloudReply::pending(this);
+    RemoteItem item;
+    item.id = mAppRootId;
+    item.name = QLatin1String(kAppFolderName);
+    item.isFolder = true;
+    pReply->setItem(item);
+    pReply->finish(CloudError());
+    return pReply;
+  }
+
+  CloudReply *pOuter = CloudReply::pending(this);
+  QUrl url(QStringLiteral("%1/me/drive/root:/%2").arg(QLatin1String(kGraphBase), QLatin1String(kAppFolderName)));
+  CloudReply *pLookup = send(QNetworkRequest(url), "GET", QByteArray(), [](CloudReply *pReply, const QByteArray &payload) {
+    pReply->setItem(itemFromJson(QJsonDocument::fromJson(payload).object()));
+  });
+  connect(pLookup, &CloudReply::finished, pOuter, [this, pOuter, pLookup]() {
+    if (!pLookup->error().isError()) {
+      mAppRootId = pLookup->item().id;
+      pOuter->setItem(pLookup->item());
+      pOuter->finish(CloudError());
+      return;
+    }
+    if (pLookup->error().code != CloudError::NotFound) {
+      pOuter->finish(pLookup->error());
+      return;
+    }
+    // First run for this account.
+    CloudReply *pCreate = createFolder(QStringLiteral("root"), QLatin1String(kAppFolderName));
+    connect(pCreate, &CloudReply::finished, pOuter, [this, pOuter, pCreate]() {
+      if (!pCreate->error().isError()) {
+        mAppRootId = pCreate->item().id;
+      }
+      pOuter->setItem(pCreate->item());
+      pOuter->finish(pCreate->error());
+    });
+  });
+  return pOuter;
+}
+
+CloudReply *OneDriveProvider::listFolder(const QString &folderId)
+{
+  CloudReply *pReply = CloudReply::pending(this);
+  QUrl url(QStringLiteral("%1/me/drive/items/%2/children").arg(QLatin1String(kGraphBase), folderId));
+  QUrlQuery query;
+  query.addQueryItem(QStringLiteral("$select"), QLatin1String(kItemSelect));
+  url.setQuery(query);
+  listPage(pReply, url, QList<RemoteItem>());
+  return pReply;
+}
+
+void OneDriveProvider::listPage(CloudReply *pReply, const QUrl &url, const QList<RemoteItem> &sofar)
+{
+  CloudReply *pPage = send(QNetworkRequest(url), "GET", QByteArray(), [](CloudReply *pInner, const QByteArray &payload) {
+    const QJsonObject object = QJsonDocument::fromJson(payload).object();
+    QList<RemoteItem> items;
+    const QJsonArray values = object.value(QStringLiteral("value")).toArray();
+    for (const QJsonValue &value : values) {
+      items << itemFromJson(value.toObject());
+    }
+    pInner->setItems(items);
+    // Graph hands back a full URL for the next page rather than a token.
+    pInner->setDeltaToken(object.value(QStringLiteral("@odata.nextLink")).toString());
+  });
+  connect(pPage, &CloudReply::finished, pReply, [this, pReply, pPage, sofar]() {
+    if (pPage->error().isError()) {
+      pReply->finish(pPage->error());
+      return;
+    }
+    QList<RemoteItem> items = sofar;
+    items << pPage->items();
+    const QString next = pPage->deltaToken();
+    if (next.isEmpty()) {
+      pReply->setItems(items);
+      pReply->finish(CloudError());
+      return;
+    }
+    listPage(pReply, QUrl(next), items);
+  });
+}
+
+CloudReply *OneDriveProvider::metadata(const QString &itemId)
+{
+  QUrl url = itemUrl(itemId);
+  QUrlQuery query;
+  query.addQueryItem(QStringLiteral("$select"), QLatin1String(kItemSelect));
+  url.setQuery(query);
+  return send(QNetworkRequest(url), "GET", QByteArray(), [](CloudReply *pReply, const QByteArray &payload) {
+    pReply->setItem(itemFromJson(QJsonDocument::fromJson(payload).object()));
+  });
+}
+
+/*!
+ * \brief Fetch a file's bytes, in two steps and deliberately: /content redirects
+ * to a pre-authenticated URL that refuses a request also carrying an
+ * Authorization header, which is what following the redirect would send.
+ */
+CloudReply *OneDriveProvider::download(const QString &fileId)
+{
+  CloudReply *pReply = CloudReply::pending(this);
+  QUrl url = itemUrl(fileId);
+  QUrlQuery query;
+  query.addQueryItem(QStringLiteral("$select"), QStringLiteral("id,@microsoft.graph.downloadUrl"));
+  url.setQuery(query);
+  CloudReply *pLookup = send(QNetworkRequest(url), "GET", QByteArray(),
+                             [](CloudReply *pInner, const QByteArray &payload) {
+    pInner->setData(QJsonDocument::fromJson(payload)
+                        .object()
+                        .value(QStringLiteral("@microsoft.graph.downloadUrl"))
+                        .toString()
+                        .toUtf8());
+  });
+  connect(pLookup, &CloudReply::finished, pReply, [this, pReply, pLookup]() {
+    if (pLookup->error().isError()) {
+      pReply->finish(pLookup->error());
+      return;
+    }
+    const QUrl downloadUrl(QString::fromUtf8(pLookup->data()));
+    if (!downloadUrl.isValid() || downloadUrl.isEmpty()) {
+      pReply->finish(CloudError(CloudError::Protocol, tr("OneDrive returned no download URL.")));
+      return;
+    }
+    QNetworkReply *pGet = mpNetworkAccessManager->get(QNetworkRequest(downloadUrl));
+    pReply->trackNetworkReply(pGet);
+    connect(pGet, &QNetworkReply::finished, pReply, [this, pReply, pGet]() {
+      pGet->deleteLater();
+      const int status = pGet->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+      const QByteArray payload = pGet->readAll();
+      if (status < 200 || status >= 300) {
+        pReply->finish(classifyError(status, payload, pGet->errorString()));
+        return;
+      }
+      pReply->setData(payload);
+      pReply->finish(CloudError());
+    });
+  });
+  return pReply;
+}
+
+CloudReply *OneDriveProvider::createFolder(const QString &parentId, const QString &name)
+{
+  QJsonObject folder;
+  folder.insert(QStringLiteral("name"), name);
+  folder.insert(QStringLiteral("folder"), QJsonObject());
+  // Two mounts of the same package must not silently merge into one folder.
+  folder.insert(QStringLiteral("@microsoft.graph.conflictBehavior"), QStringLiteral("fail"));
+
+  const QUrl url = parentId == QLatin1String("root")
+                       ? QUrl(QStringLiteral("%1/me/drive/root/children").arg(QLatin1String(kGraphBase)))
+                       : itemUrl(parentId, QStringLiteral("/children"));
+  return send(jsonRequest(url), "POST", QJsonDocument(folder).toJson(QJsonDocument::Compact),
+              [](CloudReply *pReply, const QByteArray &payload) {
+    pReply->setItem(itemFromJson(QJsonDocument::fromJson(payload).object()));
+  });
+}
+
+CloudReply *OneDriveProvider::uploadNew(const QString &parentId, const QString &name, const QByteArray &contents)
+{
+  CloudReply *pReply = CloudReply::pending(this);
+  if (contents.size() < kUploadSessionThreshold) {
+    const QUrl url(QStringLiteral("%1/me/drive/items/%2:/%3:/content")
+                       .arg(QLatin1String(kGraphBase), parentId, encodePathSegment(name)));
+    uploadSmall(pReply, url, contents, QString());
+    return pReply;
+  }
+  const QUrl sessionUrl(QStringLiteral("%1/me/drive/items/%2:/%3:/createUploadSession")
+                            .arg(QLatin1String(kGraphBase), parentId, encodePathSegment(name)));
+  uploadLarge(pReply, sessionUrl, contents);
+  return pReply;
+}
+
+CloudReply *OneDriveProvider::uploadUpdate(const QString &fileId, const QByteArray &contents,
+                                           const QString &expectedRevision)
+{
+  CloudReply *pReply = CloudReply::pending(this);
+  if (contents.size() < kUploadSessionThreshold) {
+    uploadSmall(pReply, itemUrl(fileId, QStringLiteral("/content")), contents, expectedRevision);
+    return pReply;
+  }
+  // An upload session takes no If-Match, so the guard is a conditional metadata
+  // read first. Unlike Drive this is the exception rather than the rule.
+  const QUrl sessionUrl = itemUrl(fileId, QStringLiteral("/createUploadSession"));
+  if (expectedRevision.isEmpty()) {
+    uploadLarge(pReply, sessionUrl, contents);
+    return pReply;
+  }
+  CloudReply *pCheck = metadata(fileId);
+  connect(pCheck, &CloudReply::finished, pReply, [this, pReply, pCheck, sessionUrl, contents, expectedRevision]() {
+    if (pCheck->error().isError()) {
+      pReply->finish(pCheck->error());
+      return;
+    }
+    if (pCheck->item().revision != expectedRevision) {
+      pReply->setItem(pCheck->item());
+      pReply->finish(CloudError(CloudError::Conflict, tr("The file changed in OneDrive since it was last synchronised.")));
+      return;
+    }
+    uploadLarge(pReply, sessionUrl, contents);
+  });
+  return pReply;
+}
+
+void OneDriveProvider::uploadSmall(CloudReply *pReply, const QUrl &url, const QByteArray &contents,
+                                   const QString &expectedRevision)
+{
+  QNetworkRequest request(url);
+  request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/octet-stream"));
+  if (!expectedRevision.isEmpty()) {
+    // Graph refuses the write with 412 if the file moved on; that is exactly the
+    // conflict the sync engine wants to hear about.
+    request.setRawHeader("If-Match", expectedRevision.toUtf8());
+  }
+  CloudReply *pUpload = send(request, "PUT", contents, [](CloudReply *pInner, const QByteArray &payload) {
+    pInner->setItem(itemFromJson(QJsonDocument::fromJson(payload).object()));
+  });
+  connect(pUpload, &CloudReply::progress, pReply, &CloudReply::progress);
+  connect(pUpload, &CloudReply::finished, pReply, [pReply, pUpload]() {
+    pReply->setItem(pUpload->item());
+    pReply->finish(pUpload->error());
+  });
+}
+
+void OneDriveProvider::uploadLarge(CloudReply *pReply, const QUrl &sessionUrl, const QByteArray &contents)
+{
+  QJsonObject item;
+  item.insert(QStringLiteral("@microsoft.graph.conflictBehavior"), QStringLiteral("replace"));
+  QJsonObject body;
+  body.insert(QStringLiteral("item"), item);
+
+  CloudReply *pSession = send(jsonRequest(sessionUrl), "POST", QJsonDocument(body).toJson(QJsonDocument::Compact),
+                              [](CloudReply *pInner, const QByteArray &payload) {
+    pInner->setData(QJsonDocument::fromJson(payload).object().value(QStringLiteral("uploadUrl")).toString().toUtf8());
+  });
+  connect(pSession, &CloudReply::finished, pReply, [this, pReply, pSession, contents]() {
+    if (pSession->error().isError()) {
+      pReply->finish(pSession->error());
+      return;
+    }
+    const QUrl uploadUrl(QString::fromUtf8(pSession->data()));
+    if (uploadUrl.isEmpty()) {
+      pReply->finish(CloudError(CloudError::Protocol, tr("OneDrive returned no upload URL.")));
+      return;
+    }
+    // One PUT of the whole file is within what Graph accepts; chunking only
+    // matters for resuming, which a failed pass redoes from the start anyway.
+    QNetworkRequest put(uploadUrl);
+    put.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/octet-stream"));
+    put.setRawHeader("Content-Range", QStringLiteral("bytes 0-%1/%2")
+                                          .arg(contents.size() - 1)
+                                          .arg(contents.size())
+                                          .toUtf8());
+    QNetworkReply *pPut = mpNetworkAccessManager->put(put, contents);
+    pReply->trackNetworkReply(pPut);
+    connect(pPut, &QNetworkReply::finished, pReply, [this, pReply, pPut]() {
+      pPut->deleteLater();
+      const int status = pPut->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+      const QByteArray payload = pPut->readAll();
+      if (status < 200 || status >= 300) {
+        pReply->finish(classifyError(status, payload, pPut->errorString()));
+        return;
+      }
+      pReply->setItem(itemFromJson(QJsonDocument::fromJson(payload).object()));
+      pReply->finish(CloudError());
+    });
+  });
+}
+
+CloudReply *OneDriveProvider::trashItem(const QString &itemId, const QString &expectedRevision)
+{
+  // DELETE on Graph is the recycle bin, not a permanent removal.
+  QNetworkRequest request(itemUrl(itemId));
+  if (!expectedRevision.isEmpty()) {
+    request.setRawHeader("If-Match", expectedRevision.toUtf8());
+  }
+  return send(request, "DELETE", QByteArray(), 0);
+}
+
+CloudReply *OneDriveProvider::currentDeltaToken(const QString &rootId)
+{
+  CloudReply *pReply = CloudReply::pending(this);
+  // token=latest answers with just the token for "now", skipping the listing.
+  QUrl url = itemUrl(rootId, QStringLiteral("/delta"));
+  QUrlQuery query;
+  query.addQueryItem(QStringLiteral("token"), QStringLiteral("latest"));
+  url.setQuery(query);
+  deltaPage(pReply, url, QList<RemoteItem>(), QStringList(), true);
+  return pReply;
+}
+
+CloudReply *OneDriveProvider::changes(const QString &rootId, const QString &deltaToken)
+{
+  CloudReply *pReply = CloudReply::pending(this);
+  QUrl url = itemUrl(rootId, QStringLiteral("/delta"));
+  QUrlQuery query;
+  query.addQueryItem(QStringLiteral("token"), deltaToken);
+  url.setQuery(query);
+  deltaPage(pReply, url, QList<RemoteItem>(), QStringList(), false);
+  return pReply;
+}
+
+void OneDriveProvider::deltaPage(CloudReply *pReply, const QUrl &url, const QList<RemoteItem> &sofar,
+                                 const QStringList &removed, bool tokenOnly)
+{
+  CloudReply *pPage = send(QNetworkRequest(url), "GET", QByteArray(), [](CloudReply *pInner, const QByteArray &payload) {
+    const QJsonObject object = QJsonDocument::fromJson(payload).object();
+    QList<RemoteItem> items;
+    QStringList removedIds;
+    const QJsonArray values = object.value(QStringLiteral("value")).toArray();
+    for (const QJsonValue &value : values) {
+      const QJsonObject entry = value.toObject();
+      if (entry.contains(QStringLiteral("deleted"))) {
+        removedIds << entry.value(QStringLiteral("id")).toString();
+      } else {
+        items << itemFromJson(entry);
+      }
+    }
+    pInner->setItems(items);
+    pInner->setRemovedIds(removedIds);
+    pInner->setDeltaToken(object.value(QStringLiteral("@odata.nextLink")).toString());
+    pInner->setData(object.value(QStringLiteral("@odata.deltaLink")).toString().toUtf8());
+  });
+  connect(pPage, &CloudReply::finished, pReply, [this, pReply, pPage, sofar, removed, tokenOnly]() {
+    if (pPage->error().isError()) {
+      pReply->finish(pPage->error());
+      return;
+    }
+    QList<RemoteItem> items = sofar;
+    items << pPage->items();
+    QStringList removedIds = removed;
+    removedIds << pPage->removedIds();
+    const QString next = pPage->deltaToken();
+    if (!next.isEmpty()) {
+      deltaPage(pReply, QUrl(next), items, removedIds, tokenOnly);
+      return;
+    }
+    if (!tokenOnly) {
+      pReply->setItems(items);
+      pReply->setRemovedIds(removedIds);
+    }
+    // The deltaLink is a full URL; only its token is worth keeping, so that a
+    // stored token stays valid if the service moves its endpoints.
+    const QUrlQuery deltaQuery(QUrl(QString::fromUtf8(pPage->data())).query());
+    pReply->setDeltaToken(deltaQuery.queryItemValue(QStringLiteral("token"), QUrl::FullyDecoded));
+    pReply->finish(CloudError());
+  });
+}

--- a/OMEdit/OMEditLIB/Cloud/OneDriveProvider.h
+++ b/OMEdit/OMEditLIB/Cloud/OneDriveProvider.h
@@ -1,0 +1,78 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifndef ONEDRIVEPROVIDER_H
+#define ONEDRIVEPROVIDER_H
+
+#include "Cloud/CloudProvider.h"
+
+/*!
+ * \brief OneDrive, over Microsoft Graph.
+ *
+ * Unlike Drive, Graph has real optimistic concurrency: If-Match on the eTag or
+ * cTag, so a guarded write either lands or is refused. DELETE is the recycle bin.
+ * The application keeps to one folder of its own, as it does on Drive.
+ */
+class OneDriveProvider : public CloudProvider
+{
+  Q_OBJECT
+public:
+  OneDriveProvider(OAuth2Client *pOAuth2Client, QNetworkAccessManager *pNetworkAccessManager, QObject *pParent = 0);
+
+  CloudProviderKind kind() const override { return CloudProviderKind::OneDrive; }
+
+  CloudReply *userInfo() override;
+  CloudReply *appRootFolder() override;
+  CloudReply *listFolder(const QString &folderId) override;
+  CloudReply *metadata(const QString &itemId) override;
+  CloudReply *download(const QString &fileId) override;
+  CloudReply *createFolder(const QString &parentId, const QString &name) override;
+  CloudReply *uploadNew(const QString &parentId, const QString &name, const QByteArray &contents) override;
+  CloudReply *uploadUpdate(const QString &fileId, const QByteArray &contents, const QString &expectedRevision) override;
+  CloudReply *trashItem(const QString &itemId, const QString &expectedRevision) override;
+  CloudReply *currentDeltaToken(const QString &rootId) override;
+  CloudReply *changes(const QString &rootId, const QString &deltaToken) override;
+
+private:
+  void listPage(CloudReply *pReply, const QUrl &url, const QList<RemoteItem> &sofar);
+  void deltaPage(CloudReply *pReply, const QUrl &url, const QList<RemoteItem> &sofar, const QStringList &removed,
+                 bool tokenOnly);
+  void uploadSmall(CloudReply *pReply, const QUrl &url, const QByteArray &contents, const QString &expectedRevision);
+  void uploadLarge(CloudReply *pReply, const QUrl &sessionUrl, const QByteArray &contents);
+
+  QString mAppRootId;
+};
+
+#endif // ONEDRIVEPROVIDER_H

--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -43,6 +43,14 @@
 #include "Modeling/ModelWidgetContainer.h"
 #include "Options/OptionsDialog.h"
 #include "Modeling/MessagesWidget.h"
+#include "Cloud/CloudTypes.h"
+#include "Cloud/CloudAccount.h"
+#include "Cloud/CloudBrowserDialog.h"
+#include "Cloud/CloudCache.h"
+#include "Cloud/CloudConflictDialog.h"
+#include "Cloud/CloudMount.h"
+#include "Cloud/CloudProvider.h"
+#include "Cloud/CloudSyncEngine.h"
 #include "Search/FindUsageWidget.h"
 #include "OMS/OMSProxy.h"
 #include "Modeling/LibraryTreeWidget.h"
@@ -458,7 +466,6 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   mpOMSSimulationDialog = 0;
   // Create an object of ModelWidgetContainer
   mpModelWidgetContainer = new ModelWidgetContainer(this);
-  // Create an object of WelcomePageWidget
   mpWelcomePageWidget = new WelcomePageWidget(this);
   updateRecentFileActionsAndList();
   updateRecentModelActionsAndList();
@@ -1662,7 +1669,7 @@ void MainWindow::exportModelFMU(LibraryTreeItem *pLibraryTreeItem)
       MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, tr("Exported <b>%1</b>.").arg(fmuFileName),
                                                             Helper::scriptingKind, Helper::notificationLevel));
 #if defined(__EMSCRIPTEN__)
-      if (!WasmLocalFiles::download(fmuFileName)) {
+      if (!isInsideCloudMount(fmuFileName) && !WasmLocalFiles::download(fmuFileName)) {
         MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, tr("Could not read the exported FMU <b>%1</b>.").arg(fmuFileName),
                                                               Helper::scriptingKind, Helper::errorLevel));
       }
@@ -2640,7 +2647,7 @@ void MainWindow::openRecentFile()
   QAction *pAction = qobject_cast<QAction*>(sender());
   if (pAction) {
     QStringList dataList = pAction->data().toStringList();
-    mpLibraryWidget->openFile(dataList.at(0), dataList.at(1), true, true);
+    openFileFetchingFromCloud(dataList.at(0), dataList.at(1));
   }
 }
 
@@ -2682,6 +2689,39 @@ void MainWindow::showRecentModel(const QString &nameStructure, const QString &en
                                                           tr("Unable to find the class <b>%1</b>. It might not be loaded.").arg(nameStructure),
                                                           Helper::scriptingKind, Helper::errorLevel));
   }
+}
+
+/*!
+ * \brief MainWindow::openFileFetchingFromCloud
+ * Opens a file, bringing its cloud folder down first if it is not there yet.
+ *
+ * A path inside a mount can be perfectly good and still not exist: on the web
+ * target the working copy is in memory, so after a reload the recent files point
+ * at packages that have to be fetched before they can be opened.
+ */
+void MainWindow::openFileFetchingFromCloud(const QString &fileName, const QString &encoding)
+{
+  const CloudMount mount = CloudMountManager::instance()->mountForPath(fileName);
+  if (!mount.isValid() || QFile::exists(fileName)) {
+    mpLibraryWidget->openFile(fileName, encoding, true, true);
+    return;
+  }
+  CloudAccount *pAccount = CloudAccountManager::instance()->account(mount.accountKey);
+  if (!pAccount || !pAccount->isSignedIn()) {
+    QMessageBox::information(this, QString("%1 - %2").arg(Helper::applicationName, Helper::information),
+                             tr("%1 is in the cloud folder %2. Sign in to that account to open it.")
+                                 .arg(fileName, mount.remoteName));
+    return;
+  }
+  syncMount(mount, pAccount, tr("Fetching %1...").arg(mount.remoteName), [this, fileName, encoding]() {
+    if (QFile::exists(fileName)) {
+      mpLibraryWidget->openFile(fileName, encoding, true, true);
+      return;
+    }
+    MessagesWidget::instance()->addGUIMessage(
+        MessageItem(MessageItem::Modelica, tr("%1 is no longer in the cloud folder.").arg(fileName),
+                    Helper::scriptingKind, Helper::errorLevel));
+  });
 }
 
 /*!
@@ -4451,6 +4491,14 @@ void MainWindow::createActions()
   mpOpenDirectoryAction = new QAction(tr("Open Directory"), this);
   mpOpenDirectoryAction->setStatusTip(tr("Opens the directory"));
   connect(mpOpenDirectoryAction, SIGNAL(triggered()), SLOT(openDirectory()));
+  // open from cloud storage action
+  mpOpenFromCloudAction = new QAction(tr("Open from Cloud Storage..."), this);
+  mpOpenFromCloudAction->setStatusTip(tr("Opens a package stored in Google Drive or OneDrive"));
+  connect(mpOpenFromCloudAction, SIGNAL(triggered()), SLOT(openFromCloud()));
+  // save to cloud storage action
+  mpSaveToCloudAction = new QAction(tr("Save to Cloud Storage..."), this);
+  mpSaveToCloudAction->setStatusTip(tr("Saves the active class to Google Drive or OneDrive"));
+  connect(mpSaveToCloudAction, SIGNAL(triggered()), SLOT(saveToCloud()));
   // save file action
   mpSaveAction = new QAction(QIcon(":/Resources/icons/save.svg"), Helper::save, this);
   mpSaveAction->setShortcut(QKeySequence("Ctrl+s"));
@@ -4929,9 +4977,11 @@ void MainWindow::createMenus()
   mpFileMenu->addAction(mpUnloadAllAction);
   mpFileMenu->addSeparator();
   mpFileMenu->addAction(mpOpenDirectoryAction);
+  mpFileMenu->addAction(mpOpenFromCloudAction);
   mpFileMenu->addSeparator();
   mpFileMenu->addAction(mpSaveAction);
   mpFileMenu->addAction(mpSaveAsAction);
+  mpFileMenu->addAction(mpSaveToCloudAction);
   //menuFile->addAction(saveAllAction);
   mpFileMenu->addAction(mpSaveTotalAction);
   mpFileMenu->addSeparator();
@@ -5978,4 +6028,375 @@ bool MessageTab::eventFilter(QObject *pObject, QEvent *pEvent)
     }
   }
   return QObject::eventFilter(pObject, pEvent);
+}
+
+/*!
+ * \brief MainWindow::openFromCloud
+ * Mounts a cloud folder as a local working copy, brings its contents down, and
+ * opens it like any other package - everything downstream sees an ordinary path.
+ *
+ * Nothing here uses QDialog::exec() or a nested QEventLoop, and it must stay that
+ * way: on the WebAssembly build a nested event loop parks the main thread inside
+ * Asyncify, and network replies are never delivered to it - the request completes
+ * in the browser and the finished handler simply never runs. Dialogs are opened
+ * with open() and the flow continues in signal handlers.
+ */
+void MainWindow::openFromCloud()
+{
+  CloudBrowserDialog *pBrowser = new CloudBrowserDialog(CloudBrowserDialog::OpenFolder, this);
+  pBrowser->setAttribute(Qt::WA_DeleteOnClose);
+  connect(pBrowser, &QDialog::accepted, this, [this, pBrowser]() {
+    CloudAccount *pAccount = pBrowser->selectedAccount();
+    if (!pAccount || pBrowser->selectedFolderId().isEmpty()) {
+      return;
+    }
+    const CloudMount mount = CloudMountManager::instance()->addMount(pAccount->key(), pBrowser->selectedFolderId(),
+                                                                    pBrowser->selectedFolderName());
+    QDir().mkpath(mount.localRoot);
+    // Remembered before the dialog goes away: a chosen file is opened on its own
+    // once its folder has come down.
+    const QString chosenFile = pBrowser->selectedFileName();
+    syncMount(mount, pAccount, tr("Fetching %1...").arg(mount.remoteName), [this, mount, chosenFile]() {
+      if (!chosenFile.isEmpty()) {
+        mpLibraryWidget->openFile(mount.localRoot + QLatin1Char('/') + chosenFile, Helper::utf8, true);
+        return;
+      }
+      openMountContents(mount);
+    });
+  });
+  pBrowser->open();
+}
+
+/*!
+ * \brief Forget where the children were last saved.
+ *
+ * saveModelicaLibraryTreeItemFolder() reuses a child's existing path whenever
+ * isFilePathValid(), so without this a package's subpackages are written back to
+ * wherever they came from rather than into the folder being saved to. Cleared,
+ * each child's path is derived from its parent's, which is what puts the whole
+ * package under the new root.
+ */
+static void forgetChildFileNames(LibraryTreeItem *pLibraryTreeItem)
+{
+  for (int i = 0; i < pLibraryTreeItem->childrenSize(); ++i) {
+    LibraryTreeItem *pChild = pLibraryTreeItem->child(i);
+    pChild->setFileName(QString());
+    pChild->setIsSaved(false);
+    forgetChildFileNames(pChild);
+  }
+}
+
+/*!
+ * \brief MainWindow::saveToCloud
+ * Saves the selected class into a new cloud folder and leaves it mounted, so that
+ * later saves go to the same place.
+ *
+ * The class is written to the working copy with the ordinary save path first -
+ * so package.mo, package.order and any subpackages are laid out exactly as they
+ * would be on disk - and the sync engine then pushes that tree. Nothing here
+ * knows how to upload a Modelica package; it only knows how to put one on a
+ * filesystem and let the engine mirror it.
+ *
+ * Like openFromCloud(), no exec() and no nested event loop: see the comment there.
+ */
+void MainWindow::saveToCloud()
+{
+  ModelWidget *pModelWidget = mpModelWidgetContainer->getCurrentModelWidget();
+  LibraryTreeItem *pActiveItem = pModelWidget ? pModelWidget->getLibraryTreeItem() : 0;
+  if (!pActiveItem || pActiveItem->getLibraryType() != LibraryTreeItem::Modelica) {
+    QMessageBox::information(this, QString("%1 - %2").arg(Helper::applicationName, Helper::information),
+                             tr("Open a Modelica class first; it is the active class that gets saved."));
+    return;
+  }
+  // Saving a class inside a package saves the whole package - that is what
+  // LibraryWidget::saveLibraryTreeItem() does with a non-top-level item - so the
+  // top-level class is what has to be redirected to the cloud folder. Redirecting
+  // the active child instead left the package saving to its old location while a
+  // stray file for the child appeared in the mount.
+  LibraryTreeItem *pLibraryTreeItem = LibraryTreeModel::getTopLevelLibraryTreeItem(pActiveItem);
+
+  CloudBrowserDialog *pBrowser = new CloudBrowserDialog(CloudBrowserDialog::SaveFolder, this);
+  pBrowser->setAttribute(Qt::WA_DeleteOnClose);
+  connect(pBrowser, &QDialog::accepted, this, [this, pBrowser, pLibraryTreeItem]() {
+    CloudAccount *pAccount = pBrowser->selectedAccount();
+    if (!pAccount || pBrowser->selectedFolderId().isEmpty()) {
+      return;
+    }
+    // Mount the folder the user picked. No folder is invented here: if they wanted
+    // a new one they made it in the dialog.
+    const CloudMount mount = CloudMountManager::instance()->addMount(pAccount->key(), pBrowser->selectedFolderId(),
+                                                                    pBrowser->selectedFolderName());
+    QDir().mkpath(mount.localRoot);
+
+    // The class keeps the layout it already has - a model stays one .mo file, a
+    // package saved as a directory stays a directory. Forcing a folder structure
+    // turned M.mo into M/package.mo, which is not what saving somewhere else means.
+    const QString className = pLibraryTreeItem->getName();
+    QString fileName;
+    if (pLibraryTreeItem->isSaveFolderStructure()) {
+      fileName = QStringLiteral("%1/%2/package.mo").arg(mount.localRoot, className);
+      QDir().mkpath(QStringLiteral("%1/%2").arg(mount.localRoot, className));
+    } else {
+      fileName = QStringLiteral("%1/%2.mo").arg(mount.localRoot, className);
+    }
+    // The file has to exist before the name will be honoured: isFilePathValid()
+    // tests QFileInfo::exists(), and a name pointing at nothing is treated as no
+    // name at all - whereupon the ordinary save path asks the user for a location
+    // and writes somewhere else entirely.
+    QDir().mkpath(QFileInfo(fileName).absolutePath());
+    // Truncate matters: the worker-VFS file engine only marks a file dirty - and
+    // so only creates it - when the open truncates. A plain WriteOnly open writes
+    // nothing, the file never appears, and isFilePathValid() stays false.
+    QFile placeholder(fileName);
+    if (placeholder.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+      placeholder.close();
+    }
+    pLibraryTreeItem->setFileName(fileName);
+    pLibraryTreeItem->setIsSaved(false);
+    forgetChildFileNames(pLibraryTreeItem);
+    if (!mpLibraryWidget->saveLibraryTreeItem(pLibraryTreeItem)) {
+      QMessageBox::critical(this, QString("%1 - %2").arg(Helper::applicationName, Helper::error),
+                            tr("Could not write %1 to the working copy.").arg(pLibraryTreeItem->getNameStructure()));
+      return;
+    }
+    // The empty file created above only exists to make the save path accept the
+    // name. If the save then wrote somewhere else it is still empty, and uploading
+    // it would put a file holding no class into the user's cloud storage - which
+    // is exactly what happened before the save path was redirected correctly.
+    if (QFileInfo(fileName).size() == 0) {
+      QFile::remove(fileName);
+      cloudLog(QStringLiteral("save left %1 empty; nothing uploaded").arg(fileName));
+      QMessageBox::critical(this, QString("%1 - %2").arg(Helper::applicationName, Helper::error),
+                            tr("%1 was not written to the cloud folder; nothing was uploaded.")
+                                .arg(pLibraryTreeItem->getNameStructure()));
+      return;
+    }
+    syncMount(mount, pAccount, tr("Uploading %1...").arg(className));
+  });
+  pBrowser->open();
+}
+
+/*!
+ * \brief MainWindow::openMountContents
+ * Loads what a freshly synchronised mount holds.
+ *
+ * A mounted folder is not itself a package unless it has a package.mo. Handing the
+ * bare directory to openFile() only got the folder names into the Libraries
+ * Browser, not the classes inside them, so each entry is opened on its own terms:
+ * a subfolder with a package.mo is a package, a loose .mo file is a class.
+ */
+void MainWindow::openMountContents(const CloudMount &mount)
+{
+  const QString packageFile = mount.localRoot + QStringLiteral("/package.mo");
+  if (QFile::exists(packageFile)) {
+    mpLibraryWidget->openFile(packageFile, Helper::utf8, true);
+    return;
+  }
+  const QStringList names = cloudListDirectory(mount.localRoot);
+  bool openedAnything = false;
+  for (const QString &raw : names) {
+    const bool isFolder = raw.endsWith(QLatin1Char('/'));
+    const QString name = isFolder ? raw.left(raw.size() - 1) : raw;
+    if (name.isEmpty() || name.startsWith(QLatin1Char('.'))) {
+      continue;
+    }
+    const QString path = mount.localRoot + QLatin1Char('/') + name;
+    if (isFolder) {
+      const QString childPackage = path + QStringLiteral("/package.mo");
+      if (QFile::exists(childPackage)) {
+        mpLibraryWidget->openFile(childPackage, Helper::utf8, true);
+        openedAnything = true;
+      }
+    } else if (name.endsWith(QStringLiteral(".mo"), Qt::CaseInsensitive)) {
+      mpLibraryWidget->openFile(path, Helper::utf8, true);
+      openedAnything = true;
+    }
+  }
+  if (!openedAnything) {
+    MessagesWidget::instance()->addGUIMessage(
+        MessageItem(MessageItem::Modelica, tr("%1 holds no Modelica classes.").arg(mount.remoteName),
+                    Helper::scriptingKind, Helper::notificationLevel));
+  }
+}
+
+/*!
+ * \brief MainWindow::pushMountInBackground
+ * Sends what was just saved up to the cloud, a moment later.
+ *
+ * Deferred and coalesced: a run per written file would mean several full tree
+ * comparisons for one save.
+ */
+void MainWindow::pushMountInBackground(const QString &mountId)
+{
+  QTimer *pTimer = mAutoPushTimers.value(mountId, 0);
+  if (!pTimer) {
+    pTimer = new QTimer(this);
+    pTimer->setSingleShot(true);
+    pTimer->setInterval(3000);
+    connect(pTimer, &QTimer::timeout, this, [this, mountId, pTimer]() {
+      const CloudMount mount = CloudMountManager::instance()->mount(mountId);
+      if (!mount.isValid() || !mount.autoPush) {
+        return;
+      }
+      if (mSyncingMounts.contains(mountId)) {
+        // Wait for the run in progress rather than dropping this one: it may not
+        // have seen the edit that asked for this push.
+        pTimer->start();
+        return;
+      }
+      CloudAccount *pAccount = CloudAccountManager::instance()->account(mount.accountKey);
+      if (!pAccount || !pAccount->isSignedIn()) {
+        return;
+      }
+      // Cached before the push, so an edit that cannot be uploaded now - offline,
+      // or the token gone - still survives a reload.
+      CloudCache::save(mount);
+      syncMount(mount, pAccount, tr("Saving %1 to the cloud...").arg(mount.remoteName), std::function<void()>(), true);
+    });
+    mAutoPushTimers.insert(mountId, pTimer);
+  }
+  pTimer->start();
+}
+
+/*!
+ * \brief MainWindow::syncMount
+ * Runs one synchronisation of a mount, showing progress and reporting whatever
+ * the engine decides needs a person: conflicts, and deletions large enough to
+ * want confirming.
+ *
+ * A background run - an automatic push after an ordinary save - keeps out of the
+ * way: no progress dialog, and a failure is a message rather than a box. What
+ * needs an answer still asks for one, because a conflict left unanswered is work
+ * left unsaved.
+ */
+void MainWindow::syncMount(const CloudMount &mount, CloudAccount *pAccount, const QString &title,
+                           const std::function<void()> &onSuccess, bool background)
+{
+  if (mSyncingMounts.contains(mount.mountId)) {
+    return;
+  }
+  mSyncingMounts.insert(mount.mountId);
+
+  QPointer<QProgressDialog> pProgress;
+  if (!background) {
+    pProgress = new QProgressDialog(title, Helper::cancel, 0, 0, this);
+    pProgress->setAttribute(Qt::WA_DeleteOnClose);
+    pProgress->setWindowModality(Qt::WindowModal);
+    pProgress->setMinimumDuration(0);
+    pProgress->setValue(0);
+  } else {
+    getStatusBar()->showMessage(title);
+  }
+
+  CloudSyncEngine *pEngine = new CloudSyncEngine(mount, pAccount->provider(), this);
+  if (pProgress) {
+    connect(pProgress, &QProgressDialog::canceled, pEngine, &CloudSyncEngine::cancel);
+  }
+  connect(pEngine, &CloudSyncEngine::progress, this, [this, pProgress](int done, int total, const QString &what) {
+    if (!pProgress) {
+      if (!what.isEmpty()) {
+        getStatusBar()->showMessage(what);
+      }
+      return;
+    }
+    pProgress->setMaximum(total);
+    pProgress->setValue(done);
+    if (!what.isEmpty()) {
+      pProgress->setLabelText(what);
+    }
+  });
+  connect(pEngine, &CloudSyncEngine::skipped, this, [](const QStringList &descriptions) {
+    for (const QString &description : descriptions) {
+      MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, description, Helper::scriptingKind,
+                                                            Helper::notificationLevel));
+    }
+  });
+  // Deletions are never carried out on the engine's own judgement; the user sees
+  // exactly what would go.
+  connect(pEngine, &CloudSyncEngine::deletionsNeedConfirmation, this,
+          [this, pEngine, pProgress](const QList<SyncAction> &deletions) {
+    if (pProgress) {
+      pProgress->hide();
+    }
+    QStringList names;
+    for (const SyncAction &action : deletions) {
+      names << action.relativePath;
+    }
+    // open(), not the blocking QMessageBox::question: a synchronisation is half
+    // done behind this, and stalling the main thread here is what wedges the
+    // WebAssembly build.
+    QMessageBox *pQuestion = new QMessageBox(QMessageBox::Question,
+                                             QString("%1 - %2").arg(Helper::applicationName, tr("Confirm Deletions")),
+                                             tr("This will move %n file(s) to the cloud service's trash:\n\n%1\n\n"
+                                                "Continue?", "", names.size())
+                                                 .arg(names.join(QLatin1Char('\n'))),
+                                             QMessageBox::Yes | QMessageBox::No, this);
+    pQuestion->setAttribute(Qt::WA_DeleteOnClose);
+    pQuestion->setDefaultButton(QMessageBox::No);
+    connect(pQuestion, &QMessageBox::finished, pEngine, [pEngine, pProgress, pQuestion](int) {
+      if (pProgress) {
+        pProgress->show();
+      }
+      pEngine->confirmDeletions(pQuestion->standardButton(pQuestion->clickedButton()) == QMessageBox::Yes);
+    });
+    pQuestion->open();
+  });
+  connect(pEngine, &CloudSyncEngine::conflictsDetected, this,
+          [this, pEngine, pProgress, mount](const QList<SyncAction> &conflicts) {
+    if (pProgress) {
+      pProgress->hide();
+    }
+    CloudConflictDialog *pDialog = new CloudConflictDialog(mount.remoteName, conflicts, this);
+    connect(pDialog, &QDialog::accepted, pEngine, [pEngine, pProgress, pDialog]() {
+      if (pProgress) {
+        pProgress->show();
+      }
+      pEngine->applyResolutions(pDialog->resolutions());
+    });
+    connect(pDialog, &QDialog::rejected, pEngine, &CloudSyncEngine::cancel);
+    pDialog->open();
+  });
+  connect(pEngine, &CloudSyncEngine::finished, this,
+          [this, pEngine, pProgress, mount, onSuccess, background](const CloudError &error) {
+    mSyncingMounts.remove(mount.mountId);
+    if (pProgress) {
+      pProgress->close();
+    }
+    pEngine->deleteLater();
+    // However the run ended, the manifest now describes the working copy, so the
+    // cache must come from the same state: a cache older than the manifest reads
+    // back as a local edit and uploads over the newer remote.
+    CloudCache::save(mount);
+    if (error.isError() && error.code != CloudError::Cancelled) {
+      const QString text = tr("Could not synchronise %1: %2").arg(mount.remoteName, error.message);
+      if (background) {
+        MessagesWidget::instance()->addGUIMessage(
+            MessageItem(MessageItem::Modelica, text, Helper::scriptingKind, Helper::errorLevel));
+      } else {
+        QMessageBox::critical(this, QString("%1 - %2").arg(Helper::applicationName, Helper::error), text);
+      }
+      return;
+    }
+    if (error.code == CloudError::Cancelled) {
+      getStatusBar()->showMessage(tr("Synchronisation of %1 was cancelled").arg(mount.remoteName), 5000);
+      return;
+    }
+    getStatusBar()->showMessage(tr("%1 is up to date").arg(mount.remoteName), 5000);
+    if (onSuccess) {
+      onSuccess();
+    }
+  });
+
+  // On the web target the working copy is in memory and empty after a reload.
+  // Putting the cache back first turns a full re-download into a revalidation.
+  if (cloudListDirectory(mount.localRoot).isEmpty()) {
+    CloudCache::restore(mount, [pEngine](int restored) {
+      if (restored > 0) {
+        cloudLog(QStringLiteral("cache: restored %1 file(s)").arg(restored));
+      }
+      pEngine->start();
+    });
+    return;
+  }
+  pEngine->start();
 }

--- a/OMEdit/OMEditLIB/MainWindow.h
+++ b/OMEdit/OMEditLIB/MainWindow.h
@@ -71,8 +71,13 @@ extern "C" {
 #include <QShortcut>
 #include <QRadioButton>
 #include <QTimer>
+#include <QSet>
+
+#include <functional>
 
 class OMCProxy;
+class CloudAccount;
+struct CloudMount;
 class TransformationsWidget;
 class LibraryWidget;
 class ElementWidget;
@@ -132,6 +137,13 @@ public:
   int getNumberOfProcessors() {return mNumberOfProcessors;}
   QDockWidget* getMessagesDockWidget() {return mpMessagesDockWidget;}
   LibraryWidget* getLibraryWidget() {return mpLibraryWidget;}
+  /*!
+   * \brief Whether the Libraries Browser exists yet.
+   * omc messages can be delivered as queued calls while MainWindow is still being
+   * constructed - during library loading at startup - and anything that reaches
+   * into the library tree from there works on a pointer that is not set up.
+   */
+  bool isLibraryWidgetReady() const {return mpLibraryWidget != 0;}
   ElementWidget* getElementWidget() {return mpElementWidget;}
   StackFramesWidget* getStackFramesWidget() {return mpStackFramesWidget;}
   BreakpointsWidget* getBreakpointsWidget() {return mpBreakpointsWidget;}
@@ -298,7 +310,7 @@ private:
   QDockWidget *mpMessagesDockWidget;
   NavigationManagerView *mpNavigationManagerView = nullptr;
   QDockWidget *mpNavigationManagerDockWidget = nullptr;
-  LibraryWidget *mpLibraryWidget;
+  LibraryWidget *mpLibraryWidget = 0;
   QDockWidget *mpLibraryDockWidget;
   ElementWidget *mpElementWidget;
   QDockWidget *mpElementDockWidget;
@@ -354,6 +366,8 @@ private:
   QAction *mpUnloadAllAction;
   // Directory actions
   QAction *mpOpenDirectoryAction;
+  QAction *mpOpenFromCloudAction;
+  QAction *mpSaveToCloudAction;
   QAction *mpSaveAction;
   QAction *mpSaveAsAction;
   QAction *mpSaveAllAction;
@@ -499,8 +513,20 @@ private:
   QToolBar *mpOMSimulatorToolbar;
   QHash<QString, TransformationsWidget*> mTransformationsWidgetHash;
   QMdiSubWindow *mpLastModelingSubWindow = nullptr;
+  //! Mounts with a synchronisation already running; a second one would race it.
+  QSet<QString> mSyncingMounts;
+  QHash<QString, QTimer *> mAutoPushTimers;
 signals:
   void resetMessagesTabWidgetNames();
+public:
+  void syncMount(const CloudMount &mount, CloudAccount *pAccount, const QString &title,
+                 const std::function<void()> &onSuccess = std::function<void()>(), bool background = false);
+  void openMountContents(const CloudMount &mount);
+  //! Opens a file, fetching its cloud folder first when the working copy is gone.
+  void openFileFetchingFromCloud(const QString &fileName, const QString &encoding);
+  //! Push a mount whose working copy was just written to, if it is set to auto-push.
+  void pushMountInBackground(const QString &mountId);
+
 public slots:
   void showMessageBrowser();
   void switchToWelcomePerspectiveSlot();
@@ -522,6 +548,8 @@ public slots:
   void showOpenTransformationFileDialog();
   void unloadAll(bool onlyModelicaClasses = false);
   void openDirectory();
+  void openFromCloud();
+  void saveToCloud();
   void writeOutputFileData(QString data);
   void writeErrorFileData(QString data);
   void openRecentFile();

--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
@@ -55,6 +55,7 @@
 #include "Git/CommitChangesDialog.h"
 #include "Util/ResourceCache.h"
 #include "Search/FindUsageWidget.h"
+#include "Cloud/CloudMount.h"
 #if defined(__EMSCRIPTEN__)
 #include "OMEditGUI/wasm/WasmLocalFiles.h"
 #endif
@@ -4498,6 +4499,12 @@ bool LibraryWidget::saveLibraryTreeItem(LibraryTreeItem *pLibraryTreeItem, bool 
       QFileInfo fileInfo(pLibraryTreeItem->getFileName());
       MainWindow::instance()->addRecentFile(fileInfo.absoluteFilePath(), Helper::utf8);
     }
+    // Saving into a mounted cloud folder has only written the working copy; what
+    // makes it saved is the push.
+    const CloudMount mount = CloudMountManager::instance()->mountForPath(pLibraryTreeItem->getFileName());
+    if (mount.isValid() && mount.autoPush) {
+      MainWindow::instance()->pushMountInBackground(mount.mountId);
+    }
   }
   MainWindow::instance()->getStatusBar()->clearMessage();
   MainWindow::instance()->hideProgressBar();
@@ -4771,7 +4778,11 @@ bool LibraryWidget::saveModelicaLibraryTreeItemOneFile(LibraryTreeItem *pLibrary
       }
       mpLibraryTreeModel->updateLibraryTreeItem(pLibraryTreeItem);
 #if defined(__EMSCRIPTEN__)
-      WasmLocalFiles::download(fileName);
+      // A file inside a cloud mount is uploaded by the sync engine; handing the
+      // user a download of it as well would be wrong.
+      if (!isInsideCloudMount(fileName)) {
+        WasmLocalFiles::download(fileName);
+      }
 #endif
       /* Save the traceabiliy information and send to Daemon. */
 #if !defined(__EMSCRIPTEN__)
@@ -4874,7 +4885,11 @@ bool LibraryWidget::saveModelicaLibraryTreeItemFolder(LibraryTreeItem *pLibraryT
 #if defined(__EMSCRIPTEN__)
       // One download per file; the folder structure itself stays in the omc
       // filesystem for the session.
-      WasmLocalFiles::download(fileName);
+      // A file inside a cloud mount is uploaded by the sync engine; handing the
+      // user a download of it as well would be wrong.
+      if (!isInsideCloudMount(fileName)) {
+        WasmLocalFiles::download(fileName);
+      }
 #endif
     } else {
       return false;
@@ -4979,7 +4994,11 @@ bool LibraryWidget::saveTextLibraryTreeItem(LibraryTreeItem *pLibraryTreeItem, b
       }
       mpLibraryTreeModel->updateLibraryTreeItem(pLibraryTreeItem);
 #if defined(__EMSCRIPTEN__)
-      WasmLocalFiles::download(fileName);
+      // A file inside a cloud mount is uploaded by the sync engine; handing the
+      // user a download of it as well would be wrong.
+      if (!isInsideCloudMount(fileName)) {
+        WasmLocalFiles::download(fileName);
+      }
 #endif
     } else {
       return false;

--- a/OMEdit/OMEditLIB/Modeling/MessagesWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/MessagesWidget.cpp
@@ -247,8 +247,19 @@ void MessageWidget::addGUIMessage(MessageItem messageItem)
   } else {
     message = Qt::convertFromPlainText(messageItem.getMessage()).remove("<p>").remove("</p>");
   }
+  // An omc message can be delivered as a queued call while MainWindow is still
+  // being constructed - loading libraries at startup does exactly that - and the
+  // Libraries Browser does not exist yet. Without this the lookups below run on an
+  // unset pointer, which faults somewhere inside the tree walk rather than cleanly.
+  const bool libraryReady = MainWindow::instance() && MainWindow::instance()->isLibraryWidgetReady();
   if (messageItem.getFileName().isEmpty()) { // if custom error message
     errorMessage = message;
+  } else if (!libraryReady) {
+    // No tree to look the class up in yet; name the file and move on.
+    errorMessage = QString("[%1: %2]: %3")
+        .arg(messageItem.getFileName())
+        .arg(messageItem.getLocation())
+        .arg(message);
   } else if (MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel()->findLibraryTreeItem(messageItem.getFileName())) {
     // If the class is only loaded in AST via loadString then create link for the error message.
     errorMessage = linkFormat.arg(messageItem.getFileName())

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -5682,7 +5682,7 @@ void WelcomePageWidget::readLatestNewsXML(QNetworkReply *pNetworkReply)
 
 void WelcomePageWidget::openRecentFileItem(QListWidgetItem *pItem)
 {
-  MainWindow::instance()->getLibraryWidget()->openFile(pItem->text(), pItem->data(Qt::UserRole).toString(), true, true);
+  MainWindow::instance()->openFileFetchingFromCloud(pItem->text(), pItem->data(Qt::UserRole).toString());
 }
 
 void WelcomePageWidget::openRecentModelItem(QListWidgetItem *pItem)

--- a/OMEdit/OMEditLIB/Modeling/ModelicaClassDialog.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelicaClassDialog.cpp
@@ -47,6 +47,7 @@
 #include "Modeling/ItemDelegate.h"
 #if defined(__EMSCRIPTEN__)
 #include "OMEditGUI/wasm/WasmLocalFiles.h"
+#include "Cloud/CloudMount.h"
 #endif
 
 #include <QApplication>
@@ -1340,7 +1341,10 @@ void SaveTotalFileDialog::saveTotalModel()
       mpObfuscateOutputCheckBox->isChecked(),
       mpUseSimplifiedHeuristic->isChecked());
 #if defined(__EMSCRIPTEN__)
-    WasmLocalFiles::download(fileName);
+    // Uploaded by the sync engine when it is inside a cloud mount.
+    if (!isInsideCloudMount(fileName)) {
+      WasmLocalFiles::download(fileName);
+    }
 #endif
     accept();
   }

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -106,6 +106,7 @@ static QString omcPhaseLabel(int phase) {
 #include <QEventLoop>
 #include <QTimer>
 #include <QVarLengthArray>
+#include <QPair>
 #include <QtCore/private/qwasmsuspendresumecontrol_p.h>
 
 // omc runs in the shared omc_worker.js Web Worker. Calls are posted without
@@ -261,12 +262,140 @@ EM_JS(char *, omedit_take_abi_result, (int id), {
   return stringToNewUTF8('{"error":"no response from omc worker"}');
 });
 
+/*!
+ * The pre-main-loop wait, which suspends this stack through Asyncify.
+ *
+ * Qt's DOM event handlers must be told to *only queue* while that is the case.
+ * Left alone they take the else branch of
+ *
+ *   if (control.resume) resume(); else if (control.asyncifyEnabled) {} else
+ *     Module.qtSendPendingEvents();
+ *
+ * and call synchronously into a module whose stack is unwound, which corrupts the
+ * pending-event replay - the intermittent "Cannot read properties of undefined
+ * (reading 'index')" in QWasmSuspendResumeControl::sendPendingEvents() during
+ * startup. Qt sets that flag around its own suspends but cannot know about ours.
+ * Whether it fires depends on a DOM event landing in the window, which is why it
+ * looks random and why anything that lengthens startup makes it more likely.
+ */
 EM_ASYNC_JS(void, omedit_await_call, (int id), {
-  const p = Module.__omcCallPromises[id];
-  if (p) { try { await p; } catch (e) {} }
+  const control = Module.qtSuspendResumeControl;
+  const wasEnabled = control ? control.asyncifyEnabled : false;
+  if (control) control.asyncifyEnabled = true;
+  try {
+    const p = Module.__omcCallPromises[id];
+    if (p) { try { await p; } catch (e) {} }
+  } finally {
+    if (control) control.asyncifyEnabled = wasEnabled;
+  }
 });
 
 EM_JS(void, omedit_wake_now, (), { if (Module.__omcWake) Module.__omcWake(); });
+
+/*!
+ * Work around a re-entrancy bug in Qt's WebAssembly event replay.
+ *
+ * QWasmSuspendResumeControl::sendPendingEvents() reads the queue length once and
+ * then shifts that many entries:
+ *
+ *   int count = pendingEvents["length"].as<int>();
+ *   while (count-- > 0) {
+ *       val event = pendingEvents.call<val>("shift");
+ *       auto it = m_eventHandlers.find(event["index"].as<int>());
+ *
+ * If anything drains the queue while that loop is running, shift() starts
+ * returning undefined and event["index"] throws - the intermittent "Cannot read
+ * properties of undefined (reading 'index')" that hangs startup. A DOM event
+ * arriving whenever the stack yields calls Module.qtSendPendingEvents()
+ * synchronously, which is exactly such a drain.
+ *
+ * The guard makes a nested call a no-op. Nothing is lost: entries queued during
+ * the outer loop stay in the array (its count was fixed before they arrived) and
+ * are replayed on the dispatcher's next pass.
+ *
+ * A property setter is used because Qt assigns Module.qtSendPendingEvents itself,
+ * after this runs.
+ */
+#if QT_VERSION < QT_VERSION_CHECK(6, 11, 0)
+EM_JS(void, omedit_guard_pending_events, (), {
+  if (Module.__omeditPendingEventsGuard) return;
+  Module.__omeditPendingEventsGuard = true;
+  let real = null;
+  let draining = false;
+  const wrapper = function () {
+    if (draining || !real) return;
+    draining = true;
+    try {
+      return real.apply(this, arguments);
+    } finally {
+      draining = false;
+    }
+  };
+  try {
+    Object.defineProperty(Module, "qtSendPendingEvents", {
+      configurable: true,
+      get() { return wrapper; },
+      set(fn) { real = fn; }
+    });
+  } catch (e) {
+    console.warn("[OMEdit] could not guard qtSendPendingEvents", e);
+  }
+});
+
+/*!
+ * Make an over-run of that loop harmless.
+ *
+ * The guard above only closes the JS route into a nested drain; one starting
+ * inside wasm - a handler that pumps events, reaching sendPendingEvents() through
+ * processEvents() - is invisible from there, and that is evidently what happens.
+ * So instead of preventing the over-run, make it survivable: shift() on an
+ * exhausted queue returns an entry pointing at a handler that does nothing,
+ * rather than undefined. The extra iterations then run a no-op instead of
+ * dereferencing undefined.
+ *
+ * Fixed in Qt 6.11: the loop there re-evaluates pendingEvents["length"] in its
+ * condition and splices at a bounds-checked index instead of blindly shifting.
+ * The 6.10 branch still has the old form and the fix was not backported (it comes
+ * with an m_eventFilter member 6.10.2 does not have). DELETE THIS, and
+ * omedit_guard_pending_events() with it, when the wasm kit moves to 6.11 - it
+ * compiles out there already, so nothing breaks in the meantime; this is only
+ * dead weight to be removed.
+ */
+EM_JS(void, omedit_patch_pending_shift, (int noopIndex), {
+  const control = Module.qtSuspendResumeControl;
+  if (!control || !Array.isArray(control.pendingEvents)) return;
+  const queue = control.pendingEvents;
+  if (queue.__omeditPatchedShift) return;
+  const realShift = Array.prototype.shift;
+  Object.defineProperty(queue, "__omeditPatchedShift", { value: true });
+  queue.shift = function () {
+    if (this.length > 0) {
+      return realShift.call(this);
+    }
+    return { index: noopIndex, arg: undefined };
+  };
+});
+#endif // Qt < 6.11
+
+void omcInstallPendingEventsGuard()
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 11, 0)
+  omedit_guard_pending_events();
+#endif
+}
+
+void omcInstallPendingEventsShiftGuard()
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 11, 0)
+  QWasmSuspendResumeControl *pControl = QWasmSuspendResumeControl::get();
+  if (!pControl) {
+    return;
+  }
+  // Registered once; its index is what an exhausted shift() hands back.
+  static const uint32_t noopHandler = pControl->registerEventHandler([](emscripten::val) {});
+  omedit_patch_pending_shift(int(noopHandler));
+#endif
+}
 
 // Cooperative cancel + progress control block (shared with the omc worker).
 // Available only when cross-origin isolated (SharedArrayBuffer);
@@ -460,6 +589,69 @@ bool omcWorkerWriteFile(const char *path, const QByteArray &data)
   if (!omedit_worker_ready()) return false;
   omedit_post_vfs_put(path, data.constData(), data.size());
   return true;
+}
+
+// Remove and rename, for the cloud sync engine. Unlike the write above these do
+// wait for the reply: they only run from sync code (post-exec, event loop up), and
+// a delete whose outcome is unknown cannot be reconciled against the manifest.
+EM_JS(int, omedit_post_vfs_remove, (const char *path), {
+  return Module.__omcPostCall({ cmd: "vfsRemove", path: UTF8ToString(path) });
+});
+EM_JS(int, omedit_post_vfs_rename, (const char *from, const char *to), {
+  return Module.__omcPostCall({ cmd: "vfsRename", from: UTF8ToString(from), to: UTF8ToString(to) });
+});
+EM_JS(int, omedit_take_vfs_ok, (int id), {
+  const r = Module.__omcReplies[id] || {};
+  delete Module.__omcReplies[id];
+  delete Module.__omcCallPromises[id];
+  return r && r.ok ? 1 : 0;
+});
+
+bool omcWorkerRemoveFile(const char *path)
+{
+  if (!omedit_worker_ready()) return false;
+  int id = omedit_post_vfs_remove(path);
+  omcWorkerWaitReply(id);
+  return omedit_take_vfs_ok(id) != 0;
+}
+
+bool omcWorkerRenameFile(const char *from, const char *to)
+{
+  if (!omedit_worker_ready()) return false;
+  int id = omedit_post_vfs_rename(from, to);
+  omcWorkerWaitReply(id);
+  return omedit_take_vfs_ok(id) != 0;
+}
+
+// Bulk write: restoring a cached package tree in one round trip. Returns how many
+// files the worker actually wrote, so the caller can verify the restore is complete
+// before it trusts the working copy (see CloudMount::workingCopyComplete).
+EM_JS(int, omedit_post_vfs_put_many, (), {
+  const entries = Module.__omeditVfsBatch || [];
+  Module.__omeditVfsBatch = null;
+  return Module.__omcPostCall({ cmd: "vfsPutMany", entries });
+});
+EM_JS(void, omedit_vfs_batch_add, (const char *path, const char *bytes, int len), {
+  if (!Module.__omeditVfsBatch) Module.__omeditVfsBatch = [];
+  Module.__omeditVfsBatch.push({ path: UTF8ToString(path),
+                                 bytes: HEAPU8.slice(bytes, bytes + len) });
+});
+EM_JS(int, omedit_take_vfs_written, (int id), {
+  const r = Module.__omcReplies[id] || {};
+  delete Module.__omcReplies[id];
+  delete Module.__omcCallPromises[id];
+  return (r && typeof r.written === "number") ? r.written : -1;
+});
+
+int omcWorkerWriteFiles(const QList<QPair<QString, QByteArray> > &files)
+{
+  if (!omedit_worker_ready()) return -1;
+  for (const auto &file : files) {
+    omedit_vfs_batch_add(file.first.toUtf8().constData(), file.second.constData(), file.second.size());
+  }
+  int id = omedit_post_vfs_put_many();
+  omcWorkerWaitReply(id);
+  return omedit_take_vfs_written(id);
 }
 
 // Worker-VFS directory listing (WASI fd_readdir), backing QDir over worker paths.

--- a/OMEdit/OMEditLIB/OMEditLIB.pro
+++ b/OMEdit/OMEditLIB/OMEditLIB.pro
@@ -89,6 +89,21 @@ INCLUDEPATH += . ../ \
 
 SOURCES += Util/Helper.cpp \
   Util/Utilities.cpp \
+  Util/PersistentStorage.cpp \
+  Cloud/CloudTypes.cpp \
+  Cloud/CloudConfig.cpp \
+  Cloud/CloudAccount.cpp \
+  Cloud/CloudProvider.cpp \
+  Cloud/GoogleDriveProvider.cpp \
+  Cloud/OneDriveProvider.cpp \
+  Cloud/CloudManifest.cpp \
+  Cloud/CloudMount.cpp \
+  Cloud/CloudCache.cpp \
+  Cloud/CloudSyncEngine.cpp \
+  Cloud/CloudBrowserDialog.cpp \
+  Cloud/CloudConflictDialog.cpp \
+  Cloud/OAuth2Client.cpp \
+  Cloud/OAuth2RedirectLoopback.cpp \
   Util/StringHandler.cpp \
   Util/OutputPlainTextEdit.cpp \
   Util/DirectoryOrFileSelector.cpp \
@@ -209,6 +224,21 @@ SOURCES += Util/Helper.cpp \
   Search/FindUsageWidget.cpp
 
 HEADERS  += Util/Helper.h \
+  Util/PersistentStorage.h \
+  Cloud/CloudTypes.h \
+  Cloud/CloudConfig.h \
+  Cloud/CloudAccount.h \
+  Cloud/CloudProvider.h \
+  Cloud/GoogleDriveProvider.h \
+  Cloud/OneDriveProvider.h \
+  Cloud/CloudManifest.h \
+  Cloud/CloudMount.h \
+  Cloud/CloudCache.h \
+  Cloud/CloudSyncEngine.h \
+  Cloud/CloudBrowserDialog.h \
+  Cloud/CloudConflictDialog.h \
+  Cloud/OAuth2Client.h \
+  Cloud/OAuth2Redirect.h \
   Util/Utilities.h \
   Util/StringHandler.h \
   Util/OutputPlainTextEdit.h \

--- a/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
@@ -51,6 +51,9 @@
 #include "Debugger/StackFrames/StackFramesWidget.h"
 #include "Editors/HTMLEditor.h"
 #include "Simulation/TranslationFlagsWidget.h"
+#include "Cloud/CloudAccount.h"
+#include "Cloud/CloudConfig.h"
+#include "Cloud/CloudMount.h"
 #include <limits>
 
 #include <QStringBuilder>
@@ -132,6 +135,7 @@ OptionsDialog::OptionsDialog(QWidget *pParent)
   mpOMSimulatorPage = new OMSimulatorPage(this);
   mpSensitivityOptimizationPage = new SensitivityOptimizationPage(this);
   mpTraceabilityPage = new TraceabilityPage(this);
+  mpCloudStoragePage = new CloudStoragePage(this);
   // Get the settings.
   // Don't read the settings in case we are running the testsuite. We want default OMEdit.
   if (!MainWindow::instance()->isTestsuiteRunning()) {
@@ -183,6 +187,7 @@ void OptionsDialog::readSettings()
   readOMSimulatorSettings();
   readSensitivityOptimizationSettings();
   readTraceabilitySettings();
+  readCloudStorageSettings();
 }
 
 //! Reads the General section settings from omedit.ini
@@ -3298,6 +3303,10 @@ void OptionsDialog::addListItems()
   QListWidgetItem *pTraceabilityItem = new QListWidgetItem(mpOptionsList);
   pTraceabilityItem->setIcon(QIcon(":/Resources/icons/traceability.svg"));
   pTraceabilityItem->setText(tr("Traceability"));
+  // Cloud Storage Item
+  QListWidgetItem *pCloudStorageItem = new QListWidgetItem(mpOptionsList);
+  pCloudStorageItem->setIcon(QIcon(":/Resources/icons/libraries.svg"));
+  pCloudStorageItem->setText(tr("Cloud Storage"));
 }
 
 //! Creates pages for the Options Widget. The pages are created as stacked widget and are mapped with mpOptionsList.
@@ -3328,6 +3337,7 @@ void OptionsDialog::createPages()
   addPage(mpOMSimulatorPage);
   addPage(mpSensitivityOptimizationPage);
   addPage(mpTraceabilityPage);
+  addPage(mpCloudStoragePage);
 }
 
 void OptionsDialog::addPage(QWidget* pPage)
@@ -3435,6 +3445,7 @@ void OptionsDialog::saveSettings()
   saveOMSimulatorSettings();
   saveSensitivityOptimizationSettings();
   saveTraceabilitySettings();
+  saveCloudStorageSettings();
   // emit the signal so that all text editors can set settings & line wrapping mode
   emit textSettingsChanged();
   mpSettings->sync();
@@ -6969,4 +6980,244 @@ void CRMLPage::browseCompilerProcessFile()
 void CRMLPage::resetCompilerProcessPath()
 {
   mpCompilerProcessTextBox->setText(OptionsDefaults::CRML::process);
+}
+
+void OptionsDialog::readCloudStorageSettings()
+{
+  mpCloudStoragePage->readRegistrations();
+}
+
+void OptionsDialog::saveCloudStorageSettings()
+{
+  mpCloudStoragePage->saveRegistrations();
+}
+
+//! @class CloudStoragePage
+//! Cloud storage accounts and the OAuth applications this installation uses.
+
+CloudStoragePage::CloudStoragePage(OptionsDialog *pOptionsDialog)
+  : QWidget(pOptionsDialog)
+{
+  mpOptionsDialog = pOptionsDialog;
+  // accounts
+  mpAccountsGroupBox = new QGroupBox(tr("Accounts"));
+  mpAccountsListWidget = new QListWidget;
+  mpAccountsListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+  mpAddGoogleDriveButton = new QPushButton(tr("Add Google Drive Account"));
+  connect(mpAddGoogleDriveButton, SIGNAL(clicked()), SLOT(addGoogleDriveAccount()));
+  mpAddOneDriveButton = new QPushButton(tr("Add OneDrive Account"));
+  connect(mpAddOneDriveButton, SIGNAL(clicked()), SLOT(addOneDriveAccount()));
+  mpSignOutButton = new QPushButton(tr("Sign Out"));
+  connect(mpSignOutButton, SIGNAL(clicked()), SLOT(signOutAccount()));
+  mpStatusLabel = new Label;
+  mpStatusLabel->setElideMode(Qt::ElideMiddle);
+  mpStatusLabel->setWordWrap(true);
+
+  QGridLayout *pAccountsLayout = new QGridLayout;
+  pAccountsLayout->addWidget(mpAccountsListWidget, 0, 0, 4, 1);
+  pAccountsLayout->addWidget(mpAddGoogleDriveButton, 0, 1);
+  pAccountsLayout->addWidget(mpAddOneDriveButton, 1, 1);
+  pAccountsLayout->addWidget(mpSignOutButton, 2, 1);
+  pAccountsLayout->setRowStretch(3, 1);
+  pAccountsLayout->addWidget(mpStatusLabel, 4, 0, 1, 2);
+  mpAccountsGroupBox->setLayout(pAccountsLayout);
+
+  // client registrations
+  mpRegistrationGroupBox = new QGroupBox(tr("OAuth Applications"));
+  Label *pRegistrationNoteLabel =
+      new Label(tr("Normally supplied by the deployment in cloud_config.json. Fill these in to use your own "
+                   "registered applications instead."));
+  pRegistrationNoteLabel->setWordWrap(true);
+  mpGoogleClientIdTextBox = new QLineEdit;
+  mpGoogleClientSecretTextBox = new QLineEdit;
+  // Masked, so it stays out of screenshots and screen shares. It is not actually
+  // confidential - see the tooltip - but a field labelled "secret" showing its
+  // value in the clear reads as a bug.
+  mpGoogleClientSecretTextBox->setEchoMode(QLineEdit::Password);
+  mpGoogleClientSecretTextBox->setToolTip(tr("Required by Google even though this is a public client: its token "
+                                             "endpoint rejects a PKCE exchange without one. It is not confidential - "
+                                             "the web build serves it to every visitor. The registered redirect URI "
+                                             "and origin are what protect the application."));
+  mpGoogleFullDriveScopeCheckBox = new QCheckBox(tr("Request access to the whole Google Drive"));
+  mpGoogleFullDriveScopeCheckBox->setToolTip(tr("Off, OMEdit sees only what it created. On, it asks for the whole "
+                                                "Drive - a restricted scope, which requires your own client to pass "
+                                                "Google's app verification."));
+  mpOneDriveClientIdTextBox = new QLineEdit;
+
+  QGridLayout *pRegistrationLayout = new QGridLayout;
+  pRegistrationLayout->addWidget(pRegistrationNoteLabel, 0, 0, 1, 2);
+  pRegistrationLayout->addWidget(new Label(tr("Google Drive client ID:")), 1, 0);
+  pRegistrationLayout->addWidget(mpGoogleClientIdTextBox, 1, 1);
+  pRegistrationLayout->addWidget(new Label(tr("Google Drive client secret:")), 2, 0);
+  pRegistrationLayout->addWidget(mpGoogleClientSecretTextBox, 2, 1);
+  pRegistrationLayout->addWidget(mpGoogleFullDriveScopeCheckBox, 3, 0, 1, 2);
+  pRegistrationLayout->addWidget(new Label(tr("OneDrive client ID:")), 4, 0);
+  pRegistrationLayout->addWidget(mpOneDriveClientIdTextBox, 4, 1);
+  mpRegistrationGroupBox->setLayout(pRegistrationLayout);
+
+  // mounted folders
+  mpMountsGroupBox = new QGroupBox(tr("Mounted Folders"));
+  Label *pMountsNoteLabel =
+      new Label(tr("A ticked folder is brought up to date after every save. Untick it to synchronise only when "
+                   "asked."));
+  pMountsNoteLabel->setWordWrap(true);
+  mpMountsListWidget = new QListWidget;
+  mpMountsListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+  connect(mpMountsListWidget, SIGNAL(itemChanged(QListWidgetItem*)), SLOT(mountAutoPushChanged(QListWidgetItem*)));
+  mpForgetMountButton = new QPushButton(tr("Forget Folder"));
+  connect(mpForgetMountButton, SIGNAL(clicked()), SLOT(forgetMount()));
+
+  QGridLayout *pMountsLayout = new QGridLayout;
+  pMountsLayout->addWidget(pMountsNoteLabel, 0, 0, 1, 2);
+  pMountsLayout->addWidget(mpMountsListWidget, 1, 0, 2, 1);
+  pMountsLayout->addWidget(mpForgetMountButton, 1, 1);
+  pMountsLayout->setRowStretch(2, 1);
+  mpMountsGroupBox->setLayout(pMountsLayout);
+
+  QVBoxLayout *pMainLayout = new QVBoxLayout;
+  pMainLayout->setContentsMargins(0, 0, 0, 0);
+  pMainLayout->addWidget(mpAccountsGroupBox);
+  pMainLayout->addWidget(mpMountsGroupBox);
+  pMainLayout->addWidget(mpRegistrationGroupBox);
+  pMainLayout->addStretch();
+  setLayout(pMainLayout);
+
+  connect(CloudAccountManager::instance(), SIGNAL(accountAdded(QString)), SLOT(onAccountAdded(QString)));
+  connect(CloudAccountManager::instance(), &CloudAccountManager::addAccountPhase, mpStatusLabel, &Label::setText);
+  connect(CloudAccountManager::instance(), SIGNAL(addAccountFailed(CloudError)), SLOT(onAddAccountFailed(CloudError)));
+}
+
+void CloudStoragePage::showEvent(QShowEvent *pEvent)
+{
+  QWidget::showEvent(pEvent);
+  readRegistrations();
+  refreshAccounts();
+  refreshMounts();
+}
+
+void CloudStoragePage::refreshMounts()
+{
+  mFillingMounts = true;
+  mpMountsListWidget->clear();
+  const QList<CloudMount> mounts = CloudMountManager::instance()->mounts();
+  for (const CloudMount &mount : mounts) {
+    QListWidgetItem *pItem = new QListWidgetItem(mpMountsListWidget);
+    pItem->setText(mount.remoteName);
+    pItem->setData(Qt::UserRole, mount.mountId);
+    pItem->setFlags(pItem->flags() | Qt::ItemIsUserCheckable);
+    pItem->setCheckState(mount.autoPush ? Qt::Checked : Qt::Unchecked);
+  }
+  mFillingMounts = false;
+}
+
+void CloudStoragePage::mountAutoPushChanged(QListWidgetItem *pItem)
+{
+  if (mFillingMounts || !pItem) {
+    return;
+  }
+  CloudMount mount = CloudMountManager::instance()->mount(pItem->data(Qt::UserRole).toString());
+  if (!mount.isValid()) {
+    return;
+  }
+  mount.autoPush = pItem->checkState() == Qt::Checked;
+  CloudMountManager::instance()->updateMount(mount);
+}
+
+void CloudStoragePage::forgetMount()
+{
+  QListWidgetItem *pItem = mpMountsListWidget->currentItem();
+  if (!pItem) {
+    return;
+  }
+  const int answer = QMessageBox::question(
+      this, QString("%1 - %2").arg(Helper::applicationName, tr("Forget Folder")),
+      tr("Forget %1?\n\nThe local copy and its synchronisation state are removed. Nothing in the cloud is "
+         "touched, and the folder can be opened again at any time.")
+          .arg(pItem->text()),
+      QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+  if (answer != QMessageBox::Yes) {
+    return;
+  }
+  CloudMountManager::instance()->removeMount(pItem->data(Qt::UserRole).toString());
+  refreshMounts();
+}
+
+void CloudStoragePage::refreshAccounts()
+{
+  mpAccountsListWidget->clear();
+  const QList<CloudAccount *> accounts = CloudAccountManager::instance()->accounts();
+  for (CloudAccount *pAccount : accounts) {
+    QListWidgetItem *pItem = new QListWidgetItem(mpAccountsListWidget);
+    pItem->setText(QString("%1 - %2").arg(cloudProviderDisplayName(pAccount->kind()), pAccount->displayName()));
+    pItem->setData(Qt::UserRole, pAccount->key());
+    if (!pAccount->isSignedIn()) {
+      pItem->setText(pItem->text() + tr(" (signed out)"));
+    }
+  }
+}
+
+void CloudStoragePage::readRegistrations()
+{
+  const CloudClientRegistration google = CloudConfig::instance()->registration(CloudProviderKind::GoogleDrive);
+  mpGoogleClientIdTextBox->setText(google.clientId);
+  mpGoogleClientSecretTextBox->setText(google.clientSecret);
+  mpGoogleFullDriveScopeCheckBox->setChecked(google.fullDriveScope);
+  mpOneDriveClientIdTextBox->setText(CloudConfig::instance()->registration(CloudProviderKind::OneDrive).clientId);
+}
+
+void CloudStoragePage::saveRegistrations()
+{
+  // Only write back what the user actually typed: storing the deployment's own
+  // values as user settings would pin them past a configuration update.
+  CloudClientRegistration google = CloudConfig::instance()->registration(CloudProviderKind::GoogleDrive);
+  if (mpGoogleClientIdTextBox->text() != google.clientId
+      || mpGoogleClientSecretTextBox->text() != google.clientSecret
+      || mpGoogleFullDriveScopeCheckBox->isChecked() != google.fullDriveScope) {
+    google.clientId = mpGoogleClientIdTextBox->text();
+    google.clientSecret = mpGoogleClientSecretTextBox->text();
+    google.fullDriveScope = mpGoogleFullDriveScopeCheckBox->isChecked();
+    CloudConfig::instance()->setRegistration(CloudProviderKind::GoogleDrive, google);
+  }
+  CloudClientRegistration oneDrive = CloudConfig::instance()->registration(CloudProviderKind::OneDrive);
+  if (mpOneDriveClientIdTextBox->text() != oneDrive.clientId) {
+    oneDrive.clientId = mpOneDriveClientIdTextBox->text();
+    CloudConfig::instance()->setRegistration(CloudProviderKind::OneDrive, oneDrive);
+  }
+}
+
+void CloudStoragePage::addGoogleDriveAccount()
+{
+  mpStatusLabel->setText(tr("Signing in to Google Drive..."));
+  saveRegistrations();
+  CloudAccountManager::instance()->addAccount(CloudProviderKind::GoogleDrive);
+}
+
+void CloudStoragePage::addOneDriveAccount()
+{
+  mpStatusLabel->setText(tr("Signing in to OneDrive..."));
+  saveRegistrations();
+  CloudAccountManager::instance()->addAccount(CloudProviderKind::OneDrive);
+}
+
+void CloudStoragePage::signOutAccount()
+{
+  QListWidgetItem *pItem = mpAccountsListWidget->currentItem();
+  if (!pItem) {
+    return;
+  }
+  CloudAccountManager::instance()->removeAccount(pItem->data(Qt::UserRole).toString());
+  refreshAccounts();
+  mpStatusLabel->setText(tr("Signed out."));
+}
+
+void CloudStoragePage::onAccountAdded(const QString &key)
+{
+  CloudAccount *pAccount = CloudAccountManager::instance()->account(key);
+  mpStatusLabel->setText(pAccount ? tr("Signed in as %1.").arg(pAccount->displayName()) : tr("Signed in."));
+  refreshAccounts();
+}
+
+void CloudStoragePage::onAddAccountFailed(const CloudError &error)
+{
+  mpStatusLabel->setText(tr("Sign-in failed: %1").arg(error.message));
 }

--- a/OMEdit/OMEditLIB/Options/OptionsDialog.h
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.h
@@ -42,6 +42,7 @@
 
 #include "Util/Helper.h"
 #include "Util/Utilities.h"
+#include "Cloud/CloudTypes.h"
 #include "Util/StringHandler.h"
 #include "Util/DirectoryOrFileSelector.h"
 
@@ -77,6 +78,7 @@ class FMIPage;
 class OMSimulatorPage;
 class SensitivityOptimizationPage;
 class TraceabilityPage;
+class CloudStoragePage;
 class TabSettings;
 class StackFramesWidget;
 class TranslationFlagsWidget;
@@ -125,6 +127,7 @@ public:
   void readOMSimulatorSettings();
   void readSensitivityOptimizationSettings();
   void readTraceabilitySettings();
+  void readCloudStorageSettings();
   void saveGeneralSettings();
   void saveNFAPISettings();
   void saveLibrariesSettings();
@@ -139,6 +142,7 @@ public:
   void saveOMSimulatorSettings();
   void saveSensitivityOptimizationSettings();
   void saveTraceabilitySettings();
+  void saveCloudStorageSettings();
   void saveGraphicalViewsSettings();
   void saveSimulationSettings();
   void saveGlobalSimulationSettings();
@@ -179,6 +183,7 @@ public:
   OMSimulatorPage* getOMSimulatorPage() {return mpOMSimulatorPage;}
   SensitivityOptimizationPage* getSensitivityOptimizationPage() {return mpSensitivityOptimizationPage;}
   TraceabilityPage* getTraceabilityPage() {return mpTraceabilityPage;}
+  CloudStoragePage* getCloudStoragePage() {return mpCloudStoragePage;}
   void emitModelicaEditorSettingsChanged() {emit modelicaEditorSettingsChanged();}
   void saveDialogGeometry();
   void show();
@@ -233,6 +238,7 @@ private:
   OMSimulatorPage *mpOMSimulatorPage;
   SensitivityOptimizationPage *mpSensitivityOptimizationPage;
   TraceabilityPage *mpTraceabilityPage;
+  CloudStoragePage *mpCloudStoragePage;
   QSettings *mpSettings;
   QListWidget *mpOptionsList;
   QStackedWidget *mpPagesWidget;
@@ -1167,6 +1173,64 @@ private slots:
   void browseCompilerJar();
   void browseCompilerProcessFile();
   void resetCompilerProcessPath();
+};
+
+/*!
+ * \brief Cloud storage accounts, and which OAuth applications this installation
+ * talks to.
+ *
+ * The client registrations are normally supplied by the deployment through
+ * cloud_config.json; the fields here override that for a developer or a site that
+ * registered its own applications, and are the only way to configure it when no
+ * such file is deployed.
+ */
+class CloudStoragePage : public QWidget
+{
+  Q_OBJECT
+public:
+  CloudStoragePage(OptionsDialog *pOptionsDialog);
+
+  void readRegistrations();
+  void saveRegistrations();
+
+protected:
+  //! Accounts and the deployment configuration are loaded here, not in the
+  //! constructor: the options dialog is built during startup, and reaching the
+  //! network from there stalls Qt's WebAssembly event dispatcher mid suspend and
+  //! resume. Nothing cloud-related happens until the page is actually looked at.
+  void showEvent(QShowEvent *pEvent) override;
+
+private:
+  void refreshAccounts();
+  void refreshMounts();
+
+  OptionsDialog *mpOptionsDialog;
+  QGroupBox *mpAccountsGroupBox;
+  QListWidget *mpAccountsListWidget;
+  QPushButton *mpAddGoogleDriveButton;
+  QPushButton *mpAddOneDriveButton;
+  QPushButton *mpSignOutButton;
+  Label *mpStatusLabel;
+  QGroupBox *mpRegistrationGroupBox;
+  QLineEdit *mpGoogleClientIdTextBox;
+  QLineEdit *mpGoogleClientSecretTextBox;
+  QCheckBox *mpGoogleFullDriveScopeCheckBox;
+  QLineEdit *mpOneDriveClientIdTextBox;
+  QGroupBox *mpMountsGroupBox;
+  QListWidget *mpMountsListWidget;
+  QPushButton *mpForgetMountButton;
+  //! Set while refreshMounts() fills the list, so its own changes are not
+  //! mistaken for the user ticking a box.
+  bool mFillingMounts = false;
+
+private slots:
+  void addGoogleDriveAccount();
+  void addOneDriveAccount();
+  void signOutAccount();
+  void onAccountAdded(const QString &key);
+  void onAddAccountFailed(const CloudError &error);
+  void mountAutoPushChanged(QListWidgetItem *pItem);
+  void forgetMount();
 };
 
 #endif // OPTIONSDIALOG_H

--- a/OMEdit/OMEditLIB/Util/PersistentStorage.cpp
+++ b/OMEdit/OMEditLIB/Util/PersistentStorage.cpp
@@ -1,0 +1,178 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+// Native side: the settings directory already survives a restart, so restore()
+// and the snapshots are no-ops. Only the secret store is real work — it must not
+// end up in the plain settings ini. The web target implements the same functions
+// over IndexedDB in OMEditGUI/wasm/persist_store.cpp.
+
+#if !defined(__EMSCRIPTEN__)
+
+#include "Util/PersistentStorage.h"
+#include "Util/Helper.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSaveFile>
+#include <QSettings>
+
+#if defined(Q_OS_WIN)
+#include <windows.h>
+#include <wincrypt.h>
+#endif
+
+namespace {
+
+QString secretsFilePath()
+{
+  return PersistentStorage::root() + QStringLiteral("/cloud-tokens.json");
+}
+
+#if defined(Q_OS_WIN)
+// The file is readable by the user's other processes, so wrap each value with the
+// user's logon secret rather than storing a usable token.
+QByteArray dpapi(const QByteArray &in, bool protect)
+{
+  DATA_BLOB inBlob;
+  inBlob.pbData = reinterpret_cast<BYTE *>(const_cast<char *>(in.constData()));
+  inBlob.cbData = static_cast<DWORD>(in.size());
+  DATA_BLOB outBlob = {0, nullptr};
+  const BOOL ok = protect ? CryptProtectData(&inBlob, L"OMEdit cloud token", nullptr, nullptr, nullptr, 0, &outBlob)
+                          : CryptUnprotectData(&inBlob, nullptr, nullptr, nullptr, nullptr, 0, &outBlob);
+  if (!ok) {
+    return QByteArray();
+  }
+  const QByteArray out(reinterpret_cast<const char *>(outBlob.pbData), static_cast<int>(outBlob.cbData));
+  LocalFree(outBlob.pbData);
+  return out;
+}
+#endif
+
+QByteArray encode(const QByteArray &value)
+{
+#if defined(Q_OS_WIN)
+  return dpapi(value, true).toBase64();
+#else
+  return value.toBase64();
+#endif
+}
+
+QByteArray decode(const QByteArray &stored)
+{
+  const QByteArray raw = QByteArray::fromBase64(stored);
+#if defined(Q_OS_WIN)
+  return dpapi(raw, false);
+#else
+  return raw;
+#endif
+}
+
+QJsonObject readSecrets()
+{
+  QFile file(secretsFilePath());
+  if (!file.open(QIODevice::ReadOnly)) {
+    return QJsonObject();
+  }
+  return QJsonDocument::fromJson(file.readAll()).object();
+}
+
+bool writeSecrets(const QJsonObject &object)
+{
+  QDir().mkpath(PersistentStorage::root());
+  QSaveFile file(secretsFilePath());
+  if (!file.open(QIODevice::WriteOnly)) {
+    return false;
+  }
+  file.write(QJsonDocument(object).toJson(QJsonDocument::Compact));
+  if (!file.commit()) {
+    return false;
+  }
+  return QFile::setPermissions(secretsFilePath(), QFileDevice::ReadOwner | QFileDevice::WriteOwner);
+}
+
+} // namespace
+
+QString PersistentStorage::root()
+{
+  static const QString dir =
+      QFileInfo(QSettings(QSettings::IniFormat, QSettings::UserScope, Helper::organization, Helper::application).fileName())
+          .absolutePath();
+  return dir;
+}
+
+bool PersistentStorage::restore()
+{
+  QDir().mkpath(root());
+  return true;
+}
+
+void PersistentStorage::scheduleSnapshot() {}
+
+bool PersistentStorage::snapshotNow()
+{
+  return true;
+}
+
+void PersistentStorage::startAutoSnapshot() {}
+
+QByteArray PersistentStorage::secret(const QString &key)
+{
+  const QJsonValue value = readSecrets().value(key);
+  return value.isString() ? decode(value.toString().toUtf8()) : QByteArray();
+}
+
+bool PersistentStorage::setSecret(const QString &key, const QByteArray &value)
+{
+  QJsonObject secrets = readSecrets();
+  secrets.insert(key, QString::fromUtf8(encode(value)));
+  return writeSecrets(secrets);
+}
+
+bool PersistentStorage::removeSecret(const QString &key)
+{
+  QJsonObject secrets = readSecrets();
+  secrets.remove(key);
+  return writeSecrets(secrets);
+}
+
+QStringList PersistentStorage::secretKeys()
+{
+  return readSecrets().keys();
+}
+
+#endif // !__EMSCRIPTEN__

--- a/OMEdit/OMEditLIB/Util/PersistentStorage.h
+++ b/OMEdit/OMEditLIB/Util/PersistentStorage.h
@@ -1,0 +1,85 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifndef PERSISTENTSTORAGE_H
+#define PERSISTENTSTORAGE_H
+
+#include <QByteArray>
+#include <QString>
+#include <QStringList>
+
+/*!
+ * \brief Storage that survives a restart of the application.
+ *
+ * Natively that is just the settings directory. On the web target nothing does:
+ * the page filesystem and the omc worker's VFS are both in memory and go away on
+ * reload, so the tree under root() is mirrored into IndexedDB and pulled back at
+ * startup. Callers see the same ordinary paths on both.
+ *
+ * Secrets (OAuth refresh tokens) are kept apart from the tree so that clearing
+ * settings does not sign the user out, and clearing sign-ins does not lose
+ * settings.
+ */
+namespace PersistentStorage
+{
+  QString root();
+
+  /*!
+   * \brief Bring the persisted tree into place.
+   * Must run before anything reads QSettings. Returns false if the store could not
+   * be reached, in which case this session simply starts empty.
+   */
+  bool restore();
+
+  //! Coalesced write-back; safe to call after every change.
+  void scheduleSnapshot();
+  bool snapshotNow();
+
+  /*!
+   * \brief Write the tree back by itself whenever it changes.
+   * QSettings reports no changes and there is no filesystem watcher on the web
+   * target, so this polls a cheap fingerprint of the tree rather than asking every
+   * writer to remember to call scheduleSnapshot(). Call once, after the
+   * QApplication exists.
+   */
+  void startAutoSnapshot();
+
+  QByteArray secret(const QString &key);
+  bool setSecret(const QString &key, const QByteArray &value);
+  bool removeSecret(const QString &key);
+  QStringList secretKeys();
+}
+
+#endif // PERSISTENTSTORAGE_H

--- a/OMEdit/OMEditLIB/Util/Utilities.cpp
+++ b/OMEdit/OMEditLIB/Util/Utilities.cpp
@@ -39,6 +39,7 @@
 
 #include "Utilities.h"
 #include "Helper.h"
+#include "PersistentStorage.h"
 #include "StringHandler.h"
 #include "OMC/OMCProxy.h"
 #include "Editors/BaseEditor.h"
@@ -878,7 +879,13 @@ QSettings* Utilities::getApplicationSettings()
   static QSettings *pSettings;
   if (!init) {
     init = 1;
+#if defined(__EMSCRIPTEN__)
+    // QSettings' own location is MEMFS, which the reload throws away. Put the ini
+    // in the tree PersistentStorage mirrors to IndexedDB instead.
+    pSettings = new QSettings(QString("%1/%2.ini").arg(PersistentStorage::root(), Helper::application), QSettings::IniFormat);
+#else
     pSettings = new QSettings(QSettings::IniFormat, QSettings::UserScope, Helper::organization, Helper::application);
+#endif
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     pSettings->setIniCodec(Helper::utf8.toUtf8().constData());
 #endif

--- a/OMEdit/Testsuite/CMakeLists.txt
+++ b/OMEdit/Testsuite/CMakeLists.txt
@@ -46,6 +46,14 @@ set(OMEDIT_TEST_BROWSEMSL_SOURCES BrowseMSL/BrowseMSL.cpp
                                   BrowseMSL/BrowseMSL.h)
 add_omedit_test(BrowseMSL "${OMEDIT_TEST_BROWSEMSL_SOURCES}")
 
+# Pure: the three-way sync planner and the manifest, with no network or provider.
+set(OMEDIT_TEST_CLOUD_SOURCES Cloud/CloudSyncPlanTest.cpp)
+add_omedit_test(CloudSyncPlan "${OMEDIT_TEST_CLOUD_SOURCES}")
+
+# The sync engine end to end, against an in-memory provider.
+set(OMEDIT_TEST_CLOUD_ENGINE_SOURCES Cloud/CloudSyncEngineTest.cpp)
+add_omedit_test(CloudSyncEngine "${OMEDIT_TEST_CLOUD_ENGINE_SOURCES}")
+
 set(OMEDIT_TEST_DIAGRAM_SOURCES Diagram/Diagram.cpp
                                 Diagram/Diagram.h)
 add_omedit_test(Diagram "${OMEDIT_TEST_DIAGRAM_SOURCES}")

--- a/OMEdit/Testsuite/Cloud/CloudSyncEngineTest.cpp
+++ b/OMEdit/Testsuite/Cloud/CloudSyncEngineTest.cpp
@@ -1,0 +1,587 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+// The sync engine driven end to end against a provider that lives in memory:
+// what the planner decides is one thing, carrying it out in an order that cannot
+// lose data is another. No network, and the working copy is a temporary
+// directory.
+
+#include "Cloud/CloudManifest.h"
+#include "Cloud/CloudMount.h"
+#include "Cloud/CloudProvider.h"
+#include "Cloud/CloudSyncEngine.h"
+
+#include <QCoreApplication>
+#include <QCryptographicHash>
+#include <QDir>
+#include <QElapsedTimer>
+#include <QFile>
+#include <QSettings>
+#include <QTemporaryDir>
+#include <QtTest>
+
+namespace {
+
+struct FakeItem
+{
+  QString id;
+  QString name;
+  QString parentId;
+  bool isFolder = false;
+  QByteArray contents;
+  int revision = 1;
+  bool trashed = false;
+};
+
+/*!
+ * \brief A cloud service in a QMap.
+ *
+ * Replies finish through the same queued emission the real ones use, so the
+ * engine is exercised over the event loop exactly as it is in the application.
+ */
+class FakeProvider : public CloudProvider
+{
+  Q_OBJECT
+public:
+  FakeProvider() : CloudProvider(0, 0, 0) {}
+
+  QMap<QString, FakeItem> items;
+  int nextId = 1;
+  //! Fail the nth request of this kind, to see what an interruption leaves behind.
+  QString failVerb;
+  int failAfter = -1;
+
+  QString add(const QString &name, const QString &parentId, const QByteArray &contents, bool isFolder = false)
+  {
+    FakeItem item;
+    item.id = QStringLiteral("item-%1").arg(nextId++);
+    item.name = name;
+    item.parentId = parentId;
+    item.contents = contents;
+    item.isFolder = isFolder;
+    items.insert(item.id, item);
+    return item.id;
+  }
+
+  QString idFor(const QString &name) const
+  {
+    for (const FakeItem &item : items) {
+      if (item.name == name && !item.trashed) {
+        return item.id;
+      }
+    }
+    return QString();
+  }
+
+  CloudProviderKind kind() const override { return CloudProviderKind::GoogleDrive; }
+
+  CloudReply *userInfo() override { return done(CloudReply::pending(this)); }
+  CloudReply *appRootFolder() override { return done(CloudReply::pending(this)); }
+
+  CloudReply *listFolder(const QString &folderId) override
+  {
+    CloudReply *pReply = CloudReply::pending(this);
+    QList<RemoteItem> found;
+    for (const FakeItem &item : std::as_const(items)) {
+      if (item.parentId != folderId || item.trashed) {
+        continue;
+      }
+      found << toRemote(item);
+    }
+    pReply->setItems(found);
+    return done(pReply);
+  }
+
+  CloudReply *metadata(const QString &itemId) override
+  {
+    CloudReply *pReply = CloudReply::pending(this);
+    pReply->setItem(toRemote(items.value(itemId)));
+    return done(pReply);
+  }
+
+  CloudReply *download(const QString &fileId) override
+  {
+    CloudReply *pReply = CloudReply::pending(this);
+    if (!items.contains(fileId)) {
+      return fail(pReply, CloudError::NotFound, QStringLiteral("no such file"));
+    }
+    pReply->setData(items.value(fileId).contents);
+    return done(pReply);
+  }
+
+  CloudReply *createFolder(const QString &parentId, const QString &name) override
+  {
+    CloudReply *pReply = CloudReply::pending(this);
+    if (shouldFail(QStringLiteral("createFolder"))) {
+      return fail(pReply, CloudError::Provider, QStringLiteral("refused"));
+    }
+    pReply->setItem(toRemote(items.value(add(name, parentId, QByteArray(), true))));
+    return done(pReply);
+  }
+
+  CloudReply *uploadNew(const QString &parentId, const QString &name, const QByteArray &contents) override
+  {
+    CloudReply *pReply = CloudReply::pending(this);
+    if (shouldFail(QStringLiteral("upload"))) {
+      return fail(pReply, CloudError::Provider, QStringLiteral("refused"));
+    }
+    pReply->setItem(toRemote(items.value(add(name, parentId, contents))));
+    return done(pReply);
+  }
+
+  CloudReply *uploadUpdate(const QString &fileId, const QByteArray &contents,
+                           const QString &expectedRevision) override
+  {
+    CloudReply *pReply = CloudReply::pending(this);
+    if (shouldFail(QStringLiteral("upload"))) {
+      return fail(pReply, CloudError::Provider, QStringLiteral("refused"));
+    }
+    FakeItem item = items.value(fileId);
+    if (!expectedRevision.isEmpty() && expectedRevision != QString::number(item.revision)) {
+      return fail(pReply, CloudError::Conflict, QStringLiteral("revision moved on"));
+    }
+    item.contents = contents;
+    item.revision += 1;
+    items.insert(fileId, item);
+    pReply->setItem(toRemote(item));
+    return done(pReply);
+  }
+
+  CloudReply *trashItem(const QString &itemId, const QString &expectedRevision) override
+  {
+    CloudReply *pReply = CloudReply::pending(this);
+    if (shouldFail(QStringLiteral("trash"))) {
+      return fail(pReply, CloudError::Provider, QStringLiteral("refused"));
+    }
+    FakeItem item = items.value(itemId);
+    if (!expectedRevision.isEmpty() && expectedRevision != QString::number(item.revision)) {
+      return fail(pReply, CloudError::Conflict, QStringLiteral("revision moved on"));
+    }
+    item.trashed = true;
+    items.insert(itemId, item);
+    return done(pReply);
+  }
+
+  CloudReply *currentDeltaToken(const QString &) override
+  {
+    CloudReply *pReply = CloudReply::pending(this);
+    pReply->setDeltaToken(QStringLiteral("token"));
+    return done(pReply);
+  }
+
+  CloudReply *changes(const QString &, const QString &) override { return done(CloudReply::pending(this)); }
+
+private:
+  RemoteItem toRemote(const FakeItem &item) const
+  {
+    RemoteItem remote;
+    remote.id = item.id;
+    remote.name = item.name;
+    remote.isFolder = item.isFolder;
+    remote.size = item.contents.size();
+    remote.revision = QString::number(item.revision);
+    remote.contentHash = QString::fromLatin1(
+        QCryptographicHash::hash(item.contents, QCryptographicHash::Md5).toHex());
+    return remote;
+  }
+
+  bool shouldFail(const QString &verb)
+  {
+    if (verb != failVerb || failAfter < 0) {
+      return false;
+    }
+    return failAfter-- == 0;
+  }
+
+  CloudReply *done(CloudReply *pReply)
+  {
+    pReply->finish(CloudError());
+    return pReply;
+  }
+
+  CloudReply *fail(CloudReply *pReply, CloudError::Code code, const QString &message)
+  {
+    pReply->finish(CloudError(code, message));
+    return pReply;
+  }
+};
+
+QByteArray hashOf(const QByteArray &contents)
+{
+  return QCryptographicHash::hash(contents, QCryptographicHash::Sha256);
+}
+
+void writeFile(const QString &path, const QByteArray &contents)
+{
+  QDir().mkpath(QFileInfo(path).absolutePath());
+  QFile file(path);
+  QVERIFY2(file.open(QIODevice::WriteOnly | QIODevice::Truncate), qPrintable(path));
+  file.write(contents);
+}
+
+QByteArray readFile(const QString &path)
+{
+  QFile file(path);
+  if (!file.open(QIODevice::ReadOnly)) {
+    return QByteArray();
+  }
+  return file.readAll();
+}
+
+} // namespace
+
+class CloudSyncEngineTest : public QObject
+{
+  Q_OBJECT
+private slots:
+  void initTestCase();
+  void init();
+  void cleanup();
+
+  void uploadsAWorkingCopy();
+  void downloadsIntoAnEmptyWorkingCopy();
+  void conflictKeepsBothVersions();
+  void conflictTakesTheRemoteVersion();
+  void cancellingAConflictEndsTheRun();
+  void keepingALocalDeletionRemovesTheRemote();
+  void aDeletedFileIsRemovedRemotely();
+  void declinedDeletionsChangeNothing();
+  void aWipedWorkingCopyIsRestoredNotPropagated();
+  void anInterruptedUploadLeavesNothingDeleted();
+
+private:
+  //! One run of the engine, with the answers it may ask for prepared in advance.
+  CloudError run(CloudSyncEngine *pEngine, const QHash<QString, int> &resolutions = QHash<QString, int>(),
+                 bool confirmDeletions = true);
+  CloudSyncEngine *newEngine();
+
+  QTemporaryDir *mpTempDir = 0;
+  FakeProvider *mpProvider = 0;
+  CloudMount mMount;
+  QString mRootId;
+  QList<SyncAction> mLastConflicts;
+  QList<SyncAction> mLastDeletions;
+  bool mCancelOnConflict = false;
+};
+
+void CloudSyncEngineTest::initTestCase()
+{
+  // Keep the manifests out of the real settings directory.
+  static QTemporaryDir settingsDir;
+  QSettings::setPath(QSettings::IniFormat, QSettings::UserScope, settingsDir.path());
+}
+
+void CloudSyncEngineTest::init()
+{
+  mpTempDir = new QTemporaryDir;
+  mpProvider = new FakeProvider;
+  mRootId = QStringLiteral("root");
+  mMount = CloudMount();
+  mMount.mountId = QStringLiteral("test");
+  mMount.accountKey = QStringLiteral("fake:test");
+  mMount.remoteRootId = mRootId;
+  mMount.remoteName = QStringLiteral("Package");
+  mMount.localRoot = mpTempDir->path() + QStringLiteral("/work");
+  QDir().mkpath(mMount.localRoot);
+  QFile::remove(mMount.manifestPath());
+  mLastConflicts.clear();
+  mLastDeletions.clear();
+  mCancelOnConflict = false;
+}
+
+void CloudSyncEngineTest::cleanup()
+{
+  QFile::remove(mMount.manifestPath());
+  delete mpProvider;
+  mpProvider = 0;
+  delete mpTempDir;
+  mpTempDir = 0;
+}
+
+CloudSyncEngine *CloudSyncEngineTest::newEngine()
+{
+  return new CloudSyncEngine(mMount, mpProvider, this);
+}
+
+CloudError CloudSyncEngineTest::run(CloudSyncEngine *pEngine, const QHash<QString, int> &resolutions,
+                                    bool confirmDeletions)
+{
+  CloudError result;
+  bool finished = false;
+  connect(pEngine, &CloudSyncEngine::finished, this, [&result, &finished](const CloudError &error) {
+    result = error;
+    finished = true;
+  });
+  connect(pEngine, &CloudSyncEngine::conflictsDetected, this,
+          [this, pEngine, resolutions](const QList<SyncAction> &conflicts) {
+    mLastConflicts = conflicts;
+    if (mCancelOnConflict) {
+      pEngine->cancel();
+      return;
+    }
+    QHash<QString, int> answers;
+    for (const SyncAction &conflict : conflicts) {
+      answers.insert(conflict.relativePath, resolutions.value(conflict.relativePath, CloudSyncEngine::KeepBoth));
+    }
+    pEngine->applyResolutions(answers);
+  });
+  connect(pEngine, &CloudSyncEngine::deletionsNeedConfirmation, this,
+          [this, pEngine, confirmDeletions](const QList<SyncAction> &deletions) {
+    mLastDeletions = deletions;
+    pEngine->confirmDeletions(confirmDeletions);
+  });
+  pEngine->start();
+  QElapsedTimer timer;
+  timer.start();
+  while (!finished && timer.elapsed() < 5000) {
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 20);
+  }
+  if (!finished) {
+    result = CloudError(CloudError::Network, QStringLiteral("the engine never finished"));
+  }
+  pEngine->deleteLater();
+  return result;
+}
+
+void CloudSyncEngineTest::uploadsAWorkingCopy()
+{
+  writeFile(mMount.localRoot + QStringLiteral("/package.mo"), "package P end P;");
+  writeFile(mMount.localRoot + QStringLiteral("/Sub/package.mo"), "package Sub end Sub;");
+
+  const CloudError error = run(newEngine());
+  QVERIFY(!error.isError());
+  QVERIFY(!mpProvider->idFor(QStringLiteral("Sub")).isEmpty());
+  QCOMPARE(mpProvider->items.value(mpProvider->idFor(QStringLiteral("Sub"))).isFolder, true);
+
+  CloudManifest manifest;
+  QVERIFY(manifest.load(mMount.manifestPath()));
+  QCOMPARE(manifest.fileCount(), 2);
+}
+
+void CloudSyncEngineTest::downloadsIntoAnEmptyWorkingCopy()
+{
+  const QString folder = mpProvider->add(QStringLiteral("Sub"), mRootId, QByteArray(), true);
+  mpProvider->add(QStringLiteral("package.mo"), mRootId, "package P end P;");
+  mpProvider->add(QStringLiteral("M.mo"), folder, "model M end M;");
+
+  const CloudError error = run(newEngine());
+  QVERIFY(!error.isError());
+  QCOMPARE(readFile(mMount.localRoot + QStringLiteral("/package.mo")), QByteArray("package P end P;"));
+  QCOMPARE(readFile(mMount.localRoot + QStringLiteral("/Sub/M.mo")), QByteArray("model M end M;"));
+}
+
+void CloudSyncEngineTest::conflictKeepsBothVersions()
+{
+  const QString fileId = mpProvider->add(QStringLiteral("M.mo"), mRootId, "model M end M;");
+  writeFile(mMount.localRoot + QStringLiteral("/M.mo"), "model M end M;");
+  QVERIFY(!run(newEngine()).isError());
+
+  // Both sides move away from the synced state.
+  writeFile(mMount.localRoot + QStringLiteral("/M.mo"), "model M // mine\nend M;");
+  FakeItem remote = mpProvider->items.value(fileId);
+  remote.contents = "model M // theirs\nend M;";
+  remote.revision += 1;
+  mpProvider->items.insert(fileId, remote);
+
+  QHash<QString, int> answers;
+  answers.insert(QStringLiteral("M.mo"), CloudSyncEngine::KeepBoth);
+  QVERIFY(!run(newEngine(), answers).isError());
+
+  QCOMPARE(mLastConflicts.size(), 1);
+  QCOMPARE(mLastConflicts.first().conflict, SyncAction::BothChanged);
+  // Theirs at the original name, mine beside it, and mine is up there too.
+  QCOMPARE(readFile(mMount.localRoot + QStringLiteral("/M.mo")), QByteArray("model M // theirs\nend M;"));
+  const QStringList copies = QDir(mMount.localRoot).entryList(QStringList() << QStringLiteral("M.conflict-*.mo"));
+  QCOMPARE(copies.size(), 1);
+  QCOMPARE(readFile(mMount.localRoot + QLatin1Char('/') + copies.first()), QByteArray("model M // mine\nend M;"));
+  QVERIFY(!mpProvider->idFor(copies.first()).isEmpty());
+}
+
+void CloudSyncEngineTest::conflictTakesTheRemoteVersion()
+{
+  const QString fileId = mpProvider->add(QStringLiteral("M.mo"), mRootId, "model M end M;");
+  writeFile(mMount.localRoot + QStringLiteral("/M.mo"), "model M end M;");
+  QVERIFY(!run(newEngine()).isError());
+
+  writeFile(mMount.localRoot + QStringLiteral("/M.mo"), "model M // mine\nend M;");
+  FakeItem remote = mpProvider->items.value(fileId);
+  remote.contents = "model M // theirs\nend M;";
+  remote.revision += 1;
+  mpProvider->items.insert(fileId, remote);
+
+  QHash<QString, int> answers;
+  answers.insert(QStringLiteral("M.mo"), CloudSyncEngine::TakeRemote);
+  QVERIFY(!run(newEngine(), answers).isError());
+
+  QCOMPARE(readFile(mMount.localRoot + QStringLiteral("/M.mo")), QByteArray("model M // theirs\nend M;"));
+  QCOMPARE(QDir(mMount.localRoot).entryList(QStringList() << QStringLiteral("M.conflict-*.mo")).size(), 0);
+}
+
+void CloudSyncEngineTest::cancellingAConflictEndsTheRun()
+{
+  const QString fileId = mpProvider->add(QStringLiteral("M.mo"), mRootId, "model M end M;");
+  writeFile(mMount.localRoot + QStringLiteral("/M.mo"), "model M end M;");
+  QVERIFY(!run(newEngine()).isError());
+
+  writeFile(mMount.localRoot + QStringLiteral("/M.mo"), "model M // mine\nend M;");
+  FakeItem remote = mpProvider->items.value(fileId);
+  remote.contents = "model M // theirs\nend M;";
+  remote.revision += 1;
+  mpProvider->items.insert(fileId, remote);
+
+  // Nothing is in flight while the dialog is up, so the engine has to end the run
+  // itself; otherwise a dismissed dialog leaves it waiting forever.
+  mCancelOnConflict = true;
+  const CloudError error = run(newEngine());
+  QCOMPARE(error.code, CloudError::Cancelled);
+  QCOMPARE(readFile(mMount.localRoot + QStringLiteral("/M.mo")), QByteArray("model M // mine\nend M;"));
+  QCOMPARE(mpProvider->items.value(fileId).contents, QByteArray("model M // theirs\nend M;"));
+}
+
+void CloudSyncEngineTest::keepingALocalDeletionRemovesTheRemote()
+{
+  const QString fileId = mpProvider->add(QStringLiteral("M.mo"), mRootId, "model M end M;");
+  mpProvider->add(QStringLiteral("package.mo"), mRootId, "package P end P;");
+  writeFile(mMount.localRoot + QStringLiteral("/M.mo"), "model M end M;");
+  writeFile(mMount.localRoot + QStringLiteral("/package.mo"), "package P end P;");
+  QVERIFY(!run(newEngine()).isError());
+
+  // Deleted here, changed there: keeping "mine" has to mean removing theirs, not
+  // quietly doing nothing.
+  QVERIFY(QFile::remove(mMount.localRoot + QStringLiteral("/M.mo")));
+  FakeItem remote = mpProvider->items.value(fileId);
+  remote.contents = "model M // theirs\nend M;";
+  remote.revision += 1;
+  mpProvider->items.insert(fileId, remote);
+
+  QHash<QString, int> answers;
+  answers.insert(QStringLiteral("M.mo"), CloudSyncEngine::KeepLocal);
+  QVERIFY(!run(newEngine(), answers).isError());
+
+  QCOMPARE(mLastConflicts.size(), 1);
+  QCOMPARE(mLastConflicts.first().conflict, SyncAction::LocalDeletedRemoteChanged);
+  QCOMPARE(mpProvider->items.value(fileId).trashed, true);
+  QVERIFY(!QFile::exists(mMount.localRoot + QStringLiteral("/M.mo")));
+}
+
+void CloudSyncEngineTest::aDeletedFileIsRemovedRemotely()
+{
+  const QString removedId = mpProvider->add(QStringLiteral("M0.mo"), mRootId, "model M end M;");
+  QStringList kept;
+  writeFile(mMount.localRoot + QStringLiteral("/M0.mo"), "model M end M;");
+  for (int i = 1; i < 10; ++i) {
+    const QString name = QStringLiteral("M%1.mo").arg(i);
+    kept << mpProvider->add(name, mRootId, "model M end M;");
+    writeFile(mMount.localRoot + QLatin1Char('/') + name, "model M end M;");
+  }
+  QVERIFY(!run(newEngine()).isError());
+
+  // One of ten: a routine deletion, not worth an interruption.
+  QVERIFY(QFile::remove(mMount.localRoot + QStringLiteral("/M0.mo")));
+  QVERIFY(!run(newEngine()).isError());
+  QVERIFY(mLastDeletions.isEmpty());
+  QCOMPARE(mpProvider->items.value(removedId).trashed, true);
+  for (const QString &id : std::as_const(kept)) {
+    QCOMPARE(mpProvider->items.value(id).trashed, false);
+  }
+}
+
+void CloudSyncEngineTest::declinedDeletionsChangeNothing()
+{
+  QStringList ids;
+  for (int i = 0; i < 10; ++i) {
+    const QString name = QStringLiteral("M%1.mo").arg(i);
+    ids << mpProvider->add(name, mRootId, "model M end M;");
+    writeFile(mMount.localRoot + QLatin1Char('/') + name, "model M end M;");
+  }
+  QVERIFY(!run(newEngine()).isError());
+
+  // Eight of ten is past both thresholds, so it has to be confirmed.
+  for (int i = 0; i < 8; ++i) {
+    QVERIFY(QFile::remove(mMount.localRoot + QStringLiteral("/M%1.mo").arg(i)));
+  }
+  const CloudError error = run(newEngine(), QHash<QString, int>(), false);
+  QCOMPARE(error.code, CloudError::Cancelled);
+  QCOMPARE(mLastDeletions.size(), 8);
+  for (const QString &id : std::as_const(ids)) {
+    QCOMPARE(mpProvider->items.value(id).trashed, false);
+  }
+}
+
+void CloudSyncEngineTest::aWipedWorkingCopyIsRestoredNotPropagated()
+{
+  for (int i = 0; i < 10; ++i) {
+    const QString name = QStringLiteral("M%1.mo").arg(i);
+    mpProvider->add(name, mRootId, "model M end M;");
+    writeFile(mMount.localRoot + QLatin1Char('/') + name, "model M end M;");
+  }
+  QVERIFY(!run(newEngine()).isError());
+
+  // What a browser reload leaves behind. Nothing about it says "deleted".
+  QVERIFY(QDir(mMount.localRoot).removeRecursively());
+  QDir().mkpath(mMount.localRoot);
+
+  QVERIFY(!run(newEngine()).isError());
+  QVERIFY(mLastDeletions.isEmpty());
+  for (const FakeItem &item : std::as_const(mpProvider->items)) {
+    QCOMPARE(item.trashed, false);
+  }
+  QCOMPARE(QDir(mMount.localRoot).entryList(QDir::Files).size(), 10);
+}
+
+void CloudSyncEngineTest::anInterruptedUploadLeavesNothingDeleted()
+{
+  writeFile(mMount.localRoot + QStringLiteral("/A.mo"), "model A end A;");
+  writeFile(mMount.localRoot + QStringLiteral("/B.mo"), "model B end B;");
+  mpProvider->failVerb = QStringLiteral("upload");
+  mpProvider->failAfter = 1;
+
+  QVERIFY(run(newEngine()).isError());
+  // What did get up there is on record, so the next run updates rather than
+  // duplicating it, and nothing was removed on either side.
+  CloudManifest manifest;
+  QVERIFY(manifest.load(mMount.manifestPath()));
+  QCOMPARE(manifest.fileCount(), 1);
+  QVERIFY(QFile::exists(mMount.localRoot + QStringLiteral("/A.mo")));
+  QVERIFY(QFile::exists(mMount.localRoot + QStringLiteral("/B.mo")));
+
+  mpProvider->failAfter = -1;
+  QVERIFY(!run(newEngine()).isError());
+  QCOMPARE(mpProvider->items.size(), 2);
+}
+
+QTEST_GUILESS_MAIN(CloudSyncEngineTest)
+
+#include "CloudSyncEngineTest.moc"

--- a/OMEdit/Testsuite/Cloud/CloudSyncEngineTest.cpp
+++ b/OMEdit/Testsuite/Cloud/CloudSyncEngineTest.cpp
@@ -272,6 +272,7 @@ private slots:
 
   void uploadsAWorkingCopy();
   void downloadsIntoAnEmptyWorkingCopy();
+  void identicalBytesAreAdopted();
   void conflictKeepsBothVersions();
   void conflictTakesTheRemoteVersion();
   void cancellingAConflictEndsTheRun();
@@ -400,6 +401,25 @@ void CloudSyncEngineTest::downloadsIntoAnEmptyWorkingCopy()
   QVERIFY(!error.isError());
   QCOMPARE(readFile(mMount.localRoot + QStringLiteral("/package.mo")), QByteArray("package P end P;"));
   QCOMPARE(readFile(mMount.localRoot + QStringLiteral("/Sub/M.mo")), QByteArray("model M end M;"));
+}
+
+void CloudSyncEngineTest::identicalBytesAreAdopted()
+{
+  const QByteArray contents = "package P end P;";
+  writeFile(mMount.localRoot + QStringLiteral("/package.mo"), contents);
+  mpProvider->add(QStringLiteral("package.mo"), mRootId, contents);
+
+  const CloudError error = run(newEngine());
+  QVERIFY(!error.isError());
+  QVERIFY(mLastConflicts.isEmpty());
+  QCOMPARE(mpProvider->items.size(), 1);
+
+  CloudManifest manifest;
+  QVERIFY(manifest.load(mMount.manifestPath()));
+  const ManifestEntry entry = manifest.entries.value(QStringLiteral("package.mo"));
+  QCOMPARE(entry.contentHash, hashOf(contents));
+  QCOMPARE(entry.size, qint64(contents.size()));
+  QCOMPARE(entry.isFolder, false);
 }
 
 void CloudSyncEngineTest::conflictKeepsBothVersions()

--- a/OMEdit/Testsuite/Cloud/CloudSyncPlanTest.cpp
+++ b/OMEdit/Testsuite/Cloud/CloudSyncPlanTest.cpp
@@ -1,0 +1,374 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+// The three-way sync planner. Every row of the decision matrix is asserted here,
+// plus the rules that stop a missing working copy from wiping a cloud package.
+// Pure: no network, no provider, no files beyond the manifest round trip.
+
+#include "Cloud/CloudManifest.h"
+
+#include <QCryptographicHash>
+#include <QTemporaryDir>
+#include <QtTest>
+
+namespace {
+
+QByteArray hashOf(const QByteArray &contents)
+{
+  return QCryptographicHash::hash(contents, QCryptographicHash::Sha256);
+}
+
+void addManifest(CloudManifest *pManifest, const QString &path, const QByteArray &contents, const QString &revision,
+                 bool isFolder = false)
+{
+  ManifestEntry entry;
+  entry.relativePath = path;
+  entry.remoteId = QStringLiteral("id-%1").arg(path);
+  entry.remoteRevision = revision;
+  entry.contentHash = isFolder ? QByteArray() : hashOf(contents);
+  entry.size = contents.size();
+  entry.isFolder = isFolder;
+  pManifest->entries.insert(path, entry);
+}
+
+void addLocal(QMap<QString, LocalEntry> *pLocal, const QString &path, const QByteArray &contents,
+              bool isFolder = false)
+{
+  LocalEntry entry;
+  entry.relativePath = path;
+  entry.contentHash = isFolder ? QByteArray() : hashOf(contents);
+  entry.size = contents.size();
+  entry.isFolder = isFolder;
+  pLocal->insert(path, entry);
+}
+
+void addRemote(QMap<QString, RemoteEntry> *pRemote, const QString &path, const QString &revision,
+               bool isFolder = false)
+{
+  RemoteEntry entry;
+  entry.relativePath = path;
+  entry.remoteId = QStringLiteral("id-%1").arg(path);
+  entry.remoteRevision = revision;
+  entry.isFolder = isFolder;
+  pRemote->insert(path, entry);
+}
+
+//! The single action the plan proposes for path, or a default-constructed one.
+SyncAction actionFor(const SyncPlan &plan, const QString &path)
+{
+  for (const SyncAction &action : plan.actions) {
+    if (action.relativePath == path) {
+      return action;
+    }
+  }
+  SyncAction none;
+  none.kind = SyncAction::DropManifestEntry;
+  none.relativePath = QStringLiteral("<absent>");
+  return none;
+}
+
+bool hasActionFor(const SyncPlan &plan, const QString &path)
+{
+  for (const SyncAction &action : plan.actions) {
+    if (action.relativePath == path) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool hasAction(const SyncPlan &plan, const QString &path, SyncAction::Kind kind)
+{
+  for (const SyncAction &action : plan.actions) {
+    if (action.relativePath == path && action.kind == kind) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace
+
+class CloudSyncPlanTest : public QObject
+{
+  Q_OBJECT
+private slots:
+  void matrix_data();
+  void matrix();
+  void incompleteWorkingCopyNeverDeletes();
+  void completenessIsNotPersisted();
+  void deletionThreshold();
+  void folderRemovedOnlyWhenEmpty();
+  void manifestRoundTrip();
+  void unusableRemoteNames();
+};
+
+/*!
+ * \brief One row per case in the decision matrix.
+ * "-" means the file is not present in that view.
+ */
+void CloudSyncPlanTest::matrix_data()
+{
+  QTest::addColumn<QString>("manifestContents");
+  QTest::addColumn<QString>("manifestRevision");
+  QTest::addColumn<QString>("localContents");
+  QTest::addColumn<QString>("remoteRevision");
+  QTest::addColumn<int>("expectedKind");
+  QTest::addColumn<int>("expectedConflict");
+
+  QTest::newRow("new local")
+      << "-" << "-" << "a" << "-" << int(SyncAction::UploadNew) << int(SyncAction::NoConflict);
+  QTest::newRow("new remote")
+      << "-" << "-" << "-" << "r1" << int(SyncAction::DownloadNew) << int(SyncAction::NoConflict);
+  QTest::newRow("both created")
+      << "-" << "-" << "a" << "r1" << int(SyncAction::Conflict) << int(SyncAction::BothCreated);
+  QTest::newRow("unchanged")
+      << "a" << "r1" << "a" << "r1" << -1 << int(SyncAction::NoConflict);
+  QTest::newRow("local edit")
+      << "a" << "r1" << "b" << "r1" << int(SyncAction::UpdateRemote) << int(SyncAction::NoConflict);
+  QTest::newRow("remote edit")
+      << "a" << "r1" << "a" << "r2" << int(SyncAction::DownloadUpdate) << int(SyncAction::NoConflict);
+  QTest::newRow("both edited")
+      << "a" << "r1" << "b" << "r2" << int(SyncAction::Conflict) << int(SyncAction::BothChanged);
+  QTest::newRow("local delete")
+      << "a" << "r1" << "-" << "r1" << int(SyncAction::DeleteRemote) << int(SyncAction::NoConflict);
+  QTest::newRow("remote delete")
+      << "a" << "r1" << "a" << "-" << int(SyncAction::DeleteLocal) << int(SyncAction::NoConflict);
+  QTest::newRow("local delete vs remote edit")
+      << "a" << "r1" << "-" << "r2" << int(SyncAction::Conflict) << int(SyncAction::LocalDeletedRemoteChanged);
+  QTest::newRow("local edit vs remote delete")
+      << "a" << "r1" << "b" << "-" << int(SyncAction::Conflict) << int(SyncAction::LocalChangedRemoteDeleted);
+  QTest::newRow("deleted both sides")
+      << "a" << "r1" << "-" << "-" << int(SyncAction::DropManifestEntry) << int(SyncAction::NoConflict);
+}
+
+void CloudSyncPlanTest::matrix()
+{
+  QFETCH(QString, manifestContents);
+  QFETCH(QString, manifestRevision);
+  QFETCH(QString, localContents);
+  QFETCH(QString, remoteRevision);
+  QFETCH(int, expectedKind);
+  QFETCH(int, expectedConflict);
+
+  const QString path = QStringLiteral("package.mo");
+  CloudManifest manifest;
+  // The whole matrix assumes a working copy we trust; the incomplete case has
+  // its own test below.
+  manifest.workingCopyComplete = true;
+  QMap<QString, LocalEntry> local;
+  QMap<QString, RemoteEntry> remote;
+
+  if (manifestContents != QLatin1String("-")) {
+    addManifest(&manifest, path, manifestContents.toUtf8(), manifestRevision);
+  }
+  if (localContents != QLatin1String("-")) {
+    addLocal(&local, path, localContents.toUtf8());
+  }
+  if (remoteRevision != QLatin1String("-")) {
+    addRemote(&remote, path, remoteRevision);
+  }
+
+  const SyncPlan plan = planSync(manifest, local, remote);
+
+  if (expectedKind < 0) {
+    QVERIFY2(!hasActionFor(plan, path), "a file that did not move must produce no action");
+    return;
+  }
+  QVERIFY2(hasActionFor(plan, path), "expected an action for the file");
+  const SyncAction action = actionFor(plan, path);
+  QCOMPARE(int(action.kind), expectedKind);
+  QCOMPARE(int(action.conflict), expectedConflict);
+}
+
+/*!
+ * \brief The regression this whole design exists for.
+ * On the web target the working copy lives in memory. If a restore fails, every
+ * file looks locally deleted - and a push must not turn that into a wiped
+ * package.
+ */
+void CloudSyncPlanTest::incompleteWorkingCopyNeverDeletes()
+{
+  CloudManifest manifest;
+  manifest.workingCopyComplete = false;
+  QMap<QString, RemoteEntry> remote;
+  for (int i = 0; i < 20; ++i) {
+    const QString path = QStringLiteral("Sub%1.mo").arg(i);
+    addManifest(&manifest, path, "contents", QStringLiteral("r1"));
+    addRemote(&remote, path, QStringLiteral("r1"));
+  }
+
+  // Nothing restored at all.
+  const SyncPlan plan = planSync(manifest, QMap<QString, LocalEntry>(), remote);
+  QCOMPARE(plan.count(SyncAction::DeleteRemote), 0);
+
+  // Nothing is deleted - and every missing file is fetched back instead. Skipping
+  // them left the working copy permanently empty, which on the web target is its
+  // state after every reload.
+  QCOMPARE(plan.count(SyncAction::DownloadNew), 20);
+
+  // And the same tree with the flag set does propagate the deletions, so the
+  // test above is not passing for the wrong reason.
+  manifest.workingCopyComplete = true;
+  const SyncPlan trusted = planSync(manifest, QMap<QString, LocalEntry>(), remote);
+  QCOMPARE(trusted.count(SyncAction::DeleteRemote), 20);
+  QCOMPARE(trusted.count(SyncAction::DownloadNew), 0);
+}
+
+/*!
+ * \brief A manifest never carries the completeness flag across a restart.
+ * It is written to browser storage while the working copy lives in memory, so a
+ * stored "complete" would license deleting everything the copy no longer holds.
+ */
+void CloudSyncPlanTest::completenessIsNotPersisted()
+{
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const QString path = directory.filePath(QStringLiteral("manifest.json"));
+
+  CloudManifest written;
+  written.workingCopyComplete = true;
+  addManifest(&written, QStringLiteral("package.mo"), "a", QStringLiteral("r1"));
+  QVERIFY(written.save(path));
+
+  CloudManifest read;
+  QVERIFY(read.load(path));
+  QCOMPARE(read.workingCopyComplete, false);
+}
+
+void CloudSyncPlanTest::deletionThreshold()
+{
+  CloudManifest manifest;
+  manifest.workingCopyComplete = true;
+  QMap<QString, LocalEntry> local;
+  QMap<QString, RemoteEntry> remote;
+  for (int i = 0; i < 20; ++i) {
+    const QString path = QStringLiteral("Sub%1.mo").arg(i);
+    addManifest(&manifest, path, "contents", QStringLiteral("r1"));
+    addRemote(&remote, path, QStringLiteral("r1"));
+    // Keep most of them, delete six.
+    if (i >= 6) {
+      addLocal(&local, path, "contents");
+    }
+  }
+  const SyncPlan plan = planSync(manifest, local, remote);
+  QCOMPARE(plan.count(SyncAction::DeleteRemote), 6);
+  QVERIFY2(plan.needsDeletionConfirmation(manifest.fileCount()), "six deletions must be confirmed");
+
+  // Removing a single file out of twenty is ordinary editing.
+  QMap<QString, LocalEntry> almostAll = local;
+  for (int i = 1; i < 6; ++i) {
+    addLocal(&almostAll, QStringLiteral("Sub%1.mo").arg(i), "contents");
+  }
+  const SyncPlan small = planSync(manifest, almostAll, remote);
+  QCOMPARE(small.count(SyncAction::DeleteRemote), 1);
+  QVERIFY2(!small.needsDeletionConfirmation(manifest.fileCount()), "one deletion of twenty needs no confirmation");
+}
+
+void CloudSyncPlanTest::folderRemovedOnlyWhenEmpty()
+{
+  CloudManifest manifest;
+  manifest.workingCopyComplete = true;
+  addManifest(&manifest, QStringLiteral("Sub"), QByteArray(), QStringLiteral("r1"), true);
+  addManifest(&manifest, QStringLiteral("Sub/package.mo"), "a", QStringLiteral("r1"));
+
+  QMap<QString, RemoteEntry> remote;
+  addRemote(&remote, QStringLiteral("Sub"), QStringLiteral("r1"), true);
+  addRemote(&remote, QStringLiteral("Sub/package.mo"), QStringLiteral("r1"));
+  // Something else appeared in the folder that we have never seen.
+  addRemote(&remote, QStringLiteral("Sub/Other.mo"), QStringLiteral("r1"));
+
+  // The whole subpackage is gone locally.
+  const SyncPlan plan = planSync(manifest, QMap<QString, LocalEntry>(), remote);
+  QCOMPARE(actionFor(plan, QStringLiteral("Sub/package.mo")).kind, SyncAction::DeleteRemote);
+  QCOMPARE(actionFor(plan, QStringLiteral("Sub/Other.mo")).kind, SyncAction::DownloadNew);
+  QVERIFY2(!hasAction(plan, QStringLiteral("Sub"), SyncAction::DeleteRemote),
+           "a folder still holding a file must not be removed");
+  QVERIFY(plan.skipped.contains(QStringLiteral("Sub")));
+
+  // Without the stranger, the now-empty folder goes too.
+  QMap<QString, RemoteEntry> emptied = remote;
+  emptied.remove(QStringLiteral("Sub/Other.mo"));
+  const SyncPlan cleared = planSync(manifest, QMap<QString, LocalEntry>(), emptied);
+  QVERIFY(hasAction(cleared, QStringLiteral("Sub"), SyncAction::DeleteRemote));
+  // And it must not also be proposed for local recreation - the two would cancel.
+  QVERIFY2(!hasAction(cleared, QStringLiteral("Sub"), SyncAction::CreateLocalFolder),
+           "a folder being deleted remotely must not also be created locally");
+}
+
+void CloudSyncPlanTest::manifestRoundTrip()
+{
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const QString path = directory.filePath(QStringLiteral("manifest.json"));
+
+  CloudManifest written;
+  written.remoteRootId = QStringLiteral("root-id");
+  written.deltaToken = QStringLiteral("token-1");
+  written.workingCopyComplete = true;
+  addManifest(&written, QStringLiteral("package.mo"), "a", QStringLiteral("r1"));
+  addManifest(&written, QStringLiteral("Sub"), QByteArray(), QStringLiteral("r1"), true);
+  QVERIFY(written.save(path));
+
+  CloudManifest read;
+  QVERIFY(read.load(path));
+  QCOMPARE(read.remoteRootId, written.remoteRootId);
+  QCOMPARE(read.deltaToken, written.deltaToken);
+  // Deliberately not carried across: see completenessIsNotPersisted().
+  QCOMPARE(read.workingCopyComplete, false);
+  QCOMPARE(read.entries.size(), 2);
+  QCOMPARE(read.entries.value(QStringLiteral("package.mo")).contentHash,
+           written.entries.value(QStringLiteral("package.mo")).contentHash);
+  QCOMPARE(read.entries.value(QStringLiteral("Sub")).isFolder, true);
+  QCOMPARE(read.fileCount(), 1);
+}
+
+void CloudSyncPlanTest::unusableRemoteNames()
+{
+  QString reason;
+  QVERIFY(isUsableLocalName(QStringLiteral("Package.mo"), &reason));
+  QVERIFY(!isUsableLocalName(QString(), &reason));
+  QVERIFY(!isUsableLocalName(QStringLiteral(".."), &reason));
+  QVERIFY(!isUsableLocalName(QStringLiteral("a/b.mo"), &reason));
+#if defined(Q_OS_WIN)
+  QVERIFY(!isUsableLocalName(QStringLiteral("CON.mo"), &reason));
+  QVERIFY(!isUsableLocalName(QStringLiteral("name."), &reason));
+  QVERIFY(!isUsableLocalName(QStringLiteral("a:b.mo"), &reason));
+#endif
+}
+
+QTEST_APPLESS_MAIN(CloudSyncPlanTest)
+
+#include "CloudSyncPlanTest.moc"


### PR DESCRIPTION
Adds Google Drive and OneDrive as places to open packages from and save them to, working the same way in the desktop build and the Qt-for- WebAssembly one, where there is otherwise no persistent storage at all.

## How it fits together

A mounted cloud folder is materialised as an ordinary local working copy (`/cloud/<name>-<id>` in the omc worker's filesystem on the web, the settings directory natively), so `loadFile`, the editors and `saveFile` need no cloud awareness. Synchronisation is a three-way diff between the last synced state, the working copy and the remote, not a two-way "newest wins" — the manifest is what distinguishes "deleted" from "not fetched yet", which is the difference between a correct sync and a wiped package.

Deletion is the operation that can destroy work, so it is guarded: deletions are never inferred from absence unless the working copy has been verified against the manifest; more than five, or a quarter of the package, needs confirmation listing the files; and deletes go to the service's trash, never permanently. Uploads are recorded in the manifest before any deletion is issued, so an interrupted sync leaves a file looking new, never deleted. `Testsuite/Cloud` covers every row of the decision matrix plus those guards, against a fake provider.

Authentication is OAuth 2.0 with PKCE, implemented directly rather than with QtNetworkAuth, which is in neither Qt kit here. Google's token endpoint requires a client secret even for a public client; it is deployment configuration, not a credential, and is never compiled in — `cloud_config.json` supplies it, with `-DOMEDIT_CLOUD_CONFIG=<path>` for CI. `cloud_config.json.example` documents the shape.

The browser sign-in cannot use the usual popup/opener handshake: the web build is served cross-origin isolated, so the popup's opener is severed. It returns to `oauth-callback.html` at the origin root — one registered redirect URI for every versioned deployment — which republishes the code over a BroadcastChannel.

## WebAssembly constraints this had to meet

Nothing on the wasm main thread may stall, by any mechanism, at any time:
not a nested `QEventLoop`, a modal `exec()`, a synchronous XHR, or an Asyncify suspend. Each hangs, crashes or silently drops network replies. Hence: dialogs use `open()`, replies are delivered through the event loop, no application code runs inside a fetch callback, secrets are cached in memory, and persistence uses localStorage — the only browser storage needing no wait — since `restore()` must precede QSettings.

`QDirIterator` does not enumerate through a `QAbstractFileEngine`, so the working copy is walked with the worker's own directory listing.

## Pre-existing defects fixed along the way

- Qt 6.10's `QWasmSuspendResumeControl::sendPendingEvents()` snapshots the queue length and then blindly shifts, so a re-entrant drain makes it dereference undefined and hang startup at random. Worked around behind `QT_VERSION < 6.11`, where it is fixed upstream.
- `MainWindow::mpLibraryWidget` was read before construction when an omc message arrived during library loading.
- `WorkerVfsFileEngine` had no `remove`/`rename`/`rmdir`, so deleting or renaming a worker-owned file silently failed.

## Not done yet

The three-way conflict dialog (conflicts currently keep both versions, which is safe but not the intended interface), auto-push after ordinary saves, and the IndexedDB cache of working-copy contents. OneDrive is implemented and signs in, but its file operations have not been exercised against the live service.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
