### PR TITLE
wasm FMU ME: crossing equations, failed solves, retry

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/artifact.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/artifact.rs
@@ -749,8 +749,12 @@ where
     match kind {
         InterfaceKind::ModelExchange => {
             let run = me::simulate(inst, md, opts).map_err(|e| e.to_string())?;
+            let retried = match run.retries {
+                0 => String::new(),
+                n => format!(", {n} retried steps"),
+            };
             let s = format!(
-                "{} steps, {} evaluations, {} Jacobians, {} state events, {} time events",
+                "{} steps, {} evaluations, {} Jacobians, {} state events, {} time events{retried}",
                 run.steps, run.calls, run.jacobians, run.state_events, run.time_events
             );
             Ok((run.recorder, s))

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -651,11 +651,28 @@ impl MeState {
 
     /// `functionODE` for the derivatives and the event indicators: a `--daeMode`
     /// model has no such partial evaluation, so it evaluates whole.
-    fn eval_ode(&mut self) -> driver::Result<()> {
+    fn eval_ode(&mut self) -> Result<(), Status> {
         if self.layout.dae_mode() {
             return self.update_if_needed();
         }
-        Engine.call1("functionODE", self.sim_data)
+        self.evaluate(|m| Engine.call1("functionODE", m.sim_data))
+    }
+
+    /// C's try block around one FMI call: a model error or an unsolved nonlinear
+    /// system is the master's to retry in Continuous Time Mode (`fmi3Discard`,
+    /// C's `IRES = -1`) and fails the call anywhere else.
+    fn evaluate(&mut self, f: impl FnOnce(&mut Self) -> driver::Result<()>) -> Result<(), Status> {
+        let mut e = Engine;
+        self.write_i32(self.layout.nls_fail_off, 0);
+        let region = self.continuous_time.then(|| driver::open_fmi_call_region(&mut e));
+        let run = f(self);
+        let absorbed = region.is_some_and(|save| driver::close_fmi_call_region(&mut e, save));
+        let unsolved = driver::take_nls_failure(&mut e, self.sim_data, &self.layout);
+        run.map_err(err_status)?;
+        if absorbed || unsolved {
+            return Err(if self.continuous_time { Status::Discard } else { Status::Error });
+        }
+        Ok(())
     }
 
     /// The state a value reference reads, when it is one of the continuous
@@ -699,16 +716,16 @@ impl MeState {
 
     /// C's `updateIfNeeded`. In Initialization Mode the update is the initial
     /// solve, with the sets made so far as start values.
-    fn update_if_needed(&mut self) -> driver::Result<()> {
+    fn update_if_needed(&mut self) -> Result<(), Status> {
         if !self.need_update {
             return Ok(());
         }
         // The point moved, so a Jacobian assembled at the old one is stale.
         self.jacobian_valid = false;
         if self.mode == Mode::Init {
-            self.run_init()?;
+            self.run_init().map_err(err_status)?;
         } else {
-            self.eval()?;
+            self.evaluate(|m| m.eval())?;
         }
         self.need_update = false;
         Ok(())
@@ -958,8 +975,8 @@ macro_rules! shared_instance_methods {
         let mut st = self.st.borrow_mut();
         // Only when something was set since the last solve: a get in Initialization
         // Mode has already run it otherwise.
-        if let Err(err) = st.update_if_needed() {
-            return err_status(err);
+        if let Err(status) = st.update_if_needed() {
+            return status;
         }
         st.mode = Mode::Ready;
         // `run_initialization` has run `initSample`, so the schedule is readable.
@@ -1128,9 +1145,7 @@ macro_rules! shared_instance_methods {
     }
     fn get_float64(&self, vrs: Vec<u32>) -> Result<Vec<f64>, Status> {
         let mut st = self.st.borrow_mut();
-        if let Err(err) = st.update_if_needed() {
-            return Err(err_status(err));
-        }
+        st.update_if_needed()?;
         let vrs = st.vrs.expand(&vrs);
         let mut out = Vec::with_capacity(vrs.len());
         for vr in vrs {
@@ -1149,9 +1164,7 @@ macro_rules! shared_instance_methods {
     }
     fn get_int32(&self, vrs: Vec<u32>) -> Result<Vec<i32>, Status> {
         let mut st = self.st.borrow_mut();
-        if let Err(err) = st.update_if_needed() {
-            return Err(err_status(err));
-        }
+        st.update_if_needed()?;
         let vrs = st.vrs.expand(&vrs);
         let mut out = Vec::with_capacity(vrs.len());
         for vr in vrs {
@@ -1168,9 +1181,7 @@ macro_rules! shared_instance_methods {
     // so widen/narrow around the i32.
     fn get_int64(&self, vrs: Vec<u32>) -> Result<Vec<i64>, Status> {
         let mut st = self.st.borrow_mut();
-        if let Err(err) = st.update_if_needed() {
-            return Err(err_status(err));
-        }
+        st.update_if_needed()?;
         let vrs = st.vrs.expand(&vrs);
         let mut out = Vec::with_capacity(vrs.len());
         for vr in vrs {
@@ -1194,9 +1205,7 @@ macro_rules! shared_instance_methods {
     }
     fn get_uint64(&self, vrs: Vec<u32>) -> Result<Vec<u64>, Status> {
         let mut st = self.st.borrow_mut();
-        if let Err(err) = st.update_if_needed() {
-            return Err(err_status(err));
-        }
+        st.update_if_needed()?;
         let vrs = st.vrs.expand(&vrs);
         let mut out = Vec::with_capacity(vrs.len());
         for vr in vrs {
@@ -1209,9 +1218,7 @@ macro_rules! shared_instance_methods {
     }
     fn get_boolean(&self, vrs: Vec<u32>) -> Result<Vec<bool>, Status> {
         let mut st = self.st.borrow_mut();
-        if let Err(err) = st.update_if_needed() {
-            return Err(err_status(err));
-        }
+        st.update_if_needed()?;
         let vrs = st.vrs.expand(&vrs);
         let mut out = Vec::with_capacity(vrs.len());
         for vr in vrs {
@@ -1230,9 +1237,7 @@ macro_rules! shared_instance_methods {
     }
     fn get_string(&self, vrs: Vec<u32>) -> Result<Vec<String>, Status> {
         let mut st = self.st.borrow_mut();
-        if let Err(err) = st.update_if_needed() {
-            return Err(err_status(err));
-        }
+        st.update_if_needed()?;
         let vrs = st.vrs.expand(&vrs);
         let mut out = Vec::with_capacity(vrs.len());
         for vr in vrs {
@@ -1447,9 +1452,7 @@ macro_rules! shared_instance_methods {
             return Err(Status::Error);
         }
         let mut st = self.st.borrow_mut();
-        if st.update_if_needed().is_err() {
-            return Err(Status::Error);
-        }
+        st.update_if_needed()?;
         let n = st.layout.n_states as usize;
         let rows: Vec<usize> = unknowns.iter().filter_map(|vr| st.derivative_index(*vr)).collect();
         let cols: Vec<usize> = knowns.iter().filter_map(|vr| st.state_index(*vr)).collect();
@@ -1514,9 +1517,7 @@ macro_rules! shared_instance_methods {
     /// derivative whatever order is asked for.
     fn get_output_derivatives(&self, requests: Vec<(u32, u32)>) -> Result<Vec<f64>, Status> {
         let mut st = self.st.borrow_mut();
-        if let Err(err) = st.update_if_needed() {
-            return Err(err_status(err));
-        }
+        st.update_if_needed()?;
         let mut out = Vec::with_capacity(requests.len());
         for (vr, _order) in requests {
             match st.vrs.resolve(vr) {
@@ -1578,21 +1579,12 @@ impl GuestModelExchangeInstance for Instance {
     /// getter. In DAE mode the derivatives are the importer's own, set as knowns
     /// of the residuals; in ODE mode a `--daeMode` model solves for them.
     ///
-    /// In Continuous Time Mode this is the master's integrator residual, so it holds
-    /// the region `dassl_res` does and answers `fmi3Discard` — C's `IRES = -1` — for
-    /// an absorbed model error.
+    /// In Continuous Time Mode this is the master's integrator residual, so it
+    /// answers `fmi3Discard` -- C's `IRES = -1` -- for a model error (see `evaluate`).
     fn get_continuous_state_derivatives(&self) -> Result<Vec<f64>, Status> {
         let mut st = self.st.borrow_mut();
         if st.need_update && (!st.dae_mode || st.mode == Mode::Init) {
-            let region = st.continuous_time.then(|| driver::open_integrator_region(&mut Engine));
-            let evaluated = st.eval_ode();
-            let discard = region.is_some_and(|save| driver::close_integrator_region(&mut Engine, save));
-            if let Err(err) = evaluated {
-                return Err(err_status(err));
-            }
-            if discard {
-                return Err(Status::Discard);
-            }
+            st.eval_ode()?;
         }
         let n = st.layout.n_states;
         let base = REAL_OFF + n * 8;
@@ -1600,19 +1592,19 @@ impl GuestModelExchangeInstance for Instance {
     }
     fn get_event_indicators(&self) -> Result<Vec<f64>, Status> {
         let mut st = self.st.borrow_mut();
-        let mut e = Engine;
         if st.need_update {
-            if let Err(err) = st.eval_ode() {
-                return Err(err_status(err));
-            }
+            st.eval_ode()?;
             st.need_update = false;
         }
         if st.layout.n_zc == 0 {
             return Ok(Vec::new());
         }
-        if e.call2(driver::MODEL_FN_ZC, st.sim_data, st.sim_data + st.layout.zc_off).is_err() {
-            return Err(Status::Error);
-        }
+        // C's root callbacks: a crossing may read an algebraic `functionODE` skips.
+        st.evaluate(|m| {
+            let mut e = Engine;
+            driver::eval_zc_equations(&mut e, m.sim_data, &m.layout)?;
+            e.call2(driver::MODEL_FN_ZC, m.sim_data, m.sim_data + m.layout.zc_off)
+        })?;
         Ok((0..st.layout.n_zc).map(|i| st.read_f64(st.layout.zc_off + i * 8)).collect())
     }
     fn get_continuous_states(&self) -> Result<Vec<f64>, Status> {
@@ -1640,7 +1632,7 @@ impl GuestModelExchangeInstance for Instance {
     ) -> Result<CompletedStepResult, Status> {
         let mut st = self.st.borrow_mut();
         // C's `internal_CompletedIntegratorStep`; it leaves `_need_update` set.
-        st.eval().map_err(err_status)?;
+        st.evaluate(|m| m.eval())?;
         // The only point the importer gives us to record the accepted step.
         driver::store_operators(&mut Engine, st.sim_data, &st.layout).map_err(err_status)?;
         st.need_update = true;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/me.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/me.rs
@@ -44,6 +44,8 @@ pub struct Run {
     pub time_events: u64,
     /// When the events happened, in order — what a plot marks and a test checks.
     pub event_times: Vec<f64>,
+    /// Discarded steps taken again at half the size.
+    pub retries: u64,
 }
 
 /// The value references DAE mode works through, out of the fmi-ls-dae manifest.
@@ -248,6 +250,10 @@ impl Ode for FmuOde<'_> {
     fn take_discard(&mut self) -> bool {
         core::mem::take(&mut self.discarded)
     }
+}
+
+fn is_discard(e: &Error) -> bool {
+    matches!(e, Error::Status { status: crate::api::Status::Discard, .. })
 }
 
 impl Dae for FmuOde<'_> {
@@ -680,29 +686,77 @@ pub fn simulate(
     let mut event_times = Vec::new();
     let mut cancelled = false;
     let mut terminated_at = None;
+    // C's `storeOldValues`.
+    let mut x_old = vec![0.0; ny];
+    let mut xp_old = vec![0.0; ny];
+    let mut retries = 0u64;
 
     'grid: for target in opts.output_times().skip(1) {
+        // C's `retry`: a discarded step is taken again to half way, that end is the
+        // row, and the grid point is skipped.
+        let mut halved: Option<f64> = None;
+        let mut sampled = false;
         while t < target - grid_epsilon(opts) {
             // A time event caps the step: the FMU must be asked at exactly that
             // time, never stepped past it.
             let limit = next_event.max(t);
-            let root = integrator
-                .step(&mut ode, target, limit, &mut t, &mut x, &mut xp)
-                .map_err(|e| ode.failure.take().unwrap_or(Error::Solver(e)))?;
-
-            let mut event_at = root;
-            // C's `completedIntegratorStep`: the FMU may want Event Mode for a
-            // reason the indicators do not show.
-            if needs_completed_step {
-                ode.commit_point(t, &x, &xp)?;
-                let done = ode.inst.completed_integrator_step(true)?;
-                if done.terminate {
-                    terminated_at = Some(t);
-                    break 'grid;
+            let end = halved.unwrap_or(target);
+            let t_old = t;
+            x_old.copy_from_slice(&x);
+            xp_old.copy_from_slice(&xp);
+            ode.discarded = false;
+            let stepped = (|| -> Result<(Option<f64>, bool, bool)> {
+                let root = integrator
+                    .step(&mut ode, end, limit, &mut t, &mut x, &mut xp)
+                    .map_err(|e| ode.failure.take().unwrap_or(Error::Solver(e)))?;
+                let mut event_at = root;
+                let mut terminate = false;
+                // C's `completedIntegratorStep`: the FMU may want Event Mode for a
+                // reason the indicators do not show.
+                if needs_completed_step {
+                    ode.commit_point(t, &x, &xp)?;
+                    let done = ode.inst.completed_integrator_step(true)?;
+                    terminate = done.terminate;
+                    if done.enter_event_mode {
+                        event_at = Some(t);
+                    }
                 }
-                if done.enter_event_mode {
-                    event_at = Some(t);
+                // The end of an event-free step is a row (C's `simulationUpdate`).
+                let reached = event_at.is_none()
+                    && next_event > t + grid_epsilon(opts)
+                    && t >= end - grid_epsilon(opts);
+                if reached {
+                    ode.commit_point(end, &x, &xp)?;
+                    t = end;
+                    let common: &mut dyn Fmi3 = ode.inst;
+                    rec.sample(common, t)?;
                 }
+                Ok((event_at, terminate, reached))
+            })();
+            let (mut event_at, terminate, reached) = match stepped {
+                Ok(v) => v,
+                Err(e) if halved.is_none() && (ode.discarded || is_discard(&e)) => {
+                    // C's `retrySimulationStep`: back to the accepted point.
+                    retries += 1;
+                    t = t_old;
+                    x.copy_from_slice(&x_old);
+                    xp.copy_from_slice(&xp_old);
+                    ode.forget_point();
+                    integrator.restart();
+                    halved = Some(t + 0.5 * (end - t));
+                    continue;
+                }
+                Err(e) if ode.discarded || is_discard(&e) => {
+                    // C's catch with `retry` already spent.
+                    return Err(Error::Simulation(format!(
+                        "model terminate | Simulation terminated by an assert at time: {t_old}"
+                    )));
+                }
+                Err(e) => return Err(e),
+            };
+            if terminate {
+                terminated_at = Some(t);
+                break 'grid;
             }
             if event_at.is_none() && next_event <= t + grid_epsilon(opts) {
                 event_at = Some(next_event);
@@ -711,7 +765,15 @@ pub fn simulate(
                 state_events += 1;
             }
 
-            let Some(te) = event_at else { continue };
+            let Some(te) = event_at else {
+                if reached {
+                    sampled = true;
+                    break;
+                }
+                continue;
+            };
+            // C clears `retry` with every accepted step, an event step included.
+            halved = None;
             t = te;
             event_times.push(te);
             ode.commit_point(t, &x, &xp)?;
@@ -752,11 +814,13 @@ pub fn simulate(
                 break 'grid;
             }
         }
-        // The grid point itself: the solver interpolated the states onto it.
-        ode.commit_point(target, &x, &xp)?;
-        t = target;
-        let common: &mut dyn Fmi3 = ode.inst;
-        rec.sample(common, t)?;
+        if !sampled {
+            // The grid point itself: the solver interpolated the states onto it.
+            ode.commit_point(target, &x, &xp)?;
+            t = target;
+            let common: &mut dyn Fmi3 = ode.inst;
+            rec.sample(common, t)?;
+        }
         if let Some(report) = opts.progress {
             report(t, &rec);
         }
@@ -783,6 +847,7 @@ pub fn simulate(
         state_events,
         time_events,
         event_times,
+        retries,
     })
 }
 

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_nls/src/lib.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_nls/src/lib.rs
@@ -400,6 +400,10 @@ pub const ERROR_NONLINEARSOLVER: u32 = 2;
 pub const ERROR_SIMULATION_STEP: u32 = 3;
 /// C's `handleEvents`: a model error there is not the step's to retry.
 pub const ERROR_EVENTHANDLING: u32 = 4;
+/// An exported FMU's `MMC_TRY_INTERNAL(simulationJumpBuffer)` around one FMI call:
+/// it catches as [`ERROR_INTEGRATOR`] does, while a violated `assert()` reports as
+/// [`ERROR_SIMULATION`]'s does — C's FMU export never raises the stage.
+pub const ERROR_FMI_CALL: u32 = 5;
 static ERROR_STAGE: [AtomicU32; 2] = [AtomicU32::new(ERROR_SIMULATION), AtomicU32::new(0)];
 
 /// Address of [`ERROR_STAGE`], so a driver marks a region with a store rather than
@@ -596,7 +600,7 @@ fn attempt_aborted() -> bool {
 /// [`note_assert`] and bails out instead of ending the run.
 pub fn recovering() -> bool {
     NLS_DEPTH.load(Ordering::Relaxed) > 0
-        || matches!(error_stage(), ERROR_INTEGRATOR | ERROR_NONLINEARSOLVER)
+        || matches!(error_stage(), ERROR_INTEGRATOR | ERROR_NONLINEARSOLVER | ERROR_FMI_CALL)
 }
 
 /// Whether a `throwStreamPrint` model error unwinds into a catcher: the solver

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/driver.rs
@@ -652,6 +652,9 @@ pub const ERROR_SIMULATION_STEP: i32 = 3;
 /// C's `handleEvents` stage: `getBestJumpBuffer` sends a model error raised here
 /// past the step's catch, so it ends the run instead of being retried.
 pub const ERROR_EVENTHANDLING: i32 = 4;
+/// An exported FMU's try block around one FMI call: it catches as
+/// [`ERROR_INTEGRATOR`] does, and reports as [`ERROR_SIMULATION`] does.
+pub const ERROR_FMI_CALL: i32 = 5;
 
 /// What a region displaced (C's `saveJumpState`), so regions nest.
 #[derive(Clone, Copy, Default)]
@@ -674,15 +677,15 @@ fn set_error_stage(e: &mut dyn SimEngine, addr: u32, stage: i32) -> StageSave {
     save
 }
 
-/// [`dassl_res`]'s region for a driver outside this module — an exported FMU, whose
-/// integrator is the importer's, so the callback is one FMI call.
-pub fn open_integrator_region(e: &mut dyn SimEngine) -> StageSave {
+/// C's `MMC_TRY_INTERNAL(simulationJumpBuffer)` in an exported FMU, whose integrator
+/// is the importer's — so the callback is one FMI call.
+pub fn open_fmi_call_region(e: &mut dyn SimEngine) -> StageSave {
     let addr = e.error_stage_addr();
-    set_error_stage(e, addr, ERROR_INTEGRATOR)
+    set_error_stage(e, addr, ERROR_FMI_CALL)
 }
 
 /// Close it, reporting the absorbed model error the caller answers `IRES = -1` to.
-pub fn close_integrator_region(e: &mut dyn SimEngine, save: StageSave) -> bool {
+pub fn close_fmi_call_region(e: &mut dyn SimEngine, save: StageSave) -> bool {
     let addr = e.error_stage_addr();
     took_error_stage(e, addr, save)
 }
@@ -953,13 +956,23 @@ fn assert_info(e: &dyn SimEngine, pa: &[i32; 9]) -> (AssertInfo, String) {
 /// recoverable, and `omc_assert_simulation` logs it in the integrator stage only
 /// under `LOG_SOLVER`. Consumes what the throw left; false for an engine failure.
 fn residual_model_throw(e: &mut dyn SimEngine, err: &str, t: f64) -> bool {
+    caught_model_throw(e, err, t, omclog::active(omclog::SOLVER))
+}
+
+/// C's `finishSimulation`: the simulation stage logs the block unconditionally, and
+/// the terminal row still follows.
+fn terminal_model_throw(e: &mut dyn SimEngine, err: &str, t: f64) -> bool {
+    caught_model_throw(e, err, t, true)
+}
+
+fn caught_model_throw(e: &mut dyn SimEngine, err: &str, t: f64, logged: bool) -> bool {
     let pending = e.take_pending_assert();
     if !is_model_throw(err) && pending.is_none() {
         return false;
     }
     clear_runtime_error();
     if let Some(pa) = pending
-        && omclog::active(omclog::SOLVER)
+        && logged
     {
         let (info, cond) = assert_info(e, &pa);
         log_assert_block(&info, &cond, t, pa[8] != 0);
@@ -1387,6 +1400,16 @@ fn report_nls_failure_at(e: &dyn SimEngine, sim_data: u32, nls_fail_off: u32) {
             format_g15(time),
         ),
     );
+}
+
+/// C's `equationNonlinear` throw for a host outside this module: reported and cleared.
+pub fn take_nls_failure(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> bool {
+    if read_i32(e, sim_data + layout.nls_fail_off).unwrap_or(0) == 0 {
+        return false;
+    }
+    report_nls_failure(e, sim_data, layout);
+    let _ = write_i32(e, sim_data + layout.nls_fail_off, 0);
+    true
 }
 
 /// Number of equidistant homotopy steps: C's `init_lambda_steps`, which `-ils`
@@ -3004,7 +3027,7 @@ fn eval_discrete(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Re
 }
 
 /// C's `function_ZeroCrossingsEquations`: what the crossing functions read.
-fn eval_zc_equations(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
+pub fn eval_zc_equations(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
     if layout.dae_mode() {
         return e.call2(MODEL_FN_DAE, sim_data, eval_stage::ZEROCROSS);
     }
@@ -3078,7 +3101,11 @@ pub fn emit_terminal_row(
     write_i32(e, sim_data + layout.rel_fresh_off, 1)?;
     let updated = refresh_relations(e, sim_data, layout).and_then(|_| iterate_discrete(e, sim_data, layout));
     write_i32(e, sim_data + layout.terminal_off, 0)?;
-    updated?;
+    if let Err(err) = updated
+        && !terminal_model_throw(e, err, time)
+    {
+        return Err(err);
+    }
     check_nls(e, sim_data, layout)?;
     capture_row(e, rows, sim_data, layout)?;
     check_asserts(e, sim_data, layout, omclog::WARNING)


### PR DESCRIPTION
At dev-544, 672 models verified under wasm-jit and not under wasm-jit-me, 455 of them Buildings. One bug in the component's event indicators and two missing pieces of C's step handling behind it.

**The crossing equations.** `fmi3GetEventIndicators` ran `functionODE` and then the crossing functions, as C's FMU export does. A crossing may read an algebraic no state derivative needs, and that equation is not in the ODE block: the backend keeps it in `equationsForZeroCrossings`, which C's runtime evaluates (`function_ZeroCrossingsEquations`) in every root callback and the artifact's own driver in its DASKR root function. The component never did, so the crossings were computed from whatever the last output sample had left in the slot. A model with no continuous states runs on euler in the master, and the two ends of a step then always agreed: `ModelicaTest.Blocks.Hysteresis` reported 0 state events against the standalone's 6, `CharacteristicIdealDiodes` 0 against 5. Under DASKR the flip was seen one sample late, shifting the thyristor bridges' events. The getter now runs `functionZeroCrossingsEquations` first (`eval_zc_equations` made public; the `ZEROCROSS` stage in DAE mode).

**Failed solves.** A nonlinear system that does not converge sets the model's `nls_fail` slot; the driver reads it after an evaluation and raises C's `equationNonlinear` throw, or answers `IRES = -1` from a residual. The component never read it, so a failed solve in any getter returned fmi3OK with the solver's last iterate:
`InvertingSchmittTrigger`'s saturation system fails exactly at t = 0.077
+ 0.1k and the ME face wrote those rows with `r2.v = 15.4` for 14. Every model evaluation of the component now goes through `evaluate`, C's try block around one FMI call: the failed solve is reported and cleared (`take_nls_failure`), and with an absorbed model error it answers fmi3Discard in Continuous Time Mode -- where the master's step is the thing to retry -- and fmi3Error elsewhere. The integrator region `get_continuous_state_derivatives` opened for #16539 moves in there, so the event indicators, the completed step and the getters a sample reads have it too.

**The step retry.** The master gets C's `retry`
(`perform_simulation.c.inc`): a step the FMU discards -- the integrator step, the completed step, or the row at its end -- is taken once more from the accepted point to half way, that end is a row, and the grid point is passed over; the next accepted step clears the flag, and a second discard ends the run with C's `model terminate` line. DASKR and SUNDIALS keep answering a discard with their own step-size control.

**The terminal update.** An `assert()` no state, algebraic or crossing needs carries only the discrete stage in `--daeMode`, so it is never evaluated while IDA integrates and first fires in `finishSimulation`'s terminal update, where C logs the block and still finishes. The standalone driver let that trap through unenriched ("wasm engine error ... unreachable", no result); `emit_terminal_row` now reports it as C's simulation stage does and goes on to the terminal row. The ME face, like C's FMU export, runs no terminal update.

**Verified** against the standalone `--simCodeTarget=wasm-jit` run of the same omc, `diffSimulationResults` at relTol 1e-3, DIFFER before and MATCH now:

| model                                            |
| ------------------------------------------------ |
| ModelicaTest.Blocks.{Hysteresis, Logical}        |
| Analog.Examples.CharacteristicIdealDiodes        |
| Analog.Examples.CharacteristicThyristors         |
| Analog.Examples.DemoPowerSupply                  |
| Analog.Examples.OpAmps.InvertingSchmittTrigger   |
| StateGraph.Examples.FirstExample_Variant2        |
| PowerConverters ... ThyristorBridge2mPulse_R     |
| PowerConverters ... HalfControlledBridge2mPulse  |
| Buildings ... CDL Validation (10 models sampled) |

A state + algebraic-crossing model under `-s fmi3:me:euler` went from 0 to the standalone's 10 state events; a permanently violated assert ends an ME run with "Simulation terminated by an assert at time: 0.499"; the `--daeMode` standalone matches C's terminal block line for line. The wasm FMI 3.0 ME/CS and the DAE-mode testsuite cases pass.

Assisted-by: Claude Fable 5.1

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
