### PR TITLE
Linear-time backend passes on ScalableTestSuite

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -852,6 +852,8 @@ end protectedParametersFinder;
 // remove equal function calls equations stuff
 //
 // =============================================================================
+protected type IntArray = array<Integer>;
+
 public function removeEqualRHS "author: Frenkel TUD 2011-04
   Detects equal expressions of the form a=<exp> and b=<exp> and substitutes
   them to get speed up."
@@ -876,6 +878,9 @@ algorithm
       BackendDAE.Variables vars;
       BackendDAE.EquationArray eqns;
       list<Integer> changed;
+      array<Boolean> isChanged;
+      array<Integer> degree;
+      UnorderedMap<Integer, IntArray> ranks;
       Boolean isInitial;
       BackendDAE.EqSystem syst;
       AvlTreePathFunction.Tree funcs;
@@ -885,8 +890,16 @@ algorithm
         isInitial := BackendDAEUtil.isInitializationDAE(ishared);
         funcs := BackendDAEUtil.getFunctions(ishared);
         (syst, m, mT) := BackendDAEUtil.getAdjacencyMatrixfromOption(syst, BackendDAE.NORMAL(), SOME(funcs), isInitial);
-        // check equations
-        (m, (mT,_,_,changed,_)) := AdjacencyMatrix.traverseAdjacencyMatrix(m, removeEqualFunctionCallFinder, (mT,vars,eqns,{}, isInitial));
+        degree := arrayCreate(arrayLength(mT), 0);
+        for v in 1:arrayLength(mT) loop
+          arrayUpdate(degree, v, listLength(mT[v]));
+        end for;
+        ranks := UnorderedMap.new<IntArray>(Util.id, intEq);
+        isChanged := arrayCreate(arrayLength(m), false);
+        changed := {};
+        for pos in 1:arrayLength(m) loop
+          (eqns, changed) := removeEqualFunctionCallFinder(pos, m, mT, degree, ranks, vars, eqns, changed, isChanged, isInitial);
+        end for;
         // update arrayeqns and algorithms, collect info for wrappers
         syst.m := SOME(m); syst.mT := SOME(mT); syst.matching := BackendDAE.NO_MATCHING();
         syst := BackendDAEUtil.updateAdjacencyMatrix(syst, BackendDAE.NORMAL(), NONE(), changed, isInitial);
@@ -895,51 +908,117 @@ algorithm
 end removeEqualFunctionCallsWork;
 
 protected function removeEqualFunctionCallFinder "author: Frenkel TUD 2010-12"
-  input BackendDAE.AdjacencyMatrixElement elem;
   input Integer pos;
-  input tuple<BackendDAE.AdjacencyMatrixT,BackendDAE.Variables,BackendDAE.EquationArray,list<Integer>,Boolean> inTpl;
-  output list<Integer> outList;
-  output tuple<BackendDAE.AdjacencyMatrixT,BackendDAE.Variables,BackendDAE.EquationArray,list<Integer>,Boolean> outTpl;
+  input BackendDAE.AdjacencyMatrix m;
+  input BackendDAE.AdjacencyMatrixT mT;
+  input array<Integer> degree "of the variables";
+  input UnorderedMap<Integer, IntArray> ranks;
+  input BackendDAE.Variables vars;
+  input output BackendDAE.EquationArray eqns;
+  input output list<Integer> changed;
+  input array<Boolean> isChanged;
+  input Boolean isInitial;
+protected
+  DAE.Exp exp,e1,e2,ecr;
+  list<Integer> expvars, controleqns;
 algorithm
