### PR TITLE
FMU export: remove quadratic backend passes

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAE.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAE.mo
@@ -213,6 +213,7 @@ public
 uniontype Variables
   record VARIABLES
     array<list<CrefIndex>> crefIndices "HashTB, cref->indx";
+    array<list<PrefixIndex>> prefixIndices "HashTB, array or record cref->indices of its elements";
     VariableArray varArr "Array of variables";
     Integer bucketSize "bucket size";
     Integer numberOfVars "no. of vars";
@@ -226,6 +227,16 @@ uniontype CrefIndex "Component Reference Index"
     Integer index;
   end CREFINDEX;
 end CrefIndex;
+
+public
+uniontype PrefixIndex "Indices of the variables under one array or record prefix"
+  record PREFIXINDEX
+    .DAE.ComponentRef cref "some variable name starting with the prefix";
+    Integer depth "qualifiers of cref in the prefix";
+    Integer numSubscripts "subscripts of the last qualifier in the prefix";
+    list<Integer> indices;
+  end PREFIXINDEX;
+end PrefixIndex;
 
 public
 uniontype VariableArray "array of Equations are expandable, to amortize the cost of adding

--- a/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -909,7 +909,7 @@ algorithm
       BackendDAE.Variables vars;
       BackendDAE.EquationArray eqns,eqns1;
       DAE.Exp exp,e1,e2,ecr;
-      AvlSetInt.Tree expvars;
+      list<Integer> expvars;
       list<Integer> controleqns,expvars1;
       list<list<Integer>> expvarseqns;
       Boolean isInitial;
@@ -925,9 +925,9 @@ algorithm
         // failure(DAE.CREF(componentRef=_) = exp);
         // failure(DAE.UNARY(operator=DAE.UMINUS(ty=_),exp=DAE.CREF(componentRef=_)) = exp);
         // BackendDump.debugStrExpStrExpStr(("Found ",ecr," = ",exp,"\n"));
-        expvars := BackendDAEUtil.adjacencyRowExp(exp,vars,AvlSetInt.EMPTY(),NONE(),BackendDAE.NORMAL(),isInitial);
+        expvars := BackendDAEUtil.adjacencyRowExp(exp,vars,{},NONE(),BackendDAE.NORMAL(),isInitial);
         // print("expvars "); BackendDump.debuglst((expvars,intString," ","\n"));
-        expvars1::expvarseqns := List.map2(AvlSetInt.listKeys(expvars),varEqns,pos,mT);
+        expvars1::expvarseqns := List.map2(BackendDAEUtil.uniqueRow(expvars),varEqns,pos,mT);
         // print("expvars1 "); BackendDump.debuglst((expvars1,intString," ","\n"));;
         controleqns := getControlEqns(expvars1,expvarseqns);
         // print("controleqns "); BackendDump.debuglst((controleqns,intString," ","\n"));

--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -2391,24 +2391,25 @@ algorithm
   end try;
 end adjacencyMatrixScalar;
 
+public function uniqueRow
+  "The row's variable indices without duplicates, in the descending order
+   AvlSetInt.listKeys listed them in when the row was a set."
+  input list<Integer> row;
+  output list<Integer> outRow;
+algorithm
+  outRow := List.sortedUnique(List.sort(row, intLt), intEq);
+end uniqueRow;
+
 protected function applyIndexType
 "@author: adrpo
   Applies absolute value to all entries in the given list."
-  input AvlSetInt.Tree inLst;
+  input list<Integer> inLst;
   input BackendDAE.IndexType inIndexType;
-  output AvlSetInt.Tree outLst;
+  output list<Integer> outLst;
 algorithm
   outLst := match inIndexType
     // transform to absolute indexes
-    case BackendDAE.ABSOLUTE()
-      guard not AvlSetInt.isEmpty(inLst) and AvlSetInt.smallestKey(inLst) < 0
-      algorithm
-        outLst := AvlSetInt.EMPTY();
-        for key in AvlSetInt.listKeys(inLst) loop
-          outLst := AvlSetInt.add(outLst, intAbs(key));
-        end for;
-    then outLst;
-
+    case BackendDAE.ABSOLUTE() then list(intAbs(key) for key in inLst);
     // leave as it is
     else inLst;
   end match;
@@ -2486,7 +2487,7 @@ protected
   Integer num_eqs, num_vars;
   BackendDAE.Equation eq;
   list<Integer> row;
-  AvlSetInt.Tree rowTree;
+  list<Integer> rowLst;
 algorithm
   num_eqs := BackendEquation.getNumberOfEquations(inEqns);
   num_vars := BackendVariable.varsSize(inVars);
@@ -2497,8 +2498,8 @@ algorithm
     // Get the equation.
     eq := BackendEquation.get(inEqns, idx);
     // Compute the row.
-    rowTree := adjacencyRow(eq, inVars, inIndexType, functionTree, AvlSetInt.EMPTY(), isInitial);
-    row := AvlSetInt.listKeys(rowTree);
+    rowLst := adjacencyRow(eq, inVars, inIndexType, functionTree, {}, isInitial);
+    row := uniqueRow(rowLst);
     // Put it in the arrays.
     arrayUpdate(outAdjacencyArray, idx, row);
     outAdjacencyArrayT := filladjacencyMatrixT(row, {idx}, outAdjacencyArrayT);
@@ -2518,7 +2519,7 @@ protected
   Integer num_eqs, num_vars;
   BackendDAE.Equation eq;
   list<Integer> row;
-  AvlSetInt.Tree rowTree;
+  list<Integer> rowLst;
 algorithm
   num_eqs := BackendEquation.getNumberOfEquations(inEqns);
   num_vars := BackendVariable.varsSize(inVars);
@@ -2530,8 +2531,8 @@ algorithm
       // Get the equation.
       eq := BackendEquation.get(inEqns, idx);
       // Compute the row.
-      rowTree := adjacencyRow(eq, inVars, inIndexType, functionTree, AvlSetInt.EMPTY(), isInitial);
-      row := AvlSetInt.listKeys(rowTree);
+      rowLst := adjacencyRow(eq, inVars, inIndexType, functionTree, {}, isInitial);
+      row := uniqueRow(rowLst);
       // Put it in the arrays.
       arrayUpdate(outAdjacencyArray, idx, row);
       outAdjacencyArrayT := filladjacencyMatrixT(row, {idx}, outAdjacencyArrayT);
@@ -2554,7 +2555,7 @@ protected function adjacencyMatrixDispatchScalar
 protected
   Integer num_eqs, num_vars, size, num_rows = 0;
   BackendDAE.Equation eq;
-  AvlSetInt.Tree rowTree;
+  list<Integer> rowLst;
   list<Integer> row, row_indices, imap = {};
   list<BackendDAE.AdjacencyMatrixElement> iarr = {};
 algorithm
@@ -2568,8 +2569,8 @@ algorithm
     eq := BackendEquation.get(inEqns, idx);
 
     // Compute the row.
-    (rowTree, size) := adjacencyRow(eq, inVars, inIndexType, functionTree, AvlSetInt.EMPTY(), isInitial);
-    row := AvlSetInt.listKeys(rowTree);
+    (rowLst, size) := adjacencyRow(eq, inVars, inIndexType, functionTree, {}, isInitial);
+    row := uniqueRow(rowLst);
     row_indices := List.intRange2(num_rows + 1, num_rows + size);
     num_rows := num_rows + size;
     arrayUpdate(omapEqnIncRow, idx, row_indices);
@@ -2618,9 +2619,9 @@ public function adjacencyRow
   input BackendDAE.Variables vars;
   input BackendDAE.IndexType inIndexType;
   input Option<AvlTreePathFunction.Tree> functionTree;
-  input AvlSetInt.Tree iRow;
+  input list<Integer> iRow;
   input Boolean isInitial;
-  output AvlSetInt.Tree outIntegerLst;
+  output list<Integer> outIntegerLst;
   output Integer rowSize;
 protected
   list<Integer> whenIntegerLst;
@@ -2659,7 +2660,7 @@ algorithm
 
   (outIntegerLst,rowSize) := matchcontinue inlinedEquation
     local
-      AvlSetInt.Tree lst1,res;
+      list<Integer> lst1,res;
       list<Integer> dimsize;
       DAE.Exp e1,e2,e,expCref;
       list<DAE.Exp> expl;
@@ -2810,7 +2811,7 @@ algorithm
       then
         fail();
   end matchcontinue;
-  outIntegerLst := AvlSetInt.addList(outIntegerLst, whenIntegerLst);
+  outIntegerLst := listAppend(whenIntegerLst, outIntegerLst);
 end adjacencyRow;
 
 protected
@@ -2842,9 +2843,9 @@ protected function adjacencyRowLst
   input BackendDAE.Variables inVariables;
   input BackendDAE.IndexType inIndexType;
   input Option<AvlTreePathFunction.Tree> functionTree;
-  input AvlSetInt.Tree inIntegerLst;
+  input list<Integer> inIntegerLst;
   input Boolean isInitial;
-  output AvlSetInt.Tree outIntegerLst = inIntegerLst;
+  output list<Integer> outIntegerLst = inIntegerLst;
   output Integer rowSize = 0;
 protected
   Integer size;
@@ -2864,9 +2865,9 @@ protected function adjacencyRowLstLst
   input BackendDAE.Variables inVariables;
   input BackendDAE.IndexType inIndexType;
   input Option<AvlTreePathFunction.Tree> functionTree;
-  input AvlSetInt.Tree inIntegerLst;
+  input list<Integer> inIntegerLst;
   input Boolean isInitial;
-  output AvlSetInt.Tree outIntegerLst = inIntegerLst;
+  output list<Integer> outIntegerLst = inIntegerLst;
   output Integer rowSize = 0;
 protected
   Integer size;
@@ -2885,9 +2886,9 @@ protected function adjacencyRowWhen
   input BackendDAE.Variables inVariables;
   input BackendDAE.IndexType inIndexType;
   input Option<AvlTreePathFunction.Tree> functionTree;
-  input AvlSetInt.Tree inRow;
+  input list<Integer> inRow;
   input Boolean isInitial;
-  output AvlSetInt.Tree outRow;
+  output list<Integer> outRow;
 algorithm
   outRow := match inEquation
     local
@@ -2916,9 +2917,9 @@ protected function adjacencyRowWhenOps
   input BackendDAE.Variables inVariables;
   input BackendDAE.IndexType inIndexType;
   input Option<AvlTreePathFunction.Tree> functionTree;
-  input AvlSetInt.Tree inRow;
+  input list<Integer> inRow;
   input Boolean isInitial;
-  output AvlSetInt.Tree outRow;
+  output list<Integer> outRow;
 algorithm
   outRow := match inWhenOps
     local
@@ -2969,7 +2970,7 @@ end adjacencyRowWhenOps;
 
 protected function adjacencyRowAlgorithm
   input DAE.Exp exp;
-  input output AvlSetInt.Tree row;
+  input output list<Integer> row;
   input BackendDAE.Variables inVariables;
   input Option<AvlTreePathFunction.Tree> functionTree;
   input BackendDAE.IndexType inIndexType;
@@ -3026,15 +3027,15 @@ public function adjacencyRowExp "author: PA
   returning variable indexes."
   input DAE.Exp inExp;
   input BackendDAE.Variables inVariables;
-  input AvlSetInt.Tree inIntegerLst;
+  input list<Integer> inIntegerLst;
   input Option<AvlTreePathFunction.Tree> functionTree;
   input BackendDAE.IndexType inIndexType;
   input Boolean isInitial;
-  output AvlSetInt.Tree outIntegerLst;
+  output list<Integer> outIntegerLst;
 algorithm
   outIntegerLst := match inIndexType
     local
-      AvlSetInt.Tree vallst;
+      list<Integer> vallst;
 
     case BackendDAE.SPARSE() algorithm
       (_, (_, vallst, _)) := Expression.traverseExpTopDown(inExp, traversingadjacencyRowExpFinderwithInput, (inVariables, inIntegerLst, isInitial));
@@ -3062,15 +3063,15 @@ end adjacencyRowExp;
 
 public function traversingadjacencyRowExpSolvableFinder "Helper for statesAndVarsExp"
   input DAE.Exp inExp;
-  input tuple<BackendDAE.Variables, AvlSetInt.Tree, AvlSetPath.Tree, Boolean, Option<AvlTreePathFunction.Tree>> inTpl;
+  input tuple<BackendDAE.Variables, list<Integer>, AvlSetPath.Tree, Boolean, Option<AvlTreePathFunction.Tree>> inTpl;
   output DAE.Exp outExp;
   output Boolean cont;
-  output tuple<BackendDAE.Variables, AvlSetInt.Tree, AvlSetPath.Tree, Boolean, Option<AvlTreePathFunction.Tree>> outTpl;
+  output tuple<BackendDAE.Variables, list<Integer>, AvlSetPath.Tree, Boolean, Option<AvlTreePathFunction.Tree>> outTpl;
 algorithm
   (outExp, cont, outTpl) := matchcontinue (inExp, inTpl)
     local
       list<Integer> p, p2;
-      AvlSetInt.Tree pa;
+      list<Integer> pa;
       DAE.ComponentRef cr;
       BackendDAE.Variables vars;
       DAE.Exp e1, e2;
@@ -3081,7 +3082,7 @@ algorithm
       list<DAE.ComponentRef> crlst;
       Option<AvlTreePathFunction.Tree> ofunctionTree;
       AvlTreePathFunction.Tree functionTree;
-      tuple<BackendDAE.Variables, AvlSetInt.Tree, AvlSetPath.Tree, Boolean, Option<AvlTreePathFunction.Tree>> tpl;
+      tuple<BackendDAE.Variables, list<Integer>, AvlSetPath.Tree, Boolean, Option<AvlTreePathFunction.Tree>> tpl;
       Integer diffindx;
       list<DAE.Subscript> subs;
       AvlSetPath.Tree visitedPaths;
@@ -3196,7 +3197,7 @@ protected function traversingadjacencyRowIfExpSolvableFinder
       ToDo: inside more complex expression? IF_EQUATION?"
   input output DAE.Exp e;
   output Boolean cont = false; // always false, just for convenience
-  input output tuple<BackendDAE.Variables, AvlSetInt.Tree, AvlSetPath.Tree, Boolean, Option<AvlTreePathFunction.Tree>> tpl;
+  input output tuple<BackendDAE.Variables, list<Integer>, AvlSetPath.Tree, Boolean, Option<AvlTreePathFunction.Tree>> tpl;
 algorithm
   tpl := matchcontinue e
     local
@@ -3251,12 +3252,12 @@ protected function traversingadjacencyRowIfExp
       ToDo: inside more complex expression? IF_EQUATION?"
   input output DAE.Exp e;
   output Boolean cont = false; // always false, just for convenience
-  input output tuple<BackendDAE.Variables, AvlSetInt.Tree, Boolean> tpl;
+  input output tuple<BackendDAE.Variables, list<Integer>, Boolean> tpl;
   input traverserFunction traFunc;
   partial function traverserFunction
     input output DAE.Exp exp;
     output Boolean cont;
-    input output tuple<BackendDAE.Variables, AvlSetInt.Tree, Boolean> tpl;
+    input output tuple<BackendDAE.Variables, list<Integer>, Boolean> tpl;
   end traverserFunction;
 algorithm
   tpl := matchcontinue e
@@ -3380,33 +3381,33 @@ end traversingAdjacencyRowIfExpEnhanced;
 public function traversingAdjacencyRowExpFinderBaseClock "author: lochel
   This is used for base-clock partitioning."
   input DAE.Exp inExp;
-  input tuple<BackendDAE.Variables, AvlSetInt.Tree, Boolean> inTpl;
+  input tuple<BackendDAE.Variables, list<Integer>, Boolean> inTpl;
   output DAE.Exp outExp;
   output Boolean cont;
