### PR TITLE
[NB] Unbox the result of a function pointer call (#16543)

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -272,6 +272,16 @@ public
         outExp := Expression.CALL(ty_call);
       end if;
       outExp := Inline.inlineCallExp(outExp);
+
+      // The parameters of a partial function are boxed, so calling a functional
+      // input argument gives a boxed value. Unbox it here so the rest of the
+      // expression sees the actual type, otherwise the boxed type leaks into
+      // e.g. array constructors and reductions and gives invalid code.
+      if Type.isBoxed(ty) and Type.isScalarBuiltin(Type.unbox(ty)) and
+         Function.isFunctionPointer(typedFunction(ty_call)) then
+        ty := Type.unbox(ty);
+        outExp := Expression.UNBOX(outExp, ty);
+      end if;
     end if;
   end typeCallExp;
 

--- a/testsuite/simulation/modelica/algorithms_functions/FunctionPointerArray.mos
+++ b/testsuite/simulation/modelica/algorithms_functions/FunctionPointerArray.mos
@@ -1,0 +1,90 @@
+// name: FunctionPointerArray
+// keywords: function pointer, array constructor
+// status: correct
+// teardown_command: rm -rf FunctionPointerArray.Test* output.log
+//
+// Calling a functional input argument gives a boxed value. Check that it's
+// unboxed also when it ends up in an array constructor, an array literal or a
+// reduction, and not just in a scalar context.
+//
+
+loadString("
+package FunctionPointerArray
+  partial function pfunc
+    input Real u;
+    output Real y;
+  end pfunc;
+
+  function func
+    input Real u;
+    output Real y;
+  algorithm
+    y := 2*u;
+  end func;
+
+  function evalArrayConstructor
+    input FunctionPointerArray.pfunc f;
+    input Real u;
+    input Integer n = 3;
+    output Real y;
+  protected
+    Real values[n];
+  algorithm
+    values := {f(u*k) for k in 1:n};
+    y := sum(values);
+  end evalArrayConstructor;
+
+  function evalArrayLiteral
+    input FunctionPointerArray.pfunc f;
+    input Real u;
+    output Real y;
+  protected
+    Real values[3];
+  algorithm
+    values := {f(u), 1.0, f(2*u)};
+    y := sum(values);
+  end evalArrayLiteral;
+
+  function evalReduction
+    input FunctionPointerArray.pfunc f;
+    input Real u;
+    input Integer n = 3;
+    output Real y;
+  algorithm
+    y := sum({f(u*k) for k in 1:n});
+  end evalReduction;
+
+  model Test
+    input Real u = 0; // prevent presolving
+    Real x, y, z;
+  equation
+    x = evalArrayConstructor(function func(), u + 1);
+    y = evalArrayLiteral(function func(), u + 1);
+    z = evalReduction(function func(), u + 1);
+    annotation(experiment(StopTime = 0));
+  end Test;
+end FunctionPointerArray;
+");
+getErrorString();
+
+simulate(FunctionPointerArray.Test);
+val(x, 0);
+val(y, 0);
+val(z, 0);
+getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "FunctionPointerArray.Test_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'FunctionPointerArray.Test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// 12.0
+// 7.0
+// 12.0
+// ""
+// endResult

--- a/testsuite/simulation/modelica/algorithms_functions/IntegralNewtonCotes.mos
+++ b/testsuite/simulation/modelica/algorithms_functions/IntegralNewtonCotes.mos
@@ -1,0 +1,225 @@
+// name: IntegralNewtonCotes
+// keywords: function pointer, array constructor, quadrature
+// status: correct
+// teardown_command: rm -rf IntegralNewtonCotes.MovingIntegralSinusoidal* output.log
+//
+// Newton-Cotes quadrature with a functional input argument, see #16543. The
+// variant that stores the function values in an array (quadratureNewtonCotes2)
+// used to generate a metatype_array for the array constructor of the boxed
+// calls, which doesn't compile.
+//
+
+loadModel(Modelica, {"4.1.0"}); getErrorString();
+
+loadString("within ;
+package IntegralNewtonCotes
+
+  model MovingIntegralSinusoidal
+    extends Modelica.Icons.Example;
+    import Modelica.Units.SI;
+    import Modelica.Constants.pi;
+    import funB=Modelica.Math.sin \"Sinusoidal flux density distribution\";
+    import quadratureNewtonCotes=IntegralNewtonCotes.quadratureNewtonCotes2;
+    parameter SI.MagneticFluxDensity Bpeak=1 \"Amplitude\";
+    parameter SI.Angle beta(final min=0, final max=pi)=pi \"Coil width\";
+    parameter SI.Area wlD=100*0.05*0.05 \"Number of turns x length x diameter\";
+    parameter Integer N=180 \"Number of intervals\";
+    SI.Angle pos=2*pi*time/Tend \"Position\";
+    SI.MagneticFluxDensity B=Bpeak*funB(pos) \"Flux density\";
+    SI.MagneticFlux psi0=Bpeak*wlD*sin(beta/2)*2*cos(pos)
+      \"Flux linkage(analytically)\";
+    SI.MagneticFlux psi1=Bpeak*wlD*quadratureNewtonCotes(function funB(),
+      pos + pi/2 - beta/2, pos + pi/2  + beta/2, N=N, d=1)
+      \"Flux linkage using trapezoidal rule\";
+    SI.MagneticFlux psi2=Bpeak*wlD*quadratureNewtonCotes(function funB(),
+      pos + pi/2 - beta/2, pos + pi/2  + beta/2, N=N, d=2)
+      \"Flux linkage using Simpson's rule\";
+    SI.MagneticFlux psi3=Bpeak*wlD*quadratureNewtonCotes(function funB(),
+      pos + pi/2 - beta/2, pos + pi/2  + beta/2, N=N, d=3)
+      \"Flux linkage using 3/8-rule\";
+    SI.MagneticFlux psi4=Bpeak*wlD*quadratureNewtonCotes(function funB(),
+      pos + pi/2 - beta/2, pos + pi/2  + beta/2, N=N, d=4)
+      \"Flux linkage using Boole's rule\";
+    SI.MagneticFlux psi5=Bpeak*wlD*quadratureNewtonCotes(function funB(),
+      pos + pi/2 - beta/2, pos + pi/2  + beta/2, N=N, d=5)
+      \"Flux linkage using Newton-Cotes d=5\";
+    SI.MagneticFlux psi6=Bpeak*wlD*quadratureNewtonCotes(function funB(),
+      pos + pi/2 - beta/2, pos + pi/2  + beta/2, N=N, d=6)
+      \"Flux linkage using Newton-Cotes d=6\";
+  protected
+    constant SI.Time Tend=1 \"Stop time of simulation\";
+  initial equation
+    annotation (experiment(
+        StopTime=1,
+        Interval=0.001,
+        Tolerance=1e-06), Documentation(info=\"<html>
+<p>
+This example tests quadrature functions:
+</p>
+<p>
+The function <code>funB</code> defines the spatial distribution of the flux density with respect to the rotor surface.
+</p>
+<p>
+As the rotor position increases, the flux linkage of a coil of width <code>&beta;</code> is caculated 
+by integration over the interval <code>[pos + &pi;/2 - beta/2, pos + &pi;/2 + &beta;/2]</code>.
+</p>
+<p>
+The maximum of the flux linkage <code>psi0</code> is calculated analytically. 
+</p>
+<ul>
+<li><code>psi1</code> is the result of the moving integral using <strong>d=1 trapezoidal rule</strong></li>
+<li><code>psi2</code> is the result of the moving integral using <strong>d=2 Simpson's rule</strong></li>
+<li><code>psi3</code> is the result of the moving integral using <strong>d=3 3/8-rule</strong></li>
+<li><code>psi4</code> is the result of the moving integral using <strong>d=4 Boole's rule</strong></li>
+<li><code>psi5</code> is the result of the moving integral using <strong>d=5 Newton-Cotes</strong></li>
+<li><code>psi6</code> is the result of the moving integral using <strong>d=6 Newton-Cotes</strong></li>
+</ul>
+<p>
+At <code>time = 0</code>, the positive maximum of flux density distribution is at <code>pos = &pi;/2</code>, 
+the coil spans the angle <code>[&pi;/2; - &beta;/2, &pi;/2; + &beta;/2]</code>. Therefore the flux linkage has a maximum.
+</p>
+<p>
+Since flux linkage is not differentiable, a derivative with first-order lag is used to calculate induce voltage.
+</p>
+</html>\"),
+      Diagram(graphics={
+          Ellipse(extent={{-72,-18},{-68,-22}}, lineColor={28,108,200}),
+          Ellipse(extent={{-12,-18},{-8,-22}}, lineColor={28,108,200}),
+          Text(
+            extent={{-56,0},{-24,-10}},
+            textColor={28,108,200},
+            textString=\"beta\"),
+          Line(
+            points={{-70,-10},{-10,-10}},
+            color={28,108,200},
+            arrow={Arrow.Open,Arrow.Open}),
+          Line(points={{-80,0},{-68.7,34.2},{-61.5,53.1},{-55.1,66.4},{-49.4,74.6},
+                {-43.8,79.1},{-38.2,79.8},{-32.6,76.6},{-26.9,69.7},{-21.3,59.4},{
+                -14.9,44.1},{-6.83,21.2},{10.1,-30.8},{17.3,-50.2},{23.7,-64.2},{29.3,
+                -73.1},{35,-78.4},{40.6,-80},{46.2,-77.6},{51.9,-71.5},{57.5,-61.9},
+                {63.9,-47.2},{72,-24.8},{80,0}},              smooth = Smooth.Bezier,
+            pattern=LinePattern.Dash)}));
+  end MovingIntegralSinusoidal;
+
+  function quadratureNewtonCotes1
+    \"Quadrature using the Newton-Cotes formulas\"
+    extends Modelica.Icons.Function;
+    input Modelica.Math.Nonlinear.Interfaces.partialScalarFunction f \"Integrand function\";
+    input Real a \"Lower limit of integration interval\";
+    input Real b \"Upper limit of integration interval\";
+    input Integer N = 360 \"Number of intervals\";
+    input Integer d(final min=1, final max=6) = 1 \"Degree of interpolation polynominal\";
+    output Real integral \"Integral value\";
+  protected
+    constant Real c[6,7]={
+      { 1,  1,  0,  0,  0,  0, 0},
+      { 1,  4,  1,  0,  0,  0, 0},
+      { 1,  3,  3,  1,  0,  0, 0},
+      { 7, 32, 12, 32,  7,  0, 0},
+      {19, 75, 50, 50, 75, 19, 0},
+      {41,216, 27,272, 27,216,41}} \"Coefficients\";
+    Integer n=N + mod(N, d) \"Ensure number of intervals is a multiple of d\";
+    Real h=(b - a)/n \"Width of intervals\";
+  algorithm
+    integral:=sum({sum({c[d, k + 1]*f(a + h*(kp + k - d)) for k in 0:d})
+      for kp in d:d:n})*h*d/sum(c[d,:]);
+    annotation (Documentation(info=\"<html>
+<h4>Syntax</h4>
+<blockquote><pre>
+<strong>quadratureNewtonCotes</strong>(function f(), a, b);
+<strong>quadratureNewtonCotes</strong>(function f(), a, b, N=1440);
+<strong>quadratureNewtonCotes</strong>(function f(), a, b, N=1440, d=1);
+</pre></blockquote>
+
+<h4>Description</h4>
+<p>
+Compute definite integral over function f(u,...) from u=a up to u=b using the 
+<a href=\\\"https://en.wikipedia.org/wiki/Newton%E2%80%93Cotes_formulas#Closed_Newton%E2%80%93Cotes_formulas\\\">closed Newton-Cotes formulas</a>.
+</p>
+<p>
+<code>N</code> refers to the number of intervals to be used, including the intermediate points for <code>d &ge; 2</code>.<br>
+<code>1 &le; d &le; 4</code> refers to the degree of the used interpolation polynomial.
+</p>
+</html>\"));
+  end quadratureNewtonCotes1;
+
+  function quadratureNewtonCotes2 \"Quadrature using the Newton-Cotes formulas\"
+    extends Modelica.Icons.Function;
+    input Modelica.Math.Nonlinear.Interfaces.partialScalarFunction f \"Integrand function\";
+    input Real a \"Lower limit of integration interval\";
+    input Real b \"Upper limit of integration interval\";
+    input Integer N = 360 \"Number of intervals\";
+    input Integer d(final min=1, final max=6) = 1 \"Degree of interpolation polynominal\";
+    output Real integral \"Integral value\";
+  protected
+    constant Real c[6,7]={
+      { 1,  1,  0,  0,  0,  0, 0},
+      { 1,  4,  1,  0,  0,  0, 0},
+      { 1,  3,  3,  1,  0,  0, 0},
+      { 7, 32, 12, 32,  7,  0, 0},
+      {19, 75, 50, 50, 75, 19, 0},
+      {41,216, 27,272, 27,216,41}} \"Coefficients\";
+    Integer n=N + mod(N, d) \"Ensure number of intervals is a multiple of d\";
+    Real h=(b - a)/n \"Width of intervals\";
+    Real y[n + 1] \"Function evaluation at interval borders\";
+  algorithm
+    y:={f(a + h*k) for k in 0:n};
+    integral:=sum({sum({c[d, k + 1]*y[kp + k + 1 - d] for k in 0:d})
+      for kp in d:d:n})*h*d/sum(c[d,:]);
+    annotation (Documentation(info=\"<html>
+<h4>Syntax</h4>
+<blockquote><pre>
+<strong>quadratureNewtonCotes</strong>(function f(), a, b);
+<strong>quadratureNewtonCotes</strong>(function f(), a, b, N=1440);
+<strong>quadratureNewtonCotes</strong>(function f(), a, b, N=1440, d=1);
+</pre></blockquote>
+
+<h4>Description</h4>
+<p>
+Compute definite integral over function f(u,...) from u=a up to u=b using the 
+<a href=\\\"https://en.wikipedia.org/wiki/Newton%E2%80%93Cotes_formulas#Closed_Newton%E2%80%93Cotes_formulas\\\">closed Newton-Cotes formulas</a>.
+</p>
+<p>
+<code>N</code> refers to the number of intervals to be used, including the intermediate points for <code>d &ge; 2</code>.<br>
+<code>1 &le; d &le; 4</code> refers to the degree of the used interpolation polynomial.
+</p>
+</html>\"));
+  end quadratureNewtonCotes2;
+  annotation (uses(Modelica(version=\"4.1.0\")));
+end IntegralNewtonCotes;
+");
+getErrorString();
+
+simulate(IntegralNewtonCotes.MovingIntegralSinusoidal, stopTime = 1.0);
+getErrorString();
+
+// psi0 is the analytical result, psi1 to psi6 are the quadratures.
+val(psi0, 0.0);
+val(psi1, 0.0);
+val(psi2, 0.0);
+val(psi3, 0.0);
+val(psi4, 0.0);
+val(psi5, 0.0);
+val(psi6, 0.0);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "IntegralNewtonCotes.MovingIntegralSinusoidal_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 1000, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'IntegralNewtonCotes.MovingIntegralSinusoidal', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 0.5
+// 0.49998730754306964
+// 0.5000000002577646
+// 0.5000000005799907
+// 0.4999999999999701
+// 0.49999999999993566
+// 0.5
+// endResult

--- a/testsuite/simulation/modelica/algorithms_functions/Makefile
+++ b/testsuite/simulation/modelica/algorithms_functions/Makefile
@@ -26,7 +26,9 @@ FunctionIndirectRecursion.mos \
 FunctionIndirectRecursion2.mos \
 FunctionInReinit.mos \
 FunctionPointer.mos \
+FunctionPointerArray.mos \
 FunctionTupleRecord.mos \
+IntegralNewtonCotes.mos \
 Interpolation.mos \
 InverseAlgorithm1.mos \
 InverseAlgorithm2.mos \


### PR DESCRIPTION
[NB] Unbox the result of a function pointer call

Fixes #16543.

## Problem

Calling a functional input argument (a *function pointer*) goes through the
`boxptr_` wrapper of the actual function, so it returns a boxed value. The
parameters of a partial function are boxed accordingly by the frontend
(`NFFunction.boxFunctionParameter`), which makes the return type of such a call
`METABOXED(Real)`.

That boxed type was only ever undone for scalar contexts, by the type check of
the surrounding assignment or operator. Whenever the call ended up as an
element of an array constructor, an array literal or a reduction, the boxed
type was lifted into the array type and leaked all the way to the code
generator, which then emitted a `metatype_array` for what is a `Real[:]`:

```c
metatype_array tmp4;
...
simple_alloc_1d_metatype_array(&__omcQ_24tmpVar5,tmp8);
metatype_array_get1(__omcQ_24tmpVar5, 1, tmp3++) = __omcQ_24tmpVar4;
...
real_array_copy_data(tmp4, _y);
```

`metatype_array` only exists for MetaModelica, so the generated model does not
compile:

```
MovingIntegralSinusoidal_functions.c:20:3: error: use of undeclared identifier 'metatype_array'
MovingIntegralSinusoidal_functions.c:53:5: error: call to undeclared function 'simple_alloc_1d_metatype_array'
...
10 errors generated.
```

A reduction over such an array constructor failed even earlier, during
translation:

```
Error: Internal error NFExpression.makeZero failed for: Real
```

## Fix

`NFCall.typeCallExp` now unboxes the result of a function pointer call right
away, when the unboxed type is a builtin scalar type, so that the rest of the
expression only ever sees the real type. This is exactly what the scalar case
already did through the type check, so the generated code for those is
unchanged; the array cases now get a `real_array` and the correct
`mmc_unbox_real` per element.

## Reproducer

From the ticket, `quadratureNewtonCotes2` stores the function values in an
array before summing them up (`quadratureNewtonCotes1`, which calls the
function inside the sum, was fine):

```mo
function quadratureNewtonCotes2
  input Modelica.Math.Nonlinear.Interfaces.partialScalarFunction f;
  input Real a, b;
  input Integer N = 360;
  input Integer d(final min=1, final max=6) = 1;
  output Real integral;
protected
  Integer n = N + mod(N, d);
  Real h = (b - a)/n;
  Real y[n + 1];
algorithm
  y := {f(a + h*k) for k in 0:n};
  integral := sum({sum({c[d, k + 1]*y[kp + k + 1 - d] for k in 0:d})
    for kp in d:d:n})*h*d/sum(c[d,:]);
end quadratureNewtonCotes2;
```

The model now simulates and the six quadratures agree with the analytical
result: `psi0 = 0.5` and `psi1 .. psi6 = 0.49998730754306964 ..  0.5` at
`time = 0`.

## Tests

Two new tests in `testsuite/simulation/modelica/algorithms_functions`, both of
which fail without the fix:

* `FunctionPointerArray.mos` — a function pointer call in an array
  constructor, in an array literal and in a reduction.
* `IntegralNewtonCotes.mos` — the model from the ticket, which will be part of
  MSL PR 4800.

---
Generated by Claude Code