-  (outList,outTpl):=
-  matchcontinue inTpl
-    local
-      BackendDAE.AdjacencyMatrix mT;
-      list<Integer> changed;
-      BackendDAE.Variables vars;
-      BackendDAE.EquationArray eqns,eqns1;
-      DAE.Exp exp,e1,e2,ecr;
-      list<Integer> expvars;
-      list<Integer> controleqns,expvars1;
-      list<list<Integer>> expvarseqns;
-      Boolean isInitial;
-
-    case (mT,vars,eqns,changed,isInitial)
-      algorithm
-        // check number of vars in eqns
-        _::_ := elem;
-        BackendDAE.EQUATION(exp=e1,scalar=e2) := BackendEquation.get(eqns,pos);
-        // BackendDump.debugStrExpStrExpStr(("Test ",e1," = ",e2,"\n"));
-        (ecr,exp) := functionCallEqn(e1,e2,vars);
-        // TODO: Handle this with alias-equations instead?; at least they don't replace back to the original expression...
-        // failure(DAE.CREF(componentRef=_) = exp);
-        // failure(DAE.UNARY(operator=DAE.UMINUS(ty=_),exp=DAE.CREF(componentRef=_)) = exp);
-        // BackendDump.debugStrExpStrExpStr(("Found ",ecr," = ",exp,"\n"));
-        expvars := BackendDAEUtil.adjacencyRowExp(exp,vars,{},NONE(),BackendDAE.NORMAL(),isInitial);
-        // print("expvars "); BackendDump.debuglst((expvars,intString," ","\n"));
-        expvars1::expvarseqns := List.map2(BackendDAEUtil.uniqueRow(expvars),varEqns,pos,mT);
-        // print("expvars1 "); BackendDump.debuglst((expvars1,intString," ","\n"));;
-        controleqns := getControlEqns(expvars1,expvarseqns);
-        // print("controleqns "); BackendDump.debuglst((controleqns,intString," ","\n"));
-        (eqns1,changed) := removeEqualFunctionCall(controleqns,ecr,exp,eqns,changed);
-        //print("changed1 "); BackendDump.debuglst((changed1,intString," ","\n"));
-        //print("changed2 "); BackendDump.debuglst((changed2,intString," ","\n"));
-        // print("Next\n");
-      then ({},(mT,vars,eqns1,changed,isInitial));
-    case _
-      then ({},inTpl);
-  end matchcontinue;
+  try
+    _::_ := m[pos];
+    BackendDAE.EQUATION(exp=e1,scalar=e2) := BackendEquation.get(eqns,pos);
+    (ecr,exp) := functionCallEqn(e1,e2,vars);
+    // TODO: Handle this with alias-equations instead?; at least they don't replace back to the original expression...
+    expvars := BackendDAEUtil.uniqueRow(BackendDAEUtil.adjacencyRowExp(exp,vars,{},NONE(),BackendDAE.NORMAL(),isInitial));
+    _::_ := expvars;
+    controleqns := controlEqns(expvars, pos, m, mT, degree, ranks);
+    (eqns,changed) := removeEqualFunctionCall(controleqns,ecr,exp,eqns,changed,isChanged);
+  else
+  end try;
 end removeEqualFunctionCallFinder;
+
+protected function controlEqns
+  "The other equations containing every variable of the expression, in the
+   order of the first variable's row, collected from the least used one's row."
+  input list<Integer> expvars;
+  input Integer pos;
+  input BackendDAE.AdjacencyMatrix m;
+  input BackendDAE.AdjacencyMatrixT mT;
+  input array<Integer> degree;
+  input UnorderedMap<Integer, IntArray> ranks;
+  output list<Integer> eqns = {};
+protected
+  Integer first, least, eq;
+  array<Integer> rank;
+algorithm
+  first := intAbs(listHead(expvars));
+  least := first;
+  for v in expvars loop
+    if degree[intAbs(v)] < degree[least] then
+      least := intAbs(v);
+    end if;
+  end for;
+  for i in mT[least] loop
+    eq := intAbs(i);
+    if eq <> pos and rowContainsAll(m[eq], expvars) then
+      eqns := eq :: eqns;
+    end if;
+  end for;
+  eqns := listReverse(eqns);
+  if least <> first and not listEmpty(eqns) then
+    if degree[first] <= 64 then
+      eqns := list(intAbs(i) for i guard List.isMemberOnTrue(intAbs(i), eqns, intEq) in mT[first]);
+    else
+      rank := rowRanks(first, mT, arrayLength(m), ranks);
+      eqns := List.sort(eqns, function rankGt(rank = rank));
+    end if;
+  end if;
+end controlEqns;
+
+protected function rowContainsAll
+  input list<Integer> row;
+  input list<Integer> vars;
+  output Boolean all = true;
+algorithm
+  for v in vars loop
+    if not List.isMemberOnTrue(intAbs(v), row, absIntEq) then
+      all := false;
+      return;
+    end if;
+  end for;
+end rowContainsAll;
+
+protected function absIntEq
+  input Integer a, b;
+  output Boolean eq = intAbs(a) == intAbs(b);
+end absIntEq;
+
+protected function rowRanks "the position of each equation in the row of var, built once per variable"
+  input Integer var;
+  input BackendDAE.AdjacencyMatrixT mT;
+  input Integer numEqns;
+  input UnorderedMap<Integer, IntArray> ranks;
+  output array<Integer> rank;
+protected
+  Integer i = 1;
+algorithm
+  rank := match UnorderedMap.get(var, ranks)
+    case SOME(rank) then rank;
+    else
+      algorithm
+        rank := arrayCreate(numEqns, 0);
+        for eq in mT[var] loop
+          arrayUpdate(rank, intAbs(eq), i);
+          i := i + 1;
+        end for;
+        UnorderedMap.add(var, rank, ranks);
+      then rank;
+  end match;
+end rowRanks;
+
+protected function rankGt
+  input Integer a, b;
+  input array<Integer> rank;
+  output Boolean gt = rank[a] > rank[b];
+end rankGt;
 
 protected function functionCallEqn
 "author Frenkel TUD 2011-04"