-  output tuple<BackendDAE.Variables, AvlSetInt.Tree, Boolean> outTpl;
+  output tuple<BackendDAE.Variables, list<Integer>, Boolean> outTpl;
 algorithm
   (outExp,cont,outTpl) := matchcontinue (inExp,inTpl)
     local
       list<Integer> p, p2;
-      AvlSetInt.Tree pa;
+      list<Integer> pa;
       DAE.ComponentRef cr;
       BackendDAE.Variables vars;
       DAE.Exp e;
       Boolean isInitial;
-      tuple<BackendDAE.Variables,AvlSetInt.Tree, Boolean> tpl;
+      tuple<BackendDAE.Variables,list<Integer>, Boolean> tpl;
 
     case (DAE.CREF(componentRef=cr), (vars, pa, isInitial))
       algorithm
         (_, p) := BackendVariable.getVar(cr, vars);
         (_, p2) := BackendVariable.getVar(ComponentReference.crefPrefixStart(cr), vars);
-        pa := AvlSetInt.addList(pa, p);
-        pa := AvlSetInt.addList(pa, p2);
+        pa := listAppend(p, pa);
+        pa := listAppend(p2, pa);
       then (inExp, true, (vars, pa, isInitial));
 
     case (DAE.CREF(componentRef=cr), (vars, pa, isInitial))
       algorithm
         (_, p) := BackendVariable.getVar(cr, vars);
-      then (inExp, true, (vars, AvlSetInt.addList(pa, p), isInitial));
+      then (inExp, true, (vars, listAppend(p, pa), isInitial));
 
     case (DAE.CALL(path=Absyn.IDENT(name="sample"), expLst={_, e}), _)
       algorithm
@@ -3435,32 +3436,32 @@ public function traversingAdjacencyRowExpFinderSubClock "author: lochel
   This is used for sub-clock partitioning.
   TODO: avoid code duplicates, cf. function traversingAdjacencyRowExpFinderBaseClock"
   input DAE.Exp inExp;
-  input tuple<BackendDAE.Variables, AvlSetInt.Tree, Boolean> inTpl;
+  input tuple<BackendDAE.Variables, list<Integer>, Boolean> inTpl;
   output DAE.Exp outExp;
   output Boolean cont;
-  output tuple<BackendDAE.Variables, AvlSetInt.Tree, Boolean> outTpl;
+  output tuple<BackendDAE.Variables, list<Integer>, Boolean> outTpl;
 algorithm
   (outExp,cont,outTpl) := matchcontinue (inExp,inTpl)
     local
       list<Integer> p, p2;
-      AvlSetInt.Tree pa, res;
+      list<Integer> pa, res;
       DAE.ComponentRef cr;
       BackendDAE.Variables vars;
       Boolean isInitial;
-      tuple<BackendDAE.Variables,AvlSetInt.Tree, Boolean> tpl;
+      tuple<BackendDAE.Variables,list<Integer>, Boolean> tpl;
 
     case (DAE.CREF(componentRef=cr), (vars, pa, isInitial))
       algorithm
         (_, p) := BackendVariable.getVar(cr, vars);
         (_, p2) := BackendVariable.getVar(ComponentReference.crefPrefixStart(cr), vars);
-        res := AvlSetInt.addList(pa, p);
-        res := AvlSetInt.addList(res, p2);
+        res := listAppend(p, pa);
+        res := listAppend(p2, res);
       then (inExp, true, (vars, res, isInitial));
 
     case (DAE.CREF(componentRef=cr), (vars, pa, isInitial))
       algorithm
         (_, p) := BackendVariable.getVar(cr, vars);
-        res := AvlSetInt.addList(pa, p);
+        res := listAppend(p, pa);
       then (inExp, true, (vars, res, isInitial));
 
     case (DAE.CALL(path=Absyn.IDENT(name="subSample")), _)
@@ -3489,22 +3490,22 @@ public function traversingadjacencyRowExpFinder "
   author: Frenkel TUD 2010-11
   Helper for statesAndVarsExp"
   input DAE.Exp inExp;
-  input tuple<BackendDAE.Variables,AvlSetInt.Tree, Boolean> inTpl;
+  input tuple<BackendDAE.Variables,list<Integer>, Boolean> inTpl;
   output DAE.Exp outExp;
   output Boolean cont;
-  output tuple<BackendDAE.Variables,AvlSetInt.Tree, Boolean> outTpl;
+  output tuple<BackendDAE.Variables,list<Integer>, Boolean> outTpl;
 algorithm
   (outExp,cont,outTpl) := matchcontinue(inExp,inTpl)
     local
       list<Integer> p, p2;
-      AvlSetInt.Tree pa,res;
+      list<Integer> pa,res;
       DAE.ComponentRef cr;
       BackendDAE.Variables vars;
       DAE.Exp e,e1,e2;
       list<BackendDAE.Var> varslst;
       Boolean b, b1, b2, isInitial;
       Integer i;
-      tuple<BackendDAE.Variables,AvlSetInt.Tree, Boolean> tpl;
+      tuple<BackendDAE.Variables,list<Integer>, Boolean> tpl;
 
     // cref and $START.cref
     case (e as DAE.CREF(componentRef=cr), (vars, pa, isInitial))
@@ -3597,15 +3598,15 @@ protected function adjacencyRowExp1
   "Adds an adjacency matrix entry for all variables in the inVarLst."
   input list<BackendDAE.Var> inVarLst;
   input list<Integer> inIntegerLst;
-  input AvlSetInt.Tree inVarIndxLst;
+  input list<Integer> inVarIndxLst;
   input Integer diffindex;
-  output AvlSetInt.Tree outVarIndxLst;
+  output list<Integer> outVarIndxLst;
 algorithm
   outVarIndxLst := match (inVarLst,inIntegerLst)
     local
        list<BackendDAE.Var> rest;
        list<Integer> irest;
