### PR TITLE
wasm FMU ME: recoverable model errors

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -49,7 +49,9 @@ mod model_ctx;
 mod nls;
 pub mod prof;
 mod omclog;
-pub use nls::{rt_nls_clean_history, rt_set_step_size};
+pub use nls::{
+    rt_context_addr, rt_error_stage_addr, rt_nls_clean_history, rt_no_throw_div_zero_addr, rt_set_step_size,
+};
 mod spatial;
 // SUNDIALS/KLU. The archives are wasip1-only (they need a libc) and only linked
 // when the build script found them, so `cfg(sundials)` gates the calls; the module

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -228,8 +228,14 @@ const UNKNOWN_MODEL_FN: &str = "fmi3-me: unknown model function";
 
 /// A runtime/driver failure. The FMI status alone tells the importer nothing, and
 /// C's FMUs report the reason through the logger, so say it before failing.
+///
+/// Those three have logged their own reason already (`LOG_ASSERT` / `LOG_INIT` /
+/// `model terminate`), as the standalone driver's reporting also assumes.
 fn err_status(msg: &str) -> Status {
-    fmi_log(Status::Error, CAT_ERROR, msg);
+    if msg != driver::ASSERT_ERR && msg != driver::INIT_FAILED_ERR && msg != driver::SOLVER_FAILED_ERR
+    {
+        fmi_log(Status::Error, CAT_ERROR, msg);
+    }
     Status::Error
 }
 