@@ -984,75 +1063,32 @@ algorithm
   end match;
 end functionCallEqn;
 
-protected function varEqns
-"author Frenkel TUD 2011-04"
-  input Integer v;
-  input Integer pos;
-  input BackendDAE.AdjacencyMatrixT mT;
-  output list<Integer> outVarEqns;
-protected
-  list<Integer> vareqns,vareqns1;
-algorithm
-  vareqns := mT[intAbs(v)];
-  vareqns1 := List.map(vareqns, intAbs);
-  outVarEqns := List.removeOnTrue(intAbs(pos),intEq,vareqns1);
-end varEqns;
-
-protected function getControlEqns
-"author Frenkel TUD 2011-04"
-  input list<Integer> inVarsEqn;
-  input list<list<Integer>> inVarsEqns;
-  output list<Integer> outEqns;
-algorithm
-  outEqns := match(inVarsEqn,inVarsEqns)
-    local
-      list<Integer> a,b,c,d;
-      list<list<Integer>> rest;
-    case (a,{}) then a;
-    case (a,b::rest)
-      algorithm
-       c := List.intersectionOnTrue(a,b,intEq);
-       d := getControlEqns(c,rest);
-      then d;
-  end match;
-end getControlEqns;
-
 protected function removeEqualFunctionCall
 "author: Frenkel TUD 2011-04"
   input list<Integer> inEqsLst;
   input DAE.Exp inExp;
   input DAE.Exp inECr;
-  input BackendDAE.EquationArray inEqns;
-  input list<Integer> ichanged;
-  output BackendDAE.EquationArray outEqns;
-  output list<Integer> outEqsLst;
+  input output BackendDAE.EquationArray eqns;
+  input output list<Integer> changed;
+  input array<Boolean> isChanged;
+protected
+  BackendDAE.Equation eqn;
+  Integer i;
 algorithm
-  (outEqns,outEqsLst):=
-  matchcontinue inEqsLst
-    local
-      BackendDAE.EquationArray eqns;
-      BackendDAE.Equation eqn,eqn1;
-      Integer pos,i;
-      list<Integer> rest,changed;
-    case {} then (inEqns,ichanged);
-    case pos::rest
-      algorithm
-        eqn := BackendEquation.get(inEqns,pos);
-        //BackendDump.printEquationList({eqn});
-        //BackendDump.debugStrExpStrExpStr(("Repalce ",inExp," with ",inECr,"\n"));
-        (eqn1,(_,_,i)) := BackendDAETransform.traverseBackendDAEExpsEqnWithSymbolicOperation(eqn, replaceExp, (inECr,inExp,0));
-        //BackendDump.printEquationList({eqn1});
-        //print("i="); print(intString(i)); print("\n");
-        true := intGt(i,0);
-        eqns :=  BackendEquation.setAtIndex(inEqns,pos,eqn1);
-        changed := List.consOnTrue(not listMember(pos,ichanged),pos,ichanged);
-        (eqns,changed) := removeEqualFunctionCall(rest,inExp,inECr,eqns,changed);
-      then (eqns,changed);
-    case _::rest
-      algorithm
-        (eqns,changed) := removeEqualFunctionCall(rest,inExp,inECr,inEqns,ichanged);
-      then (eqns,changed);
-  end matchcontinue;
+  for pos in inEqsLst loop
+    try
+      eqn := BackendEquation.get(eqns,pos);
+      (eqn,(_,_,i)) := BackendDAETransform.traverseBackendDAEExpsEqnWithSymbolicOperation(eqn, replaceExp, (inECr,inExp,0));
+      if i > 0 then
+        eqns := BackendEquation.setAtIndex(eqns,pos,eqn);
+        if not isChanged[pos] then
+          arrayUpdate(isChanged, pos, true);
+          changed := pos::changed;
+        end if;
+      end if;
+    else
+    end try;
+  end for;
 end removeEqualFunctionCall;
 
 protected function replaceExp

--- a/OMCompiler/Compiler/BackEnd/Matching.mo
+++ b/OMCompiler/Compiler/BackEnd/Matching.mo
@@ -127,7 +127,7 @@ public function ContinueMatching "
 protected
   Integer i, j;
   array<Integer> eMarkIx, vMarkIx;