-       AvlSetInt.Tree vars;
+       list<Integer> vars;
        Integer i,i1,diffidx;
     case ({},{}) then inVarIndxLst;
     /*If variable x is a state, der(x) is a variable in adjacency matrix,
@@ -3614,16 +3615,16 @@ algorithm
     case (BackendDAE.VAR(varKind = BackendDAE.STATE(derName=SOME(_)))::rest,i::irest)
       algorithm
         i1 := if intGe(diffindex,1) then i else -i;
-        vars := AvlSetInt.add(inVarIndxLst, i1);
+        vars := i1 :: inVarIndxLst;
       then adjacencyRowExp1(rest,irest,vars,diffindex);
     case (BackendDAE.VAR(varKind = BackendDAE.STATE(index=diffidx))::rest,i::irest)
       algorithm
         i1 := if intGe(diffindex,diffidx) then i else -i;
-        vars := AvlSetInt.add(inVarIndxLst, i1);
+        vars := i1 :: inVarIndxLst;
       then adjacencyRowExp1(rest,irest,vars,diffindex);
     case (_::rest,i::irest)
       algorithm
-        vars := AvlSetInt.add(inVarIndxLst, i);
+        vars := i :: inVarIndxLst;
       then adjacencyRowExp1(rest,irest,vars,diffindex);
   end match;
 end adjacencyRowExp1;
@@ -3632,19 +3633,19 @@ protected function adjacencyRowExp1DiscreteOrArray
   "Adds an adjacency matrix entry for all variables in the inVarLst, if they are discrete."
   input list<BackendDAE.Var> inVarLst;
   input list<Integer> inIntegerLst;
-  input AvlSetInt.Tree inVarIndxLst;
-  output AvlSetInt.Tree outVarIndxLst;
+  input list<Integer> inVarIndxLst;
+  output list<Integer> outVarIndxLst;
 algorithm
   outVarIndxLst := match (inVarLst,inIntegerLst)
     local
        list<BackendDAE.Var> rest;
        list<Integer> irest;
-       AvlSetInt.Tree vars;
+       list<Integer> vars;
        Integer i;
     case ({}, {}) then inVarIndxLst;
     case (BackendDAE.VAR(varKind = BackendDAE.DISCRETE())::rest, i::irest)
       algorithm
-        vars := AvlSetInt.add(inVarIndxLst, i);
+        vars := i :: inVarIndxLst;
       then adjacencyRowExp1DiscreteOrArray(rest,irest,vars);
     case (_::rest, _::irest)
       then adjacencyRowExp1DiscreteOrArray(rest,irest,inVarIndxLst);
@@ -3653,20 +3654,20 @@ end adjacencyRowExp1DiscreteOrArray;
 
 public function traversingadjacencyRowExpFinderwithInput "Helper for statesAndVarsExp"
   input DAE.Exp inExp;
-  input tuple<BackendDAE.Variables,AvlSetInt.Tree, Boolean> inTpl;
+  input tuple<BackendDAE.Variables,list<Integer>, Boolean> inTpl;
   output DAE.Exp outExp;
   output Boolean cont;
-  output tuple<BackendDAE.Variables,AvlSetInt.Tree, Boolean> outTpl;
+  output tuple<BackendDAE.Variables,list<Integer>, Boolean> outTpl;
 algorithm
   (outExp,cont,outTpl) := matchcontinue (inExp,inTpl)
   local
       list<Integer> p;
-      AvlSetInt.Tree pa, res;
+      list<Integer> pa, res;
       DAE.ComponentRef cr;
       BackendDAE.Variables vars;
       DAE.Exp e1, e2;
       list<BackendDAE.Var> varslst;
-      tuple<BackendDAE.Variables,AvlSetInt.Tree, Boolean> tpl;
+      tuple<BackendDAE.Variables,list<Integer>, Boolean> tpl;
       Boolean b1, b2, isInitial;
 
     // inner variable
@@ -3748,9 +3749,9 @@ end traversingadjacencyRowExpFinderwithInput;
 protected function adjacencyRowExp1withInput
   input list<BackendDAE.Var> inVarLst;
   input list<Integer> inIntegerLst;
-  input AvlSetInt.Tree vars;
+  input list<Integer> vars;
   input Integer diffindex;
-  output AvlSetInt.Tree outIntegerLst;
+  output list<Integer> outIntegerLst;
 algorithm
   outIntegerLst := match (inVarLst, inIntegerLst)
     local
@@ -3759,44 +3760,32 @@ algorithm
        Integer i;
     case ({}, {}) then vars;
     case (BackendDAE.VAR(varKind = BackendDAE.DAE_AUX_VAR())::rest, i::irest)
-      guard not AvlSetInt.hasKey(vars, i)
-      then adjacencyRowExp1(rest,irest,AvlSetInt.add(vars, i),diffindex);
+      then adjacencyRowExp1(rest,irest,i::vars,diffindex);
     case (BackendDAE.VAR(varKind = BackendDAE.DAE_RESIDUAL_VAR())::rest, i::irest)
-      guard not AvlSetInt.hasKey(vars, i)
-      then adjacencyRowExp1(rest,irest,AvlSetInt.add(vars, i),diffindex);
+      then adjacencyRowExp1(rest,irest,i::vars,diffindex);
     case (BackendDAE.VAR(varKind = BackendDAE.JAC_TMP_VAR())::rest, i::irest)
-      guard not AvlSetInt.hasKey(vars, i)
-      then adjacencyRowExp1(rest,irest,AvlSetInt.add(vars, i),diffindex);
+      then adjacencyRowExp1(rest,irest,i::vars,diffindex);
     case (BackendDAE.VAR(varKind = BackendDAE.STATE())::rest, i::irest)
-      guard not (diffindex==0 or AvlSetInt.hasKey(vars, i))
-      then adjacencyRowExp1(rest,irest,AvlSetInt.add(vars, i),diffindex);
+      guard diffindex <> 0
+      then adjacencyRowExp1(rest,irest,i::vars,diffindex);
     case (BackendDAE.VAR(varKind = BackendDAE.STATE_DER())::rest, i::irest)
-      guard not AvlSetInt.hasKey(vars, i)
-      then adjacencyRowExp1(rest,irest,AvlSetInt.add(vars, i),diffindex);
+      then adjacencyRowExp1(rest,irest,i::vars,diffindex);
     case (BackendDAE.VAR(varKind = BackendDAE.CLOCKED_STATE())::rest, i::irest)
-      guard not AvlSetInt.hasKey(vars, i)
-      then adjacencyRowExp1(rest,irest,AvlSetInt.add(vars, i),diffindex);
+      then adjacencyRowExp1(rest,irest,i::vars,diffindex);
     case (BackendDAE.VAR(varKind = BackendDAE.VARIABLE())::rest, i::irest)
-      guard not AvlSetInt.hasKey(vars, i)
-      then adjacencyRowExp1(rest,irest,AvlSetInt.add(vars, i),diffindex);
+      then adjacencyRowExp1(rest,irest,i::vars,diffindex);
     case (BackendDAE.VAR(varKind = BackendDAE.ALG_STATE())::rest, i::irest)
-      guard not AvlSetInt.hasKey(vars, i)
-      then adjacencyRowExp1(rest,irest,AvlSetInt.add(vars, i),diffindex);
+      then adjacencyRowExp1(rest,irest,i::vars,diffindex);
     case (BackendDAE.VAR(varKind = BackendDAE.DISCRETE())::rest, i::irest)
-      guard not AvlSetInt.hasKey(vars, i)
-      then adjacencyRowExp1(rest,irest,AvlSetInt.add(vars, i),diffindex);
+      then adjacencyRowExp1(rest,irest,i::vars,diffindex);
     case (BackendDAE.VAR(varKind = BackendDAE.DUMMY_DER())::rest, i::irest)
-      guard not AvlSetInt.hasKey(vars, i)
-      then adjacencyRowExp1(rest,irest,AvlSetInt.add(vars, i),diffindex);
+      then adjacencyRowExp1(rest,irest,i::vars,diffindex);
     case (BackendDAE.VAR(varKind = BackendDAE.DUMMY_STATE())::rest, i::irest)
-      guard not AvlSetInt.hasKey(vars, i)
-      then adjacencyRowExp1(rest,irest,AvlSetInt.add(vars, i),diffindex);
+      then adjacencyRowExp1(rest,irest,i::vars,diffindex);
     case (BackendDAE.VAR(varKind = BackendDAE.OPT_CONSTR())::rest, i::irest)
-      guard not AvlSetInt.hasKey(vars, i)
-      then adjacencyRowExp1(rest,irest,AvlSetInt.add(vars, i),diffindex);
+      then adjacencyRowExp1(rest,irest,i::vars,diffindex);
     case (BackendDAE.VAR(varKind = BackendDAE.OPT_FCONSTR())::rest, i::irest)
-      guard not AvlSetInt.hasKey(vars, i)
-      then adjacencyRowExp1(rest,irest,AvlSetInt.add(vars, i),diffindex);
+      then adjacencyRowExp1(rest,irest,i::vars,diffindex);
     case (_ :: _, _::_)
       then vars;
   end match;
@@ -3865,8 +3854,8 @@ algorithm
       BackendDAE.AdjacencyMatrixT mt_1,mt_2,mt_3;
       Integer e,abse;
       BackendDAE.Equation eqn;
-      AvlSetInt.Tree row,invars,outvars;
-      list<Integer> eqns,oldvars;
+      AvlSetInt.Tree invars,outvars;
+      list<Integer> row,eqns,oldvars;
 
     case {} then (m,mt);
 
@@ -3874,10 +3863,11 @@ algorithm
       algorithm
         abse := intAbs(e);
         eqn := BackendEquation.get(daeeqns, abse);
-        (row,_) := adjacencyRow(eqn,vars,inIndxType,functionTree,AvlSetInt.EMPTY(),isInitial);
+        (row,_) := adjacencyRow(eqn,vars,inIndxType,functionTree,{},isInitial);
+        row := uniqueRow(row);
         oldvars := getOldVars(m,abse);
-        m_1 := Array.replaceAtWithFill(abse,AvlSetInt.listKeys(row),{},m);
-        (_,outvars,invars) := AvlSetInt.intersection(AvlSetInt.addList(AvlSetInt.EMPTY(), oldvars),row);
+        m_1 := Array.replaceAtWithFill(abse,row,{},m);
+        (_,outvars,invars) := AvlSetInt.intersection(AvlSetInt.addList(AvlSetInt.EMPTY(), oldvars), AvlSetInt.addList(AvlSetInt.EMPTY(), row));
         mt_1 := removeValuefromMatrix(abse,AvlSetInt.listKeys(outvars),mt);
         mt_2 := addValuetoMatrix(abse,AvlSetInt.listKeys(invars),mt_1);
         (m_2,mt_3) := updateAdjacencyMatrix1(vars,daeeqns,inIndxType,functionTree,m_1,mt_2,eqns,isInitial);
@@ -3982,8 +3972,8 @@ algorithm
       BackendDAE.AdjacencyMatrixT mt_1,mt_2,mt_3;
       Integer e,abse;
       BackendDAE.Equation eqn;
-      AvlSetInt.Tree row,invarsTree,outvarsTree;
-      list<Integer> invars,outvars,eqns,oldvars,scalarindxs;
+      AvlSetInt.Tree invarsTree,outvarsTree;
+      list<Integer> row,invars,outvars,eqns,oldvars,scalarindxs;
       array<list<Integer>> mapEqnIncRow;
       array<Integer> mapIncRowEqn;
 
@@ -3993,14 +3983,15 @@ algorithm
       algorithm
         abse := intAbs(e);
         eqn := BackendEquation.get(daeeqns, abse);
-        (row,_) := adjacencyRow(eqn,vars,inIndxType,functionTree,AvlSetInt.Tree.EMPTY(),isInitial);
+        (row,_) := adjacencyRow(eqn,vars,inIndxType,functionTree,{},isInitial);
+        row := uniqueRow(row);
         scalarindxs := iMapEqnIncRow[abse];
         oldvars := getOldVars(m,listHead(scalarindxs));
-        (_,outvarsTree,invarsTree) := AvlSetInt.intersection(AvlSetInt.addList(AvlSetInt.Tree.EMPTY(), oldvars),row);
+        (_,outvarsTree,invarsTree) := AvlSetInt.intersection(AvlSetInt.addList(AvlSetInt.EMPTY(), oldvars), AvlSetInt.addList(AvlSetInt.EMPTY(), row));
         outvars := AvlSetInt.listKeys(outvarsTree);
         invars := AvlSetInt.listKeys(invarsTree);
         // do the same for each scalar indxs
-        m_1 := List.fold1r(scalarindxs,arrayUpdate,AvlSetInt.listKeys(row),m);
+        m_1 := List.fold1r(scalarindxs,arrayUpdate,row,m);
         mt_1 := List.fold1(scalarindxs,removeValuefromMatrix,outvars,mt);
         mt_2 := List.fold1(scalarindxs,addValuetoMatrix,invars,mt_1);
         (m_2,mt_3,mapEqnIncRow,mapIncRowEqn) := updateAdjacencyMatrixScalar1(vars,daeeqns,m_1,mt_2,eqns,iMapEqnIncRow,iMapIncRowEqn,inIndxType,functionTree,isInitial);
@@ -4009,14 +4000,14 @@ algorithm
     case e::eqns // Backup for non existent equations
       algorithm
         abse := intAbs(e);
-        row := AvlSetInt.Tree.EMPTY();
+        row := {};
         scalarindxs := iMapEqnIncRow[abse];
         oldvars := getOldVars(m,listHead(scalarindxs));
-        (_,outvarsTree,invarsTree) := AvlSetInt.intersection(AvlSetInt.addList(AvlSetInt.Tree.EMPTY(), oldvars),row);
+        (_,outvarsTree,invarsTree) := AvlSetInt.intersection(AvlSetInt.addList(AvlSetInt.EMPTY(), oldvars), AvlSetInt.EMPTY());
         outvars := AvlSetInt.listKeys(outvarsTree);
         invars := AvlSetInt.listKeys(invarsTree);
         // do the same for each scalar indxs
-        m_1 := List.fold1r(scalarindxs,arrayUpdate,AvlSetInt.listKeys(row),m);
+        m_1 := List.fold1r(scalarindxs,arrayUpdate,row,m);
         mt_1 := List.fold1(scalarindxs,removeValuefromMatrix,outvars,mt);
         mt_2 := List.fold1(scalarindxs,addValuetoMatrix,invars,mt_1);
         (m_2,mt_3,mapEqnIncRow,mapIncRowEqn) := updateAdjacencyMatrixScalar1(vars,daeeqns,m_1,mt_2,eqns,iMapEqnIncRow,iMapIncRowEqn,inIndxType,functionTree,isInitial);
@@ -4051,7 +4042,7 @@ algorithm
       BackendDAE.AdjacencyMatrixT mt1;
       Integer abse,rowsize,new_size;
       BackendDAE.Equation eqn;
-      AvlSetInt.Tree row;
+      list<Integer> row;
       list<Integer> scalarindxs, row_lst;
       array<list<Integer>> mapEqnIncRow;
       array<Integer> mapIncRowEqn;
@@ -4062,12 +4053,12 @@ algorithm
         abse := intAbs(index);
         eqn := BackendEquation.get(daeeqns, abse);
         rowsize := BackendEquation.equationSize(eqn);
-        (row,_) := adjacencyRow(eqn,vars,inIndxType,functionTree,AvlSetInt.EMPTY(),isInitial);
+        (row,_) := adjacencyRow(eqn,vars,inIndxType,functionTree,{},isInitial);
         new_size := size+rowsize;
         scalarindxs := List.intRange2(size+1,new_size);
         mapEqnIncRow := arrayUpdate(iMapEqnIncRow,abse,scalarindxs);
         mapIncRowEqn := List.fold1r(scalarindxs,arrayUpdate,abse,iMapIncRowEqn);
-        row_lst := AvlSetInt.listKeys(row);
+        row_lst := uniqueRow(row);
         m1:= List.fold1r(scalarindxs,arrayUpdate,row_lst,m);
         mt1 := filladjacencyMatrixT(row_lst,scalarindxs,mt);
         (m1,mt1,mapEqnIncRow,mapIncRowEqn) := updateAdjacencyMatrixScalar2(index+1,n,new_size,vars,daeeqns,m1,mt1,mapEqnIncRow,mapIncRowEqn,inIndxType,functionTree,isInitial);
@@ -4081,12 +4072,12 @@ algorithm
       algorithm
         abse := intAbs(index);
         rowsize := 1;
-        row := AvlSetInt.EMPTY();
+        row := {};
         new_size := size+rowsize;
         scalarindxs := List.intRange2(size+1,new_size);
         mapEqnIncRow := arrayUpdate(iMapEqnIncRow,abse,scalarindxs);
         mapIncRowEqn := List.fold1r(scalarindxs,arrayUpdate,abse,iMapIncRowEqn);
-        row_lst := AvlSetInt.listKeys(row);
+        row_lst := uniqueRow(row);
         m1:= List.fold1r(scalarindxs,arrayUpdate,row_lst,m);
         mt1 := filladjacencyMatrixT(row_lst,scalarindxs,mt);
         (m1,mt1,mapEqnIncRow,mapIncRowEqn) := updateAdjacencyMatrixScalar2(index+1,n,new_size,vars,daeeqns,m1,mt1,mapEqnIncRow,mapIncRowEqn,inIndxType,functionTree,isInitial);

--- a/OMCompiler/Compiler/BackEnd/BackendInline.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendInline.mo
@@ -761,13 +761,14 @@ algorithm
     local
       Inline.Functiontuple fns;
       array<list<BackendDAE.CrefIndex>> crefind;
+      array<list<BackendDAE.PrefixIndex>> prefind;
       Integer i1,i2,i3;
       array<Option<BackendDAE.Var>> vararr;
-    case(BackendDAE.VARIABLES(crefind,BackendDAE.VARIABLE_ARRAY(i3,vararr),i1,i2),fns)
+    case(BackendDAE.VARIABLES(crefind,prefind,BackendDAE.VARIABLE_ARRAY(i3,vararr),i1,i2),fns)
       algorithm
         inlined := inlineVarOptArray(vararr,fns);
       then
-        (BackendDAE.VARIABLES(crefind,BackendDAE.VARIABLE_ARRAY(i3,vararr),i1,i2),inlined);
+        (BackendDAE.VARIABLES(crefind,prefind,BackendDAE.VARIABLE_ARRAY(i3,vararr),i1,i2),inlined);
     else
       algorithm
         true := Flags.isSet(Flags.FAILTRACE);

--- a/OMCompiler/Compiler/BackEnd/BackendVariable.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVariable.mo
@@ -51,6 +51,7 @@ import BackendDAEUtil;
 import BaseHashSet;
 import BaseHashTable;
 import ComponentReference;
+import ClassInf;
 import ComponentReferenceBasics;
 import CommonSubExpression;
 import DAEUtil;
@@ -69,6 +70,7 @@ import SCodeUtil;
 import StringUtil;
 import System;
 import Types;
+import TypesDump;
 import Util;
 import ExpressionBasics;
 import Dump;
@@ -2369,6 +2371,7 @@ public function copyVariables
 algorithm
   outVariables := inVariables;
   outVariables.crefIndices := arrayCopy(inVariables.crefIndices);
+  outVariables.prefixIndices := arrayCopy(inVariables.prefixIndices);
   outVariables.varArr := copyArray(inVariables.varArr);
 end copyVariables;
 
@@ -2382,11 +2385,40 @@ protected
   BackendDAE.VariableArray arr;
 algorithm
   arr_size := max(inSize, BaseHashTable.lowBucketSize);
-  buckets := realInt(intReal(arr_size) * 1.4);
+  buckets := bucketCount(arr_size);
   indices := arrayCreate(buckets, {});
   arr := vararrayEmpty(arr_size);
-  outVariables := BackendDAE.VARIABLES(indices, arr, buckets, 0);
+  outVariables := BackendDAE.VARIABLES(indices, arrayCreate(buckets, {}), arr, buckets, 0);
 end emptyVars;
+
+protected function bucketCount
+  input Integer numVars;
+  output Integer buckets = realInt(intReal(max(numVars, BaseHashTable.lowBucketSize)) * 1.4);
+end bucketCount;
+
+protected function growBuckets
+  "Rebuilds the cref and prefix indices with buckets for twice the current
+   number of variables; the variable array is kept as it is."
+  input output BackendDAE.Variables vars;
+protected
+  array<list<BackendDAE.CrefIndex>> indices;
+  Integer buckets, idx;
+  BackendDAE.Var v;
+algorithm
+  buckets := bucketCount(2 * vars.numberOfVars);
+  indices := arrayCreate(buckets, {});
+  vars.crefIndices := indices;
+  vars.prefixIndices := arrayCreate(buckets, {});
+  vars.bucketSize := buckets;
+  for i in 1:vars.varArr.numberOfElements loop
+    if isSome(vars.varArr.varOptArr[i]) then
+      SOME(v) := vars.varArr.varOptArr[i];
+      idx := intMod(ComponentReferenceBasics.hashComponentRef(v.varName), buckets) + 1;
+      arrayUpdate(indices, idx, BackendDAE.CREFINDEX(v.varName, i - 1) :: indices[idx]);
+      updatePrefixIndices(v.varName, i - 1, vars, true);
+    end if;
+  end for;
+end growBuckets;
 
 public function emptyVarsSized
   "Returns a BackendDAE.Variables data structure that is empty."
@@ -2835,13 +2867,16 @@ protected
   Integer buckets, num_vars, hash_idx;
   DAE.ComponentRef cr;
 algorithm
-  BackendDAE.VARIABLES(indices, arr, buckets, num_vars) := inVariables;
+  BackendDAE.VARIABLES(crefIndices = indices, varArr = arr, bucketSize = buckets, numberOfVars = num_vars) := inVariables;
   (arr, outVar as BackendDAE.VAR(varName = cr)) := vararrayDelete(arr, inIndex);
   hash_idx := intMod(ComponentReferenceBasics.hashComponentRef(cr), buckets) + 1;
   cr_indices := indices[hash_idx];
   cr_indices := List.deleteMemberOnTrue(BackendDAE.CREFINDEX(cr, inIndex - 1), cr_indices, removeVar2);
   arrayUpdate(indices, hash_idx, cr_indices);
-  outVariables := BackendDAE.VARIABLES(indices, arr, buckets, num_vars-1);
+  updatePrefixIndices(cr, inIndex - 1, inVariables, false);
+  outVariables := inVariables;
+  outVariables.varArr := arr;
+  outVariables.numberOfVars := num_vars - 1;
 end removeVar;
 
 protected function removeVar2
@@ -3019,18 +3054,25 @@ public function addVar
   input BackendDAE.Variables inVariables;
   output BackendDAE.Variables outVariables = inVariables;
 protected
-  Integer hash_idx, arr_idx;
+  Integer hash, hash_idx, arr_idx;
   list<BackendDAE.CrefIndex> indices;
 algorithm
-  hash_idx := intMod(ComponentReferenceBasics.hashComponentRef(inVar.varName), inVariables.bucketSize) + 1;
+  hash := ComponentReferenceBasics.hashComponentRef(inVar.varName);
+  hash_idx := intMod(hash, inVariables.bucketSize) + 1;
   indices := arrayGet(inVariables.crefIndices, hash_idx);
 
   try
     BackendDAE.CREFINDEX(index=arr_idx) := List.getMemberOnTrue(inVar.varName, indices, crefIndexEqualCref);
     outVariables.varArr := vararraySetnth(inVariables.varArr, arr_idx+1, inVar);
   else
+    if outVariables.numberOfVars >= outVariables.bucketSize then
+      outVariables := growBuckets(outVariables);
+      hash_idx := intMod(hash, outVariables.bucketSize) + 1;
+      indices := arrayGet(outVariables.crefIndices, hash_idx);
+    end if;
     outVariables.varArr := vararrayAdd(outVariables.varArr, inVar);
     arrayUpdate(outVariables.crefIndices, hash_idx, (BackendDAE.CREFINDEX(inVar.varName, outVariables.numberOfVars)::indices));
+    updatePrefixIndices(inVar.varName, outVariables.numberOfVars, outVariables, true);
     outVariables.numberOfVars := outVariables.numberOfVars + 1;
   end try;
 end addVar;
@@ -3066,12 +3108,15 @@ protected
   Integer bsize, num_vars, idx;
   list<BackendDAE.CrefIndex> indices;
 algorithm
-  BackendDAE.VARIABLES(hashvec, varr, bsize, num_vars) := inVariables;
+  outVariables := if inVariables.numberOfVars >= inVariables.bucketSize then growBuckets(inVariables) else inVariables;
+  BackendDAE.VARIABLES(crefIndices = hashvec, varArr = varr, bucketSize = bsize, numberOfVars = num_vars) := outVariables;
   idx := intMod(ComponentReferenceBasics.hashComponentRef(inVar.varName), bsize) + 1;
   varr := vararrayAdd(varr, inVar);
   indices := hashvec[idx];
   arrayUpdate(hashvec, idx, (BackendDAE.CREFINDEX(inVar.varName, num_vars)::indices));
-  outVariables := BackendDAE.VARIABLES(hashvec, varr, bsize, num_vars + 1);
+  updatePrefixIndices(inVar.varName, num_vars, outVariables, true);
+  outVariables.varArr := varr;
+  outVariables.numberOfVars := num_vars + 1;
 end addNewVar;
 
 public function addVariables
@@ -3187,56 +3232,302 @@ public function getVar
   outputs: (Var list, int list /* indexes */)"
   input DAE.ComponentRef cr;
   input BackendDAE.Variables inVariables;
-  output list<BackendDAE.Var> outVarLst;
-  output list<Integer> outIntegerLst;
+  output list<BackendDAE.Var> outVarLst = {};
+  output list<Integer> outIntegerLst = {};
+protected
+  BackendDAE.Var v;
+  Integer hash, indx, depth;
+  Boolean found;
+  list<DAE.ComponentRef> crlst;
+  DAE.ComponentRef cr1;
+  list<Integer> indices;
+  DAE.Type ty;
+  list<DAE.Dimension> dims;
 algorithm
