### PR TITLE
[Runtime] Unbox a function pointer result of array type as an array (#16549)

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -8063,7 +8063,9 @@ template daeExpUnbox(Exp exp, Context context, Text &preExp, Text &varDecls, Tex
 ::=
 match exp
 case exp as UNBOX(__) then
-  let ty = expTypeShort(exp.ty)
+  // An array is boxed with mmc_mk_modelica_array, see daeExpBox, so it has to
+  // be unboxed as an array and not as its element type.
+  let ty = if isArrayType(exp.ty) then "array" else expTypeShort(exp.ty)
   let res = daeExp(exp.exp,context,&preExp,&varDecls, &auxFunction)
   'mmc_unbox_<%ty%>(<%res%>)'
 end daeExpUnbox;

--- a/OMCompiler/SimulationRuntime/c/meta/meta_modelica_data.h
+++ b/OMCompiler/SimulationRuntime/c/meta/meta_modelica_data.h
@@ -193,7 +193,7 @@ typedef int mmc_switch_type;
 #define mmc_unbox_integer(X) MMC_UNTAGFIXNUM(X)
 #define mmc_unbox_real(X) mmc_prim_get_real(X)
 #define mmc_unbox_string(X) MMC_STRINGDATA(X)
-#define mmc_unbox_array(X) (*((base_array_t*)X))
+#define mmc_unbox_array(X) (*((base_array_t*)(X)))
 
 #define mmc_mk_integer mmc_mk_icon
 #define mmc_mk_boolean mmc_mk_bcon

--- a/testsuite/simulation/modelica/algorithms_functions/FunctionPointerArrayOutput.mos
+++ b/testsuite/simulation/modelica/algorithms_functions/FunctionPointerArrayOutput.mos
@@ -1,0 +1,87 @@
+// name: FunctionPointerArrayOutput
+// keywords: function pointer, array
+// status: correct
+// teardown_command: rm -rf FunctionPointerArrayOutput.Test* output.log
+//
+// The result of a function pointer call is boxed, and an array is boxed with
+// mmc_mk_modelica_array. Check that such a result is unboxed as an array and
+// not as its element type.
+//
+
+loadString("
+package FunctionPointerArrayOutput
+  partial function pfuncVec
+    input Real u;
+    output Real y[2];
+  end pfuncVec;
+
+  function funcVec
+    extends pfuncVec;
+  algorithm
+    y := {u, 2*u};
+  end funcVec;
+
+  partial function pfuncMat
+    input Real u;
+    output Real y[2,2];
+  end pfuncMat;
+
+  function funcMat
+    extends pfuncMat;
+  algorithm
+    y := {{u, 2*u}, {3*u, 4*u}};
+  end funcMat;
+
+  function evalVec
+    input FunctionPointerArrayOutput.pfuncVec f;
+    input Real u;
+    output Real y;
+  protected
+    Real values[2];
+  algorithm
+    values := f(u);
+    y := values[1] + values[2];
+  end evalVec;
+
+  function evalMat
+    input FunctionPointerArrayOutput.pfuncMat f;
+    input Real u;
+    output Real y;
+  protected
+    Real values[2,2];
+  algorithm
+    values := f(u);
+    y := values[1,1] + values[1,2] + values[2,1] + values[2,2];
+  end evalMat;
+
+  model Test
+    input Real u = 0; // prevent presolving
+    Real x, y;
+  equation
+    x = evalVec(function funcVec(), u + 1);
+    y = evalMat(function funcMat(), u + 1);
+    annotation(experiment(StopTime = 0));
+  end Test;
+end FunctionPointerArrayOutput;
+");
+getErrorString();
+
+simulate(FunctionPointerArrayOutput.Test);
+val(x, 0);
+val(y, 0);
+getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "FunctionPointerArrayOutput.Test_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'FunctionPointerArrayOutput.Test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// 3.0
+// 10.0
+// ""
+// endResult

--- a/testsuite/simulation/modelica/algorithms_functions/Makefile
+++ b/testsuite/simulation/modelica/algorithms_functions/Makefile
@@ -27,6 +27,7 @@ FunctionIndirectRecursion2.mos \
 FunctionInReinit.mos \
 FunctionPointer.mos \
 FunctionPointerArray.mos \
+FunctionPointerArrayOutput.mos \
 FunctionTupleRecord.mos \
 IntegralNewtonCotes.mos \
 Interpolation.mos \


### PR DESCRIPTION
[Runtime] Unbox a function pointer result of array type as an array

Fixes #16549.

## Problem

A functional input argument whose function returns an array could not be used
at all, the generated code did not compile. No array constructor is involved,
a plain assignment of the call result is enough:

```mo
function useArr
  input pfArr f;
  input Real x;
  output Real s;
protected
  Real v[2];
algorithm
  v := f(x);
  s := v[1] + v[2];
end useArr;
```

```
NonScalar.M1_functions.c:41:24: error: passing 'double' to parameter of incompatible type 'base_array_t' (aka 'struct base_array_s')
1 error generated.
```

A function pointer call goes through the `boxptr_` wrapper of the actual
function, which boxes an array result with `mmc_mk_modelica_array`. The
unboxing at the call site was generated as the *element* type instead.

## Fix

Two things, both in the unboxing direction only:

1. `daeExpUnbox` spelled the unbox function from `expTypeShort(ty)`, which for
   an array type returns the element type, so it emitted `mmc_unbox_real`
   instead of `mmc_unbox_array`. `daeExpBox` already special cases arrays the
   other way (`mmc_mk_modelica_array`) with the same `isArrayType` test, so
   this only makes the two directions symmetric again. `isArrayType` matches
   `DAE.T_ARRAY` only, so MetaModelica arrays (`T_METAARRAY`) are untouched.
2. `mmc_unbox_array` was missing the parentheses around its parameter. A
   function pointer call expands to a conditional expression (closure or no
   closure), so the cast bound to the condition alone and the result was
   `*(void*)`.

Any code that took the first path before did not compile, so no working code
can change behaviour.

Records returning from a functional input argument are still broken
(`error: call to undeclared function 'mmc_unbox_NonScalar_R'`); that needs the
separate `mmc_unbox_record` path and is left for later.

## Tests

`FunctionPointerArrayOutput.mos` in
`testsuite/simulation/modelica/algorithms_functions`, a vector and a matrix
returned through a functional input argument. It fails without the fix with
the error above.

---
Generated by Claude Code