-  Integer eMarkN=0, vMarkN=0;
+  Integer eMarkN=0, vMarkN=0, eDead=0, vDead=0;
   Boolean success;
 algorithm
   vMark := arrayCreate(nVars, false);
@@ -139,11 +139,16 @@ algorithm
   while i <= nEqns loop
     j := ass2[i];
     if not (j>0 and ass1[j] == i) then
-      clearArrayWithKnownSetIndexes(eMark, eMarkIx, eMarkN);
-      clearArrayWithKnownSetIndexes(vMark, vMarkIx, vMarkN);
-      (success, eMarkN, vMarkN) := BBPathFound(i, m, eMark, vMark, ass1, ass2, eMarkIx, vMarkIx, 0, 0);
-      if not success then
+      // What a failed search visited is closed under alternating paths, so it
+      // stays marked and later searches skip it.
+      (success, eMarkN, vMarkN) := BBPathFound(i, m, eMark, vMark, ass1, ass2, eMarkIx, vMarkIx, eDead, vDead);
+      if success then
+        clearMarks(eMark, eMarkIx, eDead, eMarkN);
+        clearMarks(vMark, vMarkIx, vDead, vMarkN);
+      else
         perfectMatching := false;
+        eDead := eMarkN;
+        vDead := vMarkN;
         if stopAtSingularity then
           return;
         end if;
@@ -152,6 +157,16 @@ algorithm
     i := i+1;
   end while;
 end ContinueMatching;
+
+protected function clearMarks "Sets arr[arrIx[from+1:to]] to false"
+  input array<Boolean> arr;
+  input array<Integer> arrIx;
+  input Integer from, to;
+algorithm
+  for i in from+1:to loop
+    arrayUpdate(arr, arrIx[i], false);
+  end for;
+end clearMarks;
 
 public function BBMatching
   input BackendDAE.EqSystem inSys;

--- a/OMCompiler/Compiler/BackEnd/ResolveLoops.mo
+++ b/OMCompiler/Compiler/BackEnd/ResolveLoops.mo
@@ -63,6 +63,8 @@ import List;
 import Tearing;
 import Util;
 
+protected type IntList = list<Integer>;
+
 public function resolveLoops "author:Waurich TUD 2013-12
   traverses the equations and finds simple equations(i.e. linear functions
   withcoefficients of 1 or -1). if these equations form loops, they will be
@@ -208,7 +210,7 @@ algorithm
           // check if its worth to resolve the loops
           if isSome(optStructureMapping) then
             SOME((mapIndices,map,loops)) := optStructureMapping;
-            loops := List.filter1OnTrueAndUpdate(loops,evaluateTripleLoop,updateTripleLoop,(m_uncut,mapIndices,map));
+            loops := List.filter1OnTrueAndUpdate(loops,evaluateTripleLoop,updateTripleLoop,tripleLoopInfo(m_uncut,arrayLength(mT_uncut),mapIndices,map));
           else
             loops := List.filterOnFalse(loops,listEmpty);
             loops := List.filter1OnTrue(loops,evaluateLoop,(m_uncut,mT_uncut,eqCrossLst));
@@ -586,82 +588,79 @@ protected function removeEqualPaths
   input output list<list<Integer>> uniquePaths;
   input output list<Integer> mapIndices;
   input output BackendDAE.AdjacencyMatrix map;
-  input output list<Integer> accCrossNodes = {};
+  output list<Integer> accCrossNodes = {};
+protected
+  UnorderedMap<IntList, Integer> groups;
+  array<Integer> groupOf = arrayCreate(arrayLength(minAdj), 0);
+  array<Boolean> merged = arrayCreate(arrayLength(minAdj), false), collected = arrayCreate(arrayLength(minAdj), false);
+  Integer cn1, numGroups = 0, numMerged = 0;
+  list<Integer> row, nodes = crossNodes, rest, assigned, unassigned;
 algorithm