-  (outVarLst,outIntegerLst) := matchcontinue inVariables
-    local
-      BackendDAE.Var v;
-      Integer indx;
-      list<Integer> indxs;
-      list<BackendDAE.Var> vLst;
-      list<DAE.ComponentRef> crlst;
-      DAE.ComponentRef cr1;
-    case _
-      algorithm
-        (v,indx) := getVar2(cr, inVariables) "if scalar found, return it";
-      then
-        ({v},if isPresent(outIntegerLst) then {indx} else {});
-    case _ /* check if array or record */
-      algorithm
-        crlst := ComponentReference.expandCref(cr,true);
-        if isPresent(outIntegerLst) then
-          (vLst as _::_,indxs) := getVarLst(crlst,inVariables);
-        else
-          (vLst as _::_,_) := getVarLst(crlst,inVariables);
-          indxs := {};
-        end if;
-      then
-        (vLst,indxs);
+  hash := ComponentReferenceBasics.hashComponentRef(cr);
+  try
+    (v, indx) := getVarHashed(cr, hash, inVariables);
+    outVarLst := {v};
+    outIntegerLst := if isPresent(outIntegerLst) then {indx} else {};
+    found := true;
+  else
+    found := false;
+  end try;
+  if found then
+    return;
+  end if;
+
+  if isPrefixQuery(cr) then
+    (indices, depth) := getPrefixIndices(cr, hash, inVariables);
+    (ty, dims) := TypesDump.flattenArrayType(ComponentReference.crefLastType(cr));
+    // latest added first, as expanding cr and looking its elements up gave
+    for i in listReverse(indices) loop
+      v := vararrayNth(inVariables.varArr, i + 1);
+      if isElementOf(v.varName, depth, ty, listLength(dims)) then
+        outVarLst := v :: outVarLst;
+        outIntegerLst := (i + 1) :: outIntegerLst;
+      end if;
+    end for;
+    if listEmpty(outVarLst) then
+      fail();
+    end if;
+    return;
+  end if;
+
+  try
+    crlst := ComponentReference.expandCref(cr, true);
+    (outVarLst as _::_, outIntegerLst) := getVarLst(crlst, inVariables);
+  else
     // try again check if variable indexes used
-    case _
-      algorithm
-        // replace variables with WHOLEDIM()
-        (cr1,true) := replaceVarWithWholeDim(cr, false);
-        crlst := ComponentReference.expandCref(cr1,true);
-        if isPresent(outIntegerLst) then
-          (vLst as _::_,indxs) := getVarLst(crlst,inVariables);
-        else
-          (vLst as _::_,_) := getVarLst(crlst,inVariables);
-          indxs := {};
-        end if;
-      then
-        (vLst,indxs);
-    /* failure
-    case (_,_)
-      algorithm
-        fprintln(Flags.DAE_LOW, "- getVar failed on component reference: " + ComponentReferenceBasics.printComponentRefStr(cr));
-      then
-        fail();
-     */
-  end matchcontinue;
+    (cr1, true) := replaceVarWithWholeDim(cr, false);
+    crlst := ComponentReference.expandCref(cr1, true);
+    (outVarLst as _::_, outIntegerLst) := getVarLst(crlst, inVariables);
+  end try;
 end getVar;
+
+protected function isPrefixQuery
+  "Whether getVar can answer cr from the prefix index: an array or record
+   with constant indices, every qualifier but the last fully indexed, so that
+   expandCref would only append subscripts and record fields to cr."
+  input DAE.ComponentRef cr;
+  output Boolean b;
+algorithm
+  b := match cr
+    case DAE.CREF_IDENT()
+      then List.all(cr.subscriptLst, isIntSubscript) and isExpandableType(cr.identType);
+    case DAE.CREF_QUAL()
+      then List.all(cr.subscriptLst, isIntSubscript)
+        and listLength(cr.subscriptLst) >= Types.numberOfDimensions(cr.identType)
+        and isPrefixQuery(cr.componentRef);
+    else false;
+  end match;
+end isPrefixQuery;
+
+protected function isExpandableType
+  input DAE.Type ty;
+  output Boolean b;
+algorithm
+  b := match ty
+    case DAE.T_ARRAY() then true;
+    case DAE.T_COMPLEX(complexClassType = ClassInf.RECORD()) then true;
+    else false;
+  end match;
+end isExpandableType;
+
+protected function isElementOf
+  "Whether var, which the query (depth qualifiers, last one of element type ty
+   with ndims dimensions) is a proper prefix of, is one of the elements
+   expandCref lists for it: fully indexed, then only record fields. Jacobian
+   seeds like x.SeedNLSJac0 extend the scalar x without being part of it."
+  input DAE.ComponentRef var;
+  input Integer depth;
+  input DAE.Type ty;
+  input Integer ndims;
+  output Boolean b = false;
+protected
+  DAE.ComponentRef v = var;
+  DAE.Type t = ty;
+  Integer n = ndims;
+  list<DAE.Dimension> dims;
+  Option<DAE.Type> fty;
+algorithm
+  for i in 2:depth loop
+    v := ComponentReference.crefRest(v);
+  end for;
+  while listLength(ComponentReference.crefFirstSubs(v)) == n loop
+    if ComponentReference.crefIsIdent(v) then
+      b := true;
+      return;
+    end if;
+    v := ComponentReference.crefRest(v);
+    fty := recordFieldType(t, ComponentReferenceBasics.crefFirstIdent(v));
+    if isNone(fty) then
+      return;
+    end if;
+    (t, dims) := TypesDump.flattenArrayType(Util.getOption(fty));
+    n := listLength(dims);
+  end while;
+end isElementOf;
+
+protected function recordFieldType
+  input DAE.Type ty;
+  input String name;
+  output Option<DAE.Type> fty = NONE();
+algorithm
+  fty := match ty
+    case DAE.T_COMPLEX(complexClassType = ClassInf.RECORD())
+      algorithm
+        for f in ty.varLst loop
+          if f.name == name then
+            fty := SOME(f.ty);
+            break;
+          end if;
+        end for;
+      then fty;
+    else NONE();
+  end match;
+end recordFieldType;
+
+protected function isIntSubscript
+  input DAE.Subscript sub;
+  output Boolean b;
+algorithm
+  b := match sub
+    case DAE.INDEX(DAE.ICONST()) then true;
+    else false;
+  end match;
+end isIntSubscript;
+
+protected function getPrefixIndices
+  "0-based indices of the variables cr is a proper prefix of, latest added first."
+  input DAE.ComponentRef cr;
+  input Integer hash;
+  input BackendDAE.Variables vars;
+  output list<Integer> indices;
+  output Integer depth = 0 "qualifiers of cr";
+protected
+  Integer nsubs = 0;
+  DAE.ComponentRef c = cr;
+  Boolean last = false;
+algorithm
+  while not last loop
+    (nsubs, last, c) := match c
+      case DAE.CREF_IDENT() then (listLength(c.subscriptLst), true, c);
+      case DAE.CREF_QUAL() then (0, false, c.componentRef);
+    end match;
+    depth := depth + 1;
+  end while;
+  for e in arrayGet(vars.prefixIndices, intMod(hash, vars.bucketSize) + 1) loop
+    if e.depth == depth and e.numSubscripts == nsubs and prefixEqual(e.cref, cr, depth, nsubs) then
+      indices := e.indices;
+      return;
+    end if;
+  end for;
+  fail();
+end getPrefixIndices;
+
+protected function updatePrefixIndices
+  "Adds (or removes) index under every proper prefix of cr: each qualifier
+   with each leading part of its subscripts. The hash of a prefix is the sum
+   ComponentReferenceBasics.hashComponentRef would give it."
+  input DAE.ComponentRef cr;
+  input Integer index;
+  input BackendDAE.Variables vars;
+  input Boolean add;
+protected
+  DAE.ComponentRef c = cr;
+  Integer hash = 0, depth = 0, nsubs, factor, count;
+  list<DAE.Subscript> subs;
+  Boolean last, ok;
+algorithm
+  while true loop
+    (subs, last, ok) := match c
+      case DAE.CREF_IDENT() then (c.subscriptLst, true, true);
+      case DAE.CREF_QUAL() then (c.subscriptLst, false, true);
+      else ({}, true, false);
+    end match;
+    if not ok then
+      return;
+    end if;
+    depth := depth + 1;
+    hash := hash + stringHashDjb2(ComponentReferenceBasics.crefFirstIdent(c));
+    count := listLength(subs);
+    nsubs := 0;
+    factor := 1;
+    if not (last and count == 0) then
+      updatePrefixIndex(cr, depth, nsubs, hash, index, vars, add);
+    end if;
+    for sub in subs loop
+      hash := hash + ComponentReferenceBasics.hashSubscript(sub) * factor;
+      factor := factor * 1000;
+      nsubs := nsubs + 1;
+      if not (last and nsubs == count) then
+        updatePrefixIndex(cr, depth, nsubs, hash, index, vars, add);
+      end if;
+    end for;
+    if last then
+      return;
+    end if;
+    c := match c case DAE.CREF_QUAL() then c.componentRef; end match;
+  end while;
+end updatePrefixIndices;
+
+protected function updatePrefixIndex
+  input DAE.ComponentRef cr;
+  input Integer depth;
+  input Integer nsubs;
+  input Integer hash;
+  input Integer index;
+  input BackendDAE.Variables vars;
+  input Boolean add;
+protected
+  Integer b = intMod(hash, vars.bucketSize) + 1;
+  list<BackendDAE.PrefixIndex> entries = arrayGet(vars.prefixIndices, b), acc = {};
+  BackendDAE.PrefixIndex e;
+algorithm
+  while not listEmpty(entries) loop
+    e :: entries := entries;
+    if e.depth == depth and e.numSubscripts == nsubs and prefixEqual(e.cref, cr, depth, nsubs) then
+      e.indices := if add then index :: e.indices else List.deleteMemberOnTrue(index, e.indices, intEq);
+      arrayUpdate(vars.prefixIndices, b, List.append_reverse(acc, if listEmpty(e.indices) then entries else e :: entries));
+      return;
+    end if;
+    acc := e :: acc;
+  end while;
+  if add then
+    arrayUpdate(vars.prefixIndices, b, BackendDAE.PREFIXINDEX(cr, depth, nsubs, {index}) :: arrayGet(vars.prefixIndices, b));
+  end if;
+end updatePrefixIndex;
+
+protected function prefixEqual
+  "Whether the first depth qualifiers of cr1 and cr2 are equal, comparing only
+   the first nsubs subscripts of the last one. Both must be at least that long."
+  input DAE.ComponentRef cr1;
+  input DAE.ComponentRef cr2;
+  input Integer depth;
+  input Integer nsubs;
+  output Boolean equal = false;
+protected
+  DAE.ComponentRef c1 = cr1, c2 = cr2;
+  list<DAE.Subscript> s1, s2;
+  DAE.Subscript sub1, sub2;
+algorithm
+  for i in 1:depth-1 loop
+    if not (ComponentReferenceBasics.crefFirstIdent(c1) == ComponentReferenceBasics.crefFirstIdent(c2)
+            and ExpressionBasics.subscriptEqual(ComponentReference.crefFirstSubs(c1), ComponentReference.crefFirstSubs(c2))) then
+      return;
+    end if;
+    c1 := ComponentReference.crefRest(c1);
+    c2 := ComponentReference.crefRest(c2);
+  end for;
+  if ComponentReferenceBasics.crefFirstIdent(c1) <> ComponentReferenceBasics.crefFirstIdent(c2) then
+    return;
+  end if;
+  s1 := ComponentReference.crefFirstSubs(c1);
+  s2 := ComponentReference.crefFirstSubs(c2);
+  for i in 1:nsubs loop
+    sub1 :: s1 := s1;
+    sub2 :: s2 := s2;
+    if not subscriptEq(sub1, sub2) then
+      return;
+    end if;
+  end for;
+  equal := true;
+end prefixEqual;
+
+protected function subscriptEq
+  input DAE.Subscript sub1;
+  input DAE.Subscript sub2;
+  output Boolean equal;
+algorithm
+  equal := match (sub1, sub2)
+    case (DAE.WHOLEDIM(), DAE.WHOLEDIM()) then true;
+    case (DAE.INDEX(), DAE.INDEX()) then ExpressionBasics.expEqual(sub1.exp, sub2.exp);
+    case (DAE.SLICE(), DAE.SLICE()) then ExpressionBasics.expEqual(sub1.exp, sub2.exp);
+    case (DAE.WHOLE_NONEXP(), DAE.WHOLE_NONEXP()) then ExpressionBasics.expEqual(sub1.exp, sub2.exp);
+    else false;
+  end match;
+end subscriptEq;
 
 public function getVarSingle
 " Return a variable and its index in the vector.
@@ -3464,6 +3755,16 @@ public function getVar2
   input BackendDAE.Variables inVariables;
   output BackendDAE.Var outVar;
   output Integer outIndex;
+algorithm
+  (outVar, outIndex) := getVarHashed(inCref, ComponentReferenceBasics.hashComponentRef(inCref), inVariables);
+end getVar2;
+
+protected function getVarHashed
+  input DAE.ComponentRef inCref;
+  input Integer hash;
+  input BackendDAE.Variables inVariables;
+  output BackendDAE.Var outVar;
+  output Integer outIndex;
 protected
   array<list<BackendDAE.CrefIndex>> indices;
   BackendDAE.VariableArray arr;
@@ -3472,13 +3773,13 @@ protected
   DAE.ComponentRef cr;
 algorithm
   BackendDAE.VARIABLES(crefIndices=indices, varArr=arr, bucketSize=buckets) := inVariables;
-  hash_idx := intMod(ComponentReferenceBasics.hashComponentRef(inCref), buckets) + 1;
+  hash_idx := intMod(hash, buckets) + 1;
   cr_indices := indices[hash_idx];
   BackendDAE.CREFINDEX(index=outIndex) := List.getMemberOnTrue(inCref, cr_indices, crefIndexEqualCref);
   outIndex := outIndex + 1;
   outVar as BackendDAE.VAR(varName = cr) := vararrayNth(arr, outIndex);
   true := ComponentReferenceBasics.crefEqualNoStringCompare(cr, inCref);
-end getVar2;
+end getVarHashed;
 
 protected function crefIndexEqualCref
   input DAE.ComponentRef inCref;
@@ -3759,17 +4060,17 @@ public function traverseBackendDAEVarsWithUpdate<ArgT>
     output ArgT outArg;
   end FuncType;
 protected
-  array<list<BackendDAE.CrefIndex>> indices;
-  Integer buckets, num_vars1, num_vars2;
+  Integer num_vars1, num_vars2;
   array<Option<BackendDAE.Var>> vars;
 algorithm
-  BackendDAE.VARIABLES(indices, BackendDAE.VARIABLE_ARRAY(num_vars1, vars), buckets, num_vars2) := inVariables;
+  BackendDAE.VARIABLES(varArr = BackendDAE.VARIABLE_ARRAY(num_vars1, vars), numberOfVars = num_vars2) := inVariables;
   if num_vars1 <> num_vars2 then
     Error.addInternalError("function traverseBackendDAEVarsWithUpdate failed", sourceInfo());
     fail();
   end if;
   (vars, outArg) := BackendDAEUtil.traverseArrayNoCopyWithUpdate(vars, inFunc, traverseBackendDAEVarsWithUpdate2, inArg, num_vars1);
-  outVariables := BackendDAE.VARIABLES(indices, BackendDAE.VARIABLE_ARRAY(num_vars1, vars), buckets, num_vars2);
+  outVariables := inVariables;
+  outVariables.varArr := BackendDAE.VARIABLE_ARRAY(num_vars1, vars);
 end traverseBackendDAEVarsWithUpdate;
 
 protected function traverseBackendDAEVarsWithUpdate2<ArgT>

