### PR TITLE
Codegen and memory gaps from library testing

### DIFF
--- a/OMCompiler/Compiler/Main/Main.mo
+++ b/OMCompiler/Compiler/Main/Main.mo
@@ -724,6 +724,10 @@ algorithm
   ErrorExt.initAssertionFunctions();
   System.realtimeTick(ClockIndexes.RT_CLOCK_SIMULATE_TOTAL);
   args_1 := FlagsUtil.new(args);
+  // OpenBLAS sizes its thread pool from the environment when it loads.
+  if Flags.getConfigInt(Flags.NUM_PROC) == 1 then
+    System.setEnv("OPENBLAS_NUM_THREADS", "1", false);
+  end if;
   setDefaultCC();
   SymbolTable.reset();
   BackendInterfaceImplementation.initializeBackendInterface();

--- a/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/Cargo.toml
@@ -20,6 +20,7 @@ openmodelica_scripting_qt = { workspace = true, optional = true }
 openmodelica_script_util.workspace = true
 openmodelica_result_files.workspace = true
 openmodelica_util.workspace = true
+openmodelica_sim_meta.workspace = true
 # This build's revision, reported as the compiler version (`set_revision`).
 openmodelica_revision.workspace = true
 # Provides our exported `ModelicaAllocateString` (arena-backed) so the dlopen'd

