### PR TITLE
[Runtime] Unbox a function pointer result of record type field by field (#16553)

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -277,13 +277,19 @@ public
       // input argument gives a boxed value. Unbox it here so the rest of the
       // expression sees the actual type, otherwise the boxed type leaks into
       // e.g. array constructors and reductions and gives invalid code.
-      if Type.isBoxed(ty) and Type.isScalarBuiltin(Type.unbox(ty)) and
+      if Type.isBoxed(ty) and isUnboxableType(Type.unbox(ty)) and
          Function.isFunctionPointer(typedFunction(ty_call)) then
         ty := Type.unbox(ty);
         outExp := Expression.UNBOX(outExp, ty);
       end if;
     end if;
   end typeCallExp;
+
+  function isUnboxableType
+    "Returns true for the types that the code generator knows how to unbox."
+    input Type ty;
+    output Boolean unboxable = Type.isScalarBuiltin(ty) or Type.isRecord(ty);
+  end isUnboxableType;
 
   function typeNormalCall
     input output NFCall call;

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -7740,7 +7740,9 @@ template daeExpReduction(Exp exp, Context context, Text &preExp,
        <% match typeof(r.expr)
         case T_COMPLEX(complexClassType = record_state) then
           let rec_name = '<%underscorePath(ClassInfUtil.getStateName(record_state))%>'
-          'alloc_generic_array(&<%res%>, sizeof(<%rec_name%>), 1, (_index_t)<%length%>);'
+          // There is no alloc_generic_array, a record array is allocated with
+          // the alloc_<record>_array macro generated for the record itself.
+          'alloc_<%rec_name%>_array(&<%res%>, 1, (_index_t)<%length%>);'
         case T_ARRAY(__) then
           let dimSizes = dims |> dim => match dim
             case DIM_INTEGER(__) then ', (_index_t)<%integer%>'
@@ -8062,6 +8064,14 @@ template daeExpUnbox(Exp exp, Context context, Text &preExp, Text &varDecls, Tex
  "Generates code for a match expression."
 ::=
 match exp
+case exp as UNBOX(ty = t as T_COMPLEX(complexClassType = RECORD(__))) then
+  // A record is boxed field by field, so it has to be unboxed field by field
+  // as well. unboxRecord wants the boxed value in a variable, so put the
+  // expression in a temporary first.
+  let res = daeExp(exp.exp,context,&preExp,&varDecls, &auxFunction)
+  let boxed = tempDecl("modelica_metatype", &varDecls)
+  let &preExp += '<%boxed%> = <%res%>;<%\n%>'
+  unboxRecord(boxed, t, &preExp, &varDecls)
 case exp as UNBOX(__) then
   // An array is boxed with mmc_mk_modelica_array, see daeExpBox, so it has to
   // be unboxed as an array and not as its element type.

--- a/testsuite/simulation/modelica/algorithms_functions/FunctionPointerRecordOutput.mos
+++ b/testsuite/simulation/modelica/algorithms_functions/FunctionPointerRecordOutput.mos
@@ -1,0 +1,88 @@
+// name: FunctionPointerRecordOutput
+// keywords: function pointer, record
+// status: correct
+// teardown_command: rm -rf FunctionPointerRecordOutput.Test* output.log
+//
+// The result of a function pointer call is boxed, and a record is boxed field
+// by field. Check that such a result is unboxed field by field again, both in
+// a plain assignment and in an array constructor.
+//
+
+loadString("
+package FunctionPointerRecordOutput
+  record Inner
+    Real p;
+    Integer q;
+  end Inner;
+
+  record R
+    Real a;
+    Boolean b;
+    Inner nested;
+  end R;
+
+  partial function pfunc
+    input Real u;
+    output R y;
+  end pfunc;
+
+  function func
+    extends pfunc;
+  algorithm
+    y := R(u, u > 0.5, Inner(2*u, 3));
+  end func;
+
+  function evalScalar
+    input FunctionPointerRecordOutput.pfunc f;
+    input Real u;
+    output Real y;
+  protected
+    R r;
+  algorithm
+    r := f(u);
+    y := r.a + r.nested.p + r.nested.q + (if r.b then 100 else 0);
+  end evalScalar;
+
+  function evalArrayConstructor
+    input FunctionPointerRecordOutput.pfunc f;
+    input Real u;
+    input Integer n = 2;
+    output Real y;
+  protected
+    R rs[n];
+  algorithm
+    rs := {f(u*k) for k in 1:n};
+    y := sum(rs[i].a + rs[i].nested.p for i in 1:n);
+  end evalArrayConstructor;
+
+  model Test
+    input Real u = 0; // prevent presolving
+    Real x, y;
+  equation
+    x = evalScalar(function func(), u + 1);
+    y = evalArrayConstructor(function func(), u + 1);
+    annotation(experiment(StopTime = 0));
+  end Test;
+end FunctionPointerRecordOutput;
+");
+getErrorString();
+
+simulate(FunctionPointerRecordOutput.Test);
+val(x, 0);
+val(y, 0);
+getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "FunctionPointerRecordOutput.Test_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'FunctionPointerRecordOutput.Test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// 106.0
+// 9.0
+// ""
+// endResult

--- a/testsuite/simulation/modelica/algorithms_functions/Makefile
+++ b/testsuite/simulation/modelica/algorithms_functions/Makefile
@@ -28,6 +28,7 @@ FunctionInReinit.mos \
 FunctionPointer.mos \
 FunctionPointerArray.mos \
 FunctionPointerArrayOutput.mos \
+FunctionPointerRecordOutput.mos \
 FunctionTupleRecord.mos \
 IntegralNewtonCotes.mos \
 Interpolation.mos \


### PR DESCRIPTION
[Runtime] Unbox a function pointer result of record type field by field

Fixes #16553.

## Problem

A functional input argument whose function returns a record could not be used.
The `boxptr_` wrapper boxes a record field by field with `mmc_mk_box3(3,
&R__desc, ...)`, but the unboxing at the call site was generated as a single
call to a function named after the record, which does not exist:

```
error: call to undeclared function 'mmc_unbox_NonScalar_R'
error: assigning to 'NonScalar_R' from incompatible type 'int'
```

A plain assignment of the call result is enough, no array is involved. Putting
the call in an array constructor instead failed with the boxed type leaking
into the array type, the same symptom as #16543 which was fixed for scalars
only:

```
error: use of undeclared identifier 'metatype_array'
error: call to undeclared function 'simple_alloc_1d_metatype_array'
```

## Fix

Three things:

1. `daeExpUnbox` now sends a record type to `unboxRecord`, which already knows
   how to rebuild a record from its boxed fields and recurses per field with
   that field's own type (so nested records and non-Real fields work too).
   `unboxRecord` wants the boxed value in a variable, so the expression goes
   into a `modelica_metatype` temporary first.
2. `NFCall.typeCallExp` unboxed the result of a function pointer call only for
   builtin scalar types (#16546). Records are now unboxed as well, so the boxed
   type no longer leaks into array constructors and reductions. The predicate
   is factored out as `isUnboxableType` since it has to stay in step with what
   the code generator can actually unbox.
3. The array constructor code for an array of records emitted
   `alloc_generic_array(&res, sizeof(Rec), 1, len)`, which does not exist. A
   record array is allocated with the `alloc_<record>_array` macro generated
   for the record itself, exactly as the surrounding code already does for the
   declared array.

Point 3 was unreachable before, because a record never got that far.

Array-returning functional input arguments are handled in #16549 / PR #16551.
That PR touches `daeExpUnbox` too, so whichever lands second needs a trivial
rebase. Arrays inside an array constructor still stay boxed, since
`isUnboxableType` deliberately does not claim arrays until #16551 is in.

## Tests

`FunctionPointerRecordOutput.mos` in
`testsuite/simulation/modelica/algorithms_functions`: a record with a Real, a
Boolean and a nested record with a Real and an Integer, returned through a
functional input argument, used both in a plain assignment and in an array
constructor. Both halves fail without the fix.

---
Generated by Claude Code