--- a/OMCompiler/Compiler/BackEnd/Coloring.mo
+++ b/OMCompiler/Compiler/BackEnd/Coloring.mo
@@ -60,11 +60,8 @@ public function createColoring
   output array<list<Integer>> coloredArray;
 protected
   constant Boolean debug = false;
-  list<Integer> nodesList;
   array<Integer> colored;
-  array<Integer> forbiddenColor;
-  list<tuple<Integer, list<Integer>>> sparseGraph, sparseGraphT;
-  array<tuple<Integer, list<Integer>>> arraysparseGraph;
+  list<tuple<Integer, list<Integer>>> sparseGraphT;
   Integer maxColor;
 algorithm
   try
@@ -72,30 +69,24 @@ algorithm
     if Flags.isSet(Flags.DUMP_SPARSE_VERBOSE) then
       print("analytical Jacobians[SPARSE] -> build sparse graph.\n");
     end if;
-    nodesList := List.intRange2(1,sizeVarswithDep);
-    sparseGraph := Graph.buildGraph(nodesList,createBipartiteGraph,sparseArray);
     sparseGraphT := Graph.buildGraph(List.intRange2(1,sizeVars),createBipartiteGraph,sparseArrayT);
 
     // debug dump
     if Flags.isSet(Flags.DUMP_SPARSE_VERBOSE) then
       print("sparse graph: \n");
-      Graph.printGraphInt(sparseGraph);
+      Graph.printGraphInt(Graph.buildGraph(List.intRange2(1,sizeVarswithDep),createBipartiteGraph,sparseArray));
       print("transposed sparse graph: \n");
       Graph.printGraphInt(sparseGraphT);
       print("analytical Jacobians[SPARSE] -> builded graph for coloring.\n");
     end if;
 
     // color sparse bipartite graph
-    forbiddenColor := arrayCreate(sizeVars,0);
     colored := arrayCreate(sizeVars,0);
-    arraysparseGraph := listArray(sparseGraph);
     if debug then execStat("generateSparsePattern -> coloring start "); end if;
     if (sizeVars>0) then
-      Graph.partialDistance2colorInt(sparseGraphT, forbiddenColor, nodesList, arraysparseGraph, colored);
+      Graph.partialDistance2colorInt(sparseGraphT, sizeVarswithDep, colored);
     end if;
     if debug then execStat("generateSparsePattern -> coloring end "); end if;
-    GCExt.free(forbiddenColor);
-    GCExt.free(arraysparseGraph);
     // get max color used
     maxColor := Array.fold(colored, intMax, 0);
 

--- a/OMCompiler/Compiler/BackEnd/EvaluateParameter.mo
+++ b/OMCompiler/Compiler/BackEnd/EvaluateParameter.mo
@@ -63,7 +63,6 @@ public import FCore;
 public import AvlSetCR;
 
 protected import Array;
-protected import AvlSetInt;
 protected import BackendDAEUtil;
 protected import BackendDump;
 protected import BackendEquation;
@@ -302,7 +301,6 @@ algorithm
       DAE.Exp e;
       DAE.ComponentRef cref;
       Option<DAE.VariableAttributes> attr;
-      AvlSetInt.Tree tree;
       list<Integer> ilst,selectedParameters;
       Integer index;
       BackendDAE.AdjacencyMatrix m;
@@ -313,8 +311,8 @@ algorithm
 
     case (v as BackendDAE.VAR(varKind=BackendDAE.PARAM(),bindExp=SOME(e)),(globalKnownVars,index,selectParameter,selectedParameters,m,mt,ht,isInitial))
       algorithm
-        (_,(_,tree,_)) := Expression.traverseExpTopDown(e, BackendDAEUtil.traversingadjacencyRowExpFinder, (globalKnownVars,AvlSetInt.EMPTY(),isInitial));
-        ilst := AvlSetInt.listKeys(tree);
+        (_,(_,ilst,_)) := Expression.traverseExpTopDown(e, BackendDAEUtil.traversingadjacencyRowExpFinder, (globalKnownVars,{},isInitial));
+        ilst := BackendDAEUtil.uniqueRow(ilst);
         cref := BackendVariable.varCref(v);
         select := selectParameter(v) or AvlSetCR.hasKey(ht, cref);
         selectedParameters := List.consOnTrue(select, index, selectedParameters);
@@ -325,8 +323,8 @@ algorithm
     case (v as BackendDAE.VAR(varKind=BackendDAE.PARAM(),values=attr),(globalKnownVars,index,selectParameter,selectedParameters,m,mt,ht,isInitial))
       algorithm
         e := DAEUtil.getStartAttrFail(attr);
-        (_,(_,tree,_)) := Expression.traverseExpTopDown(e, BackendDAEUtil.traversingadjacencyRowExpFinder, (globalKnownVars,AvlSetInt.EMPTY(),isInitial));
-        ilst := AvlSetInt.listKeys(tree);
+        (_,(_,ilst,_)) := Expression.traverseExpTopDown(e, BackendDAEUtil.traversingadjacencyRowExpFinder, (globalKnownVars,{},isInitial));
+        ilst := BackendDAEUtil.uniqueRow(ilst);
         cref := BackendVariable.varCref(v);
         select := selectParameter(v) or AvlSetCR.hasKey(ht, cref);
         selectedParameters := List.consOnTrue(select, index, selectedParameters);
@@ -694,13 +692,13 @@ protected function evaluateFixedAttribute1
 protected
   DAE.Exp e1;
   Boolean b;
-  AvlSetInt.Tree ilst;
+  list<Integer> ilst;
   Option<DAE.VariableAttributes> attr1;
 algorithm
    // apply replacements
   (e1,_) := BackendVarTransform.replaceExp(e, repl, NONE());
-  (_,(_,ilst,_)) := Expression.traverseExpTopDown(e1, BackendDAEUtil.traversingadjacencyRowExpFinder, (globalKnownVars,AvlSetInt.EMPTY(), isInitial));
-  (globalKnownVars,cache,mark,repl) := evaluateSelectedParameters1(AvlSetInt.listKeys(ilst),globalKnownVars,m,inIEqns,cache,graph,mark,markarr,isInitial,repl);
+  (_,(_,ilst,_)) := Expression.traverseExpTopDown(e1, BackendDAEUtil.traversingadjacencyRowExpFinder, (globalKnownVars,{}, isInitial));
+  (globalKnownVars,cache,mark,repl) := evaluateSelectedParameters1(BackendDAEUtil.uniqueRow(ilst),globalKnownVars,m,inIEqns,cache,graph,mark,markarr,isInitial,repl);
   (e1,_) := BackendVarTransform.replaceExp(e1, repl, NONE());
   (e1,_) := ExpressionSimplify.simplify(e1);
    b := Expression.isConst(e1);

--- a/OMCompiler/Compiler/BackEnd/IndexReduction.mo
+++ b/OMCompiler/Compiler/BackEnd/IndexReduction.mo
@@ -2500,14 +2500,13 @@ protected function getAdjacencyMatrixLevelEquations
   input AvlTreePathFunction.Tree functionTree;
   input Boolean isInitial;
 protected
-  AvlSetInt.Tree rowTree;
   list<Integer> row, rowindxs, negrow;
   Integer i1, rowSize, size, idx = index, sidx = sindex;
 algorithm
   for e in iEqns loop
     // compute the row
-    (rowTree, size) := BackendDAEUtil.adjacencyRow(e, vars, BackendDAE.SOLVABLE(), SOME(functionTree), AvlSetInt.EMPTY(), isInitial);
-    row := AvlSetInt.listKeys(rowTree);
+    (row, size) := BackendDAEUtil.adjacencyRow(e, vars, BackendDAE.SOLVABLE(), SOME(functionTree), {}, isInitial);
+    row := BackendDAEUtil.uniqueRow(row);
     rowSize := sidx + size;
     i1 := idx+1;
     rowindxs := List.intRange2(sidx+1, rowSize);

--- a/OMCompiler/Compiler/BackEnd/Initialization.mo
+++ b/OMCompiler/Compiler/BackEnd/Initialization.mo
@@ -62,6 +62,7 @@ import BackendVariable;
 import BackendVarTransform;
 import BaseHashSet;
 import CheckModel;
+import ClassInf;
 import ComponentReference;
 protected import ComponentReferenceBasics;
 import Config;
@@ -793,7 +794,7 @@ protected
   array<Integer> secondary;
   BackendDAE.Var v;
   DAE.Exp bindExp;
-  HashSet.HashSet hs;
+  BackendDAE.Variables primary;
   list<DAE.ComponentRef> crefs;
   list<BackendDAE.Var> globalKnownVarList = {};
 algorithm
@@ -852,28 +853,28 @@ algorithm
     secondary := selectSecondaryParameters(flatComps, globalKnownVars, mT, secondary);
 
     // get primary and secondary parameters and variables
-    hs := HashSet.emptyHashSetSized(2*nGlobalKnownVars+1);
+    primary := BackendVariable.emptyVarsSized(nGlobalKnownVars);
     for i in flatComps loop
       v := BackendVariable.getVarAt(globalKnownVars, i);
       bindExp := BackendVariable.varBindExpStartValueNoFail(v);
-      crefs := Expression.getAllCrefsExpanded(bindExp);
+      crefs := Expression.extractCrefsFromExp(bindExp);
       //BackendDump.dumpVarList({v}, intString(i));
 
       () := match v
         // primary parameter
-        case BackendDAE.VAR(varKind=BackendDAE.PARAM()) guard 0 == secondary[i] and BaseHashSet.hasAll(crefs, hs)
+        case BackendDAE.VAR(varKind=BackendDAE.PARAM()) guard 0 == secondary[i] and allPrimary(crefs, primary)
           algorithm
             outAllPrimaryParameters := v::outAllPrimaryParameters;
-            hs := BaseHashSet.add(BackendVariable.varCref(v), hs);
+            primary := BackendVariable.addVar(v, primary);
         then ();
 
         // primary external object
-        case BackendDAE.VAR(varKind=BackendDAE.EXTOBJ(), bindExp=SOME(bindExp)) guard 0 == secondary[i] and BaseHashSet.hasAll(crefs, hs)
+        case BackendDAE.VAR(varKind=BackendDAE.EXTOBJ(), bindExp=SOME(bindExp)) guard 0 == secondary[i] and allPrimary(crefs, primary)
           algorithm
             outAllPrimaryParameters := v::outAllPrimaryParameters;
             v := BackendVariable.setVarFixed(v, true);
             outGlobalKnownVars := BackendVariable.addVar(v, outGlobalKnownVars);
-            hs := BaseHashSet.add(BackendVariable.varCref(v), hs);
+            primary := BackendVariable.addVar(v, primary);
         then ();
 
         // secondary parameter
@@ -886,13 +887,13 @@ algorithm
           then ();
 
         // primary variable
-        case _ guard BackendVariable.isVarAlg(v) and 0 == secondary[i] and BaseHashSet.hasAll(crefs, hs)
+        case _ guard BackendVariable.isVarAlg(v) and 0 == secondary[i] and allPrimary(crefs, primary)
           algorithm
             otherVariables := BackendVariable.addVar(v, otherVariables);
             v := BackendVariable.setVarFixed(v, true);
             v := BackendVariable.setVarFinal(v, true);
             outGlobalKnownVars := BackendVariable.addVar(v, outGlobalKnownVars);
-            hs := BaseHashSet.add(BackendVariable.varCref(v), hs);
+            primary := BackendVariable.addVar(v, primary);
           then ();
 
         // secondary variable
@@ -918,6 +919,43 @@ algorithm
     //BackendDump.dumpVariables(otherVariables, "otherVariables");
   end if;
 end selectInitializationVariablesDAE;
+
+protected function allPrimary
+  "Whether every element of every variable the crefs name is in primary;
+   a whole array or record counts only when all its elements are."
+  input list<DAE.ComponentRef> crefs;
+  input BackendDAE.Variables primary;
+  output Boolean b = true;
+protected
+  list<BackendDAE.Var> vars;
+algorithm
+  for cr in crefs loop
+    if not ComponentReferenceBasics.crefEqual(cr, DAE.crefTime) then
+      try
+        vars := BackendVariable.getVar(cr, primary);
+        b := listLength(vars) == elementCount(ComponentReference.crefTypeFull(cr));
+      else
+        b := false;
+      end try;
+      if not b then
+        return;
+      end if;
+    end if;
+  end for;
+end allPrimary;
+
+protected function elementCount
+  "The scalar variables a component of this type is made of: arrays and
+   records are expanded, anything else (an external object too) is one."
+  input DAE.Type ty;
+  output Integer n;
+algorithm
+  n := match ty
+    case DAE.T_ARRAY() then elementCount(ty.ty) * product(Expression.dimensionSize(d) for d in ty.dims);
+    case DAE.T_COMPLEX(complexClassType = ClassInf.RECORD()) then sum(elementCount(v.ty) for v in ty.varLst);
+    else 1;
+  end match;
+end elementCount;
 
 function addExtObjToGlobalKnownVars "
   Sets fixed=true for external objects with binding and adds them to globalKnownVars

--- a/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
@@ -83,6 +83,7 @@ import List;
 import StringUtil;
 import System;
 import UnorderedMap;
+import UnorderedSet;
 import Util;
 import Values;
 import ValuesUtil;
@@ -1182,6 +1183,7 @@ public function generateSparsePattern "author: wbraun
   input list<BackendDAE.Var> inIndependentVars "vars";
   input list<BackendDAE.Var> inDependentVars "eqns";
   input Boolean nonlinearPattern = false;
+  input Boolean withColoring = true "false gives one colour per column";
   output BackendDAE.SparsePattern outSparsePattern;
   output BackendDAE.SparseColoring outColoredCols;
 protected
@@ -1320,7 +1322,7 @@ algorithm
         end if;
 
         if debug then execStat("generateSparsePattern -> coloring start "); end if;
-        if nonlinearPattern or Flags.isSet(Flags.DISABLE_COLORING) then
+        if nonlinearPattern or not withColoring or Flags.isSet(Flags.DISABLE_COLORING) then
           //without coloring
           coloring := list({arrayGet(inDepCompRefs, i)} for i in 1:sizeN);
         else
@@ -1682,7 +1684,7 @@ try
     ei := backendDAE.shared.info;
     emptyBDAE := BackendDAE.DAE({BackendDAEUtil.createEqSystem(BackendVariable.emptyVars(), BackendEquation.emptyEqns())}, BackendDAEUtil.createEmptyShared(BackendDAE.JACOBIAN(), ei, cache, graph));
 
-    (sparsePattern, sparseColoring) := generateSparsePattern(backendDAE, indepVars, depVars);
+    (sparsePattern, sparseColoring) := generateSparsePattern(backendDAE, indepVars, depVars, withColoring = false);
     if Flags.isSet(Flags.JAC_DUMP2) then
       BackendDump.dumpSparsityPattern(sparsePattern, "FMI sparsity");
     end if;
@@ -1736,9 +1738,19 @@ protected
   DAE.Exp lhs, rhs;
   BackendDAE.Equation eqn;
   DAE.ComponentRef cr, rhsCr;
-  list<DAE.ComponentRef> crefsVarsToRemove, protectedCrefs;
+  UnorderedSet<DAE.ComponentRef> crefsVarsToRemove, protectedCrefs;
   BackendDAE.Variables newVars;
 algorithm
+  // Generate empty jacobian martices
+  if Flags.isSet(Flags.DIS_SYMJAC_FMI20) then
+    cache := initDAE.shared.cache;
+    graph := initDAE.shared.graph;
+    ei := initDAE.shared.info;
+    emptyBDAE := BackendDAE.DAE({BackendDAEUtil.createEqSystem(BackendVariable.emptyVars(), BackendEquation.emptyEqns())}, BackendDAEUtil.createEmptyShared(BackendDAE.JACOBIAN(), ei, cache, graph));
+    outJacobianMatrices := (SOME((emptyBDAE,"FMIDERINIT",{},{},{}, {})), BackendDAE.emptySparsePattern, {}, BackendDAE.emptyNonlinearPattern)::outJacobianMatrices;
+    outFunctionTree := initDAE.shared.functionTree;
+    return;
+  end if;
 try
 
   backendDAE_1 := BackendDAEUtil.copyBackendDAE(initDAE);
