### PR TITLE
NB: keep subscripts on injected $START occurrences

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
@@ -2524,7 +2524,7 @@ public
 
           // only save the x -> x.start dependency not the other way around
           case SOME(start) guard(BVariable.isStart(start)) algorithm
-            start_cref := BVariable.getVarName(start);
+            start_cref := ComponentRef.copySubscripts(cref, BVariable.getVarName(start));
             // add the start cref dependency in the same way the original variable occured
             // but with UNSOLVABLE as it is only relevant for sorting and cannot be solved
             UnorderedSet.add(start_cref, occs);


### PR DESCRIPTION
`addInitialStartOccurrences` adds an UNSOLVABLE occurrence of `$START.x` to every initial equation that uses `x`, so that sorting places the start equation first. It used the start variable's *array* name, so for a for-equation over `x[$i1]` the injected cref had no subscripts and resolved to every element of `$START.x` in every iteration: each row of a size-N equation got N entries, N^2 per equation/variable pair.

Copy the subscripts of the original occurrence onto the start cref, as `BVariable.getPartnerCref` and `makeStartVar` already do, so the start dependency mirrors the variable's own (diagonal for `x[$i1]`).

ScalableTestGrids.Models.Type1_N_4_M_4 with
`--newBackend -d=mergeComponents --generateDynamicJacobian=symbolic`:

| phase            | before          | after           |
| ---------------- | --------------- | --------------- |
| [INI] Causalize  | 104.3 s / 68 GB | 8.5 s / 1.7 GB  |
| [SIM] Causalize  | 3.4 s           | 3.4 s           |

Sorting-matrix entries of the N_1_M_1 initial system: 19198 -> 12294
(matching matrix: 9962), longest row 49 -> 16.

Fixes part of #14118.

Assisted-by: Claude Fable 5.1

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