-  (minAdj,uniquePaths,mapIndices,map,accCrossNodes) := match crossNodes
-    local
-      Integer cn1;
-      list<Integer> rest, assigned = {}, unassigned = {};
-    case cn1::rest algorithm
-      if not listMember(cn1, accCrossNodes) then
-        accCrossNodes:=cn1::accCrossNodes;
-      end if;
-      for cn2 in rest loop
-        if HpcOmTaskGraph.equalLists(arrayGet(minAdj,cn1),arrayGet(minAdj,cn2)) then
-          assigned := cn2::assigned;
-          arrayUpdate(minAdj,cn2,{});
-          uniquePaths := removeNode(cn2,uniquePaths);
-        else
-          unassigned := cn2::unassigned;
-          if not listMember(cn2, accCrossNodes) then
-            accCrossNodes := cn2::accCrossNodes;
-          end if;
+  groups := UnorderedMap.new<Integer>(hashIntList, HpcOmTaskGraph.equalLists);
+  for node in crossNodes loop
+    row := arrayGet(minAdj, node);
+    if not UnorderedMap.contains(row, groups) then
+      numGroups := numGroups + 1;
+      UnorderedMap.add(row, numGroups, groups);
+    end if;
+    arrayUpdate(groupOf, node, UnorderedMap.getOrFail(row, groups));
+  end for;
+  while not listEmpty(nodes) loop
+    cn1 :: rest := nodes;
+    if not collected[cn1] then
+      arrayUpdate(collected, cn1, true);
+      accCrossNodes := cn1 :: accCrossNodes;
+    end if;
+    assigned := {};
+    unassigned := {};
+    for cn2 in rest loop
+      if groupOf[cn2] == groupOf[cn1] then
+        assigned := cn2 :: assigned;
+        arrayUpdate(minAdj, cn2, {});
+        arrayUpdate(merged, cn2, true);
+        numMerged := numMerged + 1;
+      else
+        unassigned := cn2 :: unassigned;
+        if not collected[cn2] then
+          arrayUpdate(collected, cn2, true);
+          accCrossNodes := cn2 :: accCrossNodes;
         end if;
-      end for;
-      if not listEmpty(assigned) then
-         mapIndices := cn1::mapIndices;
-         map := Array.appendToElement(cn1, assigned, map);
       end if;
-      then removeEqualPaths(unassigned,minAdj,uniquePaths,mapIndices,map,accCrossNodes);
-    else (minAdj,uniquePaths,mapIndices,map,accCrossNodes);
-  end match;
+    end for;
+    if not listEmpty(assigned) then
+      mapIndices := cn1 :: mapIndices;
+      map := Array.appendToElement(cn1, assigned, map);
+    end if;
+    nodes := unassigned;
+  end while;
+  uniquePaths := list(path for path guard not pathContainsMerged(path, merged) in uniquePaths);
+  // removing them one at a time reversed the list once per node
+  if intMod(numMerged, 2) == 1 then
+    uniquePaths := listReverse(uniquePaths);
+  end if;
 end removeEqualPaths;
 
-protected function removeNode
-  "author: kabdelhak FHB 2019-06
-  Helper function for findEqualPathStructure. It removes all paths containing
-  a specific node."
-  input Integer node;
-  input list<list<Integer>> inPaths;
-  input output list<list<Integer>> accPaths={};
+protected function hashIntList
+  input list<Integer> lst;
+  output Integer hash = 17;
 algorithm
-  accPaths:=match inPaths
-    local
-      list<Integer> path;
-      list<list<Integer>> rest, acc;
-    case path::rest
-      algorithm
-        if not pathContainsNode(node,path) then
-          acc := path::accPaths;
-        else
-          acc := accPaths;
-        end if;
-      then removeNode(node,rest,acc);
-    case {}
-      then accPaths;
-  end match;
-end removeNode;
+  for i in lst loop
+    hash := intMod(hash * 31 + i, 65599);
+  end for;
+end hashIntList;
 
-protected function pathContainsNode
-  "author: kabdelhak FHB 2019-06
-  Helper function for findEqualPathStructure. Returns true, if the node is contained
-  in given path."
-  input Integer node;
-  input list<Integer> inPath;
-  output Boolean c;
+protected function pathContainsMerged
+  input list<Integer> path;
+  input array<Boolean> merged;
+  output Boolean c = false;
 algorithm
-  c := match inPath
-    local
-      Integer n;
-      list<Integer> rest;
-    case n::_ guard(intEq(n,node))
-      then true;
-    case _::rest
-      then pathContainsNode(node,rest);
-    case {}
-      then false;
-  end match;
-end pathContainsNode;
+  for n in path loop
+    if n <= arrayLength(merged) and merged[n] then
+      c := true;
+      return;
+    end if;
+  end for;
+end pathContainsMerged;
 
  protected function listContains
     input list<Integer> lst;
@@ -719,46 +718,97 @@ protected function getShortPathsBetweenEqCrossNodes"find closedLoops between 2 e
 author: vwaurich TUD 12-2016"
   input list<Integer> eqCrossLstIn;
   input AvlSetInt.Tree eqCrossSet;