@@ -1751,9 +1763,9 @@ try
    parameter Real x = 10;
    Real m = x; */
   BackendDAE.DAE(currentSystem::{}, shared) := backendDAE_1;
-  protectedCrefs := {};
+  protectedCrefs := UnorderedSet.new(ComponentReferenceBasics.hashComponentRef, ComponentReferenceBasics.crefEqual);
   for var in depVars loop
-    protectedCrefs := var.varName :: protectedCrefs;
+    UnorderedSet.add(var.varName, protectedCrefs);
     if BackendVariable.isParam(var) and not BackendVariable.varHasConstantBindExp(var) then
       //print("\n PARAM_CHECK: " + ComponentReferenceBasics.printComponentRefStr(var.varName));
       lhs := BackendVariable.varExp(var);
@@ -1772,7 +1784,7 @@ try
   // so keeping these variables would create derivative variables without
   // remaining equations after simplification.
   newOrderedEquationArray := BackendEquation.emptyEqns();
-  crefsVarsToRemove:= {};
+  crefsVarsToRemove := UnorderedSet.new(ComponentReferenceBasics.hashComponentRef, ComponentReferenceBasics.crefEqual);
   for eq in BackendEquation.equationList(currentSystem.orderedEqs) loop
     if not BackendEquation.isAlgorithm(eq) then
       lhs := BackendEquation.getEquationLHS(eq);
@@ -1781,12 +1793,12 @@ try
         cr := Expression.expCref(lhs);
         // remove lhs equation of type $Start.a = ... as it does not contribute to the jacobian and create a variable a with constant binding which is not wanted
         if ComponentReference.isStartCref(cr) then
-          crefsVarsToRemove := cr :: crefsVarsToRemove;
-        elseif Expression.isExpCref(rhs) and not listMember(cr, protectedCrefs) then
+          UnorderedSet.add(cr, crefsVarsToRemove);
+        elseif Expression.isExpCref(rhs) and not UnorderedSet.contains(cr, protectedCrefs) then
           rhsCr := Expression.expCref(rhs);
           // remove equation of form a = $START.a as it does not contribute to the jacobian and create a variable a with constant binding which is not wanted
           if ComponentReference.isStartCref(rhsCr) and ComponentReferenceBasics.crefEqual(ComponentReference.popCref(rhsCr), cr) then
-            crefsVarsToRemove := cr :: crefsVarsToRemove;
+            UnorderedSet.add(cr, crefsVarsToRemove);
           else
             BackendEquation.add(eq, newOrderedEquationArray);
           end if;
@@ -1803,9 +1815,9 @@ try
 
   newVars := BackendVariable.emptyVars();
   for var in BackendVariable.varList(currentSystem.orderedVars) loop
-    if not listMember(var.varName, crefsVarsToRemove) then
+    if not UnorderedSet.contains(var.varName, crefsVarsToRemove) then
       // make depVars crefs as unreplaceable as it might be removed by removeSimpleEquation and Optimization fails for jacobians
-      if listMember(var.varName, protectedCrefs) then
+      if UnorderedSet.contains(var.varName, protectedCrefs) then
         var := BackendVariable.setVarUnreplaceable(var, true);
       end if;
       newVars := BackendVariable.addVar(var, newVars);
@@ -1846,32 +1858,22 @@ try
   //BackendDump.dumpVarList(knvarlst, "shared simulation DAE");
   inputvars := List.select(knvarlst, BackendVariable.isVarOnTopLevelAndInput);
 
-  // Generate empty jacobian martices
-  if Flags.isSet(Flags.DIS_SYMJAC_FMI20) then
-    cache := initDAE.shared.cache;
-    graph := initDAE.shared.graph;
-    ei := initDAE.shared.info;
-    emptyBDAE := BackendDAE.DAE({BackendDAEUtil.createEqSystem(BackendVariable.emptyVars(), BackendEquation.emptyEqns())}, BackendDAEUtil.createEmptyShared(BackendDAE.JACOBIAN(), ei, cache, graph));
-    outJacobianMatrices := (SOME((emptyBDAE,"FMIDERINIT",{},{},{}, {})), BackendDAE.emptySparsePattern, {}, BackendDAE.emptyNonlinearPattern)::outJacobianMatrices;
-    outFunctionTree := initDAE.shared.functionTree;
-  else
-    // prepare more needed variables
-    paramvars := List.select(knvarlst, BackendVariable.isParam);
-    statesarr := BackendVariable.listVar1(states);
-    inputvarsarr := BackendVariable.listVar1(inputvars);
-    paramvarsarr := BackendVariable.listVar1(paramvars);
-    depVarsArr := BackendVariable.listVar1(depVars);
+  // prepare more needed variables
+  paramvars := List.select(knvarlst, BackendVariable.isParam);
+  statesarr := BackendVariable.listVar1(states);
+  inputvarsarr := BackendVariable.listVar1(inputvars);
+  paramvarsarr := BackendVariable.listVar1(paramvars);
+  depVarsArr := BackendVariable.listVar1(depVars);
 
-    //(outJacobian, outFunctionTree, _, _) := generateGenericJacobian(backendDAE_1, indepVars, BackendVariable.emptyVars(), BackendVariable.emptyVars(), BackendVariable.emptyVars(), depVarsArr, depVars, "FMIDERINIT", Flags.isSet(Flags.DIS_SYMJAC_FMI20));
-    (outJacobian, outFunctionTree, _, _) := generateGenericJacobian(backendDAE_1, indepVars, statesarr, inputvarsarr, paramvarsarr, depVarsArr, varlst, "FMIDERINIT", Flags.isSet(Flags.DIS_SYMJAC_FMI20));
+  //(outJacobian, outFunctionTree, _, _) := generateGenericJacobian(backendDAE_1, indepVars, BackendVariable.emptyVars(), BackendVariable.emptyVars(), BackendVariable.emptyVars(), depVarsArr, depVars, "FMIDERINIT", Flags.isSet(Flags.DIS_SYMJAC_FMI20));
+  (outJacobian, outFunctionTree, _, _) := generateGenericJacobian(backendDAE_1, indepVars, statesarr, inputvarsarr, paramvarsarr, depVarsArr, varlst, "FMIDERINIT", false);
 
-    if Flags.isSet(Flags.JAC_DUMP2) then
-      BackendDump.dumpSparsityPattern(sparsePattern_, "FMI sparsity");
-    end if;
-    // kabdelhak: maybe also pass nonlinearity pattern to add it here
-    outJacobianMatrices := (outJacobian, sparsePattern_, sparseColoring_, BackendDAE.emptyNonlinearPattern)::outJacobianMatrices;
-    outFunctionTree := AvlTreePathFunction.join(initDAE.shared.functionTree, outFunctionTree);
+  if Flags.isSet(Flags.JAC_DUMP2) then
+    BackendDump.dumpSparsityPattern(sparsePattern_, "FMI sparsity");
   end if;
+  // kabdelhak: maybe also pass nonlinearity pattern to add it here
+  outJacobianMatrices := (outJacobian, sparsePattern_, sparseColoring_, BackendDAE.emptyNonlinearPattern)::outJacobianMatrices;
+  outFunctionTree := AvlTreePathFunction.join(initDAE.shared.functionTree, outFunctionTree);
 else
   Error.addInternalError("function createFMIModelDerivativesForInitialization failed", sourceInfo());
   outJacobianMatrices := {};

--- a/OMCompiler/Compiler/FrontEnd/ComponentReferenceBasics.mo
+++ b/OMCompiler/Compiler/FrontEnd/ComponentReferenceBasics.mo
@@ -923,7 +923,7 @@ algorithm
   end for;
 end hashSubscripts;
 
-protected function hashSubscript "help function"
+public function hashSubscript "help function"
   input DAE.Subscript sub;
   output Integer hash;
 algorithm

--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -2421,34 +2421,6 @@ algorithm
   end if;
 end getAllCrefs2;
 
-public function getAllCrefsExpanded "author: ptaeuber
-  This function extracts all crefs from the input expression (except 'time') and expands arrays and records."
-  input DAE.Exp inExp;
-  output list<DAE.ComponentRef> outCrefs;
-algorithm
-  (_, outCrefs) := traverseExpBottomUp(inExp, getAllCrefsExpanded2, {});
-end getAllCrefsExpanded;
-
-protected function getAllCrefsExpanded2
-   input DAE.Exp inExp;
-   input list<DAE.ComponentRef> inCrefList;
-   output DAE.Exp outExp = inExp;
-   output list<DAE.ComponentRef> outCrefList = inCrefList;
-protected
-  DAE.ComponentRef cr;
-  list<DAE.ComponentRef> crlst;
-algorithm
-  if isCref(inExp) then
-    DAE.CREF(componentRef=cr) := inExp;
-    crlst := ComponentReference.expandCref(cr, true);
-    for c in crlst loop
-      if not ComponentReferenceBasics.crefEqual(c, DAE.crefTime) and not listMember(c, inCrefList) then
-        outCrefList := c::outCrefList;
-      end if;
-    end for;
-  end if;
-end getAllCrefsExpanded2;
-
 public function allTerms
 "similar to terms, but also performs expansion of
  multiplications to reveal more terms, like for instance:

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
@@ -6437,15 +6437,62 @@ fn collect_pat_names(pat: &TypedPat, out: &mut HashSet<String>) {
 /// must be a complete module-level item with a signature compatible with every
 /// call site (the generator still resolves calls to `Module::fn`).
 fn function_source_replacement(qname: &str) -> Option<&'static str> {
-    // No replacements at present. Two used to live here, both working around
-    // referenceEq lowerings that have since been fixed properly:
+    // Two used to live here, both working around referenceEq lowerings that
+    // have since been fixed properly:
     //  * `List.allReferenceEq` — generic element compare was an always-false
     //    address compare; now lowered through `metamodelica::ReferenceEq`.
     //  * `Expression.traverseCases` — `referenceEq(cases, {})` was false for
     //    the freshly-allocated `Nil` even though MMC's `{}` is a shared
     //    singleton; the `list<T>` lowering is now List-aware (Nil == Nil).
-    None
+    match qname {
+        // The MetaModelica mergesort conses a node per merge step, cheap under
+        // MMC's bump allocator and the main cost of sorting an adjacency row
+        // here. Same halving and tie rule on a Vec: for two elements the input
+        // is kept iff comp(e2, e1); merge takes from the left iff
+        // comp(right, left).
+        "List.sort" => Some(LIST_SORT_SRC),
+        _ => None,
+    }
 }
+
+const LIST_SORT_SRC: &str = r#"pub fn sort<T: Clone + 'static + metamodelica::gc::MMTrace>(inList: Arc<metamodelica::List<T>>, inCompFunc: Arc<dyn ::std::ops::Fn(T, T) -> Result<bool> + 'static>) -> Result<Arc<metamodelica::List<T>>> {
+    fn sort_slice<T: Clone>(v: &[T], comp: &dyn Fn(T, T) -> Result<bool>) -> Result<Vec<T>> {
+        let n = v.len();
+        if n < 2 {
+            return Ok(v.to_vec());
+        }
+        if n == 2 {
+            return Ok(if comp(v[1].clone(), v[0].clone())? { v.to_vec() } else { vec![v[1].clone(), v[0].clone()] });
+        }
+        let (l, r) = v.split_at(n / 2);
+        let left = sort_slice(l, comp)?;
+        let right = sort_slice(r, comp)?;
+        let mut res = Vec::with_capacity(n);
+        let (mut i, mut j) = (0, 0);
+        while i < left.len() && j < right.len() {
+            if comp(right[j].clone(), left[i].clone())? {
+                res.push(left[i].clone());
+                i += 1;
+            } else {
+                res.push(right[j].clone());
+                j += 1;
+            }
+        }
+        res.extend_from_slice(&left[i..]);
+        res.extend_from_slice(&right[j..]);
+        Ok(res)
+    }
+    let v: Vec<T> = (&*inList).into_iter().cloned().collect();
+    if v.len() < 2 || (v.len() == 2 && inCompFunc(v[1].clone(), v[0].clone())?) {
+        return Ok(inList);
+    }
+    let sorted = sort_slice(&v, &*inCompFunc)?;
+    let mut out = metamodelica::nil();
+    for e in sorted.into_iter().rev() {
+        out = metamodelica::cons(e, out);
+    }
+    Ok(out)
+}"#;
 
 // ── Inherited-algorithm (`extends`) instantiation ───────────────────────────
 //

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -13779,7 +13779,6 @@ protected
    Option<SimCode.JacobianMatrix> contPartSimDer, initPartSimDer = NONE();
    SimCodeVar.SimVars vars;
    SimCode.HashTableCrefToSimVar crefSimVarHT;
-   list<Integer> intLst;
    BackendDAE.SymbolicJacobians fmiDerInit = {};
    list<SimCode.JacobianMatrix> symJacsInit={}, symJacFMIINIT={};
    list<tuple<Integer, DAE.ComponentRef>> sortedUnknownCrefs = {}, sortedknownCrefs = {};
@@ -13807,8 +13806,7 @@ algorithm
     allUnknowns := translateSparsePatterInts2FMIUnknown(sparseInts, {});
 
     // get derivatives pattern
-    intLst := list(getVariableFMIIndex(v) for v in inModelInfo.vars.derivativeVars);
-    derivatives := list(fmiUnknown for fmiUnknown guard(List.any(intLst, function isFmiUnknown(inFMIUnknown = fmiUnknown))) in allUnknowns);
+    derivatives := fmiUnknownsOf(inModelInfo.vars.derivativeVars, allUnknowns);
 
     // get output pattern
     varsA := List.filterOnTrue(inModelInfo.vars.algVars, isOutputSimVar);
@@ -13816,13 +13814,11 @@ algorithm
     varsC := List.filterOnTrue(inModelInfo.vars.boolAlgVars, isOutputSimVar); // check for outputs in boolAlgVar
     varsD := List.filterOnTrue(inModelInfo.vars.stringAlgVars, isOutputSimVar); // check for outputs in stringAlgVars
     allOutputVars := listAppend(listAppend(varsA,varsB),listAppend(varsC,varsD));
-    intLst := list(getVariableFMIIndex(v) for v in allOutputVars);
-    outputs := list(fmiUnknown for fmiUnknown guard(List.any(intLst, function isFmiUnknown(inFMIUnknown = fmiUnknown))) in allUnknowns);
+    outputs := fmiUnknownsOf(allOutputVars, allUnknowns);
 
     // get discrete states pattern
     clockedStates := List.filterOnTrue(inModelInfo.vars.algVars, isClockedStateSimVar);
-    intLst := list(getVariableFMIIndex(v) for v in clockedStates);
-    discreteStates := list(fmiUnknown for fmiUnknown guard(List.any(intLst, function isFmiUnknown(inFMIUnknown = fmiUnknown))) in allUnknowns);
+    discreteStates := fmiUnknownsOf(clockedStates, allUnknowns);
 
     // discreteStates
     if not checkForEmptyBDAE(optcontPartDer) then
@@ -14137,7 +14133,7 @@ protected
   BackendDAE.AdjacencyMatrix outAdjacencyMatrix;
   array<Integer> match1,match2;
   Boolean debug = false;
