### PR TITLE
NB: tear the discrete part of a loop locally

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBMatching.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBMatching.mo
@@ -49,6 +49,7 @@ protected
   // NF import
   import NFFunction.Function;
   import Variable = NFVariable;
+  import ComponentRef = NFComponentRef;
 
   // NB import
   import Adjacency = NBAdjacency;
@@ -317,6 +318,32 @@ public
       end for;
     end if;
   end getMatches;
+
+  function getMatchedVars
+    "returns the variables from the map that have at least one matched scalar element"
+    input Matching matching;
+    input Option<Adjacency.Mapping> mapping_opt;
+    input UnorderedMap<ComponentRef, Integer> vars_map;
+    input VariablePointers variables;
+    output list<VariablePointer> matched = {};
+  protected
+    Integer start, size;
+  algorithm
+    for arr_idx in UnorderedMap.valueList(vars_map) loop
+      (start, size) := match mapping_opt
+        local
+          Adjacency.Mapping mapping;
+        case SOME(mapping) then mapping.var_AtS[arr_idx];
+        else (arr_idx, 1);
+      end match;
+      for scal_idx in start:start+size-1 loop
+        if scal_idx <= arrayLength(matching.var_to_eqn) and matching.var_to_eqn[scal_idx] > 0 then
+          matched := ExpandableArray.get(arr_idx, variables.varArr) :: matched;
+          break;
+        end if;
+      end for;
+    end for;
+  end getMatchedVars;
 
 protected
   function toStringSingle

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBTearing.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBTearing.mo
@@ -431,11 +431,12 @@ protected
     list<Pointer<Variable>> vars_lst, cont_vars, disc_vars, implied_vars, alg_implied;
     list<Pointer<Equation>> eqns_lst, cont_eqns, disc_eqns, alg_eqns;
     Integer num_vars, num_eqns;
-    list<Slice<VariablePointer>> matched_vars, iteration_vars = {};
-    Adjacency.Matrix adj;
+    list<Slice<VariablePointer>> iteration_vars = {};
+    Adjacency.Matrix adj, sub;
     Matching matching;
     list<StrongComponent> inner_comps;
-    UnorderedMap<ComponentRef, Integer> v, e;
+    VariablePointers disc_variables;
+    EquationPointers disc_equations;
     UnorderedSet<ComponentRef> matched_set = UnorderedSet.new(ComponentRef.hash, ComponentRef.isEqual);
   algorithm
     comp := match comp
@@ -476,23 +477,25 @@ protected
           end for;
 
           if not listEmpty(disc_eqns) then
-            // the sets of discrete variables (exclude alg-implied vars already handled) and discrete equations
-            v := UnorderedMap.subMap(variables.map, list(BVariable.getVarName(var) for var guard(not UnorderedSet.contains(BVariable.getVarName(var), matched_set)) in disc_vars));
-            e := UnorderedMap.subMap(equations.map, list(Equation.getEqnName(eqn) for eqn in disc_eqns));
+            // local system of the discrete variables and equations, in the order of the full system
+            disc_vars := sortByIndex(list(var for var guard(not UnorderedSet.contains(BVariable.getVarName(var), matched_set)) in disc_vars), BVariable.getVarName, variables.map);
+            disc_eqns := sortByIndex(disc_eqns, Equation.getEqnName, equations.map);
+            disc_variables := VariablePointers.fromList(disc_vars);
+            disc_equations := EquationPointers.fromList(disc_eqns);
+            sub := Adjacency.Matrix.subFull(full, list(UnorderedMap.getSafe(Equation.getEqnName(eqn), equations.map, sourceInfo()) for eqn in disc_eqns), disc_equations, disc_variables);
 
             // match the discretes to create inner components
-            adj         := Adjacency.Matrix.fullToFinal(full, v, e, equations, NBAdjacency.MatrixStrictness.MATCHING);
+            adj         := Adjacency.Matrix.fullToFinal(sub, disc_variables.map, disc_equations.map, disc_equations, NBAdjacency.MatrixStrictness.MATCHING);
             matching    := Matching.regular(NBMatching.EMPTY_MATCHING, adj, true, true);
 
-            // get matched vars and build the matched variables set
-            (matched_vars, _, _, _) := Matching.getMatches(matching, Adjacency.Matrix.getMappingOpt(adj), variables, equations);
-            for var in matched_vars loop
-              UnorderedSet.add(BVariable.getVarName(Slice.getT(var)), matched_set);
+            // build the matched variables set
+            for var in Matching.getMatchedVars(matching, Adjacency.Matrix.getMappingOpt(adj), disc_variables.map, disc_variables) loop
+              UnorderedSet.add(BVariable.getVarName(var), matched_set);
             end for;
 
             // upgrade adjacency matrix and sort the system creating inner equation components