-  input BackendDAE.AdjacencyMatrix mIn;
-  input BackendDAE.AdjacencyMatrixT mTIn;
+  input BackendDAE.AdjacencyMatrix mIn "rows sorted ascending";
+  input BackendDAE.AdjacencyMatrixT mTIn "rows sorted ascending";
   input list<list<Integer>> pathsIn;
   input Boolean findExactlyOneLoop;
-  output list<list<Integer>> pathsOut;
+  output list<list<Integer>> pathsOut = pathsIn;
+protected
+  Integer hub;
+  list<Integer> adjVars, adjEqs, newPath;
+  list<list<Integer>> paths;
 algorithm
-  pathsOut := match eqCrossLstIn
-    local
-      Integer crossEq, adjVar, adjEq;
-      list<Integer> rest, adjVars, newPath;
-      list<list<Integer>> paths = {};
-  case crossEq::rest
-    algorithm
-      //print("check crossEq "+intString(crossEq)+"\n");
-      adjVars := arrayGet(mIn, crossEq);
-      for adjVar in adjVars loop
-          //print("all adj eqs "+stringDelimitList(List.map(adjEqs, intString),",")+"\n");
-        //all adjEqs which are crossnodes as well
-        for adjEq in arrayGet(mTIn, adjVar) loop
-          if if adjEq > crossEq then (not AvlSetInt.hasKey(eqCrossSet, adjEq)) else true then
-            continue;
+  for crossEq in eqCrossLstIn loop
+    paths := {};
+    adjVars := arrayGet(mIn, crossEq);
+    // the row of a variable shared by most equations is not walked
+    hub := longestRow(adjVars, mTIn);
+    for adjVar in adjVars loop
+      adjEqs := if adjVar == hub then eqsSharingVia(adjVars, hub, mIn, mTIn) else arrayGet(mTIn, adjVar);
+      //all adjEqs which are crossnodes as well
+      for adjEq in adjEqs loop
+        if if adjEq > crossEq then (not AvlSetInt.hasKey(eqCrossSet, adjEq)) else true then
+          continue;
+        end if;
+        if hasSameIntSortedExcept(adjVars, arrayGet(mIn, adjEq), adjVar) then
+          newPath := adjEq::{crossEq};
+          paths := List.unionElt(newPath, paths);
+          if if findExactlyOneLoop then (not listEmpty(pathsOut)) else false then
+            fail();
           end if;
-          //print("all sharedVars "+stringDelimitList(List.map(sharedVars, intString),",")+"\n");
-          if hasSameIntSortedExcept(adjVars, arrayGet(mIn, adjEq), adjVar) then
-            newPath := adjEq::{crossEq};
-            // TODO: List.unionElt is slow
-            paths := List.unionElt(newPath, paths);
-            //print("found path "+stringDelimitList(List.map(newPath,intString)," ; ")+"\n");
-            if if findExactlyOneLoop then (not listEmpty(pathsIn)) else false then
-              fail();
-            end if;
-          end if;
-        end for;
+        end if;
       end for;
-      paths := getShortPathsBetweenEqCrossNodes(rest, eqCrossSet, mIn, mTIn, listAppend(paths, pathsIn), findExactlyOneLoop);
-    then paths;
-  case {}
-    then pathsIn;
-  end match;
+    end for;
+    pathsOut := listAppend(paths, pathsOut);
+  end for;
 end getShortPathsBetweenEqCrossNodes;
+
+protected function longestRow "walks the rows in lockstep, so a long row costs no more than the others"
+  input list<Integer> vars;
+  input BackendDAE.AdjacencyMatrixT mT;
+  output Integer var = 0;
+protected
+  list<tuple<Integer, list<Integer>>> rows = list((v, arrayGet(mT, v)) for v in vars), left;
+  Integer v;
+  list<Integer> row;
+algorithm
+  while not listEmpty(rows) loop
+    (var, _) := listHead(rows);
+    if listEmpty(listRest(rows)) then
+      return;
+    end if;
+    left := {};
+    for r in rows loop
+      (v, row) := r;
+      if not listEmpty(row) then
+        left := (v, listRest(row)) :: left;
+      end if;
+    end for;
+    rows := listReverse(left);
+  end while;
+end longestRow;
+
+protected function eqsSharingVia "the equations containing var and another of vars, ascending like the rows of mT"
+  input list<Integer> vars;
+  input Integer var;
+  input BackendDAE.AdjacencyMatrix m;
+  input BackendDAE.AdjacencyMatrixT mT;
+  output list<Integer> eqs = {};
+algorithm
+  for v in vars loop
+    if v <> var then
+      for eq in arrayGet(mT, v) loop
+        if sortedListContains(arrayGet(m, eq), var) then
+          eqs := eq :: eqs;
+        end if;
+      end for;
+    end if;
+  end for;
+  eqs := List.sortedUnique(List.sort(eqs, intGt), intEq);
+end eqsSharingVia;
+
+protected function sortedListContains
+  input list<Integer> lst "ascending";
+  input Integer x;
+  output Boolean found = false;
+algorithm
+  for i in lst loop
+    if i >= x then
+      found := i == x;
+      return;
+    end if;
+  end for;
+end sortedListContains;
 
 protected function connectsLoops "author:Waurich TUD 2014-02
   checks if the given path connects 2 closed simple Loops"