-  UnorderedSet<DAE.ComponentRef> initialUnknowns;
+  UnorderedSet<DAE.ComponentRef> initialUnknowns, indepCrefSet;
 algorithm
   initialUnknownCrefs := List.map(initialUnknownList, getCrefFromSimVar); // extract cref from initialUnknownsList
   initialUnknowns := UnorderedSet.fromList(initialUnknownCrefs,
@@ -14211,7 +14207,7 @@ algorithm
   //tmpBDAE1 := BackendDAEUtil.copyBackendDAE(tmpBDAE);
 
   // Calculate the dependecies of initialUnknowns
-  (sparsePattern, sparseColoring) := SymbolicJacobian.generateSparsePattern(tmpBDAE, indepVars, depVars);
+  (sparsePattern, sparseColoring) := SymbolicJacobian.generateSparsePattern(tmpBDAE, indepVars, depVars, withColoring = not Flags.isSet(Flags.DIS_SYMJAC_FMI20));
   if debug then
     dumpFmiInitialUnknownsDependencies(sparsePattern, "FmiInitialUnknownDependency");
   end if;
@@ -14226,11 +14222,12 @@ algorithm
   // collect the dependency list from sparse pattern
   indepCrefs := {};
   depCrefs := {};
+  indepCrefSet := UnorderedSet.new(ComponentReferenceBasics.hashComponentRef, ComponentReferenceBasics.crefEqual);
   for i in rowspt loop
     (cref, crefs) := i;
     depCrefs := cref :: depCrefs;
     for cr in crefs loop
-      if not listMember(cr, indepCrefs) then
+      if UnorderedSet.add(cr, indepCrefSet) then
         indepCrefs := cr :: indepCrefs;
       end if;
     end for;
@@ -14419,18 +14416,19 @@ algorithm
   end match;
 end isOutputSimVar;
 
-protected function isFmiUnknown
-  input Integer index;
-  input SimCode.FmiUnknown inFMIUnknown;
-  output Boolean out;
+protected function fmiUnknownsOf
+  "The unknowns that are one of the variables, in the unknowns' order."
+  input list<SimCodeVar.SimVar> vars;
+  input list<SimCode.FmiUnknown> unknowns;
+  output list<SimCode.FmiUnknown> selected;
+protected
+  UnorderedSet<Integer> indices = UnorderedSet.new(Util.id, intEq, Util.nextPrime(listLength(vars)));
 algorithm
-  out := match inFMIUnknown
-    local
-      Integer i;
-    case SimCode.FMIUNKNOWN(index=i) guard (intEq(i,index))  then true;
-    else false;
-  end match;
-end isFmiUnknown;
+  for v in vars loop
+    UnorderedSet.add(getVariableFMIIndex(v), indices);
+  end for;
+  selected := list(u for u guard UnorderedSet.contains(u.index, indices) in unknowns);
+end fmiUnknownsOf;
 
 protected function translateSparsePatterInts2FMIUnknown
 "function translates simVar integers to fmi unknowns."
@@ -14921,6 +14919,47 @@ algorithm
   setGlobalRoot(Global.fmi3ValueReferenceCache, NONE());
 end clearFMI3ValueReferences;
 
+public function fmi3UnknownDependencyAttributes
+  "The dependencies and dependenciesKind attributes of a <ModelStructure> entry,
+   the dependencies mapped from FMI indices to value references."
+  input SimCode.SimCode simCode;
+  input SimCode.FmiUnknown unknown;
+  output String attributes = "";
+protected
+  Option<array<String>> cache = getGlobalRoot(Global.fmi3ValueReferenceCache);
+  list<String> vrs = {};
+algorithm
+  if not listEmpty(unknown.dependencies) then
+    for d in unknown.dependencies loop
+      vrs := match cache
+        local array<String> table;
+        case SOME(table) guard d > 0 and d <= arrayLength(table) and not stringEmpty(arrayGet(table, d))
+          then arrayGet(table, d) :: vrs;
+        else getFMI3ValueReferenceFromFMIIndex(simCode, d) :: vrs;
+      end match;
+    end for;
+    attributes := " dependencies=\"" + stringDelimitList(listReverse(vrs), " ") + "\"";
+  end if;
+  if not listEmpty(unknown.dependenciesKind) then
+    attributes := attributes + " dependenciesKind=\"" + stringDelimitList(unknown.dependenciesKind, " ") + "\"";
+  end if;
+end fmi3UnknownDependencyAttributes;
+
+public function fmiDependenciesString
+  "Space separated, as the FMI 2.0 ModelStructure dependencies attribute."
+  input list<Integer> dependencies;
+  output String str;
+algorithm
+  str := stringDelimitList(list(intString(d) for d in dependencies), " ");
+end fmiDependenciesString;
+
+public function fmiDependenciesKindString
+  input list<String> kinds;
+  output String str;
+algorithm
+  str := stringDelimitList(kinds, " ");
+end fmiDependenciesKindString;
+
 public function getFMI3ValueReferenceFromFMIIndex
   "Maps an FMI variable index (the 1-based position in the ModelVariables list as
    stored in the FmiModelStructure unknowns/dependencies) to the globally unique
@@ -14968,24 +15007,13 @@ end getFMI3ValueReferenceFromFMIIndex;
 public function getFMI3TimeValueReference
   "Returns a value reference for the independent variable (time) that does not
    collide with any model variable. It is the first free value reference past the
-   real/integer/boolean/string blocks. The same value is emitted as a #define
-   (FMI3_TIME_VR) into the generated FMI 3.0 model code.
+   real/integer/boolean/string/binary/clock blocks. The same value is emitted as a
+   #define (FMI3_TIME_VR) into the generated FMI 3.0 model code.
    author: adrpo"
   input SimCode.SimCode inSimCode;
   output String outValueReference;
-protected
-  SimCodeVar.SimVars vars = inSimCode.modelInfo.vars;
-  // per-scalar counts (an array variable occupies getNumElems scalar slots), so
-  // that time comes after the real/integer/boolean/string scalar blocks.
-  Integer numReal = 2*numScalarElems(vars.stateVars) + numScalarElems(vars.algVars) + numScalarElems(vars.discreteAlgVars) + numScalarElems(vars.paramVars) + numScalarElems(vars.aliasVars);
-  Integer numInteger = numScalarElems(vars.intAlgVars) + numScalarElems(vars.intParamVars) + numScalarElems(vars.intAliasVars);
-  Integer numBoolean = numScalarElems(vars.boolAlgVars) + numScalarElems(vars.boolParamVars) + numScalarElems(vars.boolAliasVars);
-  Integer numString = numScalarElems(vars.stringAlgVars) + numScalarElems(vars.stringParamVars) + numScalarElems(vars.stringAliasVars);
-  // external objects (FMI 3.0 Binary) and clocks occupy their own blocks before time
-  Integer numExtObj = numScalarElems(vars.extObjVars);
-  Integer numClock = listLength(inSimCode.clockedPartitions);
 algorithm
-  outValueReference := String(numReal + numInteger + numBoolean + numString + numExtObj + numClock);
+  outValueReference := String(getFMI3ClockVROffset(inSimCode.modelInfo) + listLength(inSimCode.clockedPartitions));
 end getFMI3TimeValueReference;
 
 public function exportDaeAlgebraicStates
@@ -15018,7 +15046,7 @@ end exportIfAlgebraicState;
 public function getFMI3DaeModeValueReference
   "fmi-ls-dae: the value reference of the structural parameter that switches a
    --daeMode FMU into DAE mode, the first one past the event indicators. The
-   residuals follow it (getFMI3DaeResidualValueReference); the wasm emitter
+   residuals follow it (fmi3DaeResiduals); the wasm emitter
    (CodegenWasmJit.build_fmi_vrs) assigns the same numbers."
   input SimCode.SimCode simCode;
   output String vr;
@@ -15026,64 +15054,64 @@ algorithm
   vr := String(stringInt(getFMI3TimeValueReference(simCode)) + simCode.modelInfo.varInfo.numZeroCrossings + 1);
 end getFMI3DaeModeValueReference;
 
-public function getFMI3DaeResidualValueReference
-  input SimCodeVar.SimVar residualVar "one of daeModeData.residualVars";
-  input SimCode.SimCode simCode;
-  output String vr;
-algorithm
-  vr := String(stringInt(getFMI3DaeModeValueReference(simCode)) + 1 + residualVar.index);
-end getFMI3DaeResidualValueReference;
-
-public function getFMI3DaeResidualDependencyAttributes
-  "fmi-ls-dae: the dependencies and dependenciesKind attributes of the residual at
-   0-based row `index` of the DAE-mode Jacobian, read off its transposed sparsity.
-   A state column stands for the state and its derivative both, since DAE-mode
-   differentiation folds der(x) into x ($cj * x.Seed); the other columns are the
-   algebraic variables. Empty without a pattern, which the standard reads as a
+public function fmi3DaeResiduals
+  "fmi-ls-dae: the residuals of a --daeMode model as (valueReference, dependency
+   attributes): the value references follow the DAE-mode switch's, and the
+   dependencies and dependenciesKind attributes of each <Formulation> are read
+   off the rows of the DAE-mode Jacobian's transposed sparsity. A state column
+   stands for the state and its derivative both, since DAE-mode differentiation
+   folds der(x) into x ($cj * x.Seed); the other columns are the algebraic
+   variables. No attributes without a pattern, which the standard reads as a
    dependency on every known."
   input SimCode.SimCode simCode;
-  input Integer index;
-  output String attributes = "";
+  output list<tuple<String, String>> residuals = {};
 protected
   SimCode.DaeModeData dmd;
-  SimCode.JacobianMatrix jm;
-  list<Integer> cols = {};
-  Integer numStates, row = 0;
-  list<Integer> colsOfRow;
-  SimCodeVar.SimVar sv;
-  String stateVR;
-  list<String> acc = {};
+  Option<list<list<Integer>>> rows;
+  list<list<Integer>> rest;
+  list<Integer> cols;
+  array<String> stateVRs, algebraicVRs;
+  Integer numStates, daeModeVR;
+  String vr, attributes;
+  list<String> acc;
 algorithm
-  if isNone(simCode.daeModeData) then
-    return;
-  end if;
   SOME(dmd) := simCode.daeModeData;
-  if isNone(dmd.sparsityPattern) then
-    return;
-  end if;
-  SOME(jm) := dmd.sparsityPattern;
-  for entry in jm.sparsityT loop
-    (_, colsOfRow) := entry;
-    if row == index then
-      cols := colsOfRow;
-    end if;
-    row := row + 1;
-  end for;
+  daeModeVR := stringInt(getFMI3DaeModeValueReference(simCode));
+  rows := match dmd.sparsityPattern
+    local SimCode.JacobianMatrix jm;
+    case SOME(jm) then SOME(list(Util.tuple22(e) for e in jm.sparsityT));
+    else NONE();
+  end match;
   numStates := numScalarElems(simCode.modelInfo.vars.stateVars);
-  for c in cols loop
-    if c < numStates then
-      sv := listGet(simCode.modelInfo.vars.stateVars, c + 1);
-      stateVR := getFMI3ValueReference(sv, simCode);
-      acc := String(stringInt(stateVR) + numStates) :: stateVR :: acc;
-    else
-      sv := listGet(dmd.algebraicVars, c - numStates + 1);
-      acc := getFMI3ValueReference(sv, simCode) :: acc;
+  stateVRs := listArray(list(getFMI3ValueReference(v, simCode) for v in simCode.modelInfo.vars.stateVars));
+  algebraicVRs := listArray(list(getFMI3ValueReference(v, simCode) for v in dmd.algebraicVars));
+  for var in dmd.residualVars loop
+    attributes := "";
+    if isSome(rows) then
+      SOME(rest) := rows;
+      if listEmpty(rest) then
+        cols := {};
+      else
+        cols := listHead(rest);
+        rows := SOME(listRest(rest));
+      end if;
+      acc := {};
+      for c in cols loop
+        if c < numStates then
+          vr := arrayGet(stateVRs, c + 1);
+          acc := String(stringInt(vr) + numStates) :: vr :: acc;
+        else
+          acc := arrayGet(algebraicVRs, c - numStates + 1) :: acc;
+        end if;
+      end for;
+      acc := listReverse(acc);
+      attributes := " dependencies=\"" + stringDelimitList(acc, " ") + "\" dependenciesKind=\""
+        + stringDelimitList(list("dependent" for s in acc), " ") + "\"";
     end if;
+    residuals := (String(daeModeVR + 1 + var.index), attributes) :: residuals;
   end for;
-  acc := listReverse(acc);
-  attributes := " dependencies=\"" + stringDelimitList(acc, " ") + "\" dependenciesKind=\""
-    + stringDelimitList(list("dependent" for s in acc), " ") + "\"";
-end getFMI3DaeResidualDependencyAttributes;
+  residuals := listReverse(residuals);
+end fmi3DaeResiduals;
 
 public function getLocalValueReference
  "returns the local value reference of current OMSIFuncton of a variable for

--- a/OMCompiler/Compiler/Template/CodegenFMU3.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU3.tpl
@@ -507,18 +507,19 @@ template DaeModeVariables3(SimCode simCode)
 ::=
 match simCode
 case SIMCODE(daeModeData=SOME(dmd as DAEMODEDATA(__))) then
+  let daeModeVR = SimCodeUtil.getFMI3DaeModeValueReference(simCode)
   <<
-  <Boolean name="_D_daeMode" valueReference="<%SimCodeUtil.getFMI3DaeModeValueReference(simCode)%>" causality="structuralParameter" variability="fixed" start="false" description="Set to true to enable DAE mode as defined by FMI-LS-DAE."/>
-  <%dmd.residualVars |> var => DaeResidualVariable3(var, simCode) ;separator="\n"%>
+  <Boolean name="_D_daeMode" valueReference="<%daeModeVR%>" causality="structuralParameter" variability="fixed" start="false" description="Set to true to enable DAE mode as defined by FMI-LS-DAE."/>
+  <%dmd.residualVars |> var => DaeResidualVariable3(var, daeModeVR) ;separator="\n"%>
   >>
 end DaeModeVariables3;
 
-template DaeResidualVariable3(SimVar simVar, SimCode simCode)
+template DaeResidualVariable3(SimVar simVar, String daeModeVR)
 ::=
 match simVar
 case SIMVAR(__) then
   let nm = Util.escapeModelicaStringToXmlString(System.stringReplace(crefStrNoUnderscore(name),"$", "_D_"))
-  '<Float64 name="<%nm%>" valueReference="<%SimCodeUtil.getFMI3DaeResidualValueReference(simVar, simCode)%>" causality="local" variability="continuous" initial="calculated" description="DAE-mode residual <%index%>"/>'
+  '<Float64 name="<%nm%>" valueReference="<%intAdd(stringInt(daeModeVR), intAdd(1, index))%>" causality="local" variability="continuous" initial="calculated" description="DAE-mode residual <%index%>"/>'
 end DaeResidualVariable3;
 
 template fmiLsDaeManifest(SimCode simCode)