--- a/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/lib.rs
@@ -87,6 +87,10 @@ pub use openmodelica_util::System::{omc_set_loadmodel_callback, omc_set_plot_cal
 // keep the `#[no_mangle]` symbols in `libOpenModelicaCompiler.so`.
 pub use openmodelica_util::ModelInstanceReference::*;
 
+// Ipopt/MUMPS's LAPACK entry points (same `pub use` rationale as above).
+#[cfg(not(target_arch = "wasm32"))]
+pub use openmodelica_sim_meta::lapack_dyn::*;
+
 /// Report this build's revision as the compiler version (`getVersion()`,
 /// `omc --version`); called by every entry point that starts a session.
 fn set_revision() {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -1798,6 +1798,13 @@ pub(crate) fn compile_include_library(
     }
 }
 
+const INCLUDE_PREAMBLE: &str = "\
+/* No preamble: the Modelica specification gives an external \"C\" translation unit
+   nothing beyond what its own Include sources bring in, so omc must not add headers
+   or declarations here. A library that fails to compile is fixed upstream, or gets
+   `-std=`/`-include` flags in the library-testing configuration. */
+";
+
 #[cfg(not(target_arch = "wasm32"))]
 fn compile_include_tu(
     prefix: &str,
@@ -1814,7 +1821,7 @@ fn compile_include_tu(
     std::fs::create_dir_all(&dir).map_err(|_| "CodegenWasmJit: cannot create a temporary directory")?;
     let tu = dir.join(format!("{prefix}_includes.c"));
     let out = dir.join(format!("{prefix}_includes.wasm"));
-    std::fs::write(&tu, includes.join("\n") + "\n" + wrappers)
+    std::fs::write(&tu, [INCLUDE_PREAMBLE, &includes.join("\n"), "\n", wrappers].concat())
         .map_err(|_| "CodegenWasmJit: cannot write the external \"C\" translation unit")?;
 
     let mut cmd = Command::new(&clang);
@@ -9575,39 +9582,6 @@ fn jac_listed_vars(jm: &SimCode::JacobianMatrix) -> Vec<SimCodeVar::SimVar> {
     columns.chain(ht).collect()
 }
 
-/// The Jacobian variables with a scratch slot each, and the array bases those slots
-/// scalarize from (`u.$pDER.dummyVar` for `u.$pDER.dummyVar[1]`, `[2]`).
-struct JacSlots {
-    keys: HashSet<String>,
-    bases: HashSet<String>,
-}
-
-impl JacSlots {
-    fn of(jm: &SimCode::JacobianMatrix) -> JacSlots {
-        let mut out = JacSlots { keys: HashSet::new(), bases: HashSet::new() };
-        for sv in lst(&jm.seedVars).chain(jac_column_vars(jm).iter()) {
-            if let Ok(key) = sim_cref_key(&sv.name) {
-                out.keys.insert(key);
-            }
-            if let Ok(Some((base, _))) = array_element_of(&sv.name) {
-                out.bases.insert(base);
-            }
-        }
-        out
-    }
-
-    /// Whether the emitter can name `cr`. A Jacobian variable has to *be* one of the
-    /// slots: the whole array whose elements hold them has none of its own (no
-    /// scratch array group exists), nor has an element behind a loop index.
-    /// Anything else is a model variable, which lowering resolves by itself.
-    fn resolvable(&self, cr: &Arc<DAE::ComponentRef>) -> bool {
-        match sim_cref_key(cr) {
-            Ok(key) => self.keys.contains(&key) || !self.bases.contains(&key) || self.bases.contains(&key),
-            Err(_) => true,
-        }
-    }
-}
-
 /// A cref's name with its final subscripts dropped, spelled as [`array_element_of`]
 /// spells an element's base.
 fn cref_base_name(cr: &Arc<DAE::ComponentRef>) -> Option<String> {
@@ -9643,16 +9617,15 @@ pub(crate) fn jac_lowerable(jm: &SimCode::JacobianMatrix) -> bool {
     if lst(&jm.seedVars).chain(listed.iter()).any(|sv| sim_cref_key(&sv.name).is_err()) {
         return false;
     }
-    let slots = JacSlots::of(jm);
-    lst(&col.constantEqns).chain(lst(&col.columnEqns)).all(|eq| jac_eq_lowerable(eq, &slots))
+    lst(&col.constantEqns).chain(lst(&col.columnEqns)).all(jac_eq_lowerable)
 }
 
 /// One column equation of a symbolic Jacobian, against what [`lower_equation`]
 /// accepts: a differentiated algebraic loop is a `SES_LINEAR`, a differentiated
 /// external or table call a `SES_ALGORITHM`.
-fn jac_eq_lowerable(eq: &SimCode::SimEqSystem, slots: &JacSlots) -> bool {
+fn jac_eq_lowerable(eq: &Arc<SimCode::SimEqSystem>) -> bool {
     use SimCode::SimEqSystem as E;
-    match eq {
+    match &**eq {
         // `lower_linear_system` needs either a usable `simJac` or the residuals of a
         // torn system; the inner equations run through `lower_equation` too.
         E::SES_LINEAR { lSystem, .. } => {
@@ -9661,13 +9634,14 @@ fn jac_eq_lowerable(eq: &SimCode::SimEqSystem, slots: &JacSlots) -> bool {
                 && lst(&lSystem.simJac).all(|(_, _, e)| matches!(&**e, E::SES_RESIDUAL { .. }))
                 && count(&lSystem.beqs) == count(&lSystem.vars);
             (torn || sim_jac)
-                && lst(&lSystem.residual).all(|e| jac_eq_lowerable(e, slots))
-                && lst(&lSystem.simJac).all(|(_, _, e)| jac_eq_lowerable(e, slots))
-                && lst(&lSystem.beqs).all(|e| exp_crefs_resolvable(e, slots))
+                && lst(&lSystem.residual).all(jac_eq_lowerable)
+                && lst(&lSystem.simJac).all(|(_, _, e)| jac_eq_lowerable(e))
+                && lst(&lSystem.beqs)
+                    .all(|e| openmodelica_frontend_base::Expression::extractCrefsFromExp(e.clone()).is_ok())
         }
         // The aliased equation is a model equation, which lowering handles anyway.
         E::SES_ALIAS { .. } => true,
-        _ => jac_eq_crefs(eq).is_some_and(|crs| crs.iter().all(|c| slots.resolvable(c))),
+        _ => jac_eq_crefs(eq).is_some(),
     }
 }
 
@@ -9731,12 +9705,6 @@ fn jac_eq_crefs(eq: &SimCode::SimEqSystem) -> Option<Vec<Arc<DAE::ComponentRef>>
         }
         _ => None,
     }
-}
-
-/// [`JacSlots::resolvable`] for every cref of an expression.
-fn exp_crefs_resolvable(e: &Arc<DAE::Exp>, slots: &JacSlots) -> bool {
-    openmodelica_frontend_base::Expression::extractCrefsFromExp(e.clone())
-        .is_ok_and(|crs| lst(&crs).all(|c| slots.resolvable(c)))
 }
 
 /// The residual rows of the Jacobian's `JAC_VAR` result variables, in

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -6790,6 +6790,11 @@ fn compile_sim_cref_read(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Op
             }
         }
     }
+    if sim_cref_key(cref).is_err() {
+        if let Some(wty) = try_emit_sim_array_box(ctx, cref)? {
+            return Ok(Some(wty));
+        }
+    }
     let key = sim_cref_key_fatal(cref)?;
     let slot = match ctx.sim()?.vars.get(&key) {
         Some(s) => *s,
@@ -6815,6 +6820,9 @@ fn compile_sim_cref_read(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Op
             }
             if try_emit_empty_sim_array(ctx, cref)? {
                 return Ok(Some(WTy::I32));
+            }
+            if let Some(wty) = try_emit_sim_array_box(ctx, cref)? {
+                return Ok(Some(wty));
             }
             if let Some(wty) = emit_sim_const_index_error(ctx, cref, &key)? {
                 return Ok(Some(wty));
@@ -7210,6 +7218,199 @@ fn try_emit_empty_sim_array(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result
     emit_array_alloc(ctx, obj, &elem, &dims)?;
     ctx.emit(we::Instruction::LocalGet(obj));
     Ok(true)
+}
+
+/// A whole array or slice whose elements have slots but no group (mixed variable
+/// kinds, Jacobian seed/pDER scratch): C's `daeExpCrefRhsArrayBox`. A constant
+/// selection is boxed directly; run-time subscripts box the whole array and index
+/// or slice it at run time.
+fn try_emit_sim_array_box(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Option<WTy>> {
+    let Some((leaf_ty, leaf_subs)) = cref_leaf(cref) else { return Ok(None) };
+    let Ok(dims) = const_dims(leaf_ty) else { return Ok(None) };
+    let elem = match sig_ty_quiet(array_elem_type(leaf_ty)) {
+        Ok(s @ (SigTy::Real | SigTy::Int | SigTy::Bool | SigTy::Str | SigTy::Record { .. })) => s,
+        _ => return Ok(None),
+    };
+    let subs: Vec<&Arc<DAE::Subscript>> = (&**leaf_subs).into_iter().collect();
+    if dims.is_empty() || subs.len() > dims.len() {
+        return Ok(None);
+    }
+    // Per axis: the selected 1-based indices, and whether the axis survives.
+    let mut axes: Vec<(Vec<i32>, bool)> = Vec::with_capacity(dims.len());
+    for (k, &d) in dims.iter().enumerate() {
+        let whole = ((1..=d as i32).collect(), true);
+        axes.push(match subs.get(k).map(|s| &***s) {
+            None | Some(DAE::Subscript::WHOLEDIM) | Some(DAE::Subscript::WHOLE_NONEXP { .. }) => whole,
+            Some(DAE::Subscript::INDEX { exp }) => match const_index_value(exp) {
+                Some(i) => (vec![i], false),
+                None => return box_then_select(ctx, cref, &dims, &elem, leaf_subs),
+            },
+            Some(DAE::Subscript::SLICE { exp }) => match const_index_list(exp) {
+                Some(v) => (v, true),
+                None => return box_then_select(ctx, cref, &dims, &elem, leaf_subs),
+            },
+        });
+    }
+    if axes.iter().all(|(_, keep)| !keep) {
+        return Ok(None);
+    }
+    emit_sim_array_box(ctx, cref, &axes, &elem)?;
+    Ok(Some(WTy::I32))
+}
+
+/// Box the whole array, then apply the run-time subscripts to the boxed value.
+fn box_then_select(
+    ctx: &mut FnCtx,
+    cref: &DAE::ComponentRef,
+    dims: &[u32],
+    elem: &SigTy,
+    subs: &Arc<List<Arc<DAE::Subscript>>>,
+) -> Result<Option<WTy>> {
+    let axes: Vec<(Vec<i32>, bool)> = dims.iter().map(|&d| ((1..=d as i32).collect(), true)).collect();
+    emit_sim_array_box(ctx, cref, &axes, elem)?;
+    let rank = dims.len() as u32;
+    if !is_scalar_index(subs, rank) {
+        return slice_loaded(ctx, subs).map(Some);
+    }
+    let obj = ctx.alloc_temp(WTy::I32);
+    ctx.emit(we::Instruction::LocalSet(obj));
+    ctx.emit(we::Instruction::LocalGet(obj));
+    ctx.emit(we::Instruction::I32Const(1));
+    ctx.emit(we::Instruction::Call(rt_index("rt_array_elem_ptr")?));
+    emit_sim_flat_index(ctx, dims, &index_subscripts(subs, rank)?)?;
+    let (_, stride) = sim_array_elem_kind_stride(elem.wty());
+    ctx.emit(we::Instruction::I32Const(stride as i32));
+    ctx.emit(we::Instruction::I32Mul);
+    ctx.emit(we::Instruction::I32Add);
+    let wty = elem.wty();
+    match wty {
+        WTy::F64 => ctx.emit(we::Instruction::F64Load(mem_arg(0, 3))),
+        WTy::I32 => ctx.emit(we::Instruction::I32Load(mem_arg(0, 2))),
+    }
+    emit_retain_top(ctx, elem.is_heap())?;
+    release_temp_array(ctx, obj)?;
+    Ok(Some(wty))
+}
+
+/// A fresh array of the elements `axes` select, row-major, each read through its
+/// own cref (a record element gathers its fields). Leaves the owned handle.
+fn emit_sim_array_box(
+    ctx: &mut FnCtx,
+    cref: &DAE::ComponentRef,
+    axes: &[(Vec<i32>, bool)],
+    elem: &SigTy,
+) -> Result<()> {
+    let out_dims: Vec<u32> = axes.iter().filter(|(_, keep)| *keep).map(|(v, _)| v.len() as u32).collect();
+    let total: u32 = out_dims.iter().product();
+    let (ek, stride) = (elem.elem_kind(), sim_array_elem_kind_stride(elem.wty()).1);
+    let obj = ctx.alloc_temp(WTy::I32);
+    ctx.emit(we::Instruction::I32Const(ek as i32));
+    ctx.emit(we::Instruction::I32Const(out_dims.len() as i32));
+    ctx.emit(we::Instruction::I32Const(total as i32));
+    ctx.emit(we::Instruction::Call(rt_index("rt_array_new")?));
+    ctx.emit(we::Instruction::LocalSet(obj));
+    for (axis, d) in out_dims.iter().enumerate() {
+        ctx.emit(we::Instruction::LocalGet(obj));
+        ctx.emit(we::Instruction::I32Const(axis as i32));
+        ctx.emit(we::Instruction::I32Const(*d as i32));
+        ctx.emit(we::Instruction::Call(rt_index("rt_array_set_dim")?));
+    }
+    let data = ctx.alloc_temp(WTy::I32);
+    ctx.emit(we::Instruction::LocalGet(obj));
+    ctx.emit(we::Instruction::I32Const(1));
+    ctx.emit(we::Instruction::Call(rt_index("rt_array_elem_ptr")?));
+    ctx.emit(we::Instruction::LocalSet(data));
+    for k in 0..total {
+        let mut rem = k as usize;
+        let mut index = vec![0i32; axes.len()];
+        for (axis, (sel, _)) in axes.iter().enumerate().rev() {
+            index[axis] = sel[rem % sel.len()];
+            rem /= sel.len();
+        }
+        let elem_cref = cref_with_leaf_subs(cref, &index);
+        ctx.emit(we::Instruction::LocalGet(data));
+        let w = if matches!(elem, SigTy::Record { .. }) {
+            if !try_emit_sim_record_gather(ctx, &elem_cref)? {
+                return Err("CodegenWasmJit: array element is not a record variable");
+            }
+            WTy::I32
+        } else {
+            compile_sim_cref_read(ctx, &elem_cref)?
+                .ok_or("CodegenWasmJit: array element is not a simulation variable")?
+        };
+        coerce(ctx, w, elem.wty());
+        let off = k * stride;
+        match elem.wty() {
+            WTy::F64 => ctx.emit(we::Instruction::F64Store(mem_arg(off, 3))),
+            WTy::I32 => ctx.emit(we::Instruction::I32Store(mem_arg(off, 2))),
+        }
+    }
+    ctx.emit(we::Instruction::LocalGet(obj));
+    Ok(())
+}
+
+fn cref_leaf(cr: &DAE::ComponentRef) -> Option<(&DAE::Type, &Arc<List<Arc<DAE::Subscript>>>)> {
+    use DAE::ComponentRef as C;
+    match cr {
+        C::CREF_QUAL { componentRef, .. } => cref_leaf(componentRef),
+        C::CREF_IDENT { identType, subscriptLst, .. } => Some((identType, subscriptLst)),
+        _ => None,
+    }
+}
+
+fn array_elem_type(ty: &DAE::Type) -> &DAE::Type {
+    match ty {
+        DAE::Type::T_ARRAY { ty, .. } => array_elem_type(ty),
+        other => other,
+    }
+}
+
+/// `cr` with its leaf subscripts replaced by the constant element index.
+fn cref_with_leaf_subs(cr: &DAE::ComponentRef, index: &[i32]) -> Arc<DAE::ComponentRef> {
+    use DAE::ComponentRef as C;
+    match cr {
+        C::CREF_IDENT { ident, identType, .. } => Arc::new(C::CREF_IDENT {
+            ident: ident.clone(),
+            identType: identType.clone(),
+            subscriptLst: Arc::new(
+                index
+                    .iter()
+                    .map(|i| Arc::new(DAE::Subscript::INDEX { exp: Arc::new(DAE::Exp::ICONST { integer: *i }) }))
+                    .collect(),
+            ),
+        }),
+        C::CREF_QUAL { ident, identType, subscriptLst, componentRef } => Arc::new(C::CREF_QUAL {
+            ident: ident.clone(),
+            identType: identType.clone(),
+            subscriptLst: subscriptLst.clone(),
+            componentRef: cref_with_leaf_subs(componentRef, index),
+        }),
+        other => Arc::new(other.clone()),
+    }
+}
+
+/// The 1-based indices a constant `SLICE` subscript selects: `lo:hi`, `lo:s:hi`
+/// or `{i, j, …}` of literals.
+fn const_index_list(exp: &DAE::Exp) -> Option<Vec<i32>> {
+    match exp {
+        DAE::Exp::RANGE { start, step, stop, .. } => {
+            let lo = const_index_value(start)?;
+            let hi = const_index_value(stop)?;
+            let step = step.as_ref().map_or(Some(1), |e| const_index_value(e))?;
+            if step == 0 {
+                return None;
+            }
+            let mut out = Vec::new();
+            let mut i = lo;
+            while if step > 0 { i <= hi } else { i >= hi } {
+                out.push(i);
+                i += step;
+            }
+            Some(out)
+        }
+        DAE::Exp::ARRAY { array, .. } => (&**array).into_iter().map(|e| const_index_value(e)).collect(),
+        _ => None,
+    }
 }
 
 /// C's `Expression.hasZeroDimension` for one dimension: a size known to be zero.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/Cargo.toml
@@ -96,6 +96,6 @@ rsparse = { version = "1.2", optional = true }
 opt-level = 3
 lto = true
 panic = "abort"
-strip = true
+strip = "debuginfo"
 
 [workspace]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/engine_config.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/engine_config.rs
@@ -1,18 +1,37 @@
-//! Size the JIT linear-memory reservation to the `RLIMIT_AS` budget.
+//! Size the JIT linear-memory reservation to the address-space budget: wasmtime
+//! reserves 4 GiB per 32-bit memory (plus guards, plus 2 GiB when one moves),
+//! which a `ulimit -v` counts.
 
-const FAST_PATH_MIN_AS: u64 = 8 * 1024 * 1024 * 1024;
-const CONSTRAINED_MIB: u64 = 256;
+const MIB: u64 = 1 << 20;
+const GIB: u64 = 1 << 30;
+// wasmtime's defaults.
+const FULL_RESERVATION: u64 = 4 * GIB;
+const GUARD: u64 = 32 * MIB;
+const GROWTH: u64 = 2 * GIB;
+const HOST_HEADROOM: u64 = GIB;
+const MIN_RESERVATION: u64 = 64 * MIB;
 
-fn reservation_bytes() -> Option<u64> {
+struct Budget {
+    reservation: u64,
+    growth: u64,
+}
+
+fn budget() -> Option<Budget> {
     if let Ok(s) = std::env::var("OMC_WASM_MEMORY_RESERVATION_MB") {
         if let Ok(mb) = s.trim().parse::<u64>() {
-            return Some(mb * 1024 * 1024);
+            let reservation = mb * MIB;
+            return Some(Budget { reservation, growth: reservation.min(GROWTH) });
         }
     }
-    match address_space_limit() {
-        Some(limit) if limit < FAST_PATH_MIN_AS => Some(CONSTRAINED_MIB * 1024 * 1024),
-        _ => None,
+    let limit = address_space_limit()?;
+    let avail = limit.saturating_sub(vm_size()).saturating_sub(HOST_HEADROOM);
+    // The session's runtime and its model can hold two memories at once.
+    let per_memory = avail / 2;
+    if per_memory >= FULL_RESERVATION + 2 * GUARD + GROWTH {
+        return None;
     }
+    let reservation = (per_memory / 2).clamp(MIN_RESERVATION, FULL_RESERVATION - 64 * MIB) & !(64 * 1024 - 1);
+    Some(Budget { reservation, growth: reservation })
 }
 
 #[cfg(target_os = "linux")]
@@ -31,9 +50,24 @@ fn address_space_limit() -> Option<u64> {
     None
 }
 
+#[cfg(target_os = "linux")]
+fn vm_size() -> u64 {
+    let pages = std::fs::read_to_string("/proc/self/statm")
+        .ok()
+        .and_then(|s| s.split_whitespace().next()?.parse::<u64>().ok())
+        .unwrap_or(0);
+    pages * unsafe { libc::sysconf(libc::_SC_PAGESIZE) }.max(0) as u64
+}
+
+#[cfg(not(target_os = "linux"))]
+fn vm_size() -> u64 {
+    0
+}
+
 /// `memory_may_move` (default on) lets a memory outgrow the reservation.
 pub fn tune_memory(cfg: &mut wasmtime::Config) {
-    if let Some(bytes) = reservation_bytes() {
-        cfg.memory_reservation(bytes);
+    if let Some(b) = budget() {
+        cfg.memory_reservation(b.reservation);
+        cfg.memory_reservation_for_growth(b.growth);
     }
 }

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -15543,6 +15543,43 @@ algorithm
   end match;
 end getSimCode;
 
+public function isContiguousArrayCref
+  "Whether the scalarized elements of an array cref occupy consecutive slots of
+   one variable array, so the C target may address them through the first one."
+  input DAE.ComponentRef inCref;
+  output Boolean outContiguous = true;
+protected
+  SimCode.SimCode simCode = getSimCode();
+  SimCodeVar.SimVar v;
+  Integer next = -1;
+  Boolean param, firstParam = false;
+algorithm
+  if not simCode.scalarized then
+    return;
+  end if;
+  for cr in ComponentReference.expandCref(inCref, true) loop
+    v := cref2simvar(cr, simCode);
+    // A cref the SimCode does not know is addressed through some other value
+    // array (a Jacobian's own), where the elements are consecutive again.
+    if v.index < 0 then
+      return;
+    end if;
+    // Parameters live in their own value array (`varArrayName`).
+    param := match v.varKind case BackendDAE.PARAM() then true; else false; end match;
+    if next == -1 then
+      firstParam := param;
+    end if;
+    outContiguous := match v.aliasvar
+      case SimCodeVar.NOALIAS() then param == firstParam and (next == -1 or v.index == next);
+      else false;
+    end match;
+    if not outContiguous then
+      return;
+    end if;
+    next := v.index + 1;
+  end for;
+end isContiguousArrayCref;
+
 public function cref2simvar
 "Used by templates to find SIMVAR for given cref (to gain representaion index info mainly)."
   input DAE.ComponentRef inCref;

--- a/OMCompiler/Compiler/Stubs/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/Stubs/SimCodeUtil.mo
@@ -67,6 +67,13 @@ algorithm
   assert(false, getInstanceName());
 end cref2simvar;
 
+function isContiguousArrayCref<A>
+  input A inCref;
+  output Boolean outContiguous;
+algorithm
+  assert(false, getInstanceName());
+end isContiguousArrayCref;
+
 function simVarFromHT<A,B>
   input A inCref;
   input B simCode;

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -5632,10 +5632,12 @@ template daeExpCrefRhsSimContext(Exp ecr, Context context, Text &preExp,
               let &sub = buffer '<%indexSubs(crefDims(cr), crefSubs(crefArrayGetFirstCref(cr)), context, &preExp, &varDecls, &auxFunction)%>'
               let nosubname = contextCref(crefStripSubs(cr), context, &preExp, &varDecls, &auxFunction, &sub)
               '((modelica_<%type%>*)&(<%nosubname%>))'
-            else
+            else if isContiguousArrayCref(cr) then
               let &sub = buffer ""
               let nosubname = contextCref(crefArrayGetFirstCref(cr), context, &preExp, &varDecls, &auxFunction, &sub)
               '((modelica_<%type%>*)&(<%nosubname%>))'
+            else
+              '((modelica_<%type%>*)<%daeExpCrefRhsArrayElems(cr, type, context, &preExp, &varDecls, &auxFunction)%>.data)'
           '<%type%>_array_create(&<%wrapperArray%>, <%arrayData%>, <%dimsLenStr%>, <%dimsValuesStr%>);<%\n%>'
       let &preExp += t
     wrapperArray
@@ -5643,8 +5645,11 @@ template daeExpCrefRhsSimContext(Exp ecr, Context context, Text &preExp,
       let &sub = buffer ""
       let dimsLenStr = listLength(crefDims(cr))
       let dimsValuesStr = (crefDims(cr) |> dim => '(_index_t)<%dimension(dim, context, &preExp, &varDecls, &auxFunction)%>' ;separator=", ")
-      let arrName = contextCref(crefStripSubs(cr), context, &preExp, &varDecls, &auxFunction, &sub)
-      let &preExp += '<%type%>_array_create(&<%wrapperArray%>, (modelica_<%type%>*)&<%arrName%>, <%dimsLenStr%>, <%dimsValuesStr%>);<%\n%>'
+      let arrData = if isContiguousArrayCref(crefStripSubs(cr)) then
+          '&<%contextCref(crefStripSubs(cr), context, &preExp, &varDecls, &auxFunction, &sub)%>'
+        else
+          '<%daeExpCrefRhsArrayElems(crefStripSubs(cr), type, context, &preExp, &varDecls, &auxFunction)%>.data'
+      let &preExp += '<%type%>_array_create(&<%wrapperArray%>, (modelica_<%type%>*)<%arrData%>, <%dimsLenStr%>, <%dimsValuesStr%>);<%\n%>'
       let slicedArray = tempDecl(arrayType, &varDecls)
       let spec1 = daeExpCrefIndexSpec(crefSubs(cr), context, &preExp, &varDecls, &auxFunction)
       let &preExp += 'index_alloc_<%type%>_array(&<%wrapperArray%>, &<%spec1%>, &<%slicedArray%>);<%\n%>'
@@ -5652,10 +5657,15 @@ template daeExpCrefRhsSimContext(Exp ecr, Context context, Text &preExp,
 
   case ecr as CREF(componentRef=cr, ty=ty) then
     if crefIsScalarWithVariableSubs(cr) then
-      let &sub = buffer '<%indexSubs(crefDims(cr), crefSubs(crefArrayGetFirstCref(cr)), context, &preExp, &varDecls, &auxFunction)%>'
-      let nosubname = contextCref(crefStripSubs(cr), context, &preExp, &varDecls, &auxFunction, &sub)
-      // let cast = typeCastContextInt(context, ty)
-      '<%nosubname%>'
+      if isContiguousArrayCref(crefStripSubs(cr)) then
+        let &sub = buffer '<%indexSubs(crefDims(cr), crefSubs(crefArrayGetFirstCref(cr)), context, &preExp, &varDecls, &auxFunction)%>'
+        let nosubname = contextCref(crefStripSubs(cr), context, &preExp, &varDecls, &auxFunction, &sub)
+        '<%nosubname%>'
+      else
+        let type = expTypeShort(ty)
+        let elems = daeExpCrefRhsArrayElems(crefStripSubs(cr), type, context, &preExp, &varDecls, &auxFunction)
+        let flat = indexSubRecursive(listReverse(List.restOrEmpty(crefDims(cr))), listReverse(crefSubs(crefArrayGetFirstCref(cr))), context, &preExp, &varDecls, &auxFunction)
+        '<%type%>_get(<%elems%>, <%flat%>)'
     else if boolAnd(Flags.getConfigBool(Flags.NEW_BACKEND), boolNot(Flags.getConfigBool(Flags.SIM_CODE_SCALARIZE))) then
       // Without sim code scalarization array elements like arr[2] are not
       // standalone simvars and have to be addressed relative to the first
@@ -5677,6 +5687,20 @@ template daeExpCrefRhsSimContext(Exp ecr, Context context, Text &preExp,
     else
       error(sourceInfo(),'daeExpCrefRhsSimContext: UNHANDLED CREF: <%ExpressionDumpTpl.dumpExp(ecr,"\"")%>')
 end daeExpCrefRhsSimContext;
+
+template daeExpCrefRhsArrayElems(ComponentRef cr, String type, Context context,
+                                 Text &preExp, Text &varDecls, Text &auxFunction)
+ "A fresh 1-D array of the elements of array cref cr, for elements that are not
+  consecutive in the variable arrays (a state beside an algebraic, an alias)."
+::=
+  let elems = (expandCref(cr, true) |> e =>
+      let &sub = buffer ""
+      contextCref(e, context, &preExp, &varDecls, &auxFunction, &sub)
+    ;separator=", ")
+  let tmp = tempDecl(type + "_array", &varDecls)
+  let &preExp += 'array_alloc_scalar_<%type%>_array(&<%tmp%>, <%listLength(expandCref(cr, true))%>, <%elems%>);<%\n%>'
+  tmp
+end daeExpCrefRhsArrayElems;
 
 template daeExpCrefRhsFunContext(Exp ecr, Context context, Text &preExp,
                         Text &varDecls, Text &auxFunction)

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -1686,6 +1686,11 @@ package SimCodeUtil
     output SimCodeVar.SimVar outSimVar;
   end cref2simvar;
 
+  function isContiguousArrayCref
+    input DAE.ComponentRef inCref;
+    output Boolean outContiguous;
+  end isContiguousArrayCref;
+
   function simVarFromHT
     input DAE.ComponentRef inCref;
     input HashTableCrefSimVar.HashTable crefToSimVarHT;

--- a/OMCompiler/SimulationRuntime/rust/.cmake/rust_src_files.txt
+++ b/OMCompiler/SimulationRuntime/rust/.cmake/rust_src_files.txt
@@ -44,6 +44,7 @@ openmodelica_sim_meta/src/extinput.rs
 openmodelica_sim_meta/src/files.rs
 openmodelica_sim_meta/src/lib.rs
 openmodelica_sim_meta/src/linearize.rs
+openmodelica_sim_meta/src/lapack_dyn.rs
 openmodelica_sim_meta/src/optimization/eval.rs
 openmodelica_sim_meta/src/optimization/ipopt.rs
 openmodelica_sim_meta/src/optimization/ipopt_out.rs

--- a/OMCompiler/SimulationRuntime/rust/Cargo.lock
+++ b/OMCompiler/SimulationRuntime/rust/Cargo.lock
@@ -592,6 +592,7 @@ name = "openmodelica_sim_meta"
 version = "0.1.0"
 dependencies = [
  "daskr",
+ "libc",
  "libm",
  "openmodelica_lapack",
  "openmodelica_mat_writer",

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_nls/build.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_nls/build.rs
@@ -61,5 +61,8 @@ fn primme() {
         .compile("omc_primme_svds");
     println!("cargo:rustc-link-search=native={}", std::path::Path::new(&lib).display());
     println!("cargo:rustc-link-lib=static=primme");
+    // PRIMME's dense algebra, in all four precisions.
+    println!("cargo:rustc-link-lib=dylib=lapack");
+    println!("cargo:rustc-link-lib=dylib=blas");
     println!("cargo:rustc-cfg=primme");
 }

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/Cargo.toml
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/Cargo.toml
@@ -39,3 +39,6 @@ openmodelica_plt_writer = { path = "../openmodelica_plt_writer" }
 openmodelica_lapack = { path = "../../../Compiler/OpenModelica.rs/openmodelica_lapack", optional = true }
 
 [lib]
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/build.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/build.rs
@@ -81,11 +81,11 @@ fn ipopt() {
     for l in IPOPT_LIBS {
         println!("cargo:rustc-link-lib=static={l}");
     }
-    // Ipopt's dense algebra and MUMPS' rank-revealing QR call LAPACK/BLAS; Ipopt is
-    // C++; MUMPS is Fortran (whose runtime needs quadmath). Named `lapack`/`blas`
-    // like `openmodelica_util` does rather than a specific implementation, so both
-    // resolve to whatever this system installed.
-    for l in ["lapack", "blas", "stdc++", "gfortran", "quadmath"] {
+    // Ipopt is C++; MUMPS is Fortran (quadmath). LAPACK/BLAS: `lapack_dyn` on
+    // unix, linked by name elsewhere.
+    let unix = std::env::var_os("CARGO_CFG_UNIX").is_some();
+    let libs: &[&str] = if unix { &["stdc++", "gfortran", "quadmath"] } else { &["lapack", "blas", "stdc++", "gfortran", "quadmath"] };
+    for l in libs {
         println!("cargo:rustc-link-lib=dylib={l}");
     }
     println!("cargo:rustc-cfg=ipopt");

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/lapack_dyn.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/lapack_dyn.rs
@@ -1,0 +1,83 @@
+//! The LAPACK/BLAS routines Ipopt and MUMPS call, bound at first use so that
+//! OpenBLAS (which sizes its thread pool when it loads) sees omc's `-n`.
+
+use std::ffi::{c_char, c_int, c_void};
+use std::sync::OnceLock;
+
+macro_rules! routines {
+    ($($name:ident: fn($($arg:ident: $ty:ty),*) $(-> $ret:ty)?;)*) => {
+        struct Syms { $($name: unsafe extern "C" fn($($ty),*) $(-> $ret)?),* }
+
+        fn resolve(libs: &[*mut c_void]) -> Syms {
+            Syms { $($name: sym(libs, concat!(stringify!($name), "\0"))),* }
+        }
+
+        $(
+            #[unsafe(no_mangle)]
+            pub unsafe extern "C" fn $name($($arg: $ty),*) $(-> $ret)? {
+                unsafe { (syms().$name)($($arg),*) }
+            }
+        )*
+    };
+}
+
+// Fortran ABI; the trailing `usize`s are the hidden `character` lengths.
+routines! {
+    dasum_: fn(n: *const c_int, x: *const f64, incx: *const c_int) -> f64;
+    dlamch_: fn(cmach: *const c_char, cmach_len: usize) -> f64;
+    dlarfg_: fn(n: *const c_int, alpha: *mut f64, x: *mut f64, incx: *const c_int, tau: *mut f64);
+    dnrm2_: fn(n: *const c_int, x: *const f64, incx: *const c_int) -> f64;
+    dppsv_: fn(uplo: *const c_char, n: *const c_int, nrhs: *const c_int, ap: *mut f64, b: *mut f64,
+               ldb: *const c_int, info: *mut c_int, uplo_len: usize);
+    dswap_: fn(n: *const c_int, x: *mut f64, incx: *const c_int, y: *mut f64, incy: *const c_int);
+    dsyev_: fn(jobz: *const c_char, uplo: *const c_char, n: *const c_int, a: *mut f64, lda: *const c_int,
+               w: *mut f64, work: *mut f64, lwork: *const c_int, info: *mut c_int, jobz_len: usize,
+               uplo_len: usize);
+    dsymv_: fn(uplo: *const c_char, n: *const c_int, alpha: *const f64, a: *const f64, lda: *const c_int,
+               x: *const f64, incx: *const c_int, beta: *const f64, y: *mut f64, incy: *const c_int,
+               uplo_len: usize);
+    dsyrk_: fn(uplo: *const c_char, trans: *const c_char, n: *const c_int, k: *const c_int,
+               alpha: *const f64, a: *const f64, lda: *const c_int, beta: *const f64, c: *mut f64,
+               ldc: *const c_int, uplo_len: usize, trans_len: usize);
+    dtrtrs_: fn(uplo: *const c_char, trans: *const c_char, diag: *const c_char, n: *const c_int,
+                nrhs: *const c_int, a: *const f64, lda: *const c_int, b: *mut f64, ldb: *const c_int,
+                info: *mut c_int, uplo_len: usize, trans_len: usize, diag_len: usize);
+    idamax_: fn(n: *const c_int, x: *const f64, incx: *const c_int) -> c_int;
+    ilaenv_: fn(ispec: *const c_int, name: *const c_char, opts: *const c_char, n1: *const c_int,
+                n2: *const c_int, n3: *const c_int, n4: *const c_int, name_len: usize, opts_len: usize)
+                -> c_int;
+}
+
+#[cfg(target_os = "macos")]
+const LIBS: [&str; 2] = ["liblapack.dylib\0", "libblas.dylib\0"];
+#[cfg(not(target_os = "macos"))]
+const LIBS: [&str; 2] = ["liblapack.so.3\0", "libblas.so.3\0"];
+
+fn syms() -> &'static Syms {
+    static SYMS: OnceLock<Syms> = OnceLock::new();
+    SYMS.get_or_init(|| {
+        let libs: Vec<*mut c_void> = LIBS
+            .iter()
+            .map(|name| {
+                let h = unsafe { libc::dlopen(name.as_ptr().cast(), libc::RTLD_NOW | libc::RTLD_GLOBAL) };
+                if h.is_null() {
+                    let err = unsafe { std::ffi::CStr::from_ptr(libc::dlerror()) }.to_string_lossy().into_owned();
+                    panic!("cannot load {}: {err}", name.trim_end_matches('\0'));
+                }
+                h
+            })
+            .collect();
+        resolve(&libs)
+    })
+}
+
+fn sym<F: Copy>(libs: &[*mut c_void], name: &str) -> F {
+    assert_eq!(std::mem::size_of::<F>(), std::mem::size_of::<*mut c_void>());
+    for &lib in libs {
+        let p = unsafe { libc::dlsym(lib, name.as_ptr().cast()) };
+        if !p.is_null() {
+            return unsafe { std::mem::transmute_copy(&p) };
+        }
+    }
+    panic!("{} is in neither LAPACK nor BLAS", name.trim_end_matches('\0'));
+}

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/lib.rs
@@ -50,6 +50,10 @@ pub mod rtclock;
 /// The `LOG_STATS` block a finished run prints.
 pub mod stats;
 pub mod sync;
+#[cfg(all(feature = "std", unix, ipopt))]
+pub mod lapack_dyn;
+#[cfg(not(all(feature = "std", unix, ipopt)))]
+pub mod lapack_dyn {}
 #[cfg(sundials)]
 pub use openmodelica_solvers::sundials;
 

--- a/testsuite/simulation/modelica/arrays/ArrayBox.mo
+++ b/testsuite/simulation/modelica/arrays/ArrayBox.mo
@@ -1,0 +1,45 @@
+model ArrayBox
+  "Whole-array, slice and run-time-indexed references to arrays whose elements
+   are stored apart (a state, an algebraic, a constant; records)"
+  record R
+    Real a;
+    Real b;
+  end R;
+
+  function weightedSum
+    input Real v[:];
+    output Real s = 0;
+  algorithm
+    for i in 1:size(v, 1) loop
+      s := s + i*v[i];
+    end for;
+    annotation(Inline=false);
+  end weightedSum;
+
+  function dot
+    input R r[:];
+    output Real s = 0;
+  algorithm
+    for i in 1:size(r, 1) loop
+      s := s + r[i].a*r[i].b;
+    end for;
+    annotation(Inline=false);
+  end dot;
+
+  Real x[3](start={1, 0, 2}, fixed={true, false, false});
+  Integer k = if time < 0.5 then 1 else 2;
+  R r[2];
+  Real whole, slice, element, records;
+equation
+  der(x[1]) = -x[1];
+  x[2] = time;
+  x[3] = 2.0;
+  whole = weightedSum(x);
+  slice = weightedSum(x[2:3]);
+  element = x[k];
+  r[1].a = time;
+  r[1].b = x[1];
+  r[2].a = 3;
+  r[2].b = 4;
+  records = dot(r);
+end ArrayBox;

--- a/testsuite/simulation/modelica/arrays/ArrayBox.mos
+++ b/testsuite/simulation/modelica/arrays/ArrayBox.mos
@@ -1,0 +1,34 @@
+// name:     ArrayBox
+// keywords: array codegen
+// status: correct
+// teardown_command: rm -rf ArrayBox_* ArrayBox ArrayBox.exe ArrayBox.cpp ArrayBox.makefile ArrayBox.libs ArrayBox.log output.log
+//
+// Array references whose elements are not one contiguous block: a whole
+// array, a slice and a run-time index of it, and an array of records.
+//
+
+loadFile("ArrayBox.mo"); getErrorString();
+simulate(ArrayBox, stopTime=1.0); getErrorString();
+val(whole, 1.0);
+val(slice, 1.0);
+val(element, 0.25);
+val(element, 0.75);
+val(records, 1.0);
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "ArrayBox_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'ArrayBox', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 8.367879441171443
+// 5.0
+// 0.7788007830714049
+// 0.75
+// 12.36787944117144
+// endResult

--- a/testsuite/simulation/modelica/arrays/Makefile
+++ b/testsuite/simulation/modelica/arrays/Makefile
@@ -7,6 +7,7 @@ ABCDsystem.plt.mos \
 AlgorithmArrayEqn.mos \
 AppendElement.mos \
 ArrayAddSub1.mos \
+ArrayBox.mos \
 ArrayDivError.mos \
 ArrayEquation.mos \
 ArrayExponentiation.mos \


### PR DESCRIPTION
Fixes for the models where the library-testing master branch beat wasm-jit (run dev-555), reproduced with one omc under both targets and through the artifact path OMLT uses.

Arrays whose scalarized elements are not consecutive slots — a state beside an algebraic (`smee.is`), an alias, a Jacobian's `x.SeedNLSJac1` / `x.$pDERNLSJac0.dummyVarNLSJac0[k]` scratch — were addressed through their first element, or not at all:

| model                                    | reference                              |
| ---------------------------------------- | -------------------------------------- |
| HanserModelica SMEE_ShortCircuit2        | `smee.is` (state, dummy state, alg.)   |
| PowerSystems GeneratorTest2              | `x.$pDERNLSJac0.dummyVarNLSJac0` array |
| PowerSystems ASMav_icontrol              | `x.SeedNLSJac1` array                  |
| PowerSystems DoubleLine, WindTurbine_*   | `line.v[2,:]` of a scattered state     |

wasm-jit failed the translation ("unknown variable" / "cannot resolve"); C compiled `element = x[k]` to `(&x[1])[k-1]` and read `der(x[1])`. Both now box such an array from its element crefs, as C's own `daeExpCrefRhsArrayBox` does for expressions: wasm-jit's `try_emit_sim_array_box` (a constant selection boxed directly; run-time subscripts box the whole array and index or slice the box; Real, Integer, Boolean, String and record elements), and C's `daeExpCrefRhsArrayElems` in the three `daeExpCrefRhsSimContext` arms, gated by `SimCodeUtil.isContiguousArrayCref` (one value array, consecutive `SimVar.index`, no aliases). The Jacobian lowerability check had a tautological `resolvable` that let whole-array seed/pDER references through to a lowering error; it goes. `ArrayBox.mos` pins whole, slice, run-time element and record-array reads under both targets.

Address space: OMLT runs omc under `ulimit -v` 8 GiB (partest 6 GiB) and the geothermal and ClaRa models died there with `mmap failed to reserve 0x104000000 bytes`, `memory allocation of N bytes failed` or a garbage-address memory fault. An idle omc already held 4.7 GB of virtual address space, 3 GiB of it OpenBLAS's thread-pool buffers (128 MiB per core, reserved in its constructor), because the cdylib linked liblapack for the dozen routines Ipopt and MUMPS call; `openblas_set_num_threads` after load does not release the pool. Now:

* `openmodelica_sim_meta::lapack_dyn` binds those routines with `dlopen` at the first call, so nothing loads OpenBLAS before the flags are read; PRIMME (`openmodelica_nls`) links LAPACK itself.
* `Main.init` sets `OPENBLAS_NUM_THREADS=1` for `-n=1` unless already set. The harness runs `-n=1`; with threads OpenBLAS keeps its own.
* `engine_config.rs` sizes wasmtime's memory reservation from `RLIMIT_AS` minus the process's VmSize instead of a cliff below 8 GiB.

An idle `omc -n=1` is 1.4 GB / 2 threads instead of 4.7 GB / 25.

The wasm runtimes keep their name section (`strip = "debuginfo"`) so a trap names the runtime function, and the external "C" translation unit starts with a comment saying that omc adds no preamble in front of a library's Include sources.

Assisted-by: Claude Fable 5.1

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