@@ -1666,34 +1716,88 @@ algorithm
   end if;
 end evaluateLoop;
 
+protected uniontype TripleLoopInfo
+  record TRIPLE_LOOP_INFO
+    BackendDAE.AdjacencyMatrix m;
+    list<Integer> mapIndices;
+    BackendDAE.AdjacencyMatrix map;
+    array<Integer> count "occurrences of each variable in the merged nodes' rows";
+    Integer entries, distinct, singles "of those rows";
+  end TRIPLE_LOOP_INFO;
+end TripleLoopInfo;
+
+protected function tripleLoopInfo
+  "Every triple loop is evaluated together with the rows of all merged nodes,
+   so those are counted once."
+  input BackendDAE.AdjacencyMatrix m;
+  input Integer numVars;
+  input list<Integer> mapIndices;
+  input BackendDAE.AdjacencyMatrix map;
+  output TripleLoopInfo info;
+protected
+  array<Integer> count = arrayCreate(numVars, 0);
+  Integer entries = 0, distinct = 0, singles = 0;
+algorithm
+  for i in mapIndices loop
+    for j in arrayGet(map,i) loop
+      (entries, distinct, singles) := countRow(arrayGet(m,j), count, entries, distinct, singles, 1);
+    end for;
+  end for;
+  info := TRIPLE_LOOP_INFO(m, mapIndices, map, count, entries, distinct, singles);
+end tripleLoopInfo;
+
+protected function countRow
+  input list<Integer> row;
+  input array<Integer> count;
+  input output Integer entries, distinct, singles;
+  input Integer delta "1 to add the row, -1 to remove it again";
+protected
+  Integer c;
+algorithm
+  for v in row loop
+    c := count[v] + delta;
+    arrayUpdate(count, v, c);
+    entries := entries + delta;
+    if delta > 0 then
+      if c == 1 then
+        distinct := distinct + 1;
+        singles := singles + 1;
+      elseif c == 2 then
+        singles := singles - 1;
+      end if;
+    else
+      if c == 0 then
+        distinct := distinct - 1;
+        singles := singles - 1;
+      elseif c == 1 then
+        singles := singles + 1;
+      end if;
+    end if;
+  end for;
+end countRow;
+
 protected function evaluateTripleLoop
   "author:kabdelhak FHB 2019-07
   Special case for loops containing three eqCrossNodes"
   input list<Integer> loopIn;
-  input tuple<BackendDAE.AdjacencyMatrix,list<Integer>,BackendDAE.AdjacencyMatrix> tplIn;
+  input TripleLoopInfo info;
   output Boolean resolve = true;
 protected
   Boolean r1,r2;
-  Integer n,numInLoop=0,numOutLoop=0;
-  BackendDAE.AdjacencyMatrix m,map;
-  list<Integer> mapIndices,chk={},dup={};
+  Integer entries, distinct, singles, numInLoop, numOutLoop;
 algorithm
   if not intEq(Flags.getConfigInt(Flags.RESHUFFLE),3) then
-//print("loopIn "+stringDelimitList(List.map(loopIn,intString),",")+"\n");
-    (m,mapIndices,map) := tplIn;
+    (entries, distinct, singles) := (info.entries, info.distinct, info.singles);
     for j in loopIn loop
-      (n, chk, dup) := countDoubleEntriesInLst(arrayGet(m,j), chk, dup);
-      numInLoop := numInLoop+ n;
+      (entries, distinct, singles) := countRow(arrayGet(info.m,j), info.count, entries, distinct, singles, 1);
     end for;
-    for i in mapIndices loop
-      for j in arrayGet(map,i) loop
-        (n, chk, dup) := countDoubleEntriesInLst(arrayGet(m,j), chk, dup);
-        numInLoop := numInLoop + n;
-      end for;
+    for j in loopIn loop
+      countRow(arrayGet(info.m,j), info.count, 0, 0, 0, -1);
     end for;
