### PR TITLE
wasm-jit: C's equation split, lazy log formatting

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -950,28 +950,28 @@ fn resolve_overrides(
     let raw = flags.override_raw.as_deref();
     let file = flags.override_file.as_ref();
     if let (Some(raw), Some((path, _))) = (raw, file) {
-        omclog::info(omclog::SOLVER, false, &format!("using -override={raw} and -overrideFile={path}"));
+        omclog::info!(omclog::SOLVER, false, "using -override={raw} and -overrideFile={path}");
     }
     if let Some((path, _)) = file {
-        omclog::info(omclog::SOLVER, false, &format!("read override values from file: {path}"));
+        omclog::info!(omclog::SOLVER, false, "read override values from file: {path}");
     }
     if raw.is_none() && file.is_none() {
         omclog::info(omclog::SOLVER, false, "NO override given on the command line.");
         return (Vec::new(), Vec::new(), Vec::new());
     }
     let given = |v: Option<&str>| v.unwrap_or("[not given]").to_string();
-    omclog::info(omclog::SOLVER, false, &format!("-override={}", given(raw)));
-    omclog::info(omclog::SOLVER, false, &format!("-overrideFile={}", given(file.map(|(_, j)| j.as_str()))));
+    omclog::info!(omclog::SOLVER, false, "-override={}", given(raw));
+    omclog::info!(omclog::SOLVER, false, "-overrideFile={}", given(file.map(|(_, j)| j.as_str())));
 
     // C fills a hash map, so a repeated name keeps the last value and warns.
     let mut map: Vec<(&str, &str)> = Vec::new();
     for (name, val) in &flags.overrides {
         match map.iter_mut().find(|(n, _)| *n == name) {
             Some((_, old)) => {
-                omclog::warning(
+                omclog::warning!(
                     omclog::STDOUT,
                     false,
-                    &format!("You are overriding variable: {name}={old} again with {name}={val}."),
+                    "You are overriding variable: {name}={old} again with {name}={val}.",
                 );
                 *old = val;
             }
@@ -990,17 +990,15 @@ fn resolve_overrides(
         let Some(&(name, val)) = map.iter().find(|(n, _)| *n == name) else { continue };
         used.push(name);
         let Some(p) = model.editable_params.iter().find(|p| p.name == name) else {
-            omclog::warning(
+            omclog::warning!(
                 omclog::STDOUT,
                 false,
-                &format!(
-                    "It is not possible to override the following quantity: {name}\nIt seems to be \
-                     structural, final, protected or evaluated or has a non-constant binding.",
-                ),
+                "It is not possible to override the following quantity: {name}\nIt seems to be \
+                 structural, final, protected or evaluated or has a non-constant binding.",
             );
             continue;
         };
-        omclog::info(omclog::SOLVER, false, &format!("override {name} = {val}"));
+        omclog::info!(omclog::SOLVER, false, "override {name} = {val}");
         if p.is_string {
             strings.push((p.off, val.to_string()));
             continue;
@@ -1008,13 +1006,11 @@ fn resolve_overrides(
         // C warns only for the real and integer parameters (`warn_small_override`).
         let numeric_param = !p.is_start && (p.wty == WTy::F64 || !p.is_bool);
         if numeric_param && val.parse::<f64>().is_ok_and(|v| v.abs() < 1e-6) {
-            omclog::warning(
+            omclog::warning!(
                 omclog::STDOUT,
                 false,
-                &format!(
-                    "You are overriding {name} with a small value or zero.\nThis could lead to \
-                     numerically dirty solutions or divisions by zero if not tearingStrictness=veryStrict.",
-                ),
+                "You are overriding {name} with a small value or zero.\nThis could lead to \
+                 numerically dirty solutions or divisions by zero if not tearingStrictness=veryStrict.",
             );
         }
         let v = p.read_value(val);
@@ -1022,10 +1018,10 @@ fn resolve_overrides(
     }
     for (name, _) in &map {
         if !used.contains(name) {
-            omclog::warning(
+            omclog::warning!(
                 omclog::STDOUT,
                 false,
-                &format!("simulation_input_xml.c: override variable name not found in model: {name}\n"),
+                "simulation_input_xml.c: override variable name not found in model: {name}\n",
             );
         }
     }
@@ -5149,9 +5145,6 @@ fn build_sim_model(
     // Jacobian scratch region: nonlinear-system slots + torn-linear slots (after).
     let nls_jac_scratch_f64 = nls_jac_scratch_f64(sim_code) + lin_jac_scratch_f64(sim_code);
     let all_eqs = flatten_eqs(&sim_code.allEquations);
-    // `-reconcile` re-solves with C's `functionDAE`, which is these plus the local
-    // known variables; `all_eqs` itself is consumed by `functionAlgebraics` below.
-    let all_eqs_for_dae = all_eqs.clone();
     let local_known_eqs = flatten_eqs(&sim_code.localKnownVars);
     // `--daeMode`: `allEquations`/`odeEquations` are empty and the whole continuous
     // system is `daeModeData.daeEquations`, the residual `F(t, y, y') = 0`.
@@ -5463,11 +5456,6 @@ fn build_sim_model(
     let mut computed_params = assigned_cref_keys(&eqs_with_nested(&param_eqs));
     computed_params.extend(assigned_cref_keys(&eqs_with_nested(&initial_eqs)));
     let param_bindings = collect_param_bindings(vars, &computed_params);
-    // When the model has `when`-equations, the discrete update (when-bodies with
-    // edge detection) must run each step between the condition and output
-    // equations. `allEquations` is the full solved list in that order, so it is
-    // used as the per-step function (in place of `algebraicEquations`), and
-    // pre-values are saved after each step so the next step's edge test sees them.
     // C's `functionODE` and `functionDAE` both open with `functionLocalKnownVars`
     // (`--preOptModules+=removeLocalKnownVars` moves the equations that depend only
     // on states and inputs there); empty unless that module ran.
@@ -5479,11 +5467,10 @@ fn build_sim_model(
         out.extend(eqs);
         out
     };
-    let alg_eqs_raw = if has_when { Vec::new() } else { flatten_eqs_ll(&sim_code.algebraicEquations) };
-    let algebraic_eqs = with_local_known(if has_when { all_eqs } else { alg_eqs_raw.clone() });
-    let output_eqs = if has_when { flatten_eqs_ll(&sim_code.algebraicEquations) } else { Vec::new() };
-    // pre := live regions, appended to the per-step (algebraic) function when the
-    // model has `when`-equations (see `sim_save_pre_values`).
+    let alg_eqs_raw = flatten_eqs_ll(&sim_code.algebraicEquations);
+    let algebraic_eqs = with_local_known(alg_eqs_raw.clone());
+    // C's `storePreValues` at the end of `updateContinuousSystem`, which here tails
+    // `functionAlgebraics` (see `sim_save_pre_values`).
     let save_pre: Vec<(u32, u32, u32)> = if has_when {
         vec![
             (layout.pre_real_off, REAL_OFF, (2 * layout.n_states + layout.n_real_alg) * 8),
@@ -5723,14 +5710,22 @@ fn build_sim_model(
     splits.push(build_split_fn("functionInitialEquations", &eq_units(&initial_eqs), 1, eqfn_type, &[], &init_save, &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut pool, false)?);
     // Three orders over one equation set, so where they agree on a run they call the
     // same chunk. Not under `--parmodauto`, whose tasks *are* the ODE chunks.
-    let shared = match parmod_info.is_none() && !has_when {
-        true => eq_segments(&ode_task_eqs, &alg_eqs_raw, &all_eqs_for_dae),
+    let shared = match parmod_info.is_none() {
+        true => eq_segments(&ode_task_eqs, &alg_eqs_raw, &all_eqs),
         false => None,
+    };
+    // A chunk of its own, so the equations before it stay shared.
+    let pre_store = |pool: &mut ChunkPool, literals: &mut Literals| -> Result<Vec<usize>> {
+        match save_pre.is_empty() {
+            true => Ok(Vec::new()),
+            false => build_chunks("storePreValues", &[], 1, eqfn_type, &[], &save_pre, &var_map, &eq_index, &by_name, literals, pool, false),
+        }
     };
     let ode_split = splits.len();
     let dae_chunks = match shared {
         Some(segs) => {
-            let (ode, alg, dae) = build_shared_eq_chunks(segs, &all_eqs_for_dae, &local_known_eqs, eqfn_type, &var_map, &eq_index, &by_name, &mut literals, &mut pool)?;
+            let (ode, mut alg, dae) = build_shared_eq_chunks(segs, &all_eqs, &local_known_eqs, eqfn_type, &var_map, &eq_index, &by_name, &mut literals, &mut pool)?;
+            alg.extend(pre_store(&mut pool, &mut literals)?);
             for chunks in [ode, alg] {
                 let slot = bodies.len();
                 bodies.push(empty_eqfn());
@@ -5745,18 +5740,12 @@ fn build_sim_model(
             } else {
                 splits.push(build_split_fn("functionODE", &eq_units(&ode_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut pool, false)?);
             }
-            // A `when`-model's `functionAlgebraics` is `functionDAE` plus
-            // `storePreValues`, so the pre-store gets a chunk of its own and the rest
-            // is shared. `save_pre` is empty otherwise.
             let slot = bodies.len();
             bodies.push(empty_eqfn());
-            let eqs = build_chunks("functionAlgebraics", &eq_units(&algebraic_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut pool, false)?;
-            let mut chunks = eqs.clone();
-            if !save_pre.is_empty() {
-                chunks.extend(build_chunks("storePreValues", &[], 1, eqfn_type, &[], &save_pre, &var_map, &eq_index, &by_name, &mut literals, &mut pool, false)?);
-            }
+            let mut chunks = build_chunks("functionAlgebraics", &eq_units(&algebraic_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut pool, false)?;
+            chunks.extend(pre_store(&mut pool, &mut literals)?);
             splits.push(SplitFn { slot, chunks, n_params: 1, pre_calls: Vec::new() });
-            has_when.then_some(eqs)
+            None
         }
     };
     // eq_base + 4, before `simulate` so the in-wasm integrator can call it.
@@ -6161,20 +6150,15 @@ fn build_sim_model(
         splits.push(build_split_fn("functionZeroCrossingsEquations", &eq_units(&zc_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut pool, false)?);
         idx
     };
-    // C's `functionAlgebraics` + `storePreValues`. Only a `has_when` model needs its
-    // own: there `functionAlgebraics` is fused with the when-bodies a getter must not fire.
+    // The name the FMI getters call `functionAlgebraics` by.
     let outputs_idx = {
         let idx = import_base + bodies.len() as u32;
-        if has_when {
-            splits.push(build_split_fn("functionOutputs", &eq_units(&output_eqs), 1, eqfn_type, &[], &save_pre, &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut pool, false)?);
-        } else {
-            use we::Instruction as I;
-            let mut f = we::Function::new([]);
-            f.instruction(&I::LocalGet(0));
-            f.instruction(&I::Call(eqfn.algebraics));
-            f.instruction(&I::End);
-            bodies.push(f);
-        }
+        use we::Instruction as I;
+        let mut f = we::Function::new([]);
+        f.instruction(&I::LocalGet(0));
+        f.instruction(&I::Call(eqfn.algebraics));
+        f.instruction(&I::End);
+        bodies.push(f);
         idx
     };
     bodies[simulate_slot] = build_simulate(&layout, &eqfn, has_asserts.then_some(check_asserts_idx))?;
@@ -6343,7 +6327,7 @@ fn build_sim_model(
             }
             None => {
                 let mut units = eq_units(&local_known_eqs);
-                units.extend(eq_units(&all_eqs_for_dae));
+                units.extend(eq_units(&all_eqs));
                 splits.push(build_split_fn("functionDAE", &units, 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut pool, false)?);
             }
         }
@@ -8286,12 +8270,21 @@ fn build_chunks(
     Ok((first..pool.len()).collect())
 }
 
+/// `Dae` is C's `allEquationsPlusWhen` surplus: the when-equations, which only
+/// `functionDAE` runs.
+#[derive(Clone, Copy, PartialEq)]
+enum EqOwner {
+    Ode,
+    Alg,
+    Dae,
+}
+
 /// A run of `allEquations` that is also a run of the `odeEquations` or
 /// `algebraicEquations` list holding it, so its chunks serve both entry points, the
 /// way C's `eqFunction_<n>` do.
 struct EqSegment {
-    ode: bool,
-    /// Where the run starts in its own list.
+    owner: EqOwner,
+    /// Where the run starts in its own list (0 for an [`EqOwner::Dae`] run).
     pos: usize,
     /// Where it sits in `allEquations`.
     span: core::ops::Range<usize>,
@@ -8308,7 +8301,8 @@ fn eq_id_of(eq: &SimCode::SimEqSystem) -> i32 {
 }
 
 /// Cut `all` (C's `allEquations`) into runs shared with `ode`/`alg`; `None` unless
-/// the two tile it, which leaves the caller lowering a copy of its own.
+/// the two tile what they claim of it, which leaves the caller lowering a copy of
+/// its own.
 ///
 /// The orders differ by more than the interleaving -- `algebraicEquations` ends with
 /// C's `removedEquations` reversed -- so that tail comes back one equation per run.
@@ -8317,29 +8311,29 @@ fn eq_segments(
     alg: &[Arc<SimCode::SimEqSystem>],
     all: &[Arc<SimCode::SimEqSystem>],
 ) -> Option<Vec<EqSegment>> {
-    if all.len() != ode.len() + alg.len() {
-        return None;
-    }
-    let mut own: HashMap<i32, (bool, usize)> = HashMap::new();
-    for (is_ode, eqs) in [(true, ode), (false, alg)] {
+    let mut own: HashMap<i32, (EqOwner, usize)> = HashMap::new();
+    for (owner, eqs) in [(EqOwner::Ode, ode), (EqOwner::Alg, alg)] {
         for (pos, e) in eqs.iter().enumerate() {
-            if own.insert(eq_id_of(e), (is_ode, pos)).is_some() {
+            if own.insert(eq_id_of(e), (owner, pos)).is_some() {
                 return None;
             }
         }
     }
     let mut segs: Vec<EqSegment> = Vec::new();
     for (i, e) in all.iter().enumerate() {
-        let &(is_ode, pos) = own.get(&eq_id_of(e))?;
+        let (owner, pos) = own.get(&eq_id_of(e)).copied().unwrap_or((EqOwner::Dae, 0));
+        let joins = |s: &EqSegment| {
+            s.owner == owner && (owner == EqOwner::Dae || s.pos + s.span.len() == pos)
+        };
         match segs.last_mut() {
-            Some(s) if s.ode == is_ode && s.pos + s.span.len() == pos => s.span.end = i + 1,
-            _ => segs.push(EqSegment { ode: is_ode, pos, span: i..i + 1, chunks: Vec::new() }),
+            Some(s) if joins(s) => s.span.end = i + 1,
+            _ => segs.push(EqSegment { owner, pos, span: i..i + 1, chunks: Vec::new() }),
         }
     }
     // An entry point calls its own segments in its list's order, so they must tile it.
-    for (is_ode, len) in [(true, ode.len()), (false, alg.len())] {
+    for (owner, len) in [(EqOwner::Ode, ode.len()), (EqOwner::Alg, alg.len())] {
         let mut runs: Vec<(usize, usize)> =
-            segs.iter().filter(|s| s.ode == is_ode).map(|s| (s.pos, s.span.len())).collect();
+            segs.iter().filter(|s| s.owner == owner).map(|s| (s.pos, s.span.len())).collect();
         runs.sort_unstable();
         let mut next = 0;
         for (pos, n) in runs {
@@ -8383,12 +8377,12 @@ fn build_shared_eq_chunks(
     let call = |segs: &[&EqSegment]| -> Vec<usize> {
         head.iter().copied().chain(segs.iter().flat_map(|s| s.chunks.iter().copied())).collect()
     };
-    let own = |ode: bool| -> Vec<&EqSegment> {
-        let mut own: Vec<&EqSegment> = segs.iter().filter(|s| s.ode == ode).collect();
+    let own = |owner: EqOwner| -> Vec<&EqSegment> {
+        let mut own: Vec<&EqSegment> = segs.iter().filter(|s| s.owner == owner).collect();
         own.sort_by_key(|s| s.pos);
         own
     };
-    Ok((call(&own(true)), call(&own(false)), call(&segs.iter().collect::<Vec<_>>())))
+    Ok((call(&own(EqOwner::Ode)), call(&own(EqOwner::Alg)), call(&segs.iter().collect::<Vec<_>>())))
 }
 
 /// Lower `units` into one function, for entry points whose size is bounded by the

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -2702,14 +2702,12 @@ pub extern "C" fn rt_linsolve(a_ptr: u32, b_ptr: u32, x_ptr: u32, n: u32, eq_ind
             Some(k) => {
                 let count = ls_note_failure(eq_index);
                 // C prints `dgesv`'s 1-based `info` one too high; keep the text.
-                omclog::warning_with_limit(
+                omclog::warning_with_limit!(
                     omclog::LS,
                     count,
                     openmodelica_solvers::solverflags::max_warn_displays(),
-                    &alloc::format!(
-                        "Failed to solve linear system of equations (no. {eq_index}) at time {time:.6}, system is singular for U[{p}, {p}].",
-                        p = k + 2
-                    ),
+                    "Failed to solve linear system of equations (no. {eq_index}) at time {time:.6}, system is singular for U[{p}, {p}].",
+                    p = k + 2,
                 );
                 // Only C's `LS_DEFAULT` has a fallback: `-ls=lapack` leaves the
                 // system unsolved, which is what `tearingStrictness` relies on to
@@ -2751,7 +2749,7 @@ fn lis_initial_guess(x_ptr: u32, n: usize) -> alloc::vec::Vec<f64> {
 fn ls_print_vector(name: &str, v: &[f64]) {
     omclog::info(omclog::LS_V, true, name);
     for (i, x) in v.iter().enumerate() {
-        omclog::info(omclog::LS_V, false, &alloc::format!("[{:2}] {}", i + 1, omclog::g(*x, 20, 12)));
+        omclog::info!(omclog::LS_V, false, "[{:2}] {}", i + 1, omclog::g(*x, 20, 12));
     }
     omclog::close(omclog::LS_V);
 }
@@ -2772,13 +2770,11 @@ fn ls_print_matrix(name: &str, a: &[f64], n: usize) {
 
 /// C's per-solver `Start solving Linear System …` line.
 fn ls_start_log(eq_index: i32, size: usize, time: f64, solver: &str) {
-    omclog::info(
+    omclog::info!(
         omclog::LS,
         false,
-        &alloc::format!(
-            "Start solving Linear System {eq_index} (size {size}) at time {} with {solver} Solver",
-            openmodelica_sim_meta::driver::format_g(time, 6)
-        ),
+        "Start solving Linear System {eq_index} (size {size}) at time {} with {solver} Solver",
+        openmodelica_sim_meta::driver::format_g(time, 6),
     );
 }
 
@@ -2788,10 +2784,10 @@ fn ls_total_pivot(a: &[f64], b: &mut [f64], n: usize, eq_index: i32, time: f64) 
     if nls::total_pivot_solve(a, b, n) {
         return 0;
     }
-    omclog::warning(
+    omclog::warning!(
         omclog::STDOUT,
         false,
-        &alloc::format!("Error solving linear system of equations (no. {eq_index}) at time {time:.6}."),
+        "Error solving linear system of equations (no. {eq_index}) at time {time:.6}.",
     );
     1
 }
@@ -2802,13 +2798,11 @@ fn ls_total_pivot(a: &[f64], b: &mut [f64], n: usize, eq_index: i32, time: f64) 
 pub extern "C" fn rt_ls_failed(eq_index: i32, time: f64) {
     use openmodelica_sim_meta::driver::format_g;
     if nls::throw_reports() {
-        omclog::warning(
+        omclog::warning!(
             omclog::STDOUT,
             true,
-            &alloc::format!(
-                "Solving linear system {eq_index} fails at time {}. For more information use -lv LOG_LS.",
-                format_g(time, 6)
-            ),
+            "Solving linear system {eq_index} fails at time {}. For more information use -lv LOG_LS.",
+            format_g(time, 6),
         );
         omclog::close_warning(omclog::STDOUT);
     }
@@ -2844,14 +2838,12 @@ pub extern "C" fn rt_ls_check_step(res_ptr: u32, b_ptr: u32, n: u32, eq_index: i
         return 0;
     }
     let count = ls_note_failure(eq_index);
-    omclog::warning_with_limit(
+    omclog::warning_with_limit!(
         omclog::LS,
         count,
         openmodelica_solvers::solverflags::max_warn_displays(),
-        &alloc::format!(
-            "Failed to solve linear system of equations (no. {eq_index}) at time {time:.6}. Residual norm is {}.",
-            openmodelica_sim_meta::driver::format_g(norm, 15)
-        ),
+        "Failed to solve linear system of equations (no. {eq_index}) at time {time:.6}. Residual norm is {}.",
+        openmodelica_sim_meta::driver::format_g(norm, 15),
     );
     if casual == 0 && dense != 0 && matches!(openmodelica_solvers::solverflags::ls(), openmodelica_solvers::solverflags::Ls::Default) {
         ls_report_fallback(eq_index, time, count);
@@ -2902,13 +2894,11 @@ fn ls_report_fallback(eq_index: i32, time: f64, count: u64) {
     let e = ls_failure_entry(eq_index);
     let stream = if e.failed { omclog::LS } else { omclog::STDOUT };
     e.failed = true;
-    omclog::warning_with_limit(
+    omclog::warning_with_limit!(
         stream,
         count,
         openmodelica_solvers::solverflags::max_warn_displays(),
-        &alloc::format!(
-            "The default linear solver fails, the fallback solver with total pivoting is started at time {time:.6}. That might raise performance issues, for more information use -lv LOG_LS."
-        ),
+        "The default linear solver fails, the fallback solver with total pivoting is started at time {time:.6}. That might raise performance issues, for more information use -lv LOG_LS.",
     );
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lis.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lis.rs
@@ -175,13 +175,11 @@ fn solve_cached(
         return 0;
     }
     let code = usize::try_from(err).ok().and_then(|i| RETURNCODE.get(i)).copied().unwrap_or("LIS_ERR");
-    crate::omclog::warning(crate::omclog::LS_V, false, &alloc::format!("lis_solve : {code}(code={err})"));
-    crate::omclog::warning(
+    crate::omclog::warning!(crate::omclog::LS_V, false, "lis_solve : {code}(code={err})");
+    crate::omclog::warning!(
         crate::omclog::LS,
         false,
-        &alloc::format!(
-            "Failed to solve linear system of equations (no. {eq_index}) at time {time:.6}, system status {err}."
-        ),
+        "Failed to solve linear system of equations (no. {eq_index}) at time {time:.6}, system status {err}.",
     );
     1
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -191,14 +191,12 @@ pub extern "C" fn rt_assert_common(msg: i32, sim_data: i32, initial: i32) -> i32
     if note_no_throw_assert() {
         use openmodelica_sim_meta::TIME_OFF;
         let time = if sim_data != 0 { unsafe { load_f64(sim_data as u32 + TIME_OFF) } } else { 0.0 };
-        crate::omclog::info(
+        crate::omclog::info!(
             crate::omclog::ASSERT,
             false,
-            &alloc::format!(
-                "The following assertion has been violated {}at time {}",
-                if initial != 0 { "during initialization " } else { "" },
-                crate::omclog::f(time, 0, 6)
-            ),
+            "The following assertion has been violated {}at time {}",
+            if initial != 0 { "during initialization " } else { "" },
+            crate::omclog::f(time, 0, 6),
         );
         if msg != 0 {
             crate::rt_release(msg as u32);
@@ -209,14 +207,12 @@ pub extern "C" fn rt_assert_common(msg: i32, sim_data: i32, initial: i32) -> i32
     if nls::throw_reports() {
         use openmodelica_sim_meta::TIME_OFF;
         let time = if sim_data != 0 { unsafe { load_f64(sim_data as u32 + TIME_OFF) } } else { 0.0 };
-        crate::omclog::warning(
+        crate::omclog::warning!(
             crate::omclog::ASSERT,
             false,
-            &alloc::format!(
-                "The following assertion has been violated {}at time {}",
-                if initial != 0 { "during initialization " } else { "" },
-                crate::omclog::f(time, 0, 6)
-            ),
+            "The following assertion has been violated {}at time {}",
+            if initial != 0 { "during initialization " } else { "" },
+            crate::omclog::f(time, 0, 6),
         );
         if nls::throw_logged() {
             crate::omclog::debug(crate::omclog::ASSERT, false, &rt_string(msg));
@@ -277,13 +273,11 @@ pub extern "C" fn rt_div_sim(a: f64, b: f64, msg: u32, time: f64, initial: i32) 
         // domain check somewhere downstream.
         return 0.0;
     } else if no_throw_div_zero() {
-        crate::omclog::warning(
+        crate::omclog::warning!(
             crate::omclog::DIVISION,
             false,
-            &alloc::format!(
-                "solver will try to handle division by zero at time {}: {s}",
-                format_g(time, 16)
-            ),
+            "solver will try to handle division by zero at time {}: {s}",
+            format_g(time, 16),
         );
         a / b
     } else {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -837,11 +837,7 @@ fn apply_baked_solver_flags(flags: &str) -> Option<()> {
             Ok(f)
         })
         .map_err(|e| {
-            omclog::error(
-                omclog::ASSERT,
-                false,
-                &alloc::format!("this FMU was exported with `{flags}`: {e}"),
-            )
+            omclog::error!(omclog::ASSERT, false, "this FMU was exported with `{flags}`: {e}")
         })
         .ok()?;
     openmodelica_codegen_wasm_jit_runtime::apply_sim_flags(&parsed);

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_nls/src/jacobian_analysis.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_nls/src/jacobian_analysis.rs
@@ -96,24 +96,22 @@ pub fn derivative_test(
         }
     }
 
-    omclog::info(
+    omclog::info!(
         stream,
         true,
-        &format!(
-            "{}: Derivative test (atol={}, rtol={}, scaled = {}, Caller: {}):",
-            caller.solver(),
-            omclog::e(atol, 0, 5),
-            omclog::e(rtol, 0, 5),
-            scaled,
-            caller.full()
-        ),
+        "{}: Derivative test (atol={}, rtol={}, scaled = {}, Caller: {}):",
+        caller.solver(),
+        omclog::e(atol, 0, 5),
+        omclog::e(rtol, 0, 5),
+        scaled,
+        caller.full(),
     );
     omclog::info(stream, true, "Matrix Info");
-    omclog::info(stream, false, &format!("NLS index = {eq_index}"));
-    omclog::info(stream, false, &format!("Columns   = {n}"));
-    omclog::info(stream, false, &format!("Rows      = {n}"));
-    omclog::info(stream, false, &format!("NNZ       = {}", sym.len()));
-    omclog::info(stream, false, &format!("Curr Time = {:<11}", omclog::e(time, 0, 5)));
+    omclog::info!(stream, false, "NLS index = {eq_index}");
+    omclog::info!(stream, false, "Columns = {n}");
+    omclog::info!(stream, false, "Rows = {n}");
+    omclog::info!(stream, false, "NNZ = {}", sym.len());
+    omclog::info!(stream, false, "Curr Time = {:<11}", omclog::e(time, 0, 5));
     omclog::close(stream);
 
     omclog::info(stream, true, "Anomalies");
@@ -127,11 +125,17 @@ pub fn derivative_test(
                 return;
             }
             let name = names.get(col).map(String::as_str).unwrap_or_default();
-            omclog::info(stream, true, &format!("Column / Variable: {}, Name: {name}", col + 1));
-            omclog::info(
+            omclog::info!(stream, true, "Column / Variable: {}, Name: {name}", col + 1);
+            omclog::info!(
                 stream,
                 false,
-                &format!("{:<12} {:<6} {:<6} {:<15}  {:<15}  {:<8}", "Type", "Col", "Row", "Symbolic", "Numerical", "RelError"),
+                "{:<12} {:<6} {:<6} {:<15}  {:<15}  {:<8}",
+                "Type",
+                "Col",
+                "Row",
+                "Symbolic",
+                "Numerical",
+                "RelError",
             );
             *found = true;
         };
@@ -154,35 +158,31 @@ pub fn derivative_test(
                 }
                 if rel_error > rtol {
                     open_column(&mut found);
-                    omclog::info(
+                    omclog::info!(
                         stream,
                         false,
-                        &format!(
-                            "{:<12} {:<6} {:<6} {}  {}  {}",
-                            "Numerical",
-                            col + 1,
-                            row + 1,
-                            sgn_e(sym_value, 8),
-                            sgn_e(num_value, 8),
-                            sgn_e(rel_error, 8)
-                        ),
+                        "{:<12} {:<6} {:<6} {}  {}  {}",
+                        "Numerical",
+                        col + 1,
+                        row + 1,
+                        sgn_e(sym_value, 8),
+                        sgn_e(num_value, 8),
+                        sgn_e(rel_error, 8),
                     );
                     numerical += 1;
                 }
             } else if libm::fabs(num_value) > atol {
                 open_column(&mut found);
-                omclog::info(
+                omclog::info!(
                     stream,
                     false,
-                    &format!(
-                        "{:<12} {:<6} {:<6} {}  {}  {}",
-                        "Structural",
-                        col + 1,
-                        row + 1,
-                        sgn_e(0.0, 8),
-                        sgn_e(num_value, 8),
-                        sgn_e(1.0, 8)
-                    ),
+                    "{:<12} {:<6} {:<6} {}  {}  {}",
+                    "Structural",
+                    col + 1,
+                    row + 1,
+                    sgn_e(0.0, 8),
+                    sgn_e(num_value, 8),
+                    sgn_e(1.0, 8),
                 );
                 structural += 1;
             }
@@ -194,14 +194,14 @@ pub fn derivative_test(
     omclog::close(stream);
 
     omclog::info(stream, true, "Summary");
-    omclog::info(stream, false, &format!("Numerical errors:  {numerical} (value mismatch w.r.t. reference)"));
-    omclog::info(stream, false, &format!("Structural errors: {structural} (non-zero not in sparsity pattern)"));
-    omclog::info(stream, false, &format!("Max relative error: {}", omclog::e(max_error, 0, 3)));
+    omclog::info!(stream, false, "Numerical errors: {numerical} (value mismatch w.r.t. reference)");
+    omclog::info!(stream, false, "Structural errors: {structural} (non-zero not in sparsity pattern)");
+    omclog::info!(stream, false, "Max relative error: {}", omclog::e(max_error, 0, 3));
     if numerical + structural > 0 {
-        omclog::warning(
+        omclog::warning!(
             stream,
             false,
-            &format!("Derivative test failed ({numerical} numerical, {structural} structural errors)"),
+            "Derivative test failed ({numerical} numerical, {structural} structural errors)",
         );
     }
     omclog::close(stream);
@@ -244,11 +244,11 @@ fn dense(n: usize, colptr: &[i32], rowidx: &[i32], vals: &[f64]) -> vec::Vec<f64
 fn print_matrix_info(eq_index: u32, time: f64, n: usize, nnz: usize) {
     let s = omclog::NLS_SVD;
     omclog::info(s, true, "Matrix Info");
-    omclog::info(s, false, &format!("NLS eq index = {eq_index}"));
-    omclog::info(s, false, &format!("Columns      = {n}"));
-    omclog::info(s, false, &format!("Rows         = {n}"));
-    omclog::info(s, false, &format!("NNZ          = {nnz}"));
-    omclog::info(s, false, &format!("Curr Time    = {:<11}", omclog::e(time, 0, 5)));
+    omclog::info!(s, false, "NLS eq index = {eq_index}");
+    omclog::info!(s, false, "Columns = {n}");
+    omclog::info!(s, false, "Rows = {n}");
+    omclog::info!(s, false, "NNZ = {nnz}");
+    omclog::info!(s, false, "Curr Time = {:<11}", omclog::e(time, 0, 5));
     omclog::close(s);
 }
 
@@ -257,21 +257,25 @@ fn print_cond(cond: f64) {
     let s = omclog::NLS_SVD;
     let c = |v: f64| omclog::e(v, 0, 8);
     omclog::info(s, true, "Matrix condition");
-    omclog::info(s, false, &format!("Cond(M) = {}", c(cond)));
+    omclog::info!(s, false, "Cond(M) = {}", c(cond));
     if cond > 1e12 {
-        omclog::warning(s, false, &format!("Matrix is very ill-conditioned: 1e12 < Cond(M) = {}", c(cond)));
+        omclog::warning!(s, false, "Matrix is very ill-conditioned: 1e12 < Cond(M) = {}", c(cond));
     } else if cond > 1e8 {
-        omclog::warning(
-            s, false,
-            &format!("Matrix is fairly ill-conditioned: 1e8 < Cond(M) = {} < 1e12", c(cond)),
+        omclog::warning!(
+            s,
+            false,
+            "Matrix is fairly ill-conditioned: 1e8 < Cond(M) = {} < 1e12",
+            c(cond),
         );
     } else if cond > 1e4 {
-        omclog::warning(
-            s, false,
-            &format!("Matrix is moderately ill-conditioned: 1e4 < Cond(M) = {} < 1e8", c(cond)),
+        omclog::warning!(
+            s,
+            false,
+            "Matrix is moderately ill-conditioned: 1e4 < Cond(M) = {} < 1e8",
+            c(cond),
         );
     } else {
-        omclog::info(s, false, &format!("Matrix is well conditioned: Cond(M) = {} < 1e4", c(cond)));
+        omclog::info!(s, false, "Matrix is well conditioned: Cond(M) = {} < 1e4", c(cond));
     }
     omclog::close(s);
 }
@@ -314,7 +318,7 @@ fn print_vectors(eq_index: u32, n: usize, idx: usize, sigma: f64, v: &[f64], u: 
 
     omclog::info(s, true, "Smallest right singular vectors (variable space)");
     omclog::info(s, false, "Found 1 singular vectors.");
-    omclog::info(s, true, &format!("V[:,{idx}] (singular value {})", omclog::e(sigma, 0, 8)));
+    omclog::info!(s, true, "V[:,{idx}] (singular value {})", omclog::e(sigma, 0, 8));
     for (i, val) in by_magnitude(&scaled_by(sign, v)) {
         let name = names.get(i).map(String::as_str).unwrap_or_default();
         let line = format!(
@@ -330,7 +334,7 @@ fn print_vectors(eq_index: u32, n: usize, idx: usize, sigma: f64, v: &[f64], u: 
 
     omclog::info(s, true, "Smallest left singular vectors (function space)");
     omclog::info(s, false, "Found 1 singular vectors.");
-    omclog::info(s, true, &format!("U[:,{idx}] (singular value {})", omclog::e(sigma, 0, 8)));
+    omclog::info!(s, true, "U[:,{idx}] (singular value {})", omclog::e(sigma, 0, 8));
     for (i, val) in by_magnitude(&scaled_by(sign, u)) {
         let eq = eqns.get(i).copied().unwrap_or(0);
         let line = format!(
@@ -392,13 +396,12 @@ fn sparse_svd(
             return;
         }
         let found = (found as usize).min(want);
-        omclog::info(
-            s, true,
-            &format!(
-                "{}: sparse SVD analysis (scaled = {scaled}, Caller: {}).",
-                caller.solver(),
-                caller.full()
-            ),
+        omclog::info!(
+            s,
+            true,
+            "{}: sparse SVD analysis (scaled = {scaled}, Caller: {}).",
+            caller.solver(),
+            caller.full(),
         );
         print_matrix_info(eq_index, time, n, vals.len());
         // C's `cond`: infinite where the smallest singular value vanished.
@@ -418,9 +421,14 @@ fn sparse_svd(
         }
         omclog::close(s);
         omclog::info(s, true, "Largest Singular values");
-        omclog::info(
-            s, false,
-            &format!("sigma_{:<3} =  {}, rnorm_{:<3} =  {}", 1, omclog::e(sval_top, 0, 8), 1, omclog::e(rnorm_top, 0, 8)),
+        omclog::info!(
+            s,
+            false,
+            "sigma_{:<3} =  {}, rnorm_{:<3} =  {}",
+            1,
+            omclog::e(sval_top, 0, 8),
+            1,
+            omclog::e(rnorm_top, 0, 8),
         );
         omclog::close(s);
 
@@ -446,33 +454,31 @@ fn dense_svd(
     if openmodelica_lapack::dgesvd("A", "A", n, n, &mut a, n, &mut sv, &mut u, n, &mut vt, n) != 0 {
         return;
     }
-    omclog::info(
-        s, true,
-        &format!(
-            "{}: dense SVD analysis (scaled = {scaled}, Caller: {}).",
-            caller.solver(),
-            caller.full()
-        ),
+    omclog::info!(
+        s,
+        true,
+        "{}: dense SVD analysis (scaled = {scaled}, Caller: {}).",
+        caller.solver(),
+        caller.full(),
     );
     print_matrix_info(eq_index, time, n, vals.len());
     let sigma_min = sv[n - 1];
     print_cond(if sigma_min > 0.0 { sv[0] / sigma_min } else { f64::INFINITY });
     omclog::info(s, true, "Singular values");
     for (i, v) in sv.iter().enumerate() {
-        omclog::info(s, false, &format!("sigma_{:<3} =  {}", i + 1, omclog::e(*v, 0, 8)));
+        omclog::info!(s, false, "sigma_{:<3} = {}", i + 1, omclog::e(*v, 0, 8));
     }
     omclog::close(s);
     let tol = n as f64 * f64::EPSILON * sv[0];
     let rank = sv.iter().filter(|v| **v > tol).count();
     omclog::info(s, true, "Rank estimation");
-    omclog::info(s, false, &format!("estimated = {rank}"));
-    omclog::info(s, false, &format!("actual    = {n}"));
-    omclog::info(
-        s, false,
-        &format!(
-            "estimation tolerance = {} (= sigma_max * max(rows, cols) * DBL_EPSILON)",
-            omclog::e(tol, 0, 8)
-        ),
+    omclog::info!(s, false, "estimated = {rank}");
+    omclog::info!(s, false, "actual = {n}");
+    omclog::info!(
+        s,
+        false,
+        "estimation tolerance = {} (= sigma_max * max(rows, cols) * DBL_EPSILON)",
+        omclog::e(tol, 0, 8),
     );
     omclog::info(
         s, false,
@@ -484,9 +490,11 @@ fn dense_svd(
     if first_below == n {
         for what in ["Smallest right singular vectors (variable space)", "Smallest left singular vectors (function space)"] {
             omclog::info(s, true, what);
-            omclog::info(
-                s, false,
-                &format!("No singular values below {} (1% of max)", omclog::e(threshold, 0, 8)),
+            omclog::info!(
+                s,
+                false,
+                "No singular values below {} (1% of max)",
+                omclog::e(threshold, 0, 8),
             );
             omclog::close(s);
         }

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_nls/src/kinsol.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_nls/src/kinsol.rs
@@ -1041,13 +1041,12 @@ pub mod sun {
             };
             unsafe { KINSetUserData(self.kin, &mut ud as *mut BUd as *mut c_void) };
             let v = openmodelica_solvers::omclog::NLS_V;
-            openmodelica_solvers::omclog::info(
-                v, true,
-                &alloc::format!(
-                    "Start solving Non-Linear System {eq_index} (size {}) at time {} with Kinsol Solver",
-                    self.n,
-                    openmodelica_solvers::format_g(time, 6)
-                ),
+            openmodelica_solvers::omclog::info!(
+                v,
+                true,
+                "Start solving Non-Linear System {eq_index} (size {}) at time {} with Kinsol Solver",
+                self.n,
+                openmodelica_solvers::format_g(time, 6),
             );
             let mut success = false;
             let mut retries = 0;
@@ -1074,20 +1073,16 @@ pub mod sun {
                 if let Some((path, file)) = crate::host::take_initial_guess_request(eq_index) {
                     let mut f = vec![0.0f64; self.n];
                     ud.residual(data(self.u, self.n), &mut f);
-                    openmodelica_solvers::omclog::info(
+                    openmodelica_solvers::omclog::info!(
                         openmodelica_solvers::omclog::STDOUT,
                         false,
-                        &alloc::format!(
-                            "Trying to write write initial guess for NLS system with index {eq_index} to file {path}."
-                        ),
+                        "Trying to write write initial guess for NLS system with index {eq_index} to file {path}.",
                     );
                     match crate::host::write_initial_guess(&file) {
-                        Ok(()) => openmodelica_solvers::omclog::info(
+                        Ok(()) => openmodelica_solvers::omclog::info!(
                             openmodelica_solvers::omclog::STDOUT,
                             false,
-                            &alloc::format!(
-                                "Success: Initial guess has been written to disk (path = {path}). The program will terminate now."
-                            ),
+                            "Success: Initial guess has been written to disk (path = {path}). The program will terminate now.",
                         ),
                         Err(e) => openmodelica_solvers::omclog::error(openmodelica_solvers::omclog::STDOUT, false, &e),
                     }
@@ -1109,14 +1104,13 @@ pub mod sun {
                     && self.handle_error(flag, &mut ud, nominal, start, old, &mut retries);
                 retries += 1;
                 passes += 1;
-                openmodelica_solvers::omclog::info(
-                    v, false,
-                    &alloc::format!(
-                        "Next try? success = {}, retry = {}, retries = {retries} = {}\n",
-                        success as u32,
-                        retry as u32,
-                        !success && !retry && retries < B_RETRY_MAX
-                    ),
+                openmodelica_solvers::omclog::info!(
+                    v,
+                    false,
+                    "Next try? success = {}, retry = {}, retries = {retries} = {}\n",
+                    success as u32,
+                    retry as u32,
+                    !success && !retry && retries < B_RETRY_MAX,
                 );
                 if success || !retry || retries >= B_RETRY_MAX || passes >= 2 * B_RETRY_MAX {
                     break;

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_nls/src/lib.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_nls/src/lib.rs
@@ -510,13 +510,11 @@ pub fn dt_solving(index: i32, strict: i32, time: f64, linear: bool) {
     } else {
         alloc::format!("(CASUAL TEARING SET, strict: {strict})")
     };
-    omclog::info(
+    omclog::info!(
         omclog::DT,
         false,
-        &alloc::format!(
-            "Solving {kind} system {index} {what} at time = {}",
-            format_g(time, 6)
-        ),
+        "Solving {kind} system {index} {what} at time = {}",
+        format_g(time, 6),
     );
 }
 
@@ -1145,10 +1143,11 @@ fn homotopy_algorithm(
 
     // C's `pFile`: header (`"lambda"` then the unknowns) and the start row.
     let mut csv = export.map(|e| {
-        omclog::info(
+        omclog::info!(
             omclog::INIT_HOMOTOPY,
             false,
-            &alloc::format!("The homotopy path will be exported to {}.", e.name),
+            "The homotopy path will be exported to {}.",
+            e.name,
         );
         let mut s = alloc::string::String::from("\"sep=,\"\n\"lambda\"");
         // C names the `n` residual coordinates; lambda has its own column.
@@ -1178,7 +1177,7 @@ fn homotopy_algorithm(
     let mut tangent_pos: i32 = -1;
 
     while y0[n] < 1.0 {
-        omclog::info(log, false, &alloc::format!("homotopy parameter lambda = {}", fmt_g6(y0[n])));
+        omclog::info!(log, false, "homotopy parameter lambda = {}", fmt_g6(y0[n]));
         if iter >= max_tries {
             return Err(if pre_tau == tau { HomFail::TauStuck } else { HomFail::MaxTries(iter) });
         }
@@ -1328,7 +1327,7 @@ fn homotopy_algorithm(
             }
         }
     }
-    omclog::info(log, false, &alloc::format!("homotopy parameter lambda = {}", fmt_g6(y0[n])));
+    omclog::info!(log, false, "homotopy parameter lambda = {}", fmt_g6(y0[n]));
     if let Some((name, s)) = csv {
         host::write_file(&name, &s);
     }
@@ -1894,7 +1893,7 @@ fn hybrd_c(
     let print_vector = |name: &str, v: &[f64]| {
         omclog::info(omclog::NLS_V, true, name);
         for (i, x) in v.iter().enumerate() {
-            omclog::info(omclog::NLS_V, false, &alloc::format!("[{i:>2}] {}", omclog::g(*x, 20, 12)));
+            omclog::info!(omclog::NLS_V, false, "[{i:>2}] {}", omclog::g(*x, 20, 12));
         }
         omclog::close(omclog::NLS_V);
     };
@@ -1904,27 +1903,23 @@ fn hybrd_c(
         }
     };
     if log_v {
-        omclog::info(
+        omclog::info!(
             omclog::NLS_V,
             true,
-            &alloc::format!(
-                "Start solving Non-Linear System {} (size {n}) at time {} with Hybrd Solver",
-                t.eq_index,
-                fmt_g6(t.time)
-            ),
+            "Start solving Non-Linear System {} (size {n}) at time {} with Hybrd Solver",
+            t.eq_index,
+            fmt_g6(t.time),
         );
         for i in 0..n {
             let name = names.get(i).map_or("", |s| s.as_str());
-            omclog::info(omclog::NLS_V, true, &alloc::format!("{}. {name} = {}", i + 1, omclog::f(x_start[i], 0, 6)));
-            omclog::info(
+            omclog::info!(omclog::NLS_V, true, "{}. {name} = {}", i + 1, omclog::f(x_start[i], 0, 6));
+            omclog::info!(
                 omclog::NLS_V,
                 false,
-                &alloc::format!(
-                    "    nominal = {}\nold = {}\nextrapolated = {}",
-                    omclog::f(nominal[i], 0, 6),
-                    omclog::f(warm[i], 0, 6),
-                    omclog::f(extrapolation[i], 0, 6)
-                ),
+                "    nominal = {}\nold = {}\nextrapolated = {}",
+                omclog::f(nominal[i], 0, 6),
+                omclog::f(warm[i], 0, 6),
+                omclog::f(extrapolation[i], 0, 6),
             );
             omclog::close(omclog::NLS_V);
         }
@@ -2060,8 +2055,8 @@ fn hybrd_c(
             if log_v {
                 omclog::info(omclog::NLS_V, true, "scaling factors for residual vector");
                 for i in 0..n {
-                    omclog::info(omclog::NLS_V, true, &alloc::format!("scaled residual [{i}] : {}", omclog::e(scaled[i], 0, 20)));
-                    omclog::info(omclog::NLS_V, false, &alloc::format!("scaling factor [{i}] : {}", omclog::e(res_scaling[i], 0, 20)));
+                    omclog::info!(omclog::NLS_V, true, "scaled residual [{i}] : {}", omclog::e(scaled[i], 0, 20));
+                    omclog::info!(omclog::NLS_V, false, "scaling factor [{i}] : {}", omclog::e(res_scaling[i], 0, 20));
                     omclog::close(omclog::NLS_V);
                 }
                 omclog::close(omclog::NLS_V);
@@ -2085,7 +2080,7 @@ fn hybrd_c(
             if !attempt_aborted() {
                 if log_v {
                     omclog::info(omclog::NLS_V, true, "System solved");
-                    omclog::info(omclog::NLS_V, false, &alloc::format!("{retries} retries\n{} restarts", retries2 + retries3));
+                    omclog::info!(omclog::NLS_V, false, "{retries} retries\n{} restarts", retries2 + retries3);
                     omclog::close(omclog::NLS_V);
                 }
                 set_continuous(true);
@@ -2286,10 +2281,10 @@ fn fmt_g6(v: f64) -> alloc::string::String {
 /// C's opening of the local adaptive approach's lambda0 pre-solve.
 fn log_local_adaptive_start(sys_num: u32) {
     let s = omclog::INIT_HOMOTOPY;
-    omclog::info(
+    omclog::info!(
         s,
         false,
-        &alloc::format!("Local homotopy with adaptive step size started for nonlinear system {sys_num}."),
+        "Local homotopy with adaptive step size started for nonlinear system {sys_num}.",
     );
     omclog::info(s, true, "homotopy process\n---------------------------");
     omclog::info(s, false, "solve lambda0-system");
@@ -2525,26 +2520,22 @@ fn diag_info(eq_index: u32) -> Option<&'static newton_diagnostics::DiagInfo> {
 /// C's `printNonLinearInitialInfo`, under the `solve_nonlinear_system` header.
 fn log_nls_enter(eq_index: u32, time: f64, x: &[f64], nominal: &[f64]) {
     use omclog;
-    omclog::info(
+    omclog::info!(
         omclog::NLS,
         true,
-        &alloc::format!(
-            "############ Solve nonlinear system {eq_index} at time {} ############",
-            format_g(time, 6)
-        ),
+        "############ Solve nonlinear system {eq_index} at time {} ############",
+        format_g(time, 6),
     );
     omclog::info(omclog::NLS, true, "initial variable values:");
     let names = var_names(eq_index);
     for i in 0..x.len() {
-        omclog::info(
+        omclog::info!(
             omclog::NLS,
             false,
-            &alloc::format!(
-                "{}{}\t\t nom = {}",
-                var_label(names, i),
-                omclog::g(x[i], 16, 8),
-                omclog::g(nominal[i], 16, 8)
-            ),
+            "{}{}\t\t nom = {}",
+            var_label(names, i),
+            omclog::g(x[i], 16, 8),
+            omclog::g(nominal[i], 16, 8),
         );
     }
     omclog::close(omclog::NLS);
@@ -2560,17 +2551,13 @@ fn log_nls_leave(eq_index: u32, solved: bool, x: &[f64]) {
         true,
         if solved { "Solution status: SOLVED" } else { "Solution status: FAILED" },
     );
-    omclog::info(omclog::NLS, false, &alloc::format!(" number of iterations           : {}", c[0]));
-    omclog::info(omclog::NLS, false, &alloc::format!(" number of function evaluations : {}", c[1]));
-    omclog::info(omclog::NLS, false, &alloc::format!(" number of jacobian evaluations : {}", c[2]));
+    omclog::info!(omclog::NLS, false, " number of iterations : {}", c[0]);
+    omclog::info!(omclog::NLS, false, " number of function evaluations : {}", c[1]);
+    omclog::info!(omclog::NLS, false, " number of jacobian evaluations : {}", c[2]);
     omclog::info(omclog::NLS, false, "solution values:");
     let names = var_names(eq_index);
     for i in 0..x.len() {
-        omclog::info(
-            omclog::NLS,
-            false,
-            &alloc::format!("{}{}", var_label(names, i), omclog::g(x[i], 16, 8)),
-        );
+        omclog::info!(omclog::NLS, false, "{}{}", var_label(names, i), omclog::g(x[i], 16, 8));
     }
     omclog::close(omclog::NLS);
     omclog::close(omclog::NLS);
@@ -2619,14 +2606,12 @@ fn log_homotopy_enter(t: &HomotopyTrace, n: usize, x: &[f64], nominal: &[f64], x
     if !omclog::active(omclog::NLS_V) {
         return;
     }
-    omclog::info(
+    omclog::info!(
         omclog::NLS_V,
         true,
-        &alloc::format!(
-            "Start solving Non-Linear System {} (size {n}) at time {} with Mixed (Newton/Homotopy) Solver",
-            t.eq_index,
-            format_g(t.time, 6)
-        ),
+        "Start solving Non-Linear System {} (size {n}) at time {} with Mixed (Newton/Homotopy) Solver",
+        t.eq_index,
+        format_g(t.time, 6),
     );
     let label = if t.discrete { "System values" } else { "System extrapolation" };
     omclog::debug_vector_double(omclog::NLS_V, label, x);
@@ -2652,17 +2637,15 @@ fn log_nls_status(t: &HomotopyTrace, x: &[f64], xscaling: &[f64], bounds: &[f64]
     omclog::info(omclog::NLS_V, true, "nls status");
     omclog::info(omclog::NLS_V, false, "variables");
     for i in 0..x.len() {
-        omclog::info(
+        omclog::info!(
             omclog::NLS_V,
             false,
-            &alloc::format!(
-                "{}{}\t\t nom = {}\t\t min = {}\t\t max = {}",
-                var_label(names, i),
-                omclog::g(x[i], 16, 8),
-                omclog::g(xscaling[i], 16, 8),
-                omclog::g(bounds[2 * i], 16, 8),
-                omclog::g(bounds[2 * i + 1], 16, 8)
-            ),
+            "{}{}\t\t nom = {}\t\t min = {}\t\t max = {}",
+            var_label(names, i),
+            omclog::g(x[i], 16, 8),
+            omclog::g(xscaling[i], 16, 8),
+            omclog::g(bounds[2 * i], 16, 8),
+            omclog::g(bounds[2 * i + 1], 16, 8),
         );
     }
     omclog::close(omclog::NLS_V);
@@ -2678,16 +2661,14 @@ fn log_newton_step(t: &HomotopyTrace, x1: &[f64], step: &[f64], x: &[f64]) {
     omclog::info(omclog::NLS_V, true, "newton step");
     omclog::info(omclog::NLS_V, false, "variables");
     for i in 0..x.len() {
-        omclog::info(
+        omclog::info!(
             omclog::NLS_V,
             false,
-            &alloc::format!(
-                "{}{}\t\t step = {}\t\t old = {}",
-                var_label(names, i),
-                omclog::g(x1[i], 16, 8),
-                omclog::g(step[i], 16, 8),
-                omclog::g(x[i], 16, 8)
-            ),
+            "{}{}\t\t step = {}\t\t old = {}",
+            var_label(names, i),
+            omclog::g(x1[i], 16, 8),
+            omclog::g(step[i], 16, 8),
+            omclog::g(x[i], 16, 8),
         );
     }
     omclog::close(omclog::NLS_V);
@@ -3073,12 +3054,10 @@ fn newton_c(
                 } else {
                     alloc::format!("at time {:.6}", t.time)
                 };
-                omclog::warning(
+                omclog::warning!(
                     omclog::NLS_V,
                     false,
-                    &alloc::format!(
-                        "Homotopy solver Newton iteration: Maximum number of iterations reached {when}, but no root found."
-                    ),
+                    "Homotopy solver Newton iteration: Maximum number of iterations reached {when}, but no root found.",
                 );
                 omclog::debug_string(omclog::NLS_V, NO_CONVERGE);
                 omclog::debug_string(omclog::NLS_V, BAR);
@@ -3573,13 +3552,11 @@ pub fn solve_nls(
         // Not a model throw — see [`NLS_EVAL_THREW`].
         if xs.iter().any(|v| !v.is_finite()) {
             if let Some(i) = xs[..n.min(xs.len())].iter().position(|v| !v.is_finite()) {
-                omclog::error(
+                omclog::error!(
                     omclog::NLS,
                     false,
-                    &alloc::format!(
-                        "residualFunc{eq_index}: Iteration variable `{}` is inf or nan.",
-                        var_names(eq_index).get(i).map_or("", |s| s.as_str())
-                    ),
+                    "residualFunc{eq_index}: Iteration variable `{}` is inf or nan.",
+                    var_names(eq_index).get(i).map_or("", |s| s.as_str()),
                 );
             }
             note_eval_hit(true, false);
@@ -3807,10 +3784,10 @@ pub fn solve_nls(
             return;
         }
         let name = alloc::format!("{}_nonlinsys{sys_num}_equidistant_local_homotopy.csv", host::file_prefix());
-        omclog::info(
+        omclog::info!(
             omclog::INIT_HOMOTOPY,
             false,
-            &alloc::format!("The homotopy path of system {sys_num} will be exported to {name}."),
+            "The homotopy path of system {sys_num} will be exported to {name}.",
         );
         let mut head = alloc::string::String::from("\"sep=,\"\n\"lambda\"");
         for v in var_names(eq_index) {
@@ -3839,10 +3816,11 @@ pub fn solve_nls(
         if attempt >= 0 {
             let lambda = (attempt as f64 / hom_steps as f64).min(1.0);
             state.borrow_mut().set_lambda(lambda);
-            omclog::info(
+            omclog::info!(
                 omclog::INIT_HOMOTOPY,
                 false,
-                &alloc::format!("[system {sys_num}] homotopy parameter lambda = {}", fmt_g6(lambda)),
+                "[system {sys_num}] homotopy parameter lambda = {}",
+                fmt_g6(lambda),
             );
         }
         settled = false;
@@ -4068,13 +4046,11 @@ pub fn solve_nls(
         // attempt falls through to the sweep.
         if attempt == -2 {
             lambda0_ok = attempt_converged;
-            omclog::info(
+            omclog::info!(
                 omclog::INIT_HOMOTOPY,
                 false,
-                &alloc::format!(
-                    "solving lambda0-system done with{} success\n---------------------------",
-                    if attempt_converged { "" } else { "no" }
-                ),
+                "solving lambda0-system done with{} success\n---------------------------",
+                if attempt_converged { "" } else { "no" },
             );
             omclog::close(omclog::INIT_HOMOTOPY);
             break 'attempts false;
@@ -4084,12 +4060,10 @@ pub fn solve_nls(
                 break 'attempts true;
             }
             if adaptive_homotopy {
-                omclog::warning(
+                omclog::warning!(
                     omclog::ASSERT,
                     false,
-                    &alloc::format!(
-                        "Failed to solve the initial system {sys_num} without homotopy method."
-                    ),
+                    "Failed to solve the initial system {sys_num} without homotopy method.",
                 );
                 if pre_lambda0 {
                     log_local_adaptive_start(sys_num);
@@ -4110,13 +4084,11 @@ pub fn solve_nls(
             counters::stat_add(counters::STAT_HOMOTOPY_STEPS, hom_steps as u64);
             break 'attempts false;
         }
-        omclog::info(
+        omclog::info!(
             omclog::INIT_HOMOTOPY,
             false,
-            &alloc::format!(
-                "[system {sys_num}] homotopy parameter lambda = {} done\n---------------------------",
-                fmt_g6((attempt as f64 / hom_steps as f64).min(1.0))
-            ),
+            "[system {sys_num}] homotopy parameter lambda = {} done\n---------------------------",
+            fmt_g6((attempt as f64 / hom_steps as f64).min(1.0)),
         );
         if let Some((_, csv)) = hom_csv.as_mut() {
             csv.push_str(&omclog::g((attempt as f64 / hom_steps as f64).min(1.0), 0, 16));

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_nls/src/newton_diagnostics.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_nls/src/newton_diagnostics.rs
@@ -35,12 +35,12 @@ pub struct Callbacks<'a> {
     pub jacobian: &'a mut dyn FnMut(&[f64], &mut [f64]),
 }
 
-fn info(msg: &str) {
-    omclog::info(STREAM, false, msg);
+macro_rules! info {
+    ($($arg:tt)*) => { omclog::info!(STREAM, false, $($arg)*) };
 }
 
-fn open(msg: &str) {
-    omclog::info(STREAM, true, msg);
+macro_rules! open {
+    ($($arg:tt)*) => { omclog::info!(STREAM, true, $($arg)*) };
 }
 
 fn close() {
@@ -114,7 +114,7 @@ pub fn newton_diagnostics(
     let m = x0.len();
     let name = |j: usize| names.get(j).map_or("", |s| s.as_str());
     let mut lambda = 1.0f64;
-    info(&format!("Running newton diagnostics for system {eq_index}"));
+    info!("Running newton diagnostics for system {eq_index}");
 
     // fx[i][j] = ∂f_i/∂x_j
     let mut fj = vec![0.0f64; m * m];
@@ -134,9 +134,9 @@ pub fn newton_diagnostics(
         let mut ipiv = vec![0i32; m];
         let info_ = openmodelica_lapack::dgesv(m, 1, &mut a, m, &mut ipiv, &mut b, m);
         if info_ > 0 {
-            info(&format!(
-                "getFirstNewtonStep: the first Newton step could not be computed; the info satus is : {info_}"
-            ));
+            info!(
+                "getFirstNewtonStep: the first Newton step could not be computed; the info satus is : {info_}",
+            );
         } else {
             for j in 0..m {
                 dx[j] = -b[j];
@@ -162,7 +162,7 @@ pub fn newton_diagnostics(
             for i in 0..m {
                 let v = (fj_pls[j * m + i] - fj_min[j * m + i]) / (2.0 * delta_x);
                 if v.is_nan() {
-                    info(&format!(
+                    info!(
                         "NaN detected: fxx[{}][{}][{}]: fxPls[{}][{}] = {}, fxMin[{}][{}] = {}, delta_x = {}\n",
                         i + 1,
                         j + 1,
@@ -173,8 +173,8 @@ pub fn newton_diagnostics(
                         i + 1,
                         j + 1,
                         omclog::f(fj_min[j * m + i], 0, 6),
-                        omclog::f(delta_x, 0, 6)
-                    ));
+                        omclog::f(delta_x, 0, 6),
+                    );
                     return;
                 }
                 fxx[i][k][j] = v;
@@ -190,11 +190,11 @@ pub fn newton_diagnostics(
     while failed {
         if !first {
             let d_lambda = 0.7;
-            info(&format!(
+            info!(
                 "Dampening factor lowered from {} to {}",
                 omclog::f(lambda, 7, 3),
-                omclog::f(lambda * d_lambda, 7, 3)
-            ));
+                omclog::f(lambda * d_lambda, 7, 3),
+            );
             lambda *= d_lambda;
         }
         first = false;
@@ -208,7 +208,7 @@ pub fn newton_diagnostics(
         (0..m).filter(|&i| libm::fabs(f_x1[i] + (lambda - 1.0) * f[i]) > eps_nl).collect();
     let p = n_idx.len();
     if p == 0 {
-        info("Newton diagnostics terminated: no non-linear equations!");
+        info!("Newton diagnostics terminated: no non-linear equations!");
         return;
     }
 
@@ -219,56 +219,56 @@ pub fn newton_diagnostics(
     let q = w_idx.len();
     let z_idx: Vec<usize> = (0..m).filter(|i| !w_idx.contains(i)).collect();
 
-    open("Information about the system from non-linear pattern");
-    info(&format!("Total number of equations    = {}", diag.pattern[0]));
-    info(&format!("Number of unknowns           = {}", diag.pattern[1]));
-    info(&format!("Number of non-linear entries = {}", diag.pattern[2]));
+    open!("Information about the system from non-linear pattern");
+    info!("Total number of equations = {}", diag.pattern[0]);
+    info!("Number of unknowns = {}", diag.pattern[1]);
+    info!("Number of non-linear entries = {}", diag.pattern[2]);
     close();
 
-    open("Information about the initial guess");
-    open("Vector x0 of unknowns");
+    open!("Information about the initial guess");
+    open!("Vector x0 of unknowns");
     for i in 0..m {
-        info(&format!("x0[{}] = {}  ({})", idx(i + 1, m, true), f14(x0[i]), name(i)));
+        info!("x0[{}] = {} ({})", idx(i + 1, m, true), f14(x0[i]), name(i));
     }
     close();
-    open("Residual function values of all equations f(x0)");
+    open!("Residual function values of all equations f(x0)");
     for i in 0..m {
         if libm::fabs(f[i]) > 1.0e-9 {
-            info(&format!("f[{}] = {}", idx(i + 1, m, false), f14(f[i])));
+            info!("f[{}] = {}", idx(i + 1, m, false), f14(f[i]));
         }
     }
     close();
-    open("Vector w0 of nonlinear unknowns");
+    open!("Vector w0 of nonlinear unknowns");
     for i in 0..q {
         // C numbers w0 from q+1 on in the two widest branches.
         let no = if m < 1000 { i + 1 } else { i + q + 1 };
-        info(&format!(
+        info!(
             "w0[{}] = x0[{}] = {}  ({})",
             idx(no, m, false),
             idx(w_idx[i] + 1, m, false),
             f14(x0[w_idx[i]]),
-            name(w_idx[i])
-        ));
+            name(w_idx[i]),
+        );
     }
     close();
     if m > q {
-        open("Vector z0 of nonlinear unknowns");
+        open!("Vector z0 of nonlinear unknowns");
         for i in 0..m - q {
-            info(&format!("z0[{}] = {}  ({})", idx(i + 1, m - q, false), f14(x0[z_idx[i]]), name(z_idx[i])));
+            info!("z0[{}] = {} ({})", idx(i + 1, m - q, false), f14(x0[z_idx[i]]), name(z_idx[i]));
         }
         close();
     }
-    open("Residual function values of all nonlinear equations n(w0)");
+    open!("Residual function values of all nonlinear equations n(w0)");
     for i in 0..p {
-        info(&format!(
+        info!(
             "n[{}] = f[{}] = {}",
             idx(i + 1, m, false),
             idx(n_idx[i] + 1, m, false),
-            f14(f[n_idx[i]])
-        ));
+            f14(f[n_idx[i]]),
+        );
     }
     close();
-    info(&format!("Final damping factor lambda = {}", omclog::g(lambda, 0, 3)));
+    info!("Final damping factor lambda = {}", omclog::g(lambda, 0, 3));
     close();
 
     // Largest residual of the nonlinear part: f + fz·dz over the linear unknowns.
@@ -323,7 +323,7 @@ pub fn newton_diagnostics(
 
     // Sigma = |diag(dw)⁻¹| · (-fx⁻¹ · (dxᵀ·fxx))[w,w] · diag(dw)
     let Some(mut inv_fx) = invert(m, &fx) else {
-        info("getInvJacobian: LU factorization could not be computed; the info status is : 1");
+        info!("getInvJacobian: LU factorization could not be computed; the info status is : 1");
         return;
     };
     let mut h_i = vec![vec![0.0f64; m]; m];
@@ -346,7 +346,7 @@ pub fn newton_diagnostics(
         w_diag[i][i] = dx[w_idx[i]];
     }
     let Some(mut inv_w) = invert(q, &w_diag) else {
-        info("getInvJacobian: LU factorization could not be computed; the info status is : 1");
+        info!("getInvJacobian: LU factorization could not be computed; the info status is : 1");
         return;
     };
     for row in inv_w.iter_mut() {
@@ -357,7 +357,7 @@ pub fn newton_diagnostics(
     let sigma = mat_mult(&mat_mult(&inv_w, &tmp2), &w_diag);
 
     print_results(m, p, q, &n_idx, &w_idx, x0, &alpha, &gamma, &sigma, names, diag);
-    info("Newton diagnostics complete!");
+    info!("Newton diagnostics complete!");
 }
 
 /// C's `PrintResults`: the indicators above `eps`, then ranked by variable and by
@@ -377,40 +377,40 @@ fn print_results(
 ) {
     let name = |j: usize| names.get(j).map_or("", |s| s.as_str());
     let eps = 1.0e-2;
-    open("Values of relevant indicators");
-    open(&format!("alpha_i > {}", omclog::f(eps, 5, 3)));
+    open!("Values of relevant indicators");
+    open!("alpha_i > {}", omclog::f(eps, 5, 3));
     for i in 0..p {
         if alpha[i] > eps {
-            info(&format!("alpha_{:<3} =  {}", n_idx[i] + 1, omclog::f(alpha[i], 5, 2)));
+            info!("alpha_{:<3} = {}", n_idx[i] + 1, omclog::f(alpha[i], 5, 2));
         }
     }
     close();
-    open(&format!("Gamma_ijk > {}", omclog::f(eps, 5, 3)));
+    open!("Gamma_ijk > {}", omclog::f(eps, 5, 3));
     for i in 0..p {
         for j in 0..q {
             for k in j..q {
                 if gamma[i][j][k] > eps {
-                    info(&format!(
+                    info!(
                         "Gamma_{:<4}_{:<4}_{:<4} =  {}",
                         n_idx[i] + 1,
                         w_idx[j] + 1,
                         w_idx[k] + 1,
-                        omclog::f(gamma[i][j][k], 5, 2)
-                    ));
+                        omclog::f(gamma[i][j][k], 5, 2),
+                    );
                 }
             }
         }
     }
     close();
-    open(&format!("sigma_jj > {}", omclog::f(eps, 5, 3)));
+    open!("sigma_jj > {}", omclog::f(eps, 5, 3));
     for i in 0..q {
         if libm::fabs(sigma[i][i]) > eps {
-            info(&format!(
+            info!(
                 "sigma_{:<4}_{:<4} = {}",
                 w_idx[i] + 1,
                 w_idx[i] + 1,
-                omclog::f(libm::fabs(sigma[i][i]), 5, 2)
-            ));
+                omclog::f(libm::fabs(sigma[i][i]), 5, 2),
+            );
         }
     }
     close();
@@ -461,23 +461,23 @@ fn print_results(
         picks
     };
 
-    open("Ranked indicators");
-    open("By variable");
-    info("Var no.  Var name                                  Initial guess  max(Gamma,sigma)");
-    info("-------  ----------------------------------------  -------------  ----------------");
+    open!("Ranked indicators");
+    open!("By variable");
+    info!("Var no.  Var name                                  Initial guess  max(Gamma,sigma)");
+    info!("-------  ----------------------------------------  -------------  ----------------");
     let sig_diag: Vec<f64> = (0..q).map(|i| libm::fabs(sigma[i][i])).collect();
     let mut printed: Vec<usize> = Vec::new();
     for pick in rank(&sig_diag, &|i| sig_diag[i]) {
         match pick {
             Pick::Scalar(s) => {
                 if !printed.contains(&s) {
-                    info(&format!(
+                    info!(
                         "{:>7}  {:>40}  {}    {}",
                         w_idx[s] + 1,
                         name(w_idx[s]),
                         omclog::g(x0[w_idx[s]], 13, 7),
-                        omclog::f(sig_diag[s], 5, 2)
-                    ));
+                        omclog::f(sig_diag[s], 5, 2),
+                    );
                     printed.push(s);
                 }
             }
@@ -486,13 +486,13 @@ fn print_results(
                 let pk = printed.contains(&k);
                 for (already, v) in [(pj, j), (pk, k)] {
                     if !already {
-                        info(&format!(
+                        info!(
                             "{:>7}  {:>40}  {}  {}",
                             w_idx[v] + 1,
                             name(w_idx[v]),
                             omclog::g(x0[w_idx[v]], 13, 7),
-                            omclog::f(gamma[i][j][k], 5, 2)
-                        ));
+                            omclog::f(gamma[i][j][k], 5, 2),
+                        );
                         printed.push(v);
                     }
                 }
@@ -501,9 +501,9 @@ fn print_results(
     }
     close();
 
-    open("By equation");
-    info("Eq no.  Eq idx    max(alpha,Gamma)");
-    info("------  ------    ----------------");
+    open!("By equation");
+    info!("Eq no.  Eq idx    max(alpha,Gamma)");
+    info!("------  ------    ----------------");
     let eq_idx = |i: usize| diag.eqns.get(i).copied().unwrap_or(0);
     let mut printed: Vec<usize> = Vec::new();
     for pick in rank(alpha, &|i| alpha[i]) {
@@ -511,18 +511,18 @@ fn print_results(
             Pick::Scalar(a) => {
                 if !printed.contains(&a) {
                     let v = if alpha[a] < 1.0e3 { omclog::f(alpha[a], 5, 2) } else { omclog::e(alpha[a], 5, 2) };
-                    info(&format!("{:>6}  {:>6}  {}", n_idx[a] + 1, eq_idx(n_idx[a]), v));
+                    info!("{:>6} {:>6} {}", n_idx[a] + 1, eq_idx(n_idx[a]), v);
                     printed.push(a);
                 }
             }
             Pick::Gamma(i, j, k) => {
                 if !printed.contains(&i) {
-                    info(&format!(
+                    info!(
                         "{:>6}  {:>6}  {}",
                         n_idx[i] + 1,
                         eq_idx(n_idx[i]),
-                        omclog::f(gamma[i][j][k], 5, 2)
-                    ));
+                        omclog::f(gamma[i][j][k], 5, 2),
+                    );
                     printed.push(i);
                 }
             }

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/driver.rs
@@ -160,12 +160,10 @@ fn state_selection_set(
     if !pivot(&mut jac, nd, nc, &mut st.row_pivot, &mut st.col_pivot) && report_error {
         log_state_set_jacobian(omclog::WARNING, omclog::DSS, info, &jac, set_index);
         let t = read_f64(e, sim_data + TIME_OFF)?;
-        omclog::error(
+        omclog::error!(
             omclog::STDOUT,
             false,
-            &format!(
-                "Error, singular Jacobian for dynamic state selection at time {t:.6}\nUse -lv LOG_DSS_JAC to get the Jacobian"
-            ),
+            "Error, singular Jacobian for dynamic state selection at time {t:.6}\nUse -lv LOG_DSS_JAC to get the Jacobian",
         );
         return Err("CodegenWasmJit: singular Jacobian for dynamic state selection");
     }
@@ -197,7 +195,7 @@ fn state_selection_set(
         }
         if omclog::active(omclog::DSS) {
             let t = read_f64(e, sim_data + TIME_OFF)?;
-            omclog::info(omclog::DSS, true, &format!("StateSelection Set {set_index} at time = {t:.6}"));
+            omclog::info!(omclog::DSS, true, "StateSelection Set {set_index} at time = {t:.6}");
             print_state_selection_info(e, sim_data, info)?;
             omclog::close(omclog::DSS);
         }
@@ -215,17 +213,17 @@ fn print_state_selection_info(e: &mut dyn SimEngine, sim_data: u32, info: &State
     let ns = info.n_states as usize;
     let name = |i: usize| info.candidate_names.get(i).map(String::as_str).unwrap_or("?");
     let plural = if ns == 1 { "" } else { "s" };
-    omclog::info(omclog::DSS, false, &format!("Select {ns} state{plural} from {nc} candidates."));
+    omclog::info!(omclog::DSS, false, "Select {ns} state{plural} from {nc} candidates.");
     omclog::info(omclog::DSS, true, "State candidates:");
     for k in 0..nc {
-        omclog::info(omclog::DSS, false, &format!("[{}] {}", k + 1, name(k)));
+        omclog::info!(omclog::DSS, false, "[{}] {}", k + 1, name(k));
     }
     omclog::close(omclog::DSS);
-    omclog::info(omclog::DSS, true, &format!("Selected state{plural}"));
+    omclog::info!(omclog::DSS, true, "Selected state{plural}");
     for row in 0..ns {
         for col in 0..nc {
             if read_i32(e, sim_data + info.a_offs[row * nc + col])? == 1 {
-                omclog::info(omclog::DSS, false, &format!("[{}] {}", col + 1, name(col)));
+                omclog::info!(omclog::DSS, false, "[{}] {}", col + 1, name(col));
                 break;
             }
         }
@@ -596,12 +594,6 @@ pub trait SimEngine {
     fn no_throw_div_zero_addr(&mut self) -> u32 {
         0
     }
-    /// Whether [`eval_discrete`] should call the model's own `functionDAE` (C's
-    /// generated one, `allEquations` with `discreteCall` raised). A wasm-jit module
-    /// always exports one, so there `has_when` decides instead.
-    fn has_discrete_entry(&self) -> bool {
-        false
-    }
     /// C's `cleanUpOldValueListAfterEvent`. Default: none (an engine that never
     /// integrates).
     fn clean_nls_history(&mut self, _time: f64) {}
@@ -804,10 +796,11 @@ impl StepRetry {
         if self.armed {
             // C's catch with `retry` already spent: the run ends here.
             let t = read_f64(e, sim_data + TIME_OFF).unwrap_or(f64::NAN);
-            omclog::info(
+            omclog::info!(
                 omclog::STDOUT,
                 false,
-                &format!("model terminate | Simulation terminated by an assert at time: {}", format_g(t, 6)),
+                "model terminate | Simulation terminated by an assert at time: {}",
+                format_g(t, 6),
             );
             return Ok(None);
         }
@@ -1442,14 +1435,12 @@ fn report_nls_failure_at(e: &dyn SimEngine, sim_data: u32, nls_fail_off: u32) {
         return;
     }
     let time = read_f64(e, sim_data + TIME_OFF).unwrap_or(0.0);
-    omclog::debug(
+    omclog::debug!(
         omclog::ASSERT,
         false,
-        &format!(
-            "Solving non-linear system {} failed at time={}.\nFor more information please use -lv LOG_NLS.",
-            failed - 1,
-            format_g15(time),
-        ),
+        "Solving non-linear system {} failed at time={}.\nFor more information please use -lv LOG_NLS.",
+        failed - 1,
+        format_g15(time),
     );
 }
 
@@ -1641,16 +1632,18 @@ fn overridden_on_command_line(name: &str) -> bool {
 /// a parameter is overwritten rather than the other way round.
 fn import_start_values(e: &mut dyn SimEngine, sim_data: u32, model: &SimMeta) -> Result<()> {
     let Some(imports) = imports_store::get() else { return Ok(()) };
-    omclog::info(
+    omclog::info!(
         omclog::INIT,
         false,
-        &format!("import start values\nfile: {}\ntime: {}", imports.file, format_g(imports.time, 6)),
+        "import start values\nfile: {}\ntime: {}",
+        imports.file,
+        format_g(imports.time, 6),
     );
     // `values` is in roster order, so one cursor walks both.
     let mut next = 0usize;
     let mut flat = 0u32;
     for (group, entries) in crate::IMPORT_GROUP.iter().zip(model.import_roster()) {
-        omclog::info(omclog::INIT, false, &format!("import {group}"));
+        omclog::info!(omclog::INIT, false, "import {group}");
         // C's headers are plural, its per-quantity lines singular.
         let one = group.trim_end_matches('s');
         for (name, off, wty) in entries {
@@ -1660,20 +1653,20 @@ fn import_start_values(e: &mut dyn SimEngine, sim_data: u32, model: &SimMeta) ->
             }
             flat += 1;
             if overridden_on_command_line(name) {
-                omclog::info(
+                omclog::info!(
                     omclog::INIT_V,
                     false,
-                    &format!("| skip import of {one} {name}: overridden on command line"),
+                    "| skip import of {one} {name}: overridden on command line",
                 );
                 continue;
             }
             let Some(v) = found else {
                 // C reports a missing quantity, except for the backend's own variables.
                 if !(group.ends_with("variables") && is_generated(name)) {
-                    omclog::warning(
+                    omclog::warning!(
                         omclog::INIT,
                         false,
-                        &format!("unable to import {one} {name} from given file"),
+                        "unable to import {one} {name} from given file",
                     );
                 }
                 continue;
@@ -1681,16 +1674,16 @@ fn import_start_values(e: &mut dyn SimEngine, sim_data: u32, model: &SimMeta) ->
             match wty {
                 WTy::F64 => {
                     write_f64(e, sim_data + off, v)?;
-                    omclog::info(omclog::INIT_V, false, &format!("| {name}(start={})", format_g(v, 6)));
+                    omclog::info!(omclog::INIT_V, false, "| {name}(start={})", format_g(v, 6));
                 }
                 WTy::I32 if group.starts_with("boolean") => {
                     write_i32(e, sim_data + off, (v != 0.0) as i32)?;
                     let b = if v != 0.0 { "true" } else { "false" };
-                    omclog::info(omclog::INIT_V, false, &format!("| {name}(start={b})"));
+                    omclog::info!(omclog::INIT_V, false, "| {name}(start={b})");
                 }
                 WTy::I32 => {
                     write_i32(e, sim_data + off, v as i32)?;
-                    omclog::info(omclog::INIT_V, false, &format!("| {name}(start={})", v as i32));
+                    omclog::info!(omclog::INIT_V, false, "| {name}(start={})", v as i32);
                 }
             }
         }
@@ -1979,7 +1972,7 @@ pub(crate) fn format_f(v: f64) -> String {
 /// C's `perform_simulation` line after `simulationStep`, closing its `LOG_SOLVER` block.
 fn log_solver_finished(t: f64) {
     if omclog::active(omclog::SOLVER) {
-        omclog::info(omclog::SOLVER, false, &format!("finished solver step {}", format_g(t, 6)));
+        omclog::info!(omclog::SOLVER, false, "finished solver step {}", format_g(t, 6));
         omclog::close(omclog::SOLVER);
     }
 }
@@ -2369,7 +2362,7 @@ fn log_static_data_update(e: &mut dyn SimEngine) {
 
 /// C's `INIT_METHOD_NAME`/`INIT_METHOD_DESC` line.
 fn log_init_method(name: &str, desc: &str) {
-    omclog::info(omclog::INIT, false, &format!("initialization method: {name:<15} [{desc}]"));
+    omclog::info!(omclog::INIT, false, "initialization method: {name:<15} [{desc}]");
 }
 
 /// C's `symbolic_initialization`: solve, then check the equations the backend
@@ -2501,13 +2494,11 @@ fn check_removed_initial_equations(
         .and_then(|m| m.removed_init_desc.get(idx as usize - 1))
         .map(String::as_str)
         .unwrap_or_default();
-    omclog::error(
+    omclog::error!(
         omclog::INIT,
         false,
-        &format!(
-            "The initialization problem is inconsistent due to the following equation: 0 != {} = {desc}",
-            format_g(res, 6)
-        ),
+        "The initialization problem is inconsistent due to the following equation: 0 != {} = {desc}",
+        format_g(res, 6),
     );
     Err(report_init_failure())
 }
@@ -2616,7 +2607,7 @@ fn log_bound_attr_updates(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout, 
             "start" => "primary start-values".to_string(),
             _ => format!("{name}-values"),
         };
-        omclog::info(omclog::INIT, true, &format!("updating {header}"));
+        omclog::info!(omclog::INIT, true, "updating {header}");
         if omclog::active(omclog::INIT_V) {
             for (i, a) in entries.iter().enumerate().filter(|(_, a)| a.kind as usize == kind) {
                 let v = read_f64(e, sim_data + layout.attr_log_off + i as u32 * 8).unwrap_or(0.0);
@@ -2760,17 +2751,18 @@ fn run_homotopy_continuation(
     for step in 0..=steps {
         let lambda = (step as f64 / steps as f64).min(1.0);
         write_f64(e, sim_data + layout.lambda_off, lambda)?;
-        omclog::info(omclog::INIT_HOMOTOPY, false, &format!("homotopy parameter lambda = {}", format_g(lambda, 6)));
+        omclog::info!(omclog::INIT_HOMOTOPY, false, "homotopy parameter lambda = {}", format_g(lambda, 6));
         if step == 0 {
             call_initial_equations_lambda0(e, sim_data, layout)?;
         } else {
             write_i32(e, sim_data + layout.nls_fail_off, 0)?;
             e.call1("functionInitialEquations", sim_data)?;
         }
-        omclog::info(
+        omclog::info!(
             omclog::INIT_HOMOTOPY,
             false,
-            &format!("homotopy parameter lambda = {} done\n---------------------------", format_g(lambda, 6)),
+            "homotopy parameter lambda = {} done\n---------------------------",
+            format_g(lambda, 6),
         );
         path.row(e, sim_data, layout, lambda);
     }
@@ -2804,10 +2796,10 @@ impl HomotopyPath {
             let file = match model {
                 Some(m) if omclog::active(omclog::INIT_HOMOTOPY) => {
                     let path = format!("{}_{name}", m.prefix);
-                    omclog::info(
+                    omclog::info!(
                         omclog::INIT_HOMOTOPY,
                         false,
-                        &format!("The homotopy path will be exported to {path}."),
+                        "The homotopy path will be exported to {path}.",
                     );
                     Some((path, String::new()))
                 }
@@ -2949,7 +2941,7 @@ fn report_terminate(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout, at_ini
     }
     let time = format_f(read_f64(e, sim_data + TIME_OFF)?);
     let at = if at_init { format!("at initialization (time {time})") } else { format!("at time {time}") };
-    omclog::info(omclog::STDOUT, false, &format!("Simulation call terminate() {at}\nMessage : {msg}"));
+    omclog::info!(omclog::STDOUT, false, "Simulation call terminate() {at}\nMessage : {msg}");
     Ok(())
 }
 
@@ -2975,16 +2967,14 @@ fn steady_state_reached(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout) ->
         return Ok(false);
     }
     steady_report::mark();
-    omclog::info(
+    omclog::info!(
         omclog::STDOUT,
         false,
-        &format!(
-            "steady state reached at time = {}\n  * max(|d(x_i)/dt|/nominal(x_i)) = {}\n  * \
-             relative tolerance = {}",
-            format_g(read_f64(e, sim_data + TIME_OFF)?, 6),
-            format_g(max_der, 6),
-            format_g(tol, 6),
-        ),
+        "steady state reached at time = {}\n  * max(|d(x_i)/dt|/nominal(x_i)) = {}\n  * \
+         relative tolerance = {}",
+        format_g(read_f64(e, sim_data + TIME_OFF)?, 6),
+        format_g(max_der, 6),
+        format_g(tol, 6),
     );
     Ok(true)
 }
@@ -3064,17 +3054,12 @@ fn eval_ode(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<
     e.call1("functionODE", sim_data)
 }
 
-/// One pass of C's `functionDAE`, which evaluates `allEquations` once. A
-/// `when`-model takes it through `functionAlgebraics`, which is that list plus
-/// `storePreValues`.
+/// One pass of C's `functionDAE`, which evaluates `allEquations` once.
 fn eval_discrete(e: &mut dyn SimEngine, sim_data: u32, layout: &SimLayout) -> Result<()> {
     if layout.dae_mode() {
         return e.call2(MODEL_FN_DAE, sim_data, eval_stage::DISCRETE);
     }
-    if e.has_discrete_entry() || !layout.has_when {
-        return e.call1("functionDAE", sim_data);
-    }
-    e.call1("functionAlgebraics", sim_data)
+    e.call1("functionDAE", sim_data)
 }
 
 /// C's `function_ZeroCrossingsEquations`: what the crossing functions read.
@@ -3145,7 +3130,7 @@ pub fn emit_terminal_row(
     }
     write_i32(e, sim_data + layout.nls_fail_off, 0)?;
     write_time(e, sim_data, time)?;
-    omclog::info(omclog::EVENTS_V, false, &format!("terminal event at stop time {}", format_g(time, 6)));
+    omclog::info!(omclog::EVENTS_V, false, "terminal event at stop time {}", format_g(time, 6));
     write_i32(e, sim_data + layout.terminal_off, 1)?;
     // A discrete call, so relations are live (C's `updateDiscreteSystem`
     // prologue): a condition that only becomes true at `stop` flips here.
@@ -3579,12 +3564,12 @@ fn log_state_event(time: f64, roots: &[usize], model: &SimMeta) {
     if !omclog::active(omclog::EVENTS) {
         return;
     }
-    omclog::info(omclog::EVENTS, true, &format!("state event at time={}", format_g(time, 12)));
+    omclog::info!(omclog::EVENTS, true, "state event at time={}", format_g(time, 12));
     // Highest index first: C's `checkForStateEvent` pushes each crossing onto the
     // front of the event list it then walks, so simultaneous ones come out reversed.
     for &i in roots.iter().rev() {
         let desc = model.zc_desc.get(i).map(String::as_str).unwrap_or_default();
-        omclog::info(omclog::EVENTS, false, &format!("[{}] {desc}", i + 1));
+        omclog::info!(omclog::EVENTS, false, "[{}] {desc}", i + 1);
     }
 }
 
@@ -3596,7 +3581,7 @@ fn log_reinits(e: &mut dyn SimEngine) {
         }
         let i = off.saturating_sub(REAL_OFF) as usize / 8;
         let name = event_dump_store::with(|d| d.real_names.get(i).cloned().unwrap_or_default());
-        omclog::info(omclog::EVENTS, false, &format!("reinit {name} = {}", format_g(value, 6)));
+        omclog::info!(omclog::EVENTS, false, "reinit {name} = {}", format_g(value, 6));
     }
 }
 
@@ -3605,16 +3590,18 @@ fn log_time_event(e: &dyn SimEngine, time: f64, samples: &Samples, model: &SimMe
     if !omclog::active(omclog::EVENTS) {
         return;
     }
-    omclog::info(omclog::EVENTS, true, &format!("time event at time={}", format_g(time, 12)));
+    omclog::info!(omclog::EVENTS, true, "time event at time={}", format_g(time, 12));
     for (k, start, interval) in samples.due(time) {
         let index = e
             .sample_index(k)
             .or_else(|| model.sample_index.get(k).copied())
             .unwrap_or(k as i32 + 1);
-        omclog::info(
+        omclog::info!(
             omclog::EVENTS,
             false,
-            &format!("[{index}] sample({}, {})", format_g(start, 6), format_g(interval, 6)),
+            "[{index}] sample({}, {})",
+            format_g(start, 6),
+            format_g(interval, 6),
         );
     }
 }
@@ -3707,20 +3694,20 @@ pub fn log_event_status(e: &dyn SimEngine, sim_data: u32, layout: &SimLayout, st
     }
     let time = format_g(read_f64(e, sim_data + TIME_OFF)?, 12);
     event_dump_store::with(|d| {
-        omclog::info(stream, true, &format!("status of relations at time={time}"));
+        omclog::info!(stream, true, "status of relations at time={time}");
         for i in 0..layout.n_rel {
             let flag = |off: u32| if read_i32(e, sim_data + off + i * 4).unwrap_or(0) != 0 { " true" } else { "false" };
             let desc = d.rel_desc.get(i as usize).map(String::as_str).unwrap_or_default();
             let (pre, cur) = (flag(layout.relations_pre_off), flag(layout.relations_off));
-            omclog::info(stream, false, &format!("[{}] (pre: {pre}) {cur} = {desc}", i + 1));
+            omclog::info!(stream, false, "[{}] (pre: {pre}) {cur} = {desc}", i + 1);
         }
         omclog::close(stream);
-        omclog::info(stream, true, &format!("status of zero crossings at time={time}"));
+        omclog::info!(stream, true, "status of zero crossings at time={time}");
         for i in 0..layout.n_zc {
             let g = |off: u32| omclog::g(read_f64(e, sim_data + off + i * 8).unwrap_or(0.0), 2, 1);
             let desc = d.zc_desc.get(i as usize).map(String::as_str).unwrap_or_default();
             let (pre, cur) = (g(layout.zc_pre_off), g(layout.zc_off));
-            omclog::info(stream, false, &format!("[{}] (pre: {pre}) {cur} = {desc}", i + 1));
+            omclog::info!(stream, false, "[{}] (pre: {pre}) {cur} = {desc}", i + 1);
         }
         omclog::close(stream);
     });
@@ -3747,7 +3734,7 @@ fn discrete_pre_values(e: &dyn SimEngine, sim_data: u32) -> Result<(Vec<f64>, Ve
 /// [`discrete_snapshot`], which compares the same regions in bulk.
 fn log_discrete_changes(e: &dyn SimEngine, sim_data: u32, before: &(Vec<f64>, Vec<i32>)) -> Result<()> {
     let time = format_g(read_f64(e, sim_data + TIME_OFF)?, 12);
-    omclog::info(omclog::EVENTS_V, true, &format!("check for discrete changes at time={time}"));
+    omclog::info!(omclog::EVENTS_V, true, "check for discrete changes at time={time}");
     event_dump_store::with(|d| {
         for ((name, live, _), v1) in d.reals.iter().zip(&before.0) {
             let v2 = read_f64(e, sim_data + live)?;
@@ -3760,7 +3747,7 @@ fn log_discrete_changes(e: &dyn SimEngine, sim_data: u32, before: &(Vec<f64>, Ve
         for ((name, live, _), v1) in d.ints.iter().zip(&before.1) {
             let v2 = read_i32(e, sim_data + live)?;
             if *v1 != v2 {
-                omclog::info(omclog::EVENTS_V, false, &format!("discrete var changed: {name} from {v1} to {v2}"));
+                omclog::info!(omclog::EVENTS_V, false, "discrete var changed: {name} from {v1} to {v2}");
             }
         }
         for ((name, live, _), v1) in d.bools.iter().zip(&before.1[n_int..]) {
@@ -3977,12 +3964,10 @@ fn iterate_discrete_from(
         }
         iter += 1;
         if iter > max {
-            omclog::debug(
+            omclog::debug!(
                 omclog::ASSERT,
                 false,
-                &format!(
-                    "Simulation terminated due to too many, i.e. {max}, event iterations.\n                     This could either indicate an inconsistent system or an undersized limit of                      event iterations.\nThe limit of event iterations can be specified using the                      runtime flag '\u{2013}mei=<value>'."
-                ),
+                "Simulation terminated due to too many, i.e. {max}, event iterations.\n                     This could either indicate an inconsistent system or an undersized limit of                      event iterations.\nThe limit of event iterations can be specified using the                      runtime flag '\u{2013}mei=<value>'.",
             );
             return Err(ASSERT_ERR);
         }
@@ -4311,10 +4296,11 @@ pub fn set_zc_tolerance(
 ) -> Result<()> {
     let rtol = if tolerance > 0.0 { tolerance } else { 1e-6 };
     let tol_zc = 1e-4 * rtol.max(1e-12);
-    omclog::info(
+    omclog::info!(
         omclog::EVENTS_V,
         false,
-        &format!("Set tolerance for zero-crossing hysteresis to: {}", omclog::e(tol_zc, 0, 6)),
+        "Set tolerance for zero-crossing hysteresis to: {}",
+        omclog::e(tol_zc, 0, 6),
     );
     write_f64(e, sim_data + layout.zctol_off, tol_zc)
 }
@@ -4467,14 +4453,10 @@ fn solver_setup(e: &mut dyn SimEngine, model: &SimModel, sim_data: u32) -> Resul
     // which a host that runs those functions itself has already made.
     if !e.host_logs_system_init() {
         omclog::info(omclog::LS, true, "initialize linear system solvers");
-        omclog::info(omclog::LS, false, &format!("{} linear systems", model.n_lin_systems));
+        omclog::info!(omclog::LS, false, "{} linear systems", model.n_lin_systems);
         omclog::close(omclog::LS);
         omclog::info(omclog::NLS, true, "initialize non-linear system solvers");
-        omclog::info(
-            omclog::NLS,
-            false,
-            &format!("{} non-linear systems", model.nls_vars.len()),
-        );
+        omclog::info!(omclog::NLS, false, "{} non-linear systems", model.nls_vars.len());
         omclog::close(omclog::NLS);
     }
     set_zc_tolerance(e, sim_data, layout, model.tolerance.min(model.step_size()))?;
@@ -4583,15 +4565,13 @@ pub fn finalize_run(e: &mut dyn SimEngine, model: &SimModel, sim_data: u32) -> R
     if let Some(tol) = crate::simflags::with_flags(crate::simflags::steady_state_tol)
         && !steady_report::hit()
     {
-        omclog::warning(
+        omclog::warning!(
             omclog::STDOUT,
             false,
-            &format!(
-                "Steady state has not been reached.\nThis may be due to too restrictive relative \
-                 tolerance ({}) or short stopTime ({}).",
-                format_g(tol, 6),
-                format_g(model.stop_time, 6),
-            ),
+            "Steady state has not been reached.\nThis may be due to too restrictive relative \
+             tolerance ({}) or short stopTime ({}).",
+            format_g(tol, 6),
+            format_g(model.stop_time, 6),
         );
     }
     signal_teardown();
@@ -4641,10 +4621,10 @@ pub fn drive(
     rtclock::tick(rtclock::TOTAL);
     let lv_time = crate::simflags::with_flags(|f| f.lv_time);
     if let Some((t0, t1)) = lv_time {
-        omclog::info(
+        omclog::info!(
             omclog::STDOUT,
             false,
-            &format!("Time dependent logging enabled. Activate logging in interval [{t0:.6}, {t1:.6}]"),
+            "Time dependent logging enabled. Activate logging in interval [{t0:.6}, {t1:.6}]",
         );
         // C reactivates the streams before `callSolver` when the run starts inside the window.
         if start >= t0 {
@@ -4761,13 +4741,11 @@ pub fn drive(
                             open_assert_window();
                             let updated = emit_row(e, &mut last, sim_data, layout, t, stop);
                             let _ = close_assert_window(e, sim_data).and(updated);
-                            omclog::info(
+                            omclog::info!(
                                 omclog::STDOUT,
                                 false,
-                                &format!(
-                                    "model terminate | Integrator failed. | Simulation terminated at time {}",
-                                    format_g(t, 6)
-                                ),
+                                "model terminate | Integrator failed. | Simulation terminated at time {}",
+                                format_g(t, 6),
                             );
                         }
                         return Err(enrich_trap(e, err));
@@ -5340,7 +5318,7 @@ fn set_jacobian_method(jac: Option<&JacAInfo>, log: bool) -> JacobianMethod {
         JacAvail::Available => requested.unwrap_or(M::ColoredSymJac),
     };
     if log {
-        omclog::info(omclog::JAC, false, &format!("Using Jacobian method: {}", method.desc()));
+        omclog::info!(omclog::JAC, false, "Using Jacobian method: {}", method.desc());
     }
     // Without an adjoint C's `evalJacobian` degenerates to the colored evaluation.
     match method {
@@ -5618,16 +5596,23 @@ unsafe fn dassl_log_jacobian(
     };
     let name = |i: usize| names.get(i).map(String::as_str).unwrap_or("");
     let value = |col: usize, row: usize| -(unsafe { *pd.add(col * n + row) });
-    omclog::info(omclog::JAC, true, &format!(
+    omclog::info!(
+        omclog::JAC,
+        true,
         "DASSL-Solver: analytical Jacobian pd (column-major) at time={}",
-        format_g(t, 6)
-    ));
+        format_g(t, 6),
+    );
     for col in 0..n {
         for row in 0..n {
-            omclog::info(omclog::JAC, false, &format!(
+            omclog::info!(
+                omclog::JAC,
+                false,
                 "J(row={row}:'{}', col={col}:'{}') = {} [flat={}]",
-                name(row), name(col), format_g(value(col, row), 16), col * n + row
-            ));
+                name(row),
+                name(col),
+                format_g(value(col, row), 16),
+                col * n + row,
+            );
         }
     }
     omclog::close(omclog::JAC);
@@ -5680,14 +5665,26 @@ unsafe fn dassl_log_jacobian(
         }
     }
     omclog::info(omclog::JAC, true, "Jacobian verification: analytical vs. numerical");
-    omclog::info(omclog::JAC, false, &format!(
+    omclog::info!(
+        omclog::JAC,
+        false,
         "Max absolute difference: {} at (row={}:'{}', col={}:'{}')",
-        format_g(max_abs, 6), abs_at.0, name(abs_at.0), abs_at.1, name(abs_at.1)
-    ));
-    omclog::info(omclog::JAC, false, &format!(
+        format_g(max_abs, 6),
+        abs_at.0,
+        name(abs_at.0),
+        abs_at.1,
+        name(abs_at.1),
+    );
+    omclog::info!(
+        omclog::JAC,
+        false,
         "Max relative difference: {} at (row={}:'{}', col={}:'{}')",
-        format_g(max_rel, 6), rel_at.0, name(rel_at.0), rel_at.1, name(rel_at.1)
-    ));
+        format_g(max_rel, 6),
+        rel_at.0,
+        name(rel_at.0),
+        rel_at.1,
+        name(rel_at.1),
+    );
     omclog::close(omclog::JAC);
     Ok(())
 }
@@ -5883,7 +5880,7 @@ fn log_dassl() -> bool {
 }
 
 fn log_dassl_step(t: f64) {
-    omclog::info(omclog::DASSL, false, &format!("new step at time = {}", format_g(t, 15)));
+    omclog::info!(omclog::DASSL, false, "new step at time = {}", format_g(t, 15));
 }
 
 /// The `dassl call statistics:` block, from the work-array indices `dassl.c` reads.
@@ -5906,7 +5903,7 @@ fn report_dassl_failure(idid: i32, t: f64) -> &'static str {
     if !msg.is_empty() {
         omclog::warning(omclog::STDOUT, false, msg);
     }
-    omclog::warning(omclog::STDOUT, false, &format!("can't continue. time = {t:.6}"));
+    omclog::warning!(omclog::STDOUT, false, "can't continue. time = {t:.6}");
     solver_fail_store::set(t);
     SOLVER_FAILED_ERR
 }
@@ -6322,15 +6319,13 @@ impl Driver for DasslDriver {
             }
             // C's `perform_simulation` `LOG_SOLVER` block around `simulationStep`.
             if fresh && omclog::active(omclog::SOLVER) {
-                omclog::info(
+                omclog::info!(
                     omclog::SOLVER,
                     true,
-                    &format!(
-                        "call solver from {} to {} (stepSize: {})",
-                        format_g(self.t, 6),
-                        format_g(tout, 6),
-                        format_g15(tout - self.t)
-                    ),
+                    "call solver from {} to {} (stepSize: {})",
+                    format_g(self.t, 6),
+                    format_g(tout, 6),
+                    format_g15(tout - self.t),
                 );
             }
             let logging = log_dassl();
@@ -6671,10 +6666,12 @@ fn log_cvode_configuration(rtol: f64, root_finding: bool, config: CvodeConfig) {
     // C's compatibility warning, before the banner it belongs to.
     let (lmm, iter) = config;
     if (lmm == CvodeLmm::Adams) != (iter == CvodeIter::FixedPoint) {
-        omclog::warning(
+        omclog::warning!(
             omclog::SOLVER,
             true,
-            &format!("Combination of {} and {} not recommended.", lmm.name(), iter.name()),
+            "Combination of {} and {} not recommended.",
+            lmm.name(),
+            iter.name(),
         );
         for line in [
             "Use simflags -cvodeLinearMultistepMethod and -cvodeNonlinearSolverIteration to set.",
@@ -6692,17 +6689,14 @@ fn log_cvode_configuration(rtol: f64, root_finding: bool, config: CvodeConfig) {
     ] {
         omclog::info(omclog::SOLVER, false, &line);
     }
-    omclog::info(
-        omclog::SOLVER,
-        false,
-        &format!("CVODE Using relative error tolerance {}", format_e(rtol)),
-    );
+    omclog::info!(omclog::SOLVER, false, "CVODE Using relative error tolerance {}", format_e(rtol));
     omclog::info(omclog::SOLVER, false, "CVODE Using dense internal linear solver SUNLinSol_Dense.");
     omclog::info(omclog::SOLVER, false, "CVODE Use internal dense numeric jacobian method.");
-    omclog::info(
+    omclog::info!(
         omclog::SOLVER,
         false,
-        &format!("CVODE uses internal root finding method {}", if root_finding { "YES" } else { "NO" }),
+        "CVODE uses internal root finding method {}",
+        if root_finding { "YES" } else { "NO" },
     );
     for line in [
         "CVODE maximum absolut step size 0".to_string(),
@@ -6854,32 +6848,32 @@ impl IdaState {
             {
                 if self.setup.ramp_recovers(flag, *t) {
                     self.setup.arm_ramp(ida, self.stop_time);
-                    omclog::warning(
+                    omclog::warning!(
                         omclog::SOLVER,
                         false,
-                        &format!(
-                            "##IDA## degenerate DAE operating point at t = {} (flag {flag}); \
-                             activating homotopy ramp",
-                            format_g(*t, 15)
-                        ),
+                        "##IDA## degenerate DAE operating point at t = {} (flag {flag}); \
+                         activating homotopy ramp",
+                        format_g(*t, 15),
                     );
                 }
                 ida.reinit(*t);
                 self.restarted = true;
-                omclog::warning(
+                omclog::warning!(
                     omclog::SOLVER,
                     false,
-                    &format!("##IDA## solver failed, try once again at time = {}", format_g(*t, 15)),
+                    "##IDA## solver failed, try once again at time = {}",
+                    format_g(*t, 15),
                 );
                 Progress::WorkQuota
             }
             crate::sundials::Stop::Failed(crate::sundials::IDA_RTFUNC_FAIL) => Progress::RootThrew,
             crate::sundials::Stop::Failed(flag) => {
                 // C's last word before it gives up (`ida_solver.c`).
-                omclog::info(
+                omclog::info!(
                     omclog::STDOUT,
                     false,
-                    &format!("##IDA## {flag} error occurred at time = {}", format_g(*t, 15)),
+                    "##IDA## {flag} error occurred at time = {}",
+                    format_g(*t, 15),
                 );
                 Progress::Failed("CodegenWasmJit: IDA failed")
             }
@@ -7463,15 +7457,13 @@ impl SolverCore {
             return Ok(());
         };
         let desc = model.zc_desc.get(zc).map(String::as_str).unwrap_or("<zero-crossing>");
-        omclog::info(
+        omclog::info!(
             omclog::STDOUT,
             false,
-            &format!(
-                "Chattering detected around time {t0}..{t1} ({CHATTER_LIMIT} state events in a row \
-                 with a total time delta less than the step size {step_size}). This can be a \
-                 performance bottleneck. Use -lv LOG_EVENTS for more information. The \
-                 zero-crossing was: {desc}"
-            ),
+            "Chattering detected around time {t0}..{t1} ({CHATTER_LIMIT} state events in a row \
+             with a total time delta less than the step size {step_size}). This can be a \
+             performance bottleneck. Use -lv LOG_EVENTS for more information. The \
+             zero-crossing was: {desc}",
         );
         if chatter_store::abort() {
             omclog::debug(
@@ -7968,20 +7960,18 @@ impl SolverCore {
             if target - self.t > step_eps {
                 // C's `perform_simulation` `LOG_SOLVER` block around `simulationStep`.
                 if omclog::active(omclog::SOLVER) {
-                    omclog::info(
+                    omclog::info!(
                         omclog::SOLVER,
                         true,
-                        &format!(
-                            "call solver from {} to {} (stepSize: {})",
-                            format_g(self.t, 6),
-                            format_g(target, 6),
-                            format_g15(target - self.t)
-                        ),
+                        "call solver from {} to {} (stepSize: {})",
+                        format_g(self.t, 6),
+                        format_g(target, 6),
+                        format_g15(target - self.t),
                     );
                 }
                 let solved = self.solve_toward(target, ctx, deadline, did_step)?;
                 if omclog::active(omclog::SOLVER) {
-                    omclog::info(omclog::SOLVER, false, &format!("finished solver step {}", format_g(self.t, 6)));
+                    omclog::info!(omclog::SOLVER, false, "finished solver step {}", format_g(self.t, 6));
                     omclog::close(omclog::SOLVER);
                 }
                 let rooted = match solved {
@@ -9535,7 +9525,7 @@ struct DaeSolve {
 
 #[cfg(sundials)]
 fn dae_calc_ic(ida: &mut crate::sundials::Ida, t: f64, tol: f64) -> Result<()> {
-    omclog::info(omclog::SOLVER, false, &format!("##IDA## do event update at {}", format_g(t, 15)));
+    omclog::info!(omclog::SOLVER, false, "##IDA## do event update at {}", format_g(t, 15));
     match ida.calc_ic_at(t, tol) {
         true => Ok(()),
         false => Err("CodegenWasmJit: IDA could not find consistent initial conditions (IDACalcIC)"),
@@ -10454,13 +10444,11 @@ impl GuessStepper {
                 Ok(Solved::RootThrew(err)) | Err(err) => {
                     iter += 1;
                     if iter > 10 {
-                        omclog::warning(
+                        omclog::warning!(
                             omclog::STDOUT,
                             false,
-                            &format!(
-                                "Initial guess failure at time {}",
-                                format_g(self.core.t, 12)
-                            ),
+                            "Initial guess failure at time {}",
+                            format_g(self.core.t, 12),
                         );
                         return Err(err);
                     }

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/extinput.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/extinput.rs
@@ -29,7 +29,7 @@ impl ExternalInput {
         // `-inputPath` is already folded in by `simflags::parse`.
         let path = String::from(file);
         let Some(text) = read_file(&path) else {
-            omclog::error(omclog::STDOUT, false, &format!("Failed to read CSV-file {path}"));
+            omclog::error!(omclog::STDOUT, false, "Failed to read CSV-file {path}");
             return None;
         };
         // C's `read_csv`: a leading `"sep=<c>"` names the delimiter and the data

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/lib.rs
@@ -146,8 +146,8 @@ pub struct Layout {
     /// `algVars ++ discreteAlgVars` (the real algebraic variables emitted as
     /// time-variant result signals after the states and derivatives).
     pub n_real_alg: u32,
-    /// `functionAlgebraics` also runs the discrete update / saves `pre`, so
-    /// drivers call it only in the once-per-step order.
+    /// `functionAlgebraics` ends with C's `storePreValues`, so a driver calls it
+    /// only in the once-per-step order.
     pub has_when: bool,
     /// A nonlinear system carries the homotopy operator (C's `homotopySupport`), so
     /// the driver runs the continuation over `functionInitialEquations_lambda0`.
@@ -1388,28 +1388,24 @@ impl SimMeta {
         };
         let min_step = 4.0 * f64::EPSILON * libm::fmax(libm::fabs(self.start_time), libm::fabs(self.stop_time));
         if step < min_step && span > 0.0 {
-            omclog::warning(
+            omclog::warning!(
                 STDOUT,
                 false,
-                &alloc::format!(
-                    "The step-size {} is too small. Adjust the step-size to {}.",
-                    crate::driver::format_g(step, 6),
-                    crate::driver::format_g(min_step, 6)
-                ),
+                "The step-size {} is too small. Adjust the step-size to {}.",
+                crate::driver::format_g(step, 6),
+                crate::driver::format_g(min_step, 6),
             );
             step = min_step;
         }
         if step > span + 1e-7 {
             omclog::warning(STDOUT, true, "Integrator step size greater than length of experiment");
-            omclog::info(
+            omclog::info!(
                 STDOUT,
                 false,
-                &alloc::format!(
-                    "start time: {:.6}, stop time: {:.6}, integrator step size: {:.6}",
-                    self.start_time,
-                    self.stop_time,
-                    step
-                ),
+                "start time: {:.6}, stop time: {:.6}, integrator step size: {:.6}",
+                self.start_time,
+                self.stop_time,
+                step,
             );
             omclog::close_warning(STDOUT);
         }
@@ -1430,11 +1426,7 @@ impl SimMeta {
         // C's `startNonInteractiveSimulation`, after `read_experiment`.
         if let Some(t) = f.linearize {
             self.stop_time = t;
-            omclog::info(
-                STDOUT,
-                false,
-                &alloc::format!("Linearization will be performed at point of time: {t:.6}"),
-            );
+            omclog::info!(STDOUT, false, "Linearization will be performed at point of time: {t:.6}");
         }
     }
 

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/optimization/mod.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/optimization/mod.rs
@@ -408,11 +408,7 @@ mod run {
                 nlp.str_option("hessian_constant", "yes");
             }
             Some("num") | Some("NUM") | None => {}
-            Some(other) => omclog::warning(
-                omclog::STDOUT,
-                false,
-                &format!("not support ipopt_hesse={other}"),
-            ),
+            Some(other) => omclog::warning!(omclog::STDOUT, false, "not support ipopt_hesse={other}"),
         }
 
         if let Some(ls) = flags.ls_ipopt.as_deref() {

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/optimization/setup.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/optimization/setup.rs
@@ -145,13 +145,11 @@ fn pick_up_dim(data: &mut OptData) {
     let np = match crate::simflags::with_flags(|f| f.optimizer_np) {
         Some(n) if n == 1 || n == 3 => n as usize,
         Some(n) => {
-            omclog::warning(
+            omclog::warning!(
                 omclog::STDOUT,
                 false,
-                &format!(
-                    "FLAG_OPTIZER_NP is {n}. Currently optimizer support only 1 and 3.\n\
-                     FLAG_OPTIZER_NP set of 3"
-                ),
+                "FLAG_OPTIZER_NP is {n}. Currently optimizer support only 1 and 3.\n\
+                 FLAG_OPTIZER_NP set of 3",
             );
             3
         }
@@ -204,7 +202,7 @@ fn grid_file_rows(file: &str, nsi: usize) -> (usize, bool) {
             (nsi, false)
         }
         Ok(times) if times.len() < 2 => {
-            omclog::warning(omclog::STDOUT, false, &format!("time grid file: {file} is empty"));
+            omclog::warning!(omclog::STDOUT, false, "time grid file: {file} is empty");
             (nsi, false)
         }
         Ok(times) => (times.len() - 1, true),
@@ -226,7 +224,7 @@ fn pick_up_time(data: &mut OptData) {
         1 => vec![1.0],
         3 => C3.to_vec(),
         n => {
-            omclog::error(omclog::STDOUT, false, &format!("Not support np = {n}"));
+            omclog::error!(omclog::STDOUT, false, "Not support np = {n}");
             vec![1.0]
         }
     };
@@ -237,11 +235,7 @@ fn pick_up_time(data: &mut OptData) {
     t.dt[0] = (t.tf - t.t0) / nsi as f64;
     t.t = vec![zeros(np); nsi];
     if nsi < 1 {
-        omclog::error(
-            omclog::STDOUT,
-            false,
-            &format!("Not support numberOfIntervals = {nsi} < 1"),
-        );
+        omclog::error!(omclog::STDOUT, false, "Not support numberOfIntervals = {nsi} < 1");
     }
     let dc: Vec<f64> = c.iter().map(|ck| ck * t.dt[0]).collect();
     for k in 0..np {
@@ -286,10 +280,12 @@ fn overwrite_time_grid_file(data: &mut OptData, file: &str, c: &[f64]) {
     t.dt[0] = t.t[0][np1] - t.t0;
     if t.dt[0] <= 0.0 {
         omclog::warning(omclog::STDOUT, false, "read time grid from file fail!");
-        omclog::warning(
+        omclog::warning!(
             omclog::STDOUT,
             false,
-            &format!("line 0: {} <= {}", format_g(t.t[0][np1], 6), format_g(t.t0, 6)),
+            "line 0: {} <= {}",
+            format_g(t.t[0][np1], 6),
+            format_g(t.t0, 6),
         );
         return;
     }
@@ -305,14 +301,12 @@ fn overwrite_time_grid_file(data: &mut OptData, file: &str, c: &[f64]) {
         }
         if t.dt[i] <= 0.0 {
             omclog::warning(omclog::STDOUT, false, "read time grid");
-            omclog::warning(
+            omclog::warning!(
                 omclog::STDOUT,
                 false,
-                &format!(
-                    "line {i}/{nsi}: {} <= {}",
-                    format_g(t.t[i][np1], 6),
-                    format_g(t.t[i - 1][np1], 6)
-                ),
+                "line {i}/{nsi}: {} <= {}",
+                format_g(t.t[i][np1], 6),
+                format_g(t.t[i - 1][np1], 6),
             );
             omclog::warning(omclog::STDOUT, false, "failed!");
             return;
@@ -541,11 +535,11 @@ fn print_some_model_infos(data: &mut OptData) {
 fn pick_up_states(data: &mut OptData) {
     let Some(file) = crate::simflags::with_flags(|f| f.state_file.clone()) else { return };
     let Some(text) = crate::extinput::read_file(&file) else {
-        omclog::warning(omclog::STDOUT, false, &format!("OMC can't find the file {file}."));
+        omclog::warning!(omclog::STDOUT, false, "OMC can't find the file {file}.");
         return;
     };
     if text.lines().next().is_none() {
-        omclog::error(omclog::STDOUT, false, &format!("External input file: {file} is empty!"));
+        omclog::error!(omclog::STDOUT, false, "External input file: {file} is empty!");
         return;
     }
     let mut out = String::new();
@@ -560,10 +554,11 @@ fn pick_up_states(data: &mut OptData) {
                 data.v0[slot] = start;
                 out.push_str(&format!("\n[{i}]set {name}.start {}", format_g(start, 6)));
             }
-            None => omclog::warning(
+            None => omclog::warning!(
                 omclog::STDOUT,
                 false,
-                &format!("it was impossible to set {name}.start {}", format_g(start, 6)),
+                "it was impossible to set {name}.start {}",
+                format_g(start, 6),
             ),
         }
     }
@@ -581,10 +576,10 @@ pub(crate) fn allocate_der_struct(data: &mut OptData) -> Result<()> {
     data.dim.update_hessian = match crate::simflags::with_flags(|f| f.keep_hessian) {
         Some(n) if n >= 0 => n,
         Some(n) => {
-            omclog::warning(
+            omclog::warning!(
                 omclog::STDOUT,
                 false,
-                &format!("not support {n} for keep hessian-matrix constant."),
+                "not support {n} for keep hessian-matrix constant.",
             );
             0
         }
@@ -1026,7 +1021,7 @@ fn initial_guess_cflag(data: &mut OptData, cflag: &str) -> i32 {
             2
         }
         other => {
-            omclog::warning(omclog::STDOUT, false, &format!("not support ipopt_init={other}"));
+            omclog::warning!(omclog::STDOUT, false, "not support ipopt_init={other}");
             1
         }
     }
@@ -1161,21 +1156,20 @@ fn initial_guess_sim(data: &mut OptData, o: i32) -> Result<i32> {
                 let v = data.v(i, j)[l];
                 if v < lo || v > hi {
                     driver::log_line(omclog::STDOUT, omclog::INFO, "\n********************************************\n");
-                    omclog::warning(
+                    omclog::warning!(
                         omclog::STDOUT,
                         false,
-                        &format!("Initial guess failure at time {}", format_g(t, 6)),
+                        "Initial guess failure at time {}",
+                        format_g(t, 6),
                     );
-                    omclog::warning(
+                    omclog::warning!(
                         omclog::STDOUT,
                         false,
-                        &format!(
-                            "{}<= ({}={}) <={}",
-                            format_g(lo, 6),
-                            data.names.get(l).map(String::as_str).unwrap_or(""),
-                            format_g(v, 6),
-                            format_g(hi, 6)
-                        ),
+                        "{}<= ({}={}) <={}",
+                        format_g(lo, 6),
+                        data.names.get(l).map(String::as_str).unwrap_or(""),
+                        format_g(v, 6),
+                        format_g(hi, 6),
                     );
                     driver::log_line(omclog::STDOUT, omclog::INFO, "\n********************************************");
                 }
@@ -1267,7 +1261,7 @@ pub(crate) fn res2file(data: &mut OptData) -> Result<()> {
         ],
         1 => vec![1.0],
         n => {
-            omclog::error(omclog::STDOUT, false, &format!("Not support np = {n}"));
+            omclog::error!(omclog::STDOUT, false, "Not support np = {n}");
             return Err("CodegenWasmJit: unsupported number of collocation points");
         }
     };
@@ -1315,11 +1309,7 @@ pub(crate) fn res2file(data: &mut OptData) -> Result<()> {
     // C keeps `optimizeInput.csv` open from the initial guess to here; the rows were
     // collected in `input_csv`.
     if let Err(e) = std::fs::write("optimizeInput.csv", &data.input_csv) {
-        omclog::warning(
-            omclog::STDOUT,
-            false,
-            &format!("optimizeInput.csv could not be written: {e}"),
-        );
+        omclog::warning!(omclog::STDOUT, false, "optimizeInput.csv could not be written: {e}");
     }
     Ok(())
 }

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/profiling.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/profiling.rs
@@ -239,7 +239,7 @@ fn write_traces(p: &Profiler) {
     for (suffix, bytes) in [("_prof.realdata", &p.real), ("_prof.intdata", &p.int)] {
         let name = format!("{}{}{suffix}", p.out, p.prefix);
         if !files::write(&name, bytes) {
-            omclog::warning(omclog::STDOUT, false, &format!("Time measurements output file {name} could not be opened"));
+            omclog::warning!(omclog::STDOUT, false, "Time measurements output file {name} could not be opened");
         }
     }
 }
@@ -568,7 +568,7 @@ fn print_model_info(p: &Profiler, info: &ProfInfo, model: &SimMeta, result_file:
     let xml_name = format!("{out}{prefix}_prof.xml");
     let plt_name = format!("{out}{prefix}_prof.plt");
     if !files::write(&xml_name, x.as_bytes()) {
-        omclog::warning(omclog::STDOUT, false, &format!("Failed to open {xml_name}"));
+        omclog::warning!(omclog::STDOUT, false, "Failed to open {xml_name}");
         return;
     }
     if !files::write(&plt_name, plt.as_bytes()) {
@@ -580,7 +580,7 @@ fn print_model_info(p: &Profiler, info: &ProfInfo, model: &SimMeta, result_file:
         if html {
             let cmd = format!("gnuplot {plt_name}");
             if !run_shell(&cmd) {
-                omclog::warning(omclog::DIVISION, false, &format!("Plot command failed: {cmd}\n"));
+                omclog::warning!(omclog::DIVISION, false, "Plot command failed: {cmd}\n");
             }
         }
         let (gen_html_failed, cmd) = match openmodelica_home() {
@@ -593,19 +593,17 @@ fn print_model_info(p: &Profiler, info: &ProfInfo, model: &SimMeta, result_file:
             None => (true, "OPENMODELICAHOME missing".to_string()),
         };
         if gen_html_failed {
-            omclog::warning(omclog::STDOUT, false, &format!("Failed to generate html version of profiling results: {cmd}\n"));
+            omclog::warning!(omclog::STDOUT, false, "Failed to generate html version of profiling results: {cmd}\n");
         }
     }
     if html {
-        omclog::info(
+        omclog::info!(
             omclog::STDOUT,
             false,
-            &format!(
-                "Time measurements are stored in {out}{prefix}_prof.html (human-readable) and {out}{prefix}_prof.xml (for XSL transforms or more details)"
-            ),
+            "Time measurements are stored in {out}{prefix}_prof.html (human-readable) and {out}{prefix}_prof.xml (for XSL transforms or more details)",
         );
     } else {
-        omclog::info(omclog::STDOUT, false, &format!("Time measurements are stored in {out}{prefix}_prof.json"));
+        omclog::info!(omclog::STDOUT, false, "Time measurements are stored in {out}{prefix}_prof.json");
     }
 }
 
@@ -713,6 +711,6 @@ fn print_model_info_json(p: &Profiler, info: &ProfInfo, model: &SimMeta, result_
     j.push_str("\n]\n}");
     let name = format!("{out}{prefix}_prof.json");
     if !files::write(&name, j.as_bytes()) {
-        omclog::warning(omclog::STDOUT, false, &format!("Failed to open file {name} for writing"));
+        omclog::warning!(omclog::STDOUT, false, "Failed to open file {name} for writing");
     }
 }

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/qss.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/qss.rs
@@ -7,7 +7,6 @@
 //! Jacobian's sparsity says depend on it. There is no output grid: one result row
 //! is emitted per accepted quantum change, at that change's own time.
 
-use alloc::format;
 use alloc::vec;
 use alloc::vec::Vec;
 
@@ -173,13 +172,11 @@ impl Driver for Qss {
             if self.tqp[ind].is_infinite() {
                 // If all derivatives are zero, the states stay constant and only
                 // the time propagates till stop->time.
-                omclog::warning(
+                omclog::warning!(
                     omclog::STDOUT,
                     false,
-                    &format!(
-                        "All derivatives are zero at time {}!.",
-                        format_f(read_f64(e, sim_data + TIME_OFF)?)
-                    ),
+                    "All derivatives are zero at time {}!.",
+                    format_f(read_f64(e, sim_data + TIME_OFF)?),
                 );
                 self.current_time = self.stop_time;
                 write_f64(e, sim_data + TIME_OFF, self.current_time)?;
@@ -361,8 +358,8 @@ fn print_sparse_structure(jac: &JacAInfo, stream: omclog::Stream, name: &str) {
         return;
     }
     let nnz: usize = jac.rows_by_col.iter().map(|r| r.len()).sum();
-    omclog::info(stream, true, &format!("Sparse structure of {name} [size: {0}x{0}]", jac.n));
-    omclog::info(stream, false, &format!("{nnz} non-zero elements"));
+    omclog::info!(stream, true, "Sparse structure of {name} [size: {0}x{0}]", jac.n);
+    omclog::info!(stream, false, "{nnz} non-zero elements");
 
     omclog::info(stream, true, "Transposed sparse structure (rows: states)");
     for rows in &jac.rows_by_col {

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/sync.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/sync.rs
@@ -10,7 +10,6 @@
 //! into this list, so the model raises a flag in `SimData` and
 //! [`Sync::take_fired`] turns it into a timer once the model call returns.
 
-use alloc::format;
 use alloc::vec::Vec;
 
 use crate::driver::{
@@ -268,16 +267,18 @@ impl Sync {
             e.call2(MODEL_FN_UPDATE_SYNC, self.sim_data, base)?;
             let interval = read_f64(e, off + clock_field::INTERVAL)?;
             self.insert(Timer { base, sub: None, time: time + interval });
-            omclog::info(
+            omclog::info!(
                 omclog::SYNCHRONOUS,
                 false,
-                &format!("Activated base-clock {base} at time {}", driver::format_f(time)),
+                "Activated base-clock {base} at time {}",
+                driver::format_f(time),
             );
         } else {
-            omclog::info(
+            omclog::info!(
                 omclog::SYNCHRONOUS,
                 false,
-                &format!("Activated event-clock {base} at time {}", driver::format_f(time)),
+                "Activated event-clock {base} at time {}",
+                driver::format_f(time),
             );
         }
 
@@ -329,10 +330,11 @@ impl Sync {
         write_f64(e, s_off + clock_field::SUB_LAST_ACTIVATION, time)?;
         e.call2(MODEL_FN_EQS_SYNC, self.sim_data, flat)?;
         let what = if hold { "which triggered event " } else { "" };
-        omclog::info(
+        omclog::info!(
             omclog::SYNCHRONOUS,
             false,
-            &format!("Activated sub-clock ({base},{sub}) {what}at time {}", driver::format_f(time)),
+            "Activated sub-clock ({base},{sub}) {what}at time {}",
+            driver::format_f(time),
         );
         Ok(if hold { Fired::Event } else { Fired::Timer })
     }
@@ -343,9 +345,9 @@ impl Sync {
             return Ok(());
         }
         omclog::info(omclog::SYNCHRONOUS, true, "Initialized synchronous timers.");
-        omclog::info(omclog::SYNCHRONOUS, false, &format!("Number of base clocks: {}", self.clocks.len()));
+        omclog::info!(omclog::SYNCHRONOUS, false, "Number of base clocks: {}", self.clocks.len());
         for (i, c) in self.clocks.iter().enumerate() {
-            omclog::info(omclog::SYNCHRONOUS, true, &format!("Base clock {}", i + 1));
+            omclog::info!(omclog::SYNCHRONOUS, true, "Base clock {}", i + 1);
             let off = self.sim_data + self.layout.base_clock_off(i as u32);
             let interval = read_f64(e, off + clock_field::INTERVAL)?;
             let counter = read_i32(e, off + clock_field::INTERVAL_COUNTER)?;
@@ -354,26 +356,28 @@ impl Sync {
             } else {
                 if counter != -1 {
                     let res = read_i32(e, off + clock_field::RESOLUTION)?;
-                    omclog::info(
+                    omclog::info!(
                         omclog::SYNCHRONOUS,
                         false,
-                        &format!("intervalCounter/resolution = : {counter}/{res}"),
+                        "intervalCounter/resolution = : {counter}/{res}",
                     );
                 }
-                omclog::info(omclog::SYNCHRONOUS, false, &format!("interval: {}", omclog::e(interval, 0, 6)));
+                omclog::info!(omclog::SYNCHRONOUS, false, "interval: {}", omclog::e(interval, 0, 6));
             }
-            omclog::info(omclog::SYNCHRONOUS, false, &format!("Number of sub-clocks: {}", c.sub.len()));
+            omclog::info!(omclog::SYNCHRONOUS, false, "Number of sub-clocks: {}", c.sub.len());
             for (j, s) in c.sub.iter().enumerate() {
-                omclog::info(
+                omclog::info!(
                     omclog::SYNCHRONOUS,
                     true,
-                    &format!("Sub-clock {} of base clock {}", j + 1, i + 1),
+                    "Sub-clock {} of base clock {}",
+                    j + 1,
+                    i + 1,
                 );
-                omclog::info(omclog::SYNCHRONOUS, false, &format!("shift: {}/{}", s.shift_num, s.shift_den));
-                omclog::info(omclog::SYNCHRONOUS, false, &format!("factor: {}/{}", s.factor_num, s.factor_den));
+                omclog::info!(omclog::SYNCHRONOUS, false, "shift: {}/{}", s.shift_num, s.shift_den);
+                omclog::info!(omclog::SYNCHRONOUS, false, "factor: {}/{}", s.factor_num, s.factor_den);
                 let method = if s.external_solver { "External" } else { "none" };
-                omclog::info(omclog::SYNCHRONOUS, false, &format!("solverMethod: {method}"));
-                omclog::info(omclog::SYNCHRONOUS, false, &format!("holdEvents: {}", s.hold_events));
+                omclog::info!(omclog::SYNCHRONOUS, false, "solverMethod: {method}");
+                omclog::info!(omclog::SYNCHRONOUS, false, "holdEvents: {}", s.hold_events);
                 omclog::close(omclog::SYNCHRONOUS);
             }
             omclog::close(omclog::SYNCHRONOUS);

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/data.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/data.rs
@@ -714,10 +714,8 @@ fn layout_for(
         // equation itself, so this is a flag rather than a count.
         cb.functionRemovedInitialEquations.is_some() as u32,
         unsafe { crate::support::compiledWithSymSolver } as u8,
-        // `has_when` asks whether `functionAlgebraics` doubles as the discrete
-        // update, which is a property of the wasm-jit codegen's split. A C model
-        // keeps the `when`-equations in `functionDAE`, so its `functionAlgebraics`
-        // is the plain algebraic pass a pre-event row wants evaluated.
+        // `has_when` asks whether `functionAlgebraics` ends with `storePreValues`;
+        // only the wasm-jit codegen folds that in, C's runtime does it after.
         false,
         has_homotopy,
         openmodelica_sim_meta::HomotopyMethod::from_code(cb.homotopyMethod as u8),

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/engine.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/engine.rs
@@ -243,10 +243,6 @@ impl SimEngine for CEngine {
         true
     }
 
-    fn has_discrete_entry(&self) -> bool {
-        self.rt.callbacks().functionDAE.is_some()
-    }
-
     fn call1_raw(&mut self, name: &str, _arg: u32) -> Result<()> {
         let cb = self.rt.callbacks();
         match name {

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/iif.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/iif.rs
@@ -36,19 +36,17 @@ pub fn resolve(meta: &SimMeta, result_file: &str) -> bool {
     let Some(file) = file else { return true };
     let time = time.unwrap_or(meta.start_time);
     if file == result_file {
-        omclog::error(
+        omclog::error!(
             omclog::INIT,
             false,
-            &format!(
-                "Cannot import a result file for initialization that is also the current output file <{file}>.\nConsider redirecting the output result file (-r=<new_res.mat>) or renaming the result file that is used for initialization import."
-            ),
+            "Cannot import a result file for initialization that is also the current output file <{file}>.\nConsider redirecting the output result file (-r=<new_res.mat>) or renaming the result file that is used for initialization import.",
         );
         return false;
     }
     let mut reader = match MatReader::open(&file) {
         Ok(r) => r,
         Err(why) => {
-            omclog::debug(omclog::ASSERT, false, &format!("unable to read input-file <{file}> [{why}]"));
+            omclog::debug!(omclog::ASSERT, false, "unable to read input-file <{file}> [{why}]");
             return false;
         }
     };

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/info_json.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/info_json.rs
@@ -89,10 +89,10 @@ fn read(xml: &MODEL_DATA_XML) -> Table {
         match std::fs::read_to_string(&name) {
             Ok(s) => s,
             Err(e) => {
-                omclog::warning(
+                omclog::warning!(
                     omclog::STDOUT,
                     false,
-                    &format!("could not read {name}: {e}; equation names are unavailable"),
+                    "could not read {name}: {e}; equation names are unavailable",
                 );
                 return empty;
             }
@@ -103,11 +103,7 @@ fn read(xml: &MODEL_DATA_XML) -> Table {
     let doc: serde_json::Value = match serde_json::from_str(&text) {
         Ok(v) => v,
         Err(e) => {
-            omclog::warning(
-                omclog::STDOUT,
-                false,
-                &format!("could not parse the model's info JSON: {e}"),
-            );
+            omclog::warning!(omclog::STDOUT, false, "could not parse the model's info JSON: {e}");
             return empty;
         }
     };

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/mixed.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/mixed.rs
@@ -102,7 +102,7 @@ pub fn initialize_mixed_systems(data: *mut DATA, thread_data: *mut threadData_t)
         crate::throw(thread_data, "unrecognized mixed solver");
     }
     omclog::info(omclog::MIXED, true, "initialize mixed system solvers");
-    omclog::info(omclog::MIXED, false, &format!("{} mixed systems", md.nMixedSystems));
+    omclog::info!(omclog::MIXED, false, "{} mixed systems", md.nMixedSystems);
     for i in 0..md.nMixedSystems as usize {
         let sys = unsafe { &mut *si.mixedSystemData.add(i) };
         let size = sys.size.max(0) as usize;
@@ -148,11 +148,7 @@ fn solve_mixed_search(
     let time = unsafe { (**(*data).localData).timeValue };
     let n_rel = md.nRelations.max(0) as usize;
 
-    omclog::info(
-        omclog::MIXED,
-        true,
-        &format!("\n####  Start solver mixed equation system at time {time}."),
-    );
+    omclog::info!(omclog::MIXED, true, "\n#### Start solver mixed equation system at time {time}.");
     // C's `memset(stateofSearch, 0, systemData->size)` clears `size` *bytes* of a
     // `modelica_boolean` (an `int`) array, so its flip mask starts partly
     // uninitialised. This clears the whole thing, which is a deliberate divergence:
@@ -225,14 +221,12 @@ fn solve_mixed_search(
                 }
             } else {
                 if si.initial == 0 {
-                    omclog::warning(
+                    omclog::warning!(
                         omclog::STDOUT,
                         false,
-                        &format!(
-                            "Error solving mixed equation system with index {} at time {}",
-                            sys.equationIndex,
-                            openmodelica_sim_meta::driver::format_e(time)
-                        ),
+                        "Error solving mixed equation system with index {} at time {}",
+                        sys.equationIndex,
+                        openmodelica_sim_meta::driver::format_e(time),
                     );
                 }
                 si.needToIterate = 1;
@@ -273,14 +267,12 @@ pub extern "C" fn check_mixed_solutions(data: *mut DATA, print: c_int) -> c_int 
             ret = 1;
             if print != 0 {
                 let time = unsafe { (**(*data).localData).timeValue };
-                omclog::warning(
+                omclog::warning!(
                     omclog::MIXED,
                     false,
-                    &format!(
-                        "mixed system fails: {} at t={}",
-                        sys.equationIndex,
-                        openmodelica_sim_meta::driver::format_g(time, 6)
-                    ),
+                    "mixed system fails: {} at t={}",
+                    sys.equationIndex,
+                    openmodelica_sim_meta::driver::format_g(time, 6),
                 );
             }
         }

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/model_data.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/model_data.rs
@@ -311,10 +311,10 @@ pub fn do_override(xml: &mut InitXml, flags: &openmodelica_sim_meta::simflags::S
     let raw = flags.override_raw.as_deref();
     let file = flags.override_file.as_ref();
     if let (Some(raw), Some((path, _))) = (raw, file) {
-        omclog::info(omclog::SOLVER, false, &format!("using -override={raw} and -overrideFile={path}"));
+        omclog::info!(omclog::SOLVER, false, "using -override={raw} and -overrideFile={path}");
     }
     if let Some((path, _)) = file {
-        omclog::info(omclog::SOLVER, false, &format!("read override values from file: {path}"));
+        omclog::info!(omclog::SOLVER, false, "read override values from file: {path}");
     }
     if raw.is_none() && file.is_none() {
         omclog::info(omclog::SOLVER, false, "NO override given on the command line.");
@@ -323,12 +323,8 @@ pub fn do_override(xml: &mut InitXml, flags: &openmodelica_sim_meta::simflags::S
     fn given(v: Option<&str>) -> &str {
         v.unwrap_or("[not given]")
     }
-    omclog::info(omclog::SOLVER, false, &format!("-override={}", given(raw)));
-    omclog::info(
-        omclog::SOLVER,
-        false,
-        &format!("-overrideFile={}", given(file.map(|(_, j)| j.as_str()))),
-    );
+    omclog::info!(omclog::SOLVER, false, "-override={}", given(raw));
+    omclog::info!(omclog::SOLVER, false, "-overrideFile={}", given(file.map(|(_, j)| j.as_str())));
 
     // C fills a hash map, so a repeated name keeps the last value and warns; the
     // insertion order is the one the unused-override warnings come out in.
@@ -338,10 +334,10 @@ pub fn do_override(xml: &mut InitXml, flags: &openmodelica_sim_meta::simflags::S
         match index.get(name) {
             Some(&k) => {
                 let old = &map[k].1;
-                omclog::warning(
+                omclog::warning!(
                     omclog::STDOUT,
                     false,
-                    &format!("You are overriding variable: {name}={old} again with {name}={val}."),
+                    "You are overriding variable: {name}={old} again with {name}={val}.",
                 );
                 map[k].1 = val.clone();
             }
@@ -395,33 +391,29 @@ pub fn do_override(xml: &mut InitXml, flags: &openmodelica_sim_meta::simflags::S
         used[k] = true;
         let value = map[k].1.clone();
         if v.get("isValueChangeable") != "true" {
-            omclog::warning(
+            omclog::warning!(
                 omclog::STDOUT,
                 false,
-                &format!(
-                    "It is not possible to override the following quantity: {name}\nIt seems to be structural, final, protected or evaluated or has a non-constant binding."
-                ),
+                "It is not possible to override the following quantity: {name}\nIt seems to be structural, final, protected or evaluated or has a non-constant binding.",
             );
             continue;
         }
-        omclog::info(omclog::SOLVER, false, &format!("override {name} = {value}"));
+        omclog::info!(omclog::SOLVER, false, "override {name} = {value}");
         if warn_small && value.parse::<f64>().map(|x| x.abs() < 1e-6).unwrap_or(false) {
-            omclog::warning(
+            omclog::warning!(
                 omclog::STDOUT,
                 false,
-                &format!(
-                    "You are overriding {name} with a small value or zero.\nThis could lead to numerically dirty solutions or divisions by zero if not tearingStrictness=veryStrict."
-                ),
+                "You are overriding {name} with a small value or zero.\nThis could lead to numerically dirty solutions or divisions by zero if not tearingStrictness=veryStrict.",
             );
         }
         v.attrs.insert("start".to_string(), value);
     }
     for (k, (name, _)) in map.iter().enumerate() {
         if !used[k] {
-            omclog::warning(
+            omclog::warning!(
                 omclog::STDOUT,
                 false,
-                &format!("simulation_input_xml.c: override variable name not found in model: {name}\n"),
+                "simulation_input_xml.c: override variable name not found in model: {name}\n",
             );
         }
     }

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/nls.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/nls.rs
@@ -381,7 +381,7 @@ pub fn initialize_nonlinear_systems(data: *mut DATA, thread_data: *mut threadDat
     let md = unsafe { &*(*data).modelData };
     let si = unsafe { &mut *(*data).simulationInfo };
     omclog::info(omclog::NLS, true, "initialize non-linear system solvers");
-    omclog::info(omclog::NLS, false, &format!("{} non-linear systems", md.nNonLinearSystems));
+    omclog::info!(omclog::NLS, false, "{} non-linear systems", md.nNonLinearSystems);
     for i in 0..md.nNonLinearSystems as usize {
         let sys = unsafe { &mut *si.nonlinearSystemData.add(i) };
         let size = sys.size.max(0) as usize;
@@ -408,13 +408,12 @@ pub fn initialize_nonlinear_systems(data: *mut DATA, thread_data: *mut threadDat
             let rows = if adaptive_homotopy(data, sys) { size - 1 } else { size };
             if failed || j.sizeRows != rows || j.sizeCols != size {
                 if !failed {
-                    omclog::warning(
+                    omclog::warning!(
                         omclog::STDOUT,
                         false,
-                        &format!(
-                            "Analytic Jacobian of non-linear system {i} is {}x{}, but the system has {size} iteration variables. This indicates that something went wrong during Jacobian generation. Using a numeric Jacobian instead.",
-                            j.sizeRows, j.sizeCols
-                        ),
+                        "Analytic Jacobian of non-linear system {i} is {}x{}, but the system has {size} iteration variables. This indicates that something went wrong during Jacobian generation. Using a numeric Jacobian instead.",
+                        j.sizeRows,
+                        j.sizeCols,
                     );
                 }
                 sys.jacobianIndex = -1;
@@ -437,12 +436,10 @@ pub fn initialize_nonlinear_systems(data: *mut DATA, thread_data: *mut threadDat
         // scaling with it.
         if !sys.sparsePattern.is_null() && !sparsity_is_regular(unsafe { &*sys.sparsePattern }, size)
         {
-            omclog::warning(
+            omclog::warning!(
                 omclog::STDOUT,
                 false,
-                &format!(
-                    "Sparsity pattern for non-linear system {i} is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling."
-                ),
+                "Sparsity pattern for non-linear system {i} is not regular. This indicates that something went wrong during sparsity pattern generation. Removing sparsity pattern and disabling NLS scaling.",
             );
             crate::support::freeSparsePattern(sys.sparsePattern);
             sys.sparsePattern = core::ptr::null_mut();
@@ -699,14 +696,12 @@ fn check_nonlinear_solution(data: *mut DATA, print: c_int, sys_number: c_int) ->
     }
     if print != 0 {
         let time = unsafe { (**(*data).localData).timeValue };
-        omclog::warning(
+        omclog::warning!(
             omclog::NLS,
             false,
-            &format!(
-                "nonlinear system {} fails: at t={}",
-                sys.equationIndex,
-                openmodelica_sim_meta::driver::format_g(time, 6)
-            ),
+            "nonlinear system {} fails: at t={}",
+            sys.equationIndex,
+            openmodelica_sim_meta::driver::format_g(time, 6),
         );
         if si.initial != 0 {
             omclog::warning(
@@ -767,7 +762,7 @@ pub fn install_hooks(data: *mut DATA, thread_data: *mut threadData_t, prefix: &s
     nls::host::set_file_prefix(|| unsafe { &*PREFIX.0.get() });
     nls::host::set_write_file(|name, data| {
         if let Err(e) = std::fs::write(name, data) {
-            omclog::warning(omclog::STDOUT, false, &format!("could not write {name}: {e}"));
+            omclog::warning!(omclog::STDOUT, false, "could not write {name}: {e}");
         }
     });
     nls::host::set_note_runtime_error(|msg| omclog::debug(omclog::ASSERT, false, msg));

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/run.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/run.rs
@@ -314,7 +314,7 @@ fn start_non_interactive_simulation(
             None => file.name.clone(),
         });
         if let Err(e) = std::fs::write(&path, &file.content) {
-            omclog::error(omclog::STDOUT, false, &format!("Cannot open File {path}: {e}"));
+            omclog::error!(omclog::STDOUT, false, "Cannot open File {path}: {e}");
             return -1;
         }
         if let Some(lin) = &meta.lin {

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/systems.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/systems.rs
@@ -44,7 +44,7 @@ pub fn initialize_linear_systems(data: *mut DATA, thread_data: *mut threadData_t
     let si = unsafe { &mut *(*data).simulationInfo };
     // C prints the header whatever the count is; only the loop is conditional.
     omclog::info(omclog::LS, true, "initialize linear system solvers");
-    omclog::info(omclog::LS, false, &format!("{} linear systems", md.nLinearSystems));
+    omclog::info!(omclog::LS, false, "{} linear systems", md.nLinearSystems);
     for i in 0..md.nLinearSystems as usize {
         let ls = unsafe { &mut *si.linearSystemData.add(i) };
         let size = ls.size.max(0) as usize;
@@ -304,13 +304,11 @@ fn solve_default(
     // LOG_LS from then on, so a system that fails at every step says so once.
     let stream = if ls.failed != 0 { omclog::LS } else { omclog::STDOUT };
     let time = unsafe { (**(*data).localData).timeValue };
-    omclog::warning_with_limit(
+    omclog::warning_with_limit!(
         stream,
         ls.numberOfFailures as u64,
         unsafe { (*(*data).simulationInfo).maxWarnDisplays as u64 },
-        &format!(
-            "The default linear solver fails, the fallback solver with total pivoting is started at time {time:.6}. That might raise performance issues, for more information use -lv LOG_LS."
-        ),
+        "The default linear solver fails, the fallback solver with total pivoting is started at time {time:.6}. That might raise performance issues, for more information use -lv LOG_LS.",
     );
     let ok = solve_total_pivot(data, thread_data, ls, sys_number, aux_x);
     ls.failed = 1;
@@ -331,10 +329,10 @@ fn warn_once_unsupported_ls(method: c_int) {
         LS_UMFPACK => "umfpack",
         _ => "the requested",
     };
-    omclog::info(
+    omclog::info!(
         omclog::LS,
         false,
-        &format!("-ls: {name} linear solver is not served by this runtime; using the default."),
+        "-ls: {name} linear solver is not served by this runtime; using the default.",
     );
 }
 
@@ -352,13 +350,11 @@ fn solve_total_pivot(
     let size = ls.size.max(0) as usize;
     let time = unsafe { (**(*data).localData).timeValue };
     let eq = ls.equationIndex;
-    omclog::info(
+    omclog::info!(
         omclog::LS,
         false,
-        &format!(
-            "Start solving Linear System {eq} (size {size}) at time {} with Total Pivot Solver",
-            openmodelica_sim_meta::driver::format_g(time, 6)
-        ),
+        "Start solving Linear System {eq} (size {size}) at time {} with Total Pivot Solver",
+        openmodelica_sim_meta::driver::format_g(time, 6),
     );
     let mut a = vec![0.0f64; (size * size).max(1)];
     let mut b = vec![0.0f64; size.max(1)];
@@ -394,10 +390,10 @@ fn solve_total_pivot(
     sysstat::mark_assembly_done();
 
     if !openmodelica_nls::total_pivot_solve(&a, &mut b, size) {
-        omclog::warning(
+        omclog::warning!(
             omclog::STDOUT,
             false,
-            &format!("Error solving linear system of equations (no. {eq}) at time {time:.6}."),
+            "Error solving linear system of equations (no. {eq}) at time {time:.6}.",
         );
         return false;
     }
@@ -446,13 +442,11 @@ fn solve_lapack(
     let time = unsafe { (**(*data).localData).timeValue };
     let eq = ls.equationIndex;
     if omclog::active(omclog::LS) {
-        omclog::info(
+        omclog::info!(
             omclog::LS,
             false,
-            &format!(
-                "Start solving Linear System {eq} (size {size}) at time {} with Lapack Solver",
-                openmodelica_sim_meta::driver::format_g(time, 6)
-            ),
+            "Start solving Linear System {eq} (size {size}) at time {} with Lapack Solver",
+            openmodelica_sim_meta::driver::format_g(time, 6),
         );
     }
     // C's `reuseMatrixJac`: inside a symbolic Jacobian's later columns the matrix
@@ -526,16 +520,14 @@ fn solve_lapack(
     };
     if info != 0 {
         ls.numberOfFailures += 1;
-        omclog::warning_with_limit(
+        omclog::warning_with_limit!(
             omclog::LS,
             ls.numberOfFailures as u64,
             unsafe { (*(*data).simulationInfo).maxWarnDisplays as u64 },
-            &format!(
-                "Failed to solve linear system of equations (no. {eq}) at time {}, system is singular for U[{}, {}].",
-                openmodelica_sim_meta::driver::format_g(time, 6),
-                info + 1,
-                info + 1
-            ),
+            "Failed to solve linear system of equations (no. {eq}) at time {}, system is singular for U[{}, {}].",
+            openmodelica_sim_meta::driver::format_g(time, 6),
+            info + 1,
+            info + 1,
         );
         return false;
     }
@@ -557,14 +549,12 @@ fn solve_lapack(
         let norm = sd.work.iter().map(|v| v * v).sum::<f64>().sqrt();
         if norm.is_nan() || norm > 1e-4 {
             ls.numberOfFailures += 1;
-            omclog::warning_with_limit(
+            omclog::warning_with_limit!(
                 omclog::LS,
                 ls.numberOfFailures as u64,
                 unsafe { (*(*data).simulationInfo).maxWarnDisplays as u64 },
-                &format!(
-                    "Failed to solve linear system of equations (no. {eq}) at time {}. Residual norm is {norm:.15}.",
-                    openmodelica_sim_meta::driver::format_g(time, 6)
-                ),
+                "Failed to solve linear system of equations (no. {eq}) at time {}. Residual norm is {norm:.15}.",
+                openmodelica_sim_meta::driver::format_g(time, 6),
             );
             return false;
         }
@@ -587,14 +577,12 @@ fn check_linear_solution(data: *mut DATA, print: c_int, sys_number: c_int) -> c_
     }
     if print != 0 {
         let time = unsafe { (**(*data).localData).timeValue };
-        omclog::warning(
+        omclog::warning!(
             omclog::STDOUT,
             false,
-            &format!(
-                "Solving linear system {} fails at time {}. For more information use -lv LOG_LS.",
-                ls.equationIndex,
-                openmodelica_sim_meta::driver::format_g(time, 6)
-            ),
+            "Solving linear system {} fails at time {}. For more information use -lv LOG_LS.",
+            ls.equationIndex,
+            openmodelica_sim_meta::driver::format_g(time, 6),
         );
     }
     1

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/delay.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/delay.rs
@@ -44,7 +44,7 @@ fn print_buffer(stream: omclog::Stream, buf: &VecDeque<Row>) {
     }
     omclog::info(stream, true, "Printing ring buffer:");
     for &(t, v) in buf {
-        omclog::info(stream, false, &alloc::format!("({},{})", format_e(t), format_e(v)));
+        omclog::info!(stream, false, "({},{})", format_e(t), format_e(v));
     }
     omclog::close(stream);
 }
@@ -143,15 +143,13 @@ impl DelayState {
                 buf.pop_front();
             }
         }
-        omclog::info(
+        omclog::info!(
             omclog::DELAY,
             false,
-            &alloc::format!(
-                "storeDelayed[{idx}] ({},{}) position={}",
-                format_g(time, 6),
-                format_g(value, 6),
-                buf.len()
-            ),
+            "storeDelayed[{idx}] ({},{}) position={}",
+            format_g(time, 6),
+            format_g(value, 6),
+            buf.len(),
         );
         print_buffer(omclog::DELAY, buf);
     }
@@ -161,15 +159,13 @@ impl DelayState {
     pub fn eval(&self, idx: usize, time: f64, value: f64, delay_time: f64, delay_max: f64) -> f64 {
         let buf = &self.buffers[idx];
         let length = buf.len();
-        omclog::info(
+        omclog::info!(
             omclog::DELAY,
             false,
-            &alloc::format!(
-                "delayImpl: exprNumber = {idx}, exprValue = {}, time = {}, delayTime = {}",
-                format_g(value, 6),
-                format_g(time, 6),
-                format_g(delay_time, 6)
-            ),
+            "delayImpl: exprNumber = {idx}, exprValue = {}, time = {}, delayTime = {}",
+            format_g(value, 6),
+            format_g(time, 6),
+            format_g(delay_time, 6),
         );
         // C's `assertStreamPrint` guards, `DASSL_STEP_EPS` being 1e-13. Each one
         // throws in C, so at most one is reported and the caller's value stands in
@@ -199,13 +195,11 @@ impl DelayState {
             return value;
         }
         if length == 0 {
-            omclog::info(
+            omclog::info!(
                 omclog::EVENTS,
                 false,
-                &alloc::format!(
-                    "delayImpl: Missing initial value, using argument value {} instead.",
-                    format_g(value, 6)
-                ),
+                "delayImpl: Missing initial value, using argument value {} instead.",
+                format_g(value, 6),
             );
             return value;
         }

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/fixedstep.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/fixedstep.rs
@@ -131,13 +131,11 @@ pub fn deprecation_warning(method: &str) {
     // C also warns (one line, no replacement text) for `symSolver`, `symSolverSsc`
     // and `qss`.
     if matches!(method, "symSolver" | "symSolverSsc" | "qss") {
-        omclog::warning(
+        omclog::warning!(
             omclog::STDOUT,
             false,
-            &alloc::format!(
-                "Integration method '{method}' is deprecated and will be removed in a future \
-                 version of OpenModelica."
-            ),
+            "Integration method '{method}' is deprecated and will be removed in a future \
+             version of OpenModelica.",
         );
         return;
     }

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/gbode/conf.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/gbode/conf.rs
@@ -239,10 +239,11 @@ impl GbConf {
         let method = match get("gbfm") {
             Some(v) => {
                 let m = lookup("gbfm", &v, METHOD_NAMES)?;
-                crate::omclog::info(
+                crate::omclog::info!(
                     crate::omclog::SOLVER,
                     false,
-                    &format!("Chosen gbode method: {}", name_of(METHOD_NAMES, m)),
+                    "Chosen gbode method: {}",
+                    name_of(METHOD_NAMES, m),
                 );
                 m
             }
@@ -270,13 +271,11 @@ impl GbConf {
         };
         let interpolation = match interpolation {
             Interpolation::HermiteErrCtrl | Interpolation::DenseOutputErrCtrl => {
-                crate::omclog::warning(
+                crate::omclog::warning!(
                     crate::omclog::SOLVER,
                     false,
-                    &format!(
-                        "Chosen gbode interpolation method {} not supported for fast state integration",
-                        name_of(INTERPOL_NAMES, interpolation)
-                    ),
+                    "Chosen gbode interpolation method {} not supported for fast state integration",
+                    name_of(INTERPOL_NAMES, interpolation),
                 );
                 Interpolation::DenseOutput
             }

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/gbode/mod.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/gbode/mod.rs
@@ -183,7 +183,7 @@ impl Gbode {
         let tol = if tolerance > 0.0 { tolerance } else { 1e-6 };
         // C's `gbode_allocateData` logging, in its order (`getGB_method` first, then
         // `initButcherTableau` and `analyseButcherTableau`).
-        omclog::info(omclog::SOLVER, false, &format!("Chosen gbode method: {}", conf.method_name()));
+        omclog::info!(omclog::SOLVER, false, "Chosen gbode method: {}", conf.method_name());
         let (mut t, _nls_size) = tableau::init(conf.method, conf.err_method, n_states);
         if t.richardson {
             omclog::info(
@@ -203,16 +203,18 @@ impl Gbode {
         );
         let is_explicit = t.gm_type == GmType::Explicit;
         if !is_explicit {
-            omclog::info(
+            omclog::info!(
                 omclog::SOLVER,
                 false,
-                &format!("Chosen gbode NLS method: {}", conf.nls_method_name()),
+                "Chosen gbode NLS method: {}",
+                conf.nls_method_name(),
             );
         }
-        omclog::info(
+        omclog::info!(
             omclog::SOLVER,
             false,
-            &format!("Chosen gbode step size control: {}", conf.ctrl_method_name()),
+            "Chosen gbode step size control: {}",
+            conf.ctrl_method_name(),
         );
         let internal_nls = !is_explicit && conf.nls_method == NlsMethod::Internal;
         let two_step_fallback = tableau::finalize_error(&mut t, internal_nls).map_err(String::from)?;
@@ -294,21 +296,20 @@ impl Gbode {
                 String::from("initial step size not set")
             },
         );
-        omclog::info(
+        omclog::info!(
             omclog::SOLVER,
             false,
-            &format!(
-                "gbode performs a restart after an event occurs {}",
-                if no_restart { "NO" } else { "YES" }
-            ),
+            "gbode performs a restart after an event occurs {}",
+            if no_restart { "NO" } else { "YES" },
         );
         if let Some(msg) = jac_warning {
             omclog::warning(omclog::STDOUT, false, msg);
         }
-        omclog::info(
+        omclog::info!(
             omclog::SOLVER,
             false,
-            &format!("Chosen gbode interpolation method: {}", conf.interpolation_name()),
+            "Chosen gbode interpolation method: {}",
+            conf.interpolation_name(),
         );
         omclog::info(
             omclog::SOLVER,
@@ -331,15 +332,13 @@ impl Gbode {
             t.k_right = false;
             let i = (libm::round(n_states as f64 * conf.ratio).max(1.0) as usize)
                 .min(n_states.saturating_sub(1));
-            omclog::info(
+            omclog::info!(
                 omclog::SOLVER,
                 false,
-                &format!(
-                    "Number of states {} ({} slow states, {} fast states)",
-                    n_states,
-                    n_states - i,
-                    i
-                ),
+                "Number of states {} ({} slow states, {} fast states)",
+                n_states,
+                n_states - i,
+                i,
             );
             Some(alloc::boxed::Box::new(gbf))
         } else {
@@ -525,14 +524,12 @@ impl Gbode {
         if self.did_event_step && !self.conf.evnt_reinit {
             self.step_size = (old_step * 1e-1).max(self.step_size);
         }
-        omclog::info(
+        omclog::info!(
             omclog::SOLVER,
             false,
-            &format!(
-                "Initial step size = {} at time {}",
-                omclog::g(self.step_size, 0, 6),
-                omclog::g(self.time, 0, 6)
-            ),
+            "Initial step size = {} at time {}",
+            omclog::g(self.step_size, 0, 6),
+            omclog::g(self.time, 0, 6),
         );
         self.initial_failures = -1;
         Ok(())

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/gbode/multirate.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/gbode/multirate.rs
@@ -12,7 +12,6 @@
 //! selection — where C routes it through the T-transformation code it shares
 //! with the single-rate solve ([`super::nls`] has that for the outer systems).
 
-use alloc::format;
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -826,10 +825,11 @@ impl GbodeF {
         let internal = conf.nls_method == NlsMethod::Internal;
         let two_step_fallback =
             super::tableau::finalize_error(&mut t, internal).map_err(String::from)?;
-        omclog::info(
+        omclog::info!(
             omclog::SOLVER,
             false,
-            &format!("Step control factor is set to {}", omclog::g(t.fac, 0, 6)),
+            "Step control factor is set to {}",
+            omclog::g(t.fac, 0, 6),
         );
         let nls = (!is_explicit).then(|| GbfNls::new(&t, tol, sym_jac, internal));
         // C demotes dense output to Hermite when the method has no formula.
@@ -1147,16 +1147,14 @@ impl Gbode {
                         return Err(super::step::GBODE_MIN_STEP_ERROR);
                     }
                     gbf.cache.invalidate_keep_left();
-                    omclog::info(
+                    omclog::info!(
                         omclog::SOLVER,
                         false,
-                        &format!(
-                            "Reject step from {} to {}, error {}, new stepsize {}",
-                            omclog::g(gbf.time, 0, 6),
-                            omclog::g(gbf.time + gbf.last_step_size, 0, 6),
-                            omclog::g(err, 0, 6),
-                            omclog::g(gbf.step_size, 0, 6)
-                        ),
+                        "Reject step from {} to {}, error {}, new stepsize {}",
+                        omclog::g(gbf.time, 0, 6),
+                        omclog::g(gbf.time + gbf.last_step_size, 0, 6),
+                        omclog::g(err, 0, 6),
+                        omclog::g(gbf.step_size, 0, 6),
                     );
                     continue;
                 }
@@ -1265,16 +1263,14 @@ impl Gbode {
                 gbf.kv[..n].copy_from_slice(&kr);
                 let y = gbf.y.clone();
                 gbf.y_old.copy_from_slice(&y);
-                omclog::info(
+                omclog::info!(
                     omclog::SOLVER,
                     false,
-                    &format!(
-                        "Accept step from {} to {}, error {}, new stepsize {}",
-                        omclog::g(gbf.time - gbf.last_step_size, 0, 6),
-                        omclog::g(gbf.time, 0, 6),
-                        omclog::g(err_now, 0, 6),
-                        omclog::g(gbf.step_size, 0, 6)
-                    ),
+                    "Accept step from {} to {}, error {}, new stepsize {}",
+                    omclog::g(gbf.time - gbf.last_step_size, 0, 6),
+                    omclog::g(gbf.time, 0, 6),
+                    omclog::g(err_now, 0, 6),
+                    omclog::g(gbf.step_size, 0, 6),
                 );
             }
 
@@ -1660,14 +1656,12 @@ impl Gbode {
                 )?
             };
             if solved != Solved::Ok {
-                omclog::info(
+                omclog::info!(
                     omclog::SOLVER,
                     false,
-                    &format!(
-                        "gbodef error: Failed to solve NLS in expl_diag_impl_RK_MR in stage {} at time t={}",
-                        stage + 1,
-                        omclog::g(stage_time, 0, 6)
-                    ),
+                    "gbodef error: Failed to solve NLS in expl_diag_impl_RK_MR in stage {} at time t={}",
+                    stage + 1,
+                    omclog::g(stage_time, 0, 6),
                 );
                 return Ok(false);
             }
@@ -1780,13 +1774,11 @@ impl Gbode {
             )?
         };
         if solved != Solved::Ok {
-            omclog::info(
+            omclog::info!(
                 omclog::SOLVER,
                 false,
-                &format!(
-                    "gbode error: Failed to solve NLS in full_implicit_RK_MR at time t={}",
-                    omclog::g(time, 0, 6)
-                ),
+                "gbode error: Failed to solve NLS in full_implicit_RK_MR at time t={}",
+                omclog::g(time, 0, 6),
             );
             return Ok(false);
         }
@@ -1908,13 +1900,11 @@ impl Gbode {
             )?
         };
         if solved != Solved::Ok {
-            omclog::info(
+            omclog::info!(
                 omclog::SOLVER,
                 false,
-                &format!(
-                    "gbodef error: Failed to solve NLS in full_implicit_MS_MR at time t={}",
-                    omclog::g(time, 0, 6)
-                ),
+                "gbodef error: Failed to solve NLS in full_implicit_MS_MR at time t={}",
+                omclog::g(time, 0, 6),
             );
             return Ok(false);
         }

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/gbode/step.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/gbode/step.rs
@@ -1,7 +1,6 @@
 //! One Runge-Kutta step (C's `gbode_step.c`) and the loop around it that accepts,
 //! rejects and resizes steps (C's `gbode_main`).
 
-use alloc::format;
 use alloc::vec;
 
 use super::conf::CtrlMethod;
@@ -68,14 +67,12 @@ impl Gbode {
                     &nominals,
                 )?;
                 if solved != super::Solved::Ok {
-                    omclog::info(
+                    omclog::info!(
                         omclog::SOLVER,
                         false,
-                        &format!(
-                            "gbode error: Failed to solve NLS in expl_diag_impl_RK in stage {} at time t={}",
-                            stage + 1,
-                            omclog::g(stage_time, 0, 6)
-                        ),
+                        "gbode error: Failed to solve NLS in expl_diag_impl_RK in stage {} at time t={}",
+                        stage + 1,
+                        omclog::g(stage_time, 0, 6),
                     );
                     return Ok(false);
                 }
@@ -107,14 +104,12 @@ impl Gbode {
                     &mut x,
                 )?;
                 if solved != super::Solved::Ok {
-                    omclog::info(
+                    omclog::info!(
                         omclog::SOLVER,
                         false,
-                        &format!(
-                            "gbode error: Failed to solve NLS in expl_diag_impl_RK in stage {} at time t={}",
-                            stage + 1,
-                            omclog::g(stage_time, 0, 6)
-                        ),
+                        "gbode error: Failed to solve NLS in expl_diag_impl_RK in stage {} at time t={}",
+                        stage + 1,
+                        omclog::g(stage_time, 0, 6),
                     );
                     return Ok(false);
                 }
@@ -300,13 +295,11 @@ impl Gbode {
         };
         self.k = k;
         if solved? != super::Solved::Ok {
-            omclog::info(
+            omclog::info!(
                 omclog::SOLVER,
                 false,
-                &format!(
-                    "gbode error: Failed to solve NLS in full_implicit_RK at time t={}",
-                    omclog::g(self.time, 0, 6)
-                ),
+                "gbode error: Failed to solve NLS in full_implicit_RK at time t={}",
+                omclog::g(self.time, 0, 6),
             );
             return Ok(false);
         }
@@ -377,13 +370,11 @@ impl Gbode {
             gnls.solve(ode, &mut resid, time + step_size, &[&start], &nominals, &mut guess)?
         };
         if solved != super::Solved::Ok {
-            omclog::info(
+            omclog::info!(
                 omclog::SOLVER,
                 false,
-                &format!(
-                    "gbode error: Failed to solve NLS in full_implicit_MS at time t={}",
-                    omclog::g(self.time, 0, 6)
-                ),
+                "gbode error: Failed to solve NLS in full_implicit_MS at time t={}",
+                omclog::g(self.time, 0, 6),
             );
             return Ok(false);
         }
@@ -623,14 +614,12 @@ impl Gbode {
                 };
                 if !stepped {
                     self.stats.convergence_test_failures += 1;
-                    omclog::info(
+                    omclog::info!(
                         omclog::SOLVER,
                         false,
-                        &format!(
-                            "gbode_main: Failed to calculate step at time = {} with step size h = {}.",
-                            omclog::g(self.time, 0, 6),
-                            omclog::g(self.step_size, 0, 6)
-                        ),
+                        "gbode_main: Failed to calculate step at time = {} with step size h = {}.",
+                        omclog::g(self.time, 0, 6),
+                        omclog::g(self.step_size, 0, 6),
                     );
                     if const_step {
                         return Err(GBODE_CONST_STEP_FAILED);
@@ -689,16 +678,14 @@ impl Gbode {
                 }
 
                 if err > 1.0 && !const_step {
-                    omclog::info(
+                    omclog::info!(
                         omclog::SOLVER,
                         false,
-                        &format!(
-                            "Reject step from {} to {}, error {}, new stepsize {}",
-                            omclog::g(self.time, 0, 16),
-                            omclog::g(self.time + self.step_size, 0, 16),
-                            omclog::g(err, 0, 16),
-                            omclog::g(self.step_size * 0.5, 0, 16)
-                        ),
+                        "Reject step from {} to {}, error {}, new stepsize {}",
+                        omclog::g(self.time, 0, 16),
+                        omclog::g(self.time + self.step_size, 0, 16),
+                        omclog::g(err, 0, 16),
+                        omclog::g(self.step_size * 0.5, 0, 16),
                     );
                     self.stats.err_test_failures += 1;
                     self.step_size *= if self.event_happened { 0.1 } else { 0.5 };
@@ -728,17 +715,15 @@ impl Gbode {
                         if self.step_size < GB_MINIMAL_STEP_SIZE {
                             return Err(GBODE_MIN_INTERP_ERROR);
                         }
-                        omclog::info(
+                        omclog::info!(
                             omclog::SOLVER,
                             false,
-                            &format!(
-                                "Reject step from {} to {}, error {}, interpolation error {}, new stepsize {}",
-                                omclog::g(self.time, 0, 16),
-                                omclog::g(self.time + self.step_size, 0, 16),
-                                omclog::g(err, 0, 16),
-                                omclog::g(self.err_int, 0, 16),
-                                omclog::g(self.step_size, 0, 16)
-                            ),
+                            "Reject step from {} to {}, error {}, interpolation error {}, new stepsize {}",
+                            omclog::g(self.time, 0, 16),
+                            omclog::g(self.time + self.step_size, 0, 16),
+                            omclog::g(err, 0, 16),
+                            omclog::g(self.err_int, 0, 16),
+                            omclog::g(self.step_size, 0, 16),
                         );
                         continue;
                     }
@@ -818,17 +803,15 @@ impl Gbode {
                 break;
             }
 
-            omclog::info(
+            omclog::info!(
                 omclog::SOLVER,
                 false,
-                &format!(
-                    "Accept step from {} to {}, error {} interpolation error {}, new stepsize {}",
-                    omclog::g(self.time_left, 0, 16),
-                    omclog::g(self.time_right, 0, 16),
-                    omclog::g(err, 0, 16),
-                    omclog::g(self.err_int, 0, 16),
-                    omclog::g(self.step_size, 0, 16)
-                ),
+                "Accept step from {} to {}, error {} interpolation error {}, new stepsize {}",
+                omclog::g(self.time_left, 0, 16),
+                omclog::g(self.time_right, 0, 16),
+                omclog::g(err, 0, 16),
+                omclog::g(self.err_int, 0, 16),
+                omclog::g(self.step_size, 0, 16),
             );
             self.time = self.time_right;
             self.y_old.copy_from_slice(&self.y_right);
@@ -877,20 +860,19 @@ impl Gbode {
         if !no_grid && abs(target - stop_time) < GB_MINIMAL_STEP_SIZE {
             if self.multi_rate {
                 let fast = self.gbf.as_ref().expect("multirate without gbf").conf.method_name();
-                omclog::info(
+                omclog::info!(
                     omclog::STATS,
                     false,
-                    &format!(
-                        "gbode (birate integration): slow: {} / fast: {}",
-                        self.conf.method_name(),
-                        fast
-                    ),
+                    "gbode (birate integration): slow: {} / fast: {}",
+                    self.conf.method_name(),
+                    fast,
                 );
             } else {
-                omclog::info(
+                omclog::info!(
                     omclog::STATS,
                     false,
-                    &format!("gbode (single-rate integration): {}", self.conf.method_name()),
+                    "gbode (single-rate integration): {}",
+                    self.conf.method_name(),
                 );
             }
         }

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/lib.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/lib.rs
@@ -18,6 +18,50 @@ use alloc::format;
 use alloc::string::{String, ToString};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
+/// `omclog::info!(stream, indent_next, "…", args)`, the form to write: an
+/// inactive stream costs the check alone, where the function plus a `&format!`
+/// built the message either way. C's `infoStreamPrint` is variadic for the same
+/// reason.
+#[macro_export]
+macro_rules! omclog_info {
+    ($stream:expr, $indent:expr, $($arg:tt)*) => {
+        $crate::omclog::info_fmt($stream, $indent, ::core::format_args!($($arg)*))
+    };
+}
+
+/// [`omclog_info`] for [`omclog::warning`](omclog::warning).
+#[macro_export]
+macro_rules! omclog_warning {
+    ($stream:expr, $indent:expr, $($arg:tt)*) => {
+        $crate::omclog::warning_fmt($stream, $indent, ::core::format_args!($($arg)*))
+    };
+}
+
+/// [`omclog_info`] for [`omclog::warning_with_limit`](omclog::warning_with_limit).
+#[macro_export]
+macro_rules! omclog_warning_with_limit {
+    ($stream:expr, $n:expr, $max:expr, $($arg:tt)*) => {
+        $crate::omclog::warning_with_limit_fmt($stream, $n, $max, ::core::format_args!($($arg)*))
+    };
+}
+
+/// [`omclog_info`] for [`omclog::debug`](omclog::debug).
+#[macro_export]
+macro_rules! omclog_debug {
+    ($stream:expr, $indent:expr, $($arg:tt)*) => {
+        $crate::omclog::debug_fmt($stream, $indent, ::core::format_args!($($arg)*))
+    };
+}
+
+/// [`omclog_info`] for [`omclog::error`](omclog::error), which prints whatever the
+/// mask says and so only drops the `&format!`.
+#[macro_export]
+macro_rules! omclog_error {
+    ($stream:expr, $indent:expr, $($arg:tt)*) => {
+        $crate::omclog::error_fmt($stream, $indent, ::core::format_args!($($arg)*))
+    };
+}
+
 pub mod clock;
 pub mod counters;
 pub mod dassl;

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/omclog.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/omclog.rs
@@ -370,9 +370,24 @@ pub fn reactivate() {
     });
 }
 
+// The macros the `_fmt` entry points below exist for; `omclog::info!` and the
+// function `omclog::info` are different namespaces, so both names stay.
+pub use crate::{
+    omclog_debug as debug, omclog_error as error, omclog_info as info,
+    omclog_warning as warning, omclog_warning_with_limit as warning_with_limit,
+};
+
 pub fn info(stream: Stream, indent_next: bool, msg: &str) {
     if active(stream) {
         message_text(INFO, stream, indent_next, msg);
+    }
+}
+
+/// [`info`] over `format_args!`: nothing is built for a stream that is off. The
+/// `omclog::info!` macro is how to reach it.
+pub fn info_fmt(stream: Stream, indent_next: bool, args: core::fmt::Arguments<'_>) {
+    if active(stream) {
+        message_text(INFO, stream, indent_next, &alloc::fmt::format(args));
     }
 }
 
@@ -380,6 +395,25 @@ pub fn info(stream: Stream, indent_next: bool, msg: &str) {
 pub fn warning(stream: Stream, indent_next: bool, msg: &str) {
     if active(stream) || store::with(|s| s.use_stream & SHOW_ALL_WARNINGS != 0) {
         message_text(WARNING, stream, indent_next, msg);
+    }
+}
+
+/// [`warning`] over `format_args!`; see [`info_fmt`].
+pub fn warning_fmt(stream: Stream, indent_next: bool, args: core::fmt::Arguments<'_>) {
+    if active(stream) || store::with(|s| s.use_stream & SHOW_ALL_WARNINGS != 0) {
+        message_text(WARNING, stream, indent_next, &alloc::fmt::format(args));
+    }
+}
+
+/// [`warning_with_limit`] over `format_args!`; see [`info_fmt`].
+pub fn warning_with_limit_fmt(
+    stream: Stream,
+    n_displayed: u64,
+    max_displayed: u64,
+    args: core::fmt::Arguments<'_>,
+) {
+    if active(stream) || store::with(|s| s.use_stream & SHOW_ALL_WARNINGS != 0) {
+        warning_with_limit(stream, n_displayed, max_displayed, &alloc::fmt::format(args));
     }
 }
 
@@ -411,8 +445,20 @@ pub fn debug(stream: Stream, indent_next: bool, msg: &str) {
     }
 }
 
+/// [`debug`] over `format_args!`; see [`info_fmt`].
+pub fn debug_fmt(stream: Stream, indent_next: bool, args: core::fmt::Arguments<'_>) {
+    if active(stream) {
+        message_text(DEBUG_TYPE, stream, indent_next, &alloc::fmt::format(args));
+    }
+}
+
 pub fn error(stream: Stream, indent_next: bool, msg: &str) {
     message_text(ERROR, stream, indent_next, msg);
+}
+
+/// [`error`] over `format_args!`; unconditional, as [`error`] is.
+pub fn error_fmt(stream: Stream, indent_next: bool, args: core::fmt::Arguments<'_>) {
+    message_text(ERROR, stream, indent_next, &alloc::fmt::format(args));
 }
 
 /// C's `messageClose`: end a block opened with `indent_next`.
@@ -652,14 +698,14 @@ pub fn debug_string(stream: Stream, msg: &str) {
 /// `infoStreamPrint` is — the nonlinear solver calls these per iteration.
 pub fn debug_int(stream: Stream, msg: &str, v: i32) {
     if active(stream) {
-        info(stream, false, &format!("{msg} {v}"));
+        info!(stream, false, "{msg} {v}");
     }
 }
 
 /// C's `debugDouble`: `"%s %18.10e"`; guarded as [`debug_int`] is.
 pub fn debug_double(stream: Stream, msg: &str, v: f64) {
     if active(stream) {
-        info(stream, false, &format!("{msg} {}", e(v, 18, 10)));
+        info!(stream, false, "{msg} {}", e(v, 18, 10));
     }
 }
 
@@ -669,7 +715,7 @@ pub fn debug_vector_double(stream: Stream, name: &str, v: &[f64]) {
     if !active(stream) {
         return;
     }
-    info(stream, true, &format!("{name} [{}-dim]", v.len()));
+    info!(stream, true, "{name} [{}-dim]", v.len());
     let mut line = String::new();
     for (i, x) in v.iter().enumerate() {
         if i > 0 {
@@ -694,7 +740,7 @@ pub fn debug_matrix_double(stream: Stream, name: &str, a: &[f64], n: usize, m: u
     if !active(stream) {
         return;
     }
-    info(stream, true, &format!("{name} [{n}x{m}-dim]"));
+    info!(stream, true, "{name} [{n}x{m}-dim]");
     for i in 0..n {
         let mut line = String::new();
         for j in 0..m {
@@ -711,7 +757,7 @@ pub fn debug_vector_int(stream: Stream, name: &str, v: &[i32]) {
     if !active(stream) {
         return;
     }
-    info(stream, true, &format!("{name} [{}-dim]", v.len()));
+    info!(stream, true, "{name} [{}-dim]", v.len());
     let mut line = String::new();
     for (i, x) in v.iter().enumerate() {
         if i > 0 {

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/spatial.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/spatial.rs
@@ -163,39 +163,39 @@ impl Spatial {
             return;
         }
         for n in &self.profile {
-            omclog::info(omclog::SPATIALDISTR, false, &format!("({},{})", e(n.pos), e(n.val)));
+            omclog::info!(omclog::SPATIALDISTR, false, "({},{})", e(n.pos), e(n.val));
         }
         omclog::info(omclog::SPATIALDISTR, false, "List of events");
         for ev in &self.events {
-            omclog::info(omclog::SPATIALDISTR, false, &format!("({},{})", e(ev.pos), e(ev.sign)));
+            omclog::info!(omclog::SPATIALDISTR, false, "({},{})", e(ev.pos), e(ev.sign));
         }
     }
 
     /// C `initSpatialDistribution`: the parameter profile becomes the initial one,
     /// with an event for every pair of `initialPoints` sharing a position.
     fn init_profile(&mut self, index: u32, points: &[f64], values: &[f64]) {
-        omclog::info(
+        omclog::info!(
             omclog::SPATIALDISTR,
             true,
-            &format!("Initializing spatial distributions (index={index})"),
+            "Initializing spatial distributions (index={index})",
         );
         let n = points.len();
         if n < 2 || values.len() != n {
             fatal("Initialization of spatial distribution failed: initialPoints and initialValues must have the same size >= 2.");
         }
         if points[0].abs() > SPATIAL_EPS {
-            omclog::error(
+            omclog::error!(
                 omclog::STDOUT,
                 true,
-                &format!("Initialization of spatial distribution with index {index} failed."),
+                "Initialization of spatial distribution with index {index} failed.",
             );
             fatal(&format!("initialPoints[0] = {} is not zero.", e(points[0])));
         }
         if (points[n - 1] - 1.0).abs() > SPATIAL_EPS {
-            omclog::error(
+            omclog::error!(
                 omclog::STDOUT,
                 true,
-                &format!("Initialization of spatial distribution with index {index} failed."),
+                "Initialization of spatial distribution with index {index} failed.",
             );
             fatal(&format!("initialPoints[end] = {} is not one.", e(points[n - 1])));
         }
@@ -206,15 +206,16 @@ impl Spatial {
         let mut sign = -1.0;
         for i in 0..n - 1 {
             if points[i] > points[i + 1] {
-                omclog::error(
+                omclog::error!(
                     omclog::STDOUT,
                     true,
-                    &format!("Initialization of spatial distribution with index {index} failed."),
+                    "Initialization of spatial distribution with index {index} failed.",
                 );
-                omclog::error(
+                omclog::error!(
                     omclog::STDOUT,
                     false,
-                    &format!("initialPoints[{i}] > initialPoints[{}]", i + 1),
+                    "initialPoints[{i}] > initialPoints[{}]",
+                    i + 1,
                 );
                 fatal(&format!("{} > {}", f(points[i]), f(points[i + 1])));
             }
@@ -222,19 +223,17 @@ impl Spatial {
             if points[i] == points[i + 1] {
                 num_same += 1;
                 if num_same > 1 {
-                    omclog::error(
+                    omclog::error!(
                         omclog::STDOUT,
                         true,
-                        &format!("Initialization of spatial distribution with index {index} failed."),
+                        "Initialization of spatial distribution with index {index} failed.",
                     );
-                    omclog::error(
+                    omclog::error!(
                         omclog::STDOUT,
                         false,
-                        &format!(
-                            "initialPoints[{}] = initialPoints[{i}] = initialPoints[{}]",
-                            i - 1,
-                            i + 1
-                        ),
+                        "initialPoints[{}] = initialPoints[{i}] = initialPoints[{}]",
+                        i - 1,
+                        i + 1,
                     );
                     fatal("Only events with one pre-value and one value are allowed.");
                 }
@@ -248,10 +247,10 @@ impl Spatial {
         self.initialized = true;
         self.log_lists();
         omclog::close(omclog::SPATIALDISTR);
-        omclog::info(
+        omclog::info!(
             omclog::SPATIALDISTR,
             false,
-            &format!("Finished initializing spatial distribution (index={index})"),
+            "Finished initializing spatial distribution (index={index})",
         );
     }
 
@@ -293,21 +292,20 @@ impl Spatial {
     /// becomes a new node at the input edge and whatever left the domain is dropped.
     fn store(&mut self, index: u32, time: f64, in0: f64, in1: f64, pos_x: f64, positive: bool) {
         let pos_x = self.shift(pos_x);
-        omclog::info(
+        omclog::info!(
             omclog::SPATIALDISTR,
             true,
-            &format!("Calling storeSpatialDistribution (index={index}, time={})", e(time)),
+            "Calling storeSpatialDistribution (index={index}, time={})",
+            e(time),
         );
-        omclog::info(
+        omclog::info!(
             omclog::SPATIALDISTR,
             false,
-            &format!(
-                "spatialDistribution({}, {}, {}, {})",
-                f(in0),
-                f(in1),
-                f(pos_x),
-                if positive { "true" } else { "false" }
-            ),
+            "spatialDistribution({}, {}, {}, {})",
+            f(in0),
+            f(in1),
+            f(pos_x),
+            if positive { "true" } else { "false" },
         );
         self.log_lists();
 
@@ -338,13 +336,11 @@ impl Spatial {
                 true,
                 "Removed more then one event from spatialDistribution. Step size to big!",
             );
-            omclog::warning(
+            omclog::warning!(
                 omclog::STDOUT,
                 false,
-                &format!(
-                    "time: {}, spatialDistribution index: {index}, number of events: {walked}",
-                    f(time)
-                ),
+                "time: {}, spatialDistribution index: {index}, number of events: {walked}",
+                f(time),
             );
             omclog::close_warning(omclog::STDOUT);
         }
@@ -355,15 +351,13 @@ impl Spatial {
     /// C `addNewNodeSpatialDistribution`: a new node at the front (positive
     /// velocity) or the back, plus its event when it is a discontinuity.
     fn add_node(&mut self, front: bool, pos: f64, val: f64, is_event: bool) {
-        omclog::info(
+        omclog::info!(
             omclog::SPATIALDISTR,
             false,
-            &format!(
-                "Adding ({},{}) at {}.",
-                e(pos),
-                e(val),
-                if front { "front" } else { "back" }
-            ),
+            "Adding ({},{}) at {}.",
+            e(pos),
+            e(val),
+            if front { "front" } else { "back" },
         );
         if front {
             if pos > self.front().pos {
@@ -410,15 +404,13 @@ impl Spatial {
         } else {
             self.events.push_back(ev);
         }
-        omclog::info(
+        omclog::info!(
             omclog::SPATIALDISTR,
             false,
-            &format!(
-                "Adding event ({},{}) at {}.",
-                e(ev.pos),
-                e(ev.sign),
-                if front { "front" } else { "back" }
-            ),
+            "Adding event ({},{}) at {}.",
+            e(ev.pos),
+            e(ev.sign),
+            if front { "front" } else { "back" },
         );
         self.log_lists();
     }
@@ -463,10 +455,11 @@ impl Spatial {
                 (self.profile[prev], self.profile[i])
             };
             self.profile[prev] = Node { pos: target, val: interpolate(left, right, target) };
-            omclog::info(
+            omclog::info!(
                 omclog::SPATIALDISTR,
                 false,
-                &format!("Interpolate at {}", if positive { "end" } else { "front" }),
+                "Interpolate at {}",
+                if positive { "end" } else { "front" },
             );
         }
         if positive {
@@ -586,21 +579,20 @@ impl Spatial {
         mode: u32,
     ) -> (f64, f64) {
         let pos_x = self.shift(pos_x);
-        omclog::info(
+        omclog::info!(
             omclog::SPATIALDISTR,
             true,
-            &format!("Calling spatialDistribution (index={index}, time={})", e(time)),
+            "Calling spatialDistribution (index={index}, time={})",
+            e(time),
         );
-        omclog::info(
+        omclog::info!(
             omclog::SPATIALDISTR,
             false,
-            &format!(
-                "(out0,out1) = spatialDistribution(in0={}, in1={}, x={}, isPositiveVelocity={})",
-                f(in0),
-                f(in1),
-                f(pos_x),
-                if positive { "true" } else { "false" }
-            ),
+            "(out0,out1) = spatialDistribution(in0={}, in1={}, x={}, isPositiveVelocity={})",
+            f(in0),
+            f(in1),
+            f(pos_x),
+            if positive { "true" } else { "false" },
         );
         self.log_lists();
 
@@ -628,14 +620,12 @@ impl Spatial {
                     true,
                     "Need to output more then one event from spatialDistribution. Step size to big!",
                 );
-                omclog::warning(
+                omclog::warning!(
                     omclog::STDOUT,
                     false,
-                    &format!(
-                        "time: {}, spatialDistribution index: {index}, number of events: {}",
-                        f(time),
-                        read.events
-                    ),
+                    "time: {}, spatialDistribution index: {index}, number of events: {}",
+                    f(time),
+                    read.events,
                 );
                 omclog::close_warning(omclog::STDOUT);
             }
@@ -645,10 +635,11 @@ impl Spatial {
             let mut out = read.out;
             if read.events > 0 && !discrete {
                 if let Some(pre) = read.event_pre {
-                    omclog::info(
+                    omclog::info!(
                         omclog::SPATIALDISTR,
                         false,
-                        &format!("Found event in spatial distribution at time {}", f(time)),
+                        "Found event in spatial distribution at time {}",
+                        f(time),
                     );
                     out = pre;
                 }
@@ -677,11 +668,7 @@ impl Spatial {
                 (out, out1)
             }
         };
-        omclog::info(
-            omclog::SPATIALDISTR,
-            false,
-            &format!("(out0,out1) = ({}, {})", f(out0), f(out1)),
-        );
+        omclog::info!(omclog::SPATIALDISTR, false, "(out0,out1) = ({}, {})", f(out0), f(out1));
         omclog::close(omclog::SPATIALDISTR);
         self.out1 = out1;
         (out0, out1)
@@ -695,14 +682,12 @@ impl Spatial {
     /// (the signs alternate, so "the one above, not negated" is the same value).
     fn zc(&self, pos_x: f64, positive: bool, zc_pre: f64) -> f64 {
         if self.events.is_empty() {
-            omclog::info(
+            omclog::info!(
                 omclog::SPATIALDISTR,
                 false,
-                &format!(
-                    "spatialDistributionZeroCrossing({}) = {} (no stored events, returning previous value)",
-                    e(pos_x),
-                    e(zc_pre)
-                ),
+                "spatialDistributionZeroCrossing({}) = {} (no stored events, returning previous value)",
+                e(pos_x),
+                e(zc_pre),
             );
             return zc_pre;
         }
@@ -722,14 +707,12 @@ impl Spatial {
         // is reached, leaving no sign change to find.
         let below = self.events.partition_point(|ev| ev.pos <= read + SPATIAL_EPS);
         let value = if below == 0 { self.events[0].sign } else { -self.events[below - 1].sign };
-        omclog::info(
+        omclog::info!(
             omclog::SPATIALDISTR,
             false,
-            &format!(
-                "List of events for spatialDistributionZeroCrossing({}) = {}",
-                e(pos_x),
-                e(value)
-            ),
+            "List of events for spatialDistributionZeroCrossing({}) = {}",
+            e(pos_x),
+            e(value),
         );
         self.log_lists();
         value
@@ -744,10 +727,10 @@ pub struct SpatialState {
 impl SpatialState {
     /// C `allocSpatialDistribution`: `n` uninitialized operators for a fresh run.
     pub fn new(n: usize) -> Self {
-        omclog::info(
+        omclog::info!(
             omclog::SPATIALDISTR,
             false,
-            &format!("Allocating memory for {n} spatial distribution(s)."),
+            "Allocating memory for {n} spatial distribution(s).",
         );
         SpatialState { ops: (0..n).map(|_| Spatial::new()).collect() }
     }

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/sundials.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/sundials.rs
@@ -92,16 +92,14 @@ unsafe extern "C" fn err_handler(
         false => unsafe { core::ffi::CStr::from_ptr(p) }.to_string_lossy().into_owned(),
     };
     crate::omclog::info(crate::omclog::SOLVER, true, "#### SUNDIALS error message #####");
-    crate::omclog::info(
+    crate::omclog::info!(
         crate::omclog::SOLVER,
         false,
-        &alloc::format!(
-            " -> error code {err_code}\n -> function {}\n -> at {}:{line}",
-            text(func),
-            text(file)
-        ),
+        " -> error code {err_code}\n -> function {}\n -> at {}:{line}",
+        text(func),
+        text(file),
     );
-    crate::omclog::info(crate::omclog::SOLVER, false, &alloc::format!(" Message: {}", text(msg)));
+    crate::omclog::info!(crate::omclog::SOLVER, false, " Message: {}", text(msg));
     crate::omclog::close(crate::omclog::SOLVER);
 }
 /// `mxstep` internal steps taken without reaching `tout`; resuming continues.
@@ -743,10 +741,11 @@ impl Ida {
     }
 
     fn log_calc_ic(&self, flag: c_int) {
-        crate::omclog::info(
+        crate::omclog::info!(
             crate::omclog::SOLVER,
             false,
-            &alloc::format!("##IDA## IDACalcIC run status {flag}.\nIterations : {}\n", self.nonlin_iters()),
+            "##IDA## IDACalcIC run status {flag}.\nIterations : {}\n",
+            self.nonlin_iters(),
         );
     }
 
@@ -778,10 +777,11 @@ impl Ida {
         if h < f64::EPSILON {
             h = f64::EPSILON;
             self.set_init_step(h);
-            crate::omclog::info(
+            crate::omclog::info!(
                 crate::omclog::SOLVER,
                 false,
-                &alloc::format!("##IDA## corrected step-size at {}", crate::omclog::g(h, 0, 15)),
+                "##IDA## corrected step-size at {}",
+                crate::omclog::g(h, 0, 15),
             );
         }
         let mut flag = self.calc_ic(t + h);


### PR DESCRIPTION
A `when`-model fused the discrete update into the per-step function: `functionAlgebraics` was `allEquations` plus `storePreValues`, so the driver's `functionODE` + `functionAlgebraics` on every output row evaluated the ODE equations twice. The three entry points now mean what C's mean -- `functionODE` is `odeEquations`, `functionAlgebraics` is `algebraicEquations` (plus the pre-store C's `updateContinuousSystem` ends with), `functionDAE` is `allEquations` -- and `eval_discrete` always calls `functionDAE`, so a when-body fires only at a discrete call.

`eq_segments` takes the surplus in C's `allEquationsPlusWhen`, the when-equations that are in neither list, as segments only the DAE entry point calls. A when-model therefore shares one lowering of `allEquations` across all three entry points like every other model; IMC_Conveyor's module went from 274 kB to 220 kB.

The other half of the gap was logging. `info(stream, indent, &format!(…))` built the message whether or not the stream was on; C's `infoStreamPrint` is variadic and formats nothing when it is off. That had been fixed site by site twice already (`debug_int`/`debug_double`, then `ls_start_log`, one `format!` with a float per linear-system solve), so the guard is structural now: `omclog::info!` and its siblings take `format_args!` and hand it to an `info_fmt` that checks the stream first. A macro and a function of the same name live in different namespaces, so `omclog::info` still names the `&str` entry point that a fixed-message call site uses.

All 309 `X(…, &format!(…))` sites are converted, which caught two more on a per-call path: `Delay::store` / `Delay::eval`, once per `delay()` evaluation, and `SpatialDistribution::store` / `eval` / `zc`, two to five messages a call. `newton_diagnostics.rs` reached the stream through local `info` / `open` helpers; those are macros now too. What still holds a `format!` is the handful whose message is a `match` or a local rather than a format call, all of them once per run.

`Modelica...InductionMachines.IMC_Conveyor` (MSL 4.0.0, 200k rows x 3.7k signals), best of two alternating rounds:

| IMC_Conveyor         | before | after  | C      |
| -------------------- | ------ | ------ | ------ |
| `timeSimulation`     | 14.6 s | 8.5 s  | 9.0 s  |
| LOG_STATS total      | 14.6 s | 8.5 s  | 8.8 s  |
| `functionODE`        | 4.82 s | 2.84 s | 2.92 s |
| `functionAlgebraics` | 6.03 s | 1.83 s | 1.50 s |

The last two rows are from `-lv=LOG_STATS,LOG_STATS_V` runs, which cost two clock reads a solve and inflate the totals. The six size-1/2 linear systems went 1.9-2.5 us to 0.69-1.33 us a solve (C: 0.49-1.42). `diffSimulationResults` against the C run reports the same variables it reported before the change.

470 wasm-jit tests over events, synchronous, statemachines, initialization, solver, equations, others, algorithms_functions, tearing, nonlinear_system, linear_system, arrays and daemode fail the same 7 as before (6 want the `Cpp` target this build lacks, 1 is the `Differentiate.mo` line-number gap), and `-lv=LOG_LS,LOG_DELAY` still renders what it did.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
