### PR TITLE
CI: Temporarily disable OMEdit on macos

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -244,6 +244,7 @@ pipeline {
                 "-DCMAKE_CXX_COMPILER=g++",
                 "-DCMAKE_Fortran_COMPILER=gfortran",
                 "-DOM_QT_MAJOR_VERSION=5",          // Use Qt5 on old macOS machines
+                "-DOM_ENABLE_OMEDIT=OFF",           // webengine not available for now
                 "-DOM_OMC_ENABLE_COLPACK=OFF"])     // Disable ColPack (missing OpenMP)
             }
           }


### PR DESCRIPTION
/cc @AnHeuermann 
```
CMake Error at /opt/local/lib/cmake/Qt5/Qt5Config.cmake:28 (find_package):
  Could not find a package configuration file provided by
  "Qt5WebEngineWidgets" with any of the following names:
    Qt5WebEngineWidgetsConfig.cmake
    qt5webenginewidgets-config.cmake
```