+    numInLoop := entries - distinct;
+    numOutLoop := singles;
 
     // check if its worth to resolve the loop. Therefore compare the amount of vars in and outside the loop
-    numOutLoop := listLength(chk)-listLength(dup);
     r1 := intGe(numInLoop,numOutLoop-1) and intLe(numInLoop,10);
     r2 := intGe(numInLoop,numOutLoop-2);
     r1 := if intEq(Flags.getConfigInt(Flags.RESHUFFLE),1) then r1 else false;
@@ -1705,14 +1809,10 @@ protected function updateTripleLoop
   "author:kabdelhak FHB 2019-07
   Update function for special case including for loops containing three eqCrossNodes"
   input output list<Integer> loopFull;
-  input tuple<BackendDAE.AdjacencyMatrix,list<Integer>,BackendDAE.AdjacencyMatrix> tplIn;
-protected
-  BackendDAE.AdjacencyMatrix map;
-  list<Integer> mapIndices;
+  input TripleLoopInfo info;
 algorithm
-  (_,mapIndices,map) := tplIn;
-  for i in mapIndices loop
-    loopFull := listAppend(arrayGet(map,i),loopFull);
+  for i in info.mapIndices loop
+    loopFull := listAppend(arrayGet(info.map,i),loopFull);
   end for;
 end updateTripleLoop;
 


### PR DESCRIPTION
Four backend passes grew with the square of the model size in the library testing of ScalableTestSuite and ScalableTestGrids (master run of 2026-09-02, measured with scaling-analyze.py from OpenModelicaLibraryTesting). Each is linear now, with the generated C byte-identical (modulo GUID) for 16 models, among them CauerLowPassAnalog, ChuaCircuit, Rectifier, SMPM_Inverter, HeatingSystem and DoublePendulum, and 796 rtest cases of the backend directories (initialization, daemode, indexreduction, tearing, dataReconciliation, equations, linear_system, nonlinear_system, others, events, algorithms_functions, arrays, records, synchronous, commonSubExp, resolveLoops) passing.

| pass                   | model                    | size    | before | after  |
| ---------------------- | ------------------------ | ------- | ------ | ------ |
| analyzeInitialSystem   | CascadedFirstOrder       | N=6400  | 2.93 s | 0.13 s |
| preOpt comSubExp       | SimpleAdvection          | N=12800 | 13.4 s | 0.33 s |
| preOpt removeEqualRHS  | PowerSystemStepLoad      | N=64    | 9.27 s | 0.46 s |
| preOpt resolveLoops    | TransmissionLineModelica | N=1280  | 10.9 s | 0.72 s |

analyzeInitialSystem: Matching.ContinueMatching searched an augmenting path from every unmatched equation with fresh marks, so a chain of failures re-walked every earlier failed search; balanceInitialSystem matches the initial system before the start-value equations exist, and the search from each unfixed der(x[i]) walked the chain x[i]..x[N]. What a failed search visits is closed under alternating paths (only matched variables and the equations they are matched to, with every variable of a visited equation visited), so no later augmenting path can enter it: those marks now stay and only a successful search's are cleared. The matching found is the same. The eMark/vMark outputs become the union of the failed searches, i.e. the structurally singular part, where they used to be whatever the last search touched; their only reader is the -d=initialization dump of fixInitialSystem.

comSubExp: CommonSubExpression.getCSE3 finds equation pairs sharing two variables through ResolveLoops.getShortPathsBetweenEqCrossNodes, which walked the rows of all variables of every cross node; a variable in most equations (the velocity in SimpleAdvection) was walked once per equation. The equations sharing that variable and another one are collected from the other variables' rows and sorted like the row was, so the same pairs are found in the same order. The most shared variable is found by walking the rows in lockstep, so its row costs no more than the others.

removeEqualRHS: the equations sharing every variable of a right-hand side were the intersection of the variables' rows, starting from the first, and List.intersectionOnTrue is the product of the lengths. The candidates come from the least used variable's row and are checked against the equation's own row; the result keeps the order of the first variable's row (filtered for a short row, sorted by a rank built once per variable for a long one), and "changed" is deduplicated with a mark array.

resolveLoops, on the equation-cross-nodes-only path: removeEqualPaths compared every cross node's row with every later one to merge equal ones; the rows get a group id from a map once, and the paths through merged nodes are dropped in one pass at the end, reversed once per merged node as removing them one at a time did. evaluateTripleLoop recounted the rows of all merged nodes for every triple loop with listMember over a growing list; the count only depends on the occurrences per variable, so the merged rows are counted once per partition and a loop adds and removes its own.

Assisted-by: Claude Fable 5.1

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