@@ -539,7 +540,7 @@ case SIMCODE(daeModeData=SOME(dmd as DAEMODEDATA(__)), modelStructure=modelStruc
       >>
     else ''
   let indicators = EventIndicators3(simCode)
-  let residuals = (dmd.residualVars |> var hasindex i0 => DaeResidual3(simCode, var, i0) ;separator="\n")
+  let residuals = (SimCodeUtil.fmi3DaeResiduals(simCode) |> (vr, dependencyAttributes) => DaeResidual3(vr, dependencyAttributes) ;separator="\n")
   let _ = SimCodeUtil.clearFMI3ValueReferences()
   <<
   <fmi-ls-dae
@@ -561,11 +562,11 @@ case SIMCODE(daeModeData=SOME(dmd as DAEMODEDATA(__)), modelStructure=modelStruc
   >>
 end fmiLsDaeManifest;
 
-template DaeResidual3(SimCode simCode, SimVar residualVar, Integer row)
+template DaeResidual3(String vr, String dependencyAttributes)
 ::=
   <<
   <Residual>
-    <Formulation valueReference="<%SimCodeUtil.getFMI3DaeResidualValueReference(residualVar, simCode)%>"<%SimCodeUtil.getFMI3DaeResidualDependencyAttributes(simCode, row)%>/>
+    <Formulation valueReference="<%vr%>"<%dependencyAttributes%>/>
   </Residual>
   >>
 end DaeResidual3;
@@ -858,12 +859,8 @@ template FmiUnknown3(SimCode simCode, FmiUnknown fmiUnknown, String element)
 ::=
 match fmiUnknown
 case FMIUNKNOWN(__) then
-  let vr = SimCodeUtil.getFMI3ValueReferenceFromFMIIndex(simCode, index)
-  let deps = (dependencies |> d => SimCodeUtil.getFMI3ValueReferenceFromFMIIndex(simCode, d) ;separator=" ")
-  let depsAttr = if dependencies then ' dependencies="<%deps%>"'
-  let depsKindAttr = if dependenciesKind then ' dependenciesKind="<%dependenciesKind |> k => k ;separator=" "%>"'
   <<
-  <<%element%> valueReference="<%vr%>"<%depsAttr%><%depsKindAttr%>/>
+  <<%element%> valueReference="<%SimCodeUtil.getFMI3ValueReferenceFromFMIIndex(simCode, index)%>"<%SimCodeUtil.fmi3UnknownDependencyAttributes(simCode, fmiUnknown)%>/>
   >>
 end FmiUnknown3;
 

--- a/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
@@ -498,14 +498,14 @@ template FmiUnknownDependencies(list<Integer> dependencies)
   // Note: dependencies="" means no dependencies;
   // missing dependencies means dependent on all knowns (see FMI 2.0 spec).
   <<
-   dependencies="<%dependencies |> dependency => dependency ;separator=" "%>"
+   dependencies="<%SimCodeUtil.fmiDependenciesString(dependencies)%>"
   >>
 end FmiUnknownDependencies;
 
 template FmiUnknownDependenciesKind(list<String> dependenciesKind)
 ::=
   <<
-   dependenciesKind="<%dependenciesKind |> dependencyKind => dependencyKind ;separator=" "%>"
+   dependenciesKind="<%SimCodeUtil.fmiDependenciesKindString(dependenciesKind)%>"
   >>
 end FmiUnknownDependenciesKind;
 

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -1459,11 +1459,27 @@ package SimCodeUtil
     output String outValueReference;
   end getFMI3ValueReference;
 
+  function fmi3UnknownDependencyAttributes
+    input SimCode.SimCode simCode;
+    input SimCode.FmiUnknown unknown;
+    output String attributes;
+  end fmi3UnknownDependencyAttributes;
+
   function getFMI3ValueReferenceFromFMIIndex
     input SimCode.SimCode inSimCode;
     input Integer inFMIIndex;
     output String outValueReference;
   end getFMI3ValueReferenceFromFMIIndex;
+
+  function fmiDependenciesString
+    input list<Integer> dependencies;
+    output String str;
+  end fmiDependenciesString;
+
+  function fmiDependenciesKindString
+    input list<String> kinds;
+    output String str;
+  end fmiDependenciesKindString;
 
   function cacheFMI3ValueReferences
     input SimCode.SimCode simCode;
@@ -1540,17 +1556,10 @@ package SimCodeUtil
     output String vr;
   end getFMI3DaeModeValueReference;
 
-  function getFMI3DaeResidualValueReference
-    input SimCodeVar.SimVar residualVar;
+  function fmi3DaeResiduals
     input SimCode.SimCode simCode;
-    output String vr;
-  end getFMI3DaeResidualValueReference;
-
-  function getFMI3DaeResidualDependencyAttributes
-    input SimCode.SimCode simCode;
-    input Integer index;
-    output String attributes;
-  end getFMI3DaeResidualDependencyAttributes;
+    output list<tuple<String, String>> residuals;
+  end fmi3DaeResiduals;
 
   function getLocalValueReference
     input SimCodeVar.SimVar inSimVar;

--- a/OMCompiler/Compiler/Util/Graph.mo
+++ b/OMCompiler/Compiler/Util/Graph.mo
@@ -44,6 +44,7 @@ encapsulated package Graph
   records that we don't yet support in MetaModelica."
 
 protected import Error;
+protected import Array;
 protected import List;
 
 public replaceable type NodeType subtypeof Any;
@@ -940,77 +941,69 @@ for each vertex w such that (ui , w) in E do
 for each colored vertex x such that (w, x) in E do
 forbiddenColors[color[x]] <- ui
 color[ui ] <- min{c > 0 : forbiddenColors[c] = ui }
-"
-  input list<tuple<Integer, list<Integer>>> inGraphT;
-  input array<Integer> inforbiddenColor;
-  input list<Integer> inColors;
-  input array<tuple<Integer, list<Integer>>> inGraph;
-  input array<Integer> inColored;
-protected
-  Integer node, color;
-  list<Integer>  nodes;
-algorithm
-  try
-    for tpl in inGraphT loop
-      (node,nodes) := tpl;
-      addForbiddenColorsInt(node, nodes, inColored, inforbiddenColor, inGraph);
-      color := arrayFindMinColorIndexInt(inforbiddenColor, node);
-      arrayUpdate(inColored, node, color);
-    end for;
-  else
-    Error.addSourceMessage(Error.INTERNAL_ERROR, {"Graph.partialDistance2colorInt failed."}, sourceInfo());
-  end try;
-end partialDistance2colorInt;
 
-protected function addForbiddenColorsInt
-  input Integer inNode;
-  input list<Integer> nodes;
-  input array<Integer> inColored;
-  input array<Integer> forbiddenColor;
-  input array<tuple<Integer, list<Integer>>> inGraph;
+The colors of each w's colored vertices are kept as a bit set, so the inner
+loop is a union of bit sets rather than a walk over every x of w for every
+ui of w, which is quadratic in the degree of w."
+  input list<tuple<Integer, list<Integer>>> inGraphT "each vertex of V2 with its neighbours in V1";
+  input Integer numNodes "size of V1";
+  input array<Integer> inColored "color per vertex of V2, 0 while uncolored";
 protected
-  list<Integer> indexes;
+  constant Integer wordBits = 30;
+  constant Integer fullWord = 1073741823;
+  Integer node, color, words = 1, usedWords = 1, k, w, bit;
+  list<Integer> nodes;
+  array<array<Integer>> nodeColors = arrayCreate(numNodes, arrayCreate(0, 0));
+  array<Integer> forbidden = arrayCreate(1, 0), colors;
 algorithm
-  try
-    for node in nodes loop
-      (_,indexes) := arrayGet(inGraph,node);
-      updateForbiddenColorArrayInt(indexes, inColored, forbiddenColor, inNode);
-    end for;
-  else
-    Error.addSourceMessage(Error.INTERNAL_ERROR, {"Graph.addForbiddenColorsInt failed."}, sourceInfo());
-    fail();
-  end try;
-end addForbiddenColorsInt;
-
-protected function updateForbiddenColorArrayInt
-  input list<Integer> inIndexes;
-  input array<Integer> inColored;
-  input array<Integer> inForbiddenColor;
-  input Integer inNode;
-protected
-  Integer colorIndex;
-algorithm
-  for index in inIndexes loop
-    colorIndex := arrayGet(inColored, index);
-    if colorIndex > 0 then
-      arrayUpdate(inForbiddenColor, colorIndex, inNode);
-    end if;
+  for i in 1:numNodes loop
+    arrayUpdate(nodeColors, i, arrayCreate(words, 0));
   end for;
-end updateForbiddenColorArrayInt;
-
-protected function arrayFindMinColorIndexInt
-  input array<Integer> inForbiddenColor;
-  input Integer inNode;
-  output Integer outColor = 1;
-algorithm
-  while true loop
-    if arrayGet(inForbiddenColor, outColor) <> inNode then
-      return;
-    else
-      outColor := outColor + 1;
+  for tpl in inGraphT loop
+    (node, nodes) := tpl;
+    for j in 1:usedWords loop
+      arrayUpdate(forbidden, j, 0);
+    end for;
+    for n in nodes loop
+      colors := arrayGet(nodeColors, n);
+      for j in 1:usedWords loop
+        arrayUpdate(forbidden, j, intBitOr(arrayGet(forbidden, j), arrayGet(colors, j)));
+      end for;
+    end for;
+    color := 0;
+    k := 1;
+    while color == 0 loop
+      if k > usedWords then
+        color := (k - 1) * wordBits + 1;
+      else
+        w := arrayGet(forbidden, k);
+        if w <> fullWord then
+          bit := 0;
+          while intBitAnd(w, intBitLShift(1, bit)) <> 0 loop
+            bit := bit + 1;
+          end while;
+          color := (k - 1) * wordBits + bit + 1;
+        end if;
+        k := k + 1;
+      end if;
+    end while;
+    arrayUpdate(inColored, node, color);
+    k := intDiv(color - 1, wordBits) + 1;
+    if k > words then
+      words := 2 * words;
+      forbidden := Array.expandToSize(words, forbidden, 0);
+      for i in 1:numNodes loop
+        arrayUpdate(nodeColors, i, Array.expandToSize(words, arrayGet(nodeColors, i), 0));
+      end for;
     end if;
-  end while;
-end arrayFindMinColorIndexInt;
+    usedWords := intMax(usedWords, k);
+    bit := intBitLShift(1, intMod(color - 1, wordBits));
+    for n in nodes loop
+      colors := arrayGet(nodeColors, n);
+      arrayUpdate(colors, k, intBitOr(arrayGet(colors, k), bit));
+    end for;
+  end for;
+end partialDistance2colorInt;
 
 public function filterGraph
   "Removes any node for which the given function evaluates to false, as well as


### PR DESCRIPTION
The library-testing wasm-jit lane runs `buildModelFMU`, not `simulate()`, so its backend, SimCode and template columns are the FMU export path. That path spent minutes in passes whose cost grew with the square of the model size, on models whose `simulate()` translation takes seconds. Measured with `-d=execstat` and callgrind on `platforms={"wasm"}` exports:

| model | step | before | after |
| --- | --- | --- | --- |
| Buildings LBNL_71T ElectroChromicWindow | whole export | 55 s | 21 s | | ScalableTestSuite Table_N_400_M_400 | jacobian parts | 185 s | 15 s | | MSL Spice3 FourBitBinaryAdder | jacobian parts | 275 s | 17 s | | OpenIPSL Nordic44_Base_Case | FMI SimCode | 124 s | 21 s | | OpenIPSL Nordic44_Base_Case | modelDescription.xml | 17 s | 2.7 s | | ScalableTestGrids Type1_N_2_M_4 | both FMI XML files | 31 s | 1.4 s | | synthetic `p[N] = f(q[N])`, N=2000 | whole export | 128 s | 58 s | | Buildings FEFLOW MassFlowRatePulse100 | phase time | 633 s | 324 s |

Generated C, init XML, FMU sources and `-d=bltdump`, `-d=symjacdump`, `-d=initialization`, `-d=dumpSparsePattern` dumps are byte-identical to before (modulo GUID); 765 backend and FMI rtest cases are unchanged.

## `BackendVariable.Variables`

* The bucket table never grew. `emptyVars` sizes it for the variables known at creation and `addVar` kept adding to the same buckets, so a table created for an initialization system and then fed every parameter of the model (`getFmiInitialUnknowns` does exactly that) degraded to a linear scan per lookup, 97 % of the SimCode phase on Table_N_400_M_400. `addVar` and `addNewVar` now rebuild both indices for twice the current count once the load factor reaches 1.
* `getVar` on a name that is not a scalar variable (a whole array, a record, a partially indexed array) expanded it with `expandCref` and looked every element up, and did the same before failing on a miss. `BUILDING_FMU` scalarizes array parameters bound to function calls (NFScalarize, #7516), so a 264-element parameter becomes 264 bindings that each reference three whole 100+-element arrays, and every adjacency-matrix pass over the parameter system expanded them again: 75 G of 165 G instructions on ElectroChromicWindow. `VARIABLES.prefixIndices` maps every proper prefix of a variable name (each qualifier, with each leading part of its subscripts) to the indices below it, hashed as `hashComponentRef` hashes the prefix. `getVar` tries the exact name, then the prefix index when the name has constant indices, fully indexed qualifiers and an array or record type, and falls back to expansion only for slices and non-constant indices. A prefix miss is definitive. Candidates are checked against the query's type the way `expandCref` enumerates elements, because a name prefix is not an element: Jacobian seeds are named `x7.SeedNLSJac0`, and treating `x7` as their prefix dropped the iteration variable from `calcJacobianDependencies` in 24 tearing and initialization tests.

## Adjacency rows

Every variable index an equation references went into an `AvlSetInt` one `add` at a time; a whole-array reference inserts every element, so the scalarized bindings above cost N*N path-copying inserts per pass, four to five passes per translation. The row is now a plain list while the equation is traversed and is sorted and deduplicated once by `BackendDAEUtil.uniqueRow`, in the descending order `AvlSetInt.listKeys` produced, so matching and BLT sorting see the same rows. The `SPARSE` finder used to stop walking an array reference's elements when its first element was already in the row; all elements are added now, which only differs when a scalar element is referenced before its whole array in the same equation.

`List.sort` gets a native body in the Rust port (mmtorust's `function_source_replacement`, the same halving and tie rule on a `Vec`): the MetaModelica mergesort conses a node per merge step, cheap under MMC's bump allocator and 32 % of the synthetic model in Rust.

## Initialization and Jacobians

* `selectInitializationVariablesDAE` decided whether a binding depends only on primary parameters by expanding every cref in it. The primary set is a `Variables` now and the unexpanded crefs go through the prefix index; a whole array or record is primary when the lookup finds as many elements as its type has. An external object counts as one element (`Expression.sizeOf` says zero, which would have made CombiTimeTable's `t_min` secondary). `getAllCrefsExpanded` had no other caller and is gone.
* `createFMIModelDerivativesForInitialization` copied, collapsed and matched the initialization DAE before noticing that the FMIDERINIT Jacobian is disabled by default (`-d=disableDirectionalDerivatives`), and the FMI sparsity coloring is skipped while directional derivatives are off: nothing reads it then, and it was 24 % of the synthetic model.
* `Graph.partialDistance2colorInt`, the greedy partial distance-2 coloring of every sparsity pattern, walked every column of a row once per column of that row, the sum of the squared row degrees: 8.9e9 steps on Nordic44's initial-unknowns pattern (1246 rows with ~2650 of 6760 columns each), 92 % of its FMI SimCode step. The colors a row's columns have received are kept as a bit set per row and a column's forbidden colors are the union of its rows' sets. Greedy order, forbidden sets and every color are unchanged. `createColoring` no longer builds the untransposed graph except for the verbose dump.

## SimCode and templates

* `createFMIModelStructure` picked the derivative, output and clocked-state unknowns with a `List.any` over the variables' indices per unknown; the indices go into a set once.
* `getFMI3TimeValueReference` recounted the scalars of every variable list per call, once per DAE-mode residual from both the model description and the fmi-ls-dae manifest, and the manifest rescanned the transposed sparsity per row. `fmi3DaeResiduals` computes the residuals' value references and dependency attributes in one pass.
* Each `<ModelStructure>` entry rendered its dependencies as a Susan iteration, one template token and one `getFMI3ValueReferenceFromFMIIndex` call (taking the whole SimCode) per dependency: Tpl's per-token work in the Rust port is ~15 k instructions. `fmi3UnknownDependencyAttributes` builds both attributes off the cached index -> value reference table, and the FMI 2.0 lists are one `stringDelimitList` each.
* The `listMember` dedups over the dependency and protected-cref lists in `getFmiInitialUnknowns` and the FMIDERINIT setup are sets.

The bootstrapped compiler miscompiles a match whose tuple result takes a String from a record field (the string lands in `tmpMeta` but is read from `tmp_c0`), so the prefix walk fetches identifiers through `crefFirstIdent`. The N x M dependency block itself comes from the FMU-mode scalarization of #7516, whose reason is not recorded; keeping the array binding would remove it entirely and is left as is.

Assisted-by: Claude Fable 5.1

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