@@ -463,6 +469,16 @@ impl SimEngine for Engine {
     fn clean_nls_history(&mut self, time: f64) {
         openmodelica_codegen_wasm_jit_runtime::rt_nls_clean_history(time);
     }
+    // The adapter, the runtime and the model kernel share one linear memory.
+    fn context_addr(&mut self) -> u32 {
+        openmodelica_codegen_wasm_jit_runtime::rt_context_addr()
+    }
+    fn error_stage_addr(&mut self) -> u32 {
+        openmodelica_codegen_wasm_jit_runtime::rt_error_stage_addr()
+    }
+    fn no_throw_div_zero_addr(&mut self) -> u32 {
+        openmodelica_codegen_wasm_jit_runtime::rt_no_throw_div_zero_addr()
+    }
     // `+profiling`'s clocks: the artifact links the model and the runtime into one
     // module, so they are this module's own.
     fn prof_row(&mut self) -> u32 {
@@ -529,6 +545,8 @@ struct MeState {
     defer: openmodelica_sim_meta::driver::CsDefer,
     vrs: Vrs,
     mode: Mode,
+    /// C's `model_state_me_continuous_time_mode`.
+    continuous_time: bool,
     /// fmi-ls-dae: the `EnableDAE` structural parameter's value reference (0 when
     /// the model has no DAE formulation), whether it is set, and whether the
     /// importer is in Configuration Mode, the only place it may be set.
@@ -835,6 +853,7 @@ fn new_state() -> Option<MeState> {
         #[cfg(feature = "cs")]
         defer: CsDefer::None,
         mode: Mode::Instantiated,
+        continuous_time: false,
         dae_enable_vr,
         dae_mode: false,
         configuring: false,
@@ -959,6 +978,7 @@ macro_rules! shared_instance_methods {
     }
 
     fn enter_event_mode(&self) -> Status {
+        self.st.borrow_mut().continuous_time = false;
         Status::Ok
     }
 
@@ -1056,6 +1076,7 @@ macro_rules! shared_instance_methods {
             core::ptr::write_bytes(st.sim_data as *mut u8, 0, st.layout.total as usize);
         }
         st.mode = Mode::Instantiated;
+        st.continuous_time = false;
         st.dae_mode = false;
         st.configuring = false;
         st.need_update = true;
@@ -1509,6 +1530,7 @@ impl GuestModelExchangeInstance for Instance {
     }
 
     fn enter_continuous_time_mode(&self) -> Status {
+        self.st.borrow_mut().continuous_time = true;
         Status::Ok
     }
 
@@ -1533,11 +1555,21 @@ impl GuestModelExchangeInstance for Instance {
     /// C's `internalGetDerivatives`, which leaves `_need_update` set for the next
     /// getter. In DAE mode the derivatives are the importer's own, set as knowns
     /// of the residuals; in ODE mode a `--daeMode` model solves for them.
+    ///
+    /// In Continuous Time Mode this is the master's integrator residual, so it holds
+    /// the region `dassl_res` does and answers `fmi3Discard` — C's `IRES = -1` — for
+    /// an absorbed model error.
     fn get_continuous_state_derivatives(&self) -> Result<Vec<f64>, Status> {
         let mut st = self.st.borrow_mut();
         if st.need_update && (!st.dae_mode || st.mode == Mode::Init) {
-            if let Err(err) = st.eval_ode() {
+            let region = st.continuous_time.then(|| driver::open_integrator_region(&mut Engine));
+            let evaluated = st.eval_ode();
+            let discard = region.is_some_and(|save| driver::close_integrator_region(&mut Engine, save));
+            if let Err(err) = evaluated {
                 return Err(err_status(err));
+            }
+            if discard {
+                return Err(Status::Discard);
             }
         }
         let n = st.layout.n_states;
@@ -1586,13 +1618,13 @@ impl GuestModelExchangeInstance for Instance {
     ) -> Result<CompletedStepResult, Status> {
         let mut st = self.st.borrow_mut();
         // C's `internal_CompletedIntegratorStep`; it leaves `_need_update` set.
-        st.eval().map_err(|_| Status::Error)?;
+        st.eval().map_err(err_status)?;
         // The only point the importer gives us to record the accepted step.
-        driver::store_operators(&mut Engine, st.sim_data, &st.layout).map_err(|_| Status::Error)?;
+        driver::store_operators(&mut Engine, st.sim_data, &st.layout).map_err(err_status)?;
         st.need_update = true;
         let sim_data = st.sim_data;
         let m = &mut *st;
-        let switching = m.dss.would_change(&mut Engine, sim_data, &m.meta).map_err(|_| Status::Error)?;
+        let switching = m.dss.would_change(&mut Engine, sim_data, &m.meta).map_err(err_status)?;
         Ok(CompletedStepResult {
             enter_event_mode: switching,
             terminate_simulation: st.read_i32(st.layout.terminate_off) != 0,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/wit/fmi3-types.wit
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/wit/fmi3-types.wit
@@ -47,7 +47,8 @@ interface types {
     ok,
     /// Non-fatal issue; result may still be used.
     warning,
-    /// Step was discarded; do not use results (only from fmi3DoStep).
+    /// The FMU cannot answer for the point it was given; the master may retry
+    /// elsewhere -- a shorter step, another trial point.
     discard,
     /// Unrecoverable error; instance must be freed.
     error,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/me.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/me.rs
@@ -85,6 +85,8 @@ struct FmuOde<'a> {
     dae: Option<DaeVrs>,
     /// What the FMU actually said, behind the static message the solvers carry.
     failure: Option<Error>,
+    /// The last evaluation was answered `fmi3Discard`, so the solver may retry.
+    discarded: bool,
     /// `-alarm`, polled here rather than only at the output points: a solver that
     /// stops converging never reaches them.
     deadline: Deadline,
@@ -162,8 +164,13 @@ impl FmuOde<'_> {
     }
 
     /// Keep the FMU's error and hand the solvers the one static message they
-    /// carry; [`Run`] surfaces the real one.
+    /// carry; [`Run`] surfaces the real one. `fmi3Discard` answers for the trial
+    /// point, not the run, so it is flagged rather than kept.
     fn note(&mut self, e: Error) -> &'static str {
+        self.discarded = matches!(e, Error::Status { status: crate::api::Status::Discard, .. });
+        if self.discarded {
+            return "the FMU discarded the point it was asked to evaluate";
+        }
         self.failure.get_or_insert(e);
         "the FMU reported an error while being integrated"
     }
@@ -237,6 +244,10 @@ impl Ode for FmuOde<'_> {
     fn calls(&self) -> u64 {
         self.calls
     }
+
+    fn take_discard(&mut self) -> bool {
+        core::mem::take(&mut self.discarded)
+    }
 }
 
 impl Dae for FmuOde<'_> {
@@ -268,6 +279,10 @@ impl Dae for FmuOde<'_> {
 
     fn note_call(&mut self) {
         self.calls += 1;
+    }
+
+    fn take_discard(&mut self) -> bool {
+        core::mem::take(&mut self.discarded)
     }
 }
 
@@ -645,6 +660,7 @@ pub fn simulate(
         committed: None,
         dae,
         failure: None,
+        discarded: false,
         deadline: Deadline::arm(opts),
         polls: 0,
     };

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/driver.rs
@@ -651,7 +651,7 @@ pub const ERROR_EVENTHANDLING: i32 = 4;
 
 /// What a region displaced (C's `saveJumpState`), so regions nest.
 #[derive(Clone, Copy, Default)]
-struct StageSave {
+pub struct StageSave {
     stage: i32,
     hit: i32,
 }
@@ -668,6 +668,19 @@ fn set_error_stage(e: &mut dyn SimEngine, addr: u32, stage: i32) -> StageSave {
     let _ = write_i32(e, addr, stage);
     let _ = write_i32(e, addr + 4, 0);
     save
+}
+
+/// [`dassl_res`]'s region for a driver outside this module — an exported FMU, whose
+/// integrator is the importer's, so the callback is one FMI call.
+pub fn open_integrator_region(e: &mut dyn SimEngine) -> StageSave {
+    let addr = e.error_stage_addr();
+    set_error_stage(e, addr, ERROR_INTEGRATOR)
+}
+
+/// Close it, reporting the absorbed model error the caller answers `IRES = -1` to.
+pub fn close_integrator_region(e: &mut dyn SimEngine, save: StageSave) -> bool {
+    let addr = e.error_stage_addr();
+    took_error_stage(e, addr, save)
 }
 
 fn stage_hit(e: &dyn SimEngine, addr: u32) -> bool {

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/dassl.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/dassl.rs
@@ -330,10 +330,14 @@ unsafe fn residual(
             }
         }
         Err(e) => {
-            // IRES = -1 asks DASKR to retry with a smaller step; a model that
-            // cannot be evaluated at all is reported once the call returns.
-            ctx.failed.get_or_insert(e);
-            unsafe { *ires = -1 };
+            // IRES = -1 asks DASKR to retry with a smaller step; a model that cannot
+            // be evaluated at all is IRES = -2, reported once the call returns.
+            if ctx.ode.take_discard() {
+                unsafe { *ires = -1 };
+            } else {
+                ctx.failed.get_or_insert(e);
+                unsafe { *ires = -2 };
+            }
         }
     }
 }
@@ -445,19 +449,26 @@ unsafe fn jacobian(
             ctx.step[ci] = step;
             y[ci] += step;
         }
-        if let Err(e) = ctx.ode.eval(time, y, ctx.residual) {
-            ctx.failed.get_or_insert(e);
-            break;
-        }
+        let evaluated = ctx.ode.eval(time, y, ctx.residual);
         for &col in group {
             let ci = col as usize;
-            for &row in rows_by_col.get(ci).map(Vec::as_slice).unwrap_or(&[]) {
-                let ri = row as usize;
-                // G at the perturbed point, less the base residual DASKR passed.
-                let g = yprime[ri] - ctx.residual[ri];
-                matrix[ci * n + ri] = (g - base[ri]) / ctx.step[ci];
+            if evaluated.is_ok() {
+                for &row in rows_by_col.get(ci).map(Vec::as_slice).unwrap_or(&[]) {
+                    let ri = row as usize;
+                    // G at the perturbed point, less the base residual DASKR passed.
+                    let g = yprime[ri] - ctx.residual[ri];
+                    matrix[ci * n + ri] = (g - base[ri]) / ctx.step[ci];
+                }
             }
             y[ci] = ctx.saved[ci];
+        }
+        // No IRES here: a discarded point leaves its columns as they stand, as C's
+        // assembly does.
+        if let Err(e) = evaluated
+            && !ctx.ode.take_discard()
+        {
+            ctx.failed.get_or_insert(e);
+            break;
         }
     }
     ctx.ode.set_context_algebraic();

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/lib.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/lib.rs
@@ -118,6 +118,13 @@ pub trait Ode {
     /// Count one evaluation. Solvers call this; an implementation that does not
     /// track evaluations can ignore it.
     fn note_call(&mut self) {}
+
+    /// Whether the error the last [`Ode::eval`] returned is that trial point's
+    /// rather than the run's (C's `IRES = -1`, FMI's `fmi3Discard`), so a solver
+    /// that can shorten its step retries instead of failing.
+    fn take_discard(&mut self) -> bool {
+        false
+    }
 }
 
 /// A model in residual form, `F(t, y, y') = 0` over `y = [states | algebraic
@@ -136,6 +143,11 @@ pub trait Dae {
     }
 
     fn note_call(&mut self) {}
+
+    /// As [`Ode::take_discard`], for the last [`Dae::residual`].
+    fn take_discard(&mut self) -> bool {
+        false
+    }
 }
 
 /// C's `bisection` iteration bound (`events.c`, `gbode_events.c`): `-mbi` when it

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/sundials_ode.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/sundials_ode.rs
@@ -53,8 +53,15 @@ unsafe extern "C" fn roots(t: f64, y: NVector, gout: *mut f64, user: *mut c_void
     let (y, g) = unsafe {
         (core::slice::from_raw_parts(nv_data(y), n), core::slice::from_raw_parts_mut(gout, n_zc))
     };
-    let r = c.ode.eval_zc(t, y, g);
-    fail(c, r)
+    // A root function has no recoverable answer.
+    match c.ode.eval_zc(t, y, g) {
+        Ok(()) => 0,
+        Err(e) => {
+            c.ode.take_discard();
+            c.failed = Some(e);
+            -1
+        }
+    }
 }
 
 unsafe extern "C" fn ida_res(
@@ -73,9 +80,9 @@ unsafe extern "C" fn ida_res(
             core::slice::from_raw_parts_mut(nv_data(rr), n),
         )
     };
-    if let Err(e) = c.ode.eval(t, y, c.f) {
-        c.failed = Some(e);
-        return -1;
+    let evaluated = c.ode.eval(t, y, c.f);
+    if evaluated.is_err() {
+        return fail(c, evaluated);
     }
     for i in 0..n {
         r[i] = yp[i] - c.f[i];
@@ -93,10 +100,15 @@ unsafe extern "C" fn ida_roots(
     unsafe { roots(t, yy, gout, user) }
 }
 
+/// SUNDIALS' right-hand-side convention: 0 success, positive a point to retry from,
+/// negative a failure that ends the run.
 fn fail(c: &mut Ctx, r: Result<()>) -> c_int {
     match r {
         Ok(()) => 0,
         Err(e) => {
+            if c.ode.take_discard() {
+                return 1;
+            }
             c.failed = Some(e);
             -1
         }
@@ -419,6 +431,9 @@ unsafe extern "C" fn dae_res(t: f64, yy: NVector, yp: NVector, rr: NVector, user
     match c.dae.residual(t, y, yp, r) {
         Ok(()) => 0,
         Err(e) => {
+            if c.dae.take_discard() {
+                return 1;
+            }
             c.failed = Some(e);
             -1
         }
@@ -438,6 +453,7 @@ unsafe extern "C" fn dae_roots(t: f64, yy: NVector, yp: NVector, gout: *mut f64,
     match c.dae.eval_zc(t, y, yp, g) {
         Ok(()) => 0,
         Err(e) => {
+            c.dae.take_discard();
             c.failed = Some(e);
             -1
         }


### PR DESCRIPTION
A failed model `assert()` at an integrator trial point ended the run, where the standalone runtime shrugs it off.
`SystemDynamics.WorldDynamics.World2.Scenario_1` under `-s fmi3:me:daskr` died with

    logStatusError: assertion failed          (x15)
    om_fmi3GetContinuousStateDerivatives returned error

on `SystemDynamics.Functions.Utilities.Piecewise`'s "Out of range" guard, which DASKR trips whenever it probes a state outside the table's grid.

Three causes, all of them needed:

`openmodelica_fmi3_wasm`'s `Engine` never implemented `error_stage_addr`, `context_addr` or `no_throw_div_zero_addr`, so `set_error_stage` was a no-op inside the component and `nls::recovering()` never true: the model's emitted `assert()` took the trapping arm instead of the record-and-bail one. The standalone `dassl_res` holds `ERROR_INTEGRATOR` over the call and answers `IRES = -1`. The adapter, the runtime and the model kernel share one linear memory, so the three addresses are ordinary ones.

The FMI boundary then had nothing but `fmi3Error` to say it with, which is terminal. `fmi3GetContinuousStateDerivatives` now holds the same region while in Continuous Time Mode and answers `fmi3Discard`.

`dassl.rs` latched every failure: the residual raised `IRES = -1` *and* `ctx.failed`, returned after `ddaskr` came back, so one discarded trial point failed the run even when DASKR had recovered. `Ode`/`Dae` grew `take_discard`; a discard is `IRES = -1` and nothing else, anything else is `IRES = -2` plus the latch, and the numerical Jacobian leaves a discarded colour's columns as they stand (as C's assembly does). `sundials_ode.rs` gets the same split -- SUNDIALS reads positive as retry, negative as fatal.

`fmi3CompletedIntegratorStep` reports its reason instead of dropping it.

World2 now matches the standalone `--simCodeTarget=wasm-jit` run with no DIFFERs. `CoupledClutches`, `Blocks.Examples.Filter` and `Fluid.Examples.PumpingSystem` still match it under both `fmi3:me:daskr` and `fmi3:cs`.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