-            adj         := Adjacency.Matrix.upgrade(adj, full, v, e, equations, NBAdjacency.MatrixStrictness.SORTING);
-            inner_comps := listAppend(Sorting.tarjan(adj, matching, variables, equations), inner_comps);
+            adj         := Adjacency.Matrix.upgrade(adj, sub, disc_variables.map, disc_equations.map, disc_equations, NBAdjacency.MatrixStrictness.SORTING);
+            inner_comps := listAppend(Sorting.tarjan(adj, matching, disc_variables, disc_equations), inner_comps);
           end if;
 
           // only take variables that are not in the matched set
@@ -511,6 +514,23 @@ protected
       else comp;
     end match;
   end minimal;
+
+  function sortByIndex<T>
+    "sorts the elements by their index in the map"
+    input list<T> lst;
+    input getName func;
+    input UnorderedMap<ComponentRef, Integer> map;
+    output list<T> sorted;
+    partial function getName
+      input T t;
+      output ComponentRef name;
+    end getName;
+  protected
+    list<tuple<Integer, T>> indexed = list((UnorderedMap.getSafe(func(t), map, sourceInfo()), t) for t in lst);
+  algorithm
+    indexed := List.sort(indexed, function Util.compareTupleIntGt());
+    sorted := list(Util.tuple22(tpl) for tpl in indexed);
+  end sortByIndex;
 
   function guru extends Module.tearingInterface;
   protected

--- a/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
@@ -467,6 +467,42 @@ public
       end if;
     end createFull;
 
+    function subFull
+      "creates the full matrix of a subset of equations and variables from an
+      existing one, sharing its per-equation maps. eqn_indices are the indices
+      of eqns in full, in the order of eqns."
+      input Matrix full;
+      input list<Integer> eqn_indices;
+      input EquationPointers eqns;
+      input VariablePointers vars;
+      output Matrix sub;
+    protected
+      Integer size = listLength(eqn_indices), j = 1;
+      array<ComponentRef> equation_names;
+      array<UnorderedSet<ComponentRef>> occurrences, repetitions;
+      array<UnorderedMap<ComponentRef, Dependency>> dependencies;
+      array<UnorderedMap<ComponentRef, Solvability>> solvabilities;
+    algorithm
+      sub := match full
+        case FULL() guard(size > 0) algorithm
+          equation_names  := arrayCreate(size, ComponentRef.EMPTY());
+          occurrences     := arrayCreate(size, UnorderedSet.new(ComponentRef.hash, ComponentRef.isEqual));
+          dependencies    := arrayCreate(size, UnorderedMap.new<Dependency>(ComponentRef.hash, ComponentRef.isEqual));
+          solvabilities   := arrayCreate(size, UnorderedMap.new<Solvability>(ComponentRef.hash, ComponentRef.isEqual));
+          repetitions     := arrayCreate(size, UnorderedSet.new(ComponentRef.hash, ComponentRef.isEqual));
+          for i in eqn_indices loop
+            equation_names[j] := full.equation_names[i];
+            occurrences[j]    := full.occurrences[i];
+            dependencies[j]   := full.dependencies[i];
+            solvabilities[j]  := full.solvabilities[i];
+            repetitions[j]    := full.repetitions[i];
+            j := j + 1;
+          end for;
+        then FULL(equation_names, occurrences, dependencies, solvabilities, repetitions, Mapping.create(eqns, vars));
+        else EMPTY(MatrixStrictness.FULL);
+      end match;
+    end subFull;
+
     function fullToFinal
       input Matrix full;
       input UnorderedMap<ComponentRef, Integer> vars_map;


### PR DESCRIPTION
`Tearing.minimal` matched and sorted the discrete equations of every mixed algebraic loop on matrices sized for the whole partition: `fullToFinal` allocated and transposed system-sized scalar arrays, the matching and `Sorting.tarjan` walked all of them, and `Matching.getMatches` hashed every variable and equation of the system into slice maps just to find the handful of matched discrete variables. With one mixed loop per generator this made `[INI] Tearing` quadratic on the ScalableTestGrids models.

Build a local system instead: `VariablePointers`/`EquationPointers` of the loop's discrete part, and `Adjacency.Matrix.subFull`, which copies the per-equation occurrence, dependency and solvability maps out of the existing full matrix (so nothing is recollected or refined again) with a local index mapping. Matching, upgrade and sorting then work on arrays of the loop's size. The local lists are sorted by their global index so the matching and sorting see the same relative order as before; the `-d=tearingdump` output is unchanged.

`Matching.getMatchedVars` replaces the `getMatches` call: it scans the matching only for the variables in the given map.

ScalableTestGrids.Models.Type1_N_*_M_4 with
`--newBackend -d=mergeComponents --generateDynamicJacobian=symbolic`, `[INI] Tearing`:

| model   | before          | after           |
| ------- | --------------- | --------------- |
| N_4_M_4 |  9.6 s / 1.3 GB | 0.12 s /  44 MB |
| N_8_M_4 | 17.2 s / 14 GB  | 0.83 s / 245 MB |

Part of #14118.

Assisted-by: Claude Fable 5.1

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
