### PR TITLE
Allow evaluation of non-structural parameters

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -344,7 +344,7 @@ algorithm
   exp := match cref
     case ComponentRef.CREF(node = c as InstNode.COMPONENT_NODE())
       guard not ComponentRef.isIterator(cref) and
-            ComponentRef.nodeVariability(cref) < Variability.NON_STRUCTURAL_PARAMETER
+            ComponentRef.nodeVariability(cref) <= Variability.NON_STRUCTURAL_PARAMETER
       then evalComponentBinding(c, cref, defaultExp, target, evalSubscripts, liftExp);
 
     else defaultExp;

--- a/testsuite/flattening/modelica/scodeinst/CevalIf2.mo
+++ b/testsuite/flattening/modelica/scodeinst/CevalIf2.mo
@@ -71,7 +71,7 @@ end CevalIf2;
 // class CevalIf2
 //   final parameter Real ets.dat.mEva_flow_nominal = datHeaPum.mEva_flow_nominal;
 //   parameter ExternalCombiTable2D ets.dat.tableID_QCon_flow = datHeaPum.tableID_QCon_flow;
-//   final parameter Real ets.pumEva.m_flow_nominal = datHeaPum.mEva_flow_nominal;
+//   final parameter Real ets.pumEva.m_flow_nominal = ets.dat.mEva_flow_nominal;
 //   parameter Real datHeaPum.mEva_flow_nominal = getTable2DValue(datHeaPum.tableID_QCon_flow);
 //   parameter ExternalCombiTable2D datHeaPum.tableID_QCon_flow = ExternalCombiTable2D.constructor("NoName");
 // end CevalIf2;

--- a/testsuite/flattening/modelica/scodeinst/CevalRecord9.mo
+++ b/testsuite/flattening/modelica/scodeinst/CevalRecord9.mo
@@ -1,0 +1,36 @@
+// name: CevalRecord9
+// keywords:
+// status: correct
+//
+
+record MaterialThermalGeneral
+  parameter Real c = 1000.0;
+end MaterialThermalGeneral;
+
+model HeatConduction1DNodes
+  parameter MaterialThermalGeneral material annotation(Evaluate = true);
+end HeatConduction1DNodes;
+
+model MultiLayerHeatConduction1DNodes
+  HeatConduction1DNodes layer(material = material);
+  parameter MaterialThermalGeneral material;
+end MultiLayerHeatConduction1DNodes;
+
+model WallThermal1DNodes
+  parameter MaterialThermalGeneral material;
+  MultiLayerHeatConduction1DNodes construction(material = material);
+end WallThermal1DNodes;
+
+model CevalRecord9
+  parameter Real AAmb = 1.0 annotation(Evaluate = false);
+  WallThermal1DNodes ambientConstructions(material(final c = 1/AAmb));
+end CevalRecord9;
+
+// Result:
+// class CevalRecord9
+//   parameter Real AAmb = 1.0;
+//   final parameter Real ambientConstructions.material.c = 1.0 / AAmb;
+//   parameter Real ambientConstructions.construction.layer.material.c = ambientConstructions.material.c;
+//   parameter Real ambientConstructions.construction.material.c = 1.0;
+// end CevalRecord9;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -203,6 +203,7 @@ CevalRecord5.mo \
 CevalRecord6.mo \
 CevalRecord7.mo \
 CevalRecord8.mo \
+CevalRecord9.mo \
 CevalRecordArray1.mo \
 CevalRecordArray2.mo \
 CevalRecordArray3.mo \


### PR DESCRIPTION
- Allow Ceval.evalCref to evaluate parameters that have been marked as non-structural if necessary.
