### PR TITLE
Two whole-model passes the FMU export did not need

### DIFF
--- a/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
@@ -1725,11 +1725,11 @@ public function createFMIModelDerivativesForInitialization
   output BackendDAE.SymbolicJacobians outJacobianMatrices = {};
   output AvlTreePathFunction.Tree outFunctionTree "may contain functions created by the differentiation, e.g. partial derivatives";
 protected
-  BackendDAE.BackendDAE backendDAE, backendDAE_1, emptyBDAE;
-  BackendDAE.EqSystem eqSyst, currentSystem;
+  BackendDAE.BackendDAE backendDAE_1, emptyBDAE;
+  BackendDAE.EqSystem currentSystem;
   Option<BackendDAE.SymbolicJacobian> outJacobian;
-  list<BackendDAE.Var> varlst, knvarlst, states, inputvars, paramvars;
-  BackendDAE.Variables v, globalKnownVars, statesarr, inputvarsarr, paramvarsarr, depVarsArr;
+  list<BackendDAE.Var> varlst, knvarlst, states, clockedStates, inputvars, paramvars;
+  BackendDAE.Variables statesarr, inputvarsarr, paramvarsarr, depVarsArr;
   BackendDAE.ExtraInfo ei;
   FCore.Cache cache;
   FCore.Graph graph;
@@ -1841,16 +1841,18 @@ try
 
   //BackendDump.printBackendDAE(backendDAE_1);
 
-  //prepare simulation DAE
-  backendDAE := BackendDAEUtil.copyBackendDAE(simDAE);
-  backendDAE := BackendDAEOptimize.collapseIndependentBlocks(backendDAE);
-
-  eqSyst::{} := backendDAE.eqs;
-  v := eqSyst.orderedVars;
-  // get state var from simulation DAE
-  states := if Config.languageStandardAtLeast(Config.LanguageStandard._3_3) then
-    BackendVariable.getAllClockedStatesFromVariables(v) else {};
-  states := listAppend(BackendVariable.getAllStateVarFromVariables(v), states);
+  // Only the state variables are read from the simulation DAE, so it needs
+  // neither a copy nor a collapse. The finders cons and collapsing folds the
+  // systems in reverse, so reading them forwards keeps the old order.
+  states := {};
+  clockedStates := {};
+  for syst in simDAE.eqs loop
+    states := List.append_reverse(BackendVariable.getAllStateVarFromVariables(syst.orderedVars), states);
+    if Config.languageStandardAtLeast(Config.LanguageStandard._3_3) then
+      clockedStates := List.append_reverse(BackendVariable.getAllClockedStatesFromVariables(syst.orderedVars), clockedStates);
+    end if;
+  end for;
+  states := listAppend(listReverse(states), listReverse(clockedStates));
 
   // prepare all needed variables from initialization DAE
   varlst := BackendVariable.varList(currentSystem.orderedVars);

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -4486,8 +4486,8 @@ algorithm
 end callTranslateModelFMU;
 
 public function generateFMI3GraphicalRepresentation
-  "FMI 3.0 graphical user annotations (issue #15686 task 9). Using the in-memory
-   model instance (issue #15219) for the *graphical* side only, this renders the
+  "FMI 3.0 graphical user annotations (issue #15686 task 9). From an in-memory
+   structure holding the model's graphics alone (issue #15219), this renders the
    model Icon to terminalsAndIcons/icon.png (+ icon.svg), adds an FMI 3.0
    <GraphicalRepresentation> to terminalsAndIcons.xml, and for every placed
    connector component renders its port icon to terminalsAndIcons/<iconBaseName>.png
@@ -4510,9 +4510,7 @@ protected
   list<String> parts;
 algorithm
   try
-    // Full in-memory model instance: the model Icon plus the connector components
-    // (placement + connector-type icons). Graphics only.
-    Values.INTEGER(handle) := NFApi.getModelInstanceReference(className, className, "");
+    Values.INTEGER(handle) := NFApi.getModelInstanceIconReference(className);
     if handle > 0 then
       // Inner try so the model-instance handle is released on EVERY exit path
       // (a failure in the graphics work below must not leak the reference).

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -843,6 +843,29 @@ algorithm
   end try;
 end getModelInstanceReference;
 
+function getModelInstanceIconReference
+  "Like getModelInstanceReference, but stores only what an icon renderer reads:
+   the class' Icon with its extends chain, and the locally declared connector
+   components' Placement and type Icon. A lookup and an expand per class,
+   against an instantiation and a dump of every component."
+  input Absyn.Path classPath;
+  output Values.Value res;
+protected
+  JSON json;
+  Integer handle;
+algorithm
+  try
+    json := buildModelInstanceIconJSON(classPath);
+    json := JSON.toListForm(json);
+    handle := storeModelInstanceReference(json);
+    res := Values.INTEGER(handle);
+    Inst.clearCaches();
+  else
+    Inst.clearCaches();
+    fail();
+  end try;
+end getModelInstanceIconReference;
+
 function getModelInstanceAnnotation
   input Absyn.Path classPath;
   input list<String> filter;
@@ -962,6 +985,23 @@ algorithm
 
   json := dumpJSONInstanceAnnotation(cls_node, filter);
 end buildModelInstanceAnnotationJSON;
+
+function buildModelInstanceIconJSON
+  input Absyn.Path classPath;
+  output JSON json;
+protected
+  InstNode top, cls_node;
+  InstContext.Type context;
+algorithm
+  context := InstContext.set(NFInstContext.RELAXED, NFInstContext.CLASS);
+  context := InstContext.set(context, NFInstContext.INSTANCE_API);
+
+  (_, top) := mkTop(SymbolTable.getAbsyn(), AbsynUtil.pathString(classPath));
+  cls_node := Inst.lookupRootClass(classPath, top, context);
+  cls_node := InstNode.resolveInner(cls_node);
+
+  json := dumpJSONInstanceAnnotation(cls_node, {"Icon"}, dumpConnectors = true, dumpDerivedBase = true);
+end buildModelInstanceIconJSON;
 
 function storeModelInstanceReference
   "Stores a boxed JSON value and returns a 1-based handle (0 on failure)."
@@ -1219,16 +1259,19 @@ end dumpJSONInstanceTree;
 function dumpJSONInstanceAnnotation
   input InstNode node;
   input list<String> filter;
+  input Boolean dumpConnectors = false "the class' own connector components";
+  input Boolean dumpDerivedBase = false "a short class definition's base class";
   output JSON json = JSON.makeNull();
 protected
   Option<SCode.Comment> cmt;
   SCode.Annotation ann;
-  array<InstNode> exts;
   JSON j;
   InstNode scope = node;
   InstContext.Type context;
   Boolean annotation_is_literal = true;
+  Boolean any_element = false;
   SCode.Element def;
+  Class cls;
 algorithm
   Inst.expand(node, NFInstContext.RELAXED);
   def := InstNode.definition(node);
@@ -1239,15 +1282,41 @@ algorithm
 
   json := JSON.addPairNotNull("prefixes", dumpJSONClassPrefixes(def, InstNode.parent(node)), json);
 
-  exts := ClassTree.getExtends(Class.classTree(InstNode.getClass(node)));
+  cls := InstNode.getClass(node);
+  j := JSON.emptyArray();
 
-  if not arrayEmpty(exts) then
-    j := JSON.emptyArray();
+  // Class.classTree looks through a derived class, so its extends array is the
+  // base's: listing both would count the base's chain twice.
+  if dumpDerivedBase then
+    () := match cls
+      case Class.EXPANDED_DERIVED()
+        algorithm
+          j := JSON.addElement(dumpJSONInstanceAnnotationExtends(cls.baseClass, filter, true), j);
+          any_element := true;
+        then ();
 
-    for ext in exts loop
-      j := JSON.addElement(dumpJSONInstanceAnnotationExtends(ext, filter), j);
+      case Class.TYPED_DERIVED()
+        algorithm
+          j := JSON.addElement(dumpJSONInstanceAnnotationExtends(cls.baseClass, filter, true), j);
+          any_element := true;
+        then ();
+
+      else ();
+    end match;
+  end if;
+
+  if not any_element then
+    for ext in ClassTree.getExtends(Class.classTree(cls)) loop
+      j := JSON.addElement(dumpJSONInstanceAnnotationExtends(ext, filter, dumpDerivedBase), j);
+      any_element := true;
     end for;
+  end if;
 
+  if dumpConnectors then
+    (j, any_element) := dumpJSONInstanceAnnotationConnectors(node, j, any_element);
+  end if;
+
+  if any_element then
     json := JSON.addPair("elements", j, json);
   end if;
 
@@ -1286,13 +1355,53 @@ algorithm
   json := dumpJSONCommentOpt(cmt, scope, json, failOnError = true);
 end dumpJSONInstanceAnnotation;
 
+function dumpJSONInstanceAnnotationConnectors
+  "One element per locally declared connector component: name, Placement and
+   the type's icon annotation. A model instance nests the inherited ones under
+   the extends element, so only the class' own belong here."
+  input InstNode node;
+  input output JSON json;
+  input output Boolean any;
+protected
+  InstContext.Type context = InstContext.set(NFInstContext.RELAXED, NFInstContext.CLASS);
+  InstNode ty_node;
+  JSON e;
+algorithm
+  for el in SCodeUtil.getClassElements(InstNode.definition(node)) loop
+    () := match el
+      case SCode.Element.COMPONENT()
+        algorithm
+          try
+            ty_node := Lookup.lookupClassName(AbsynUtil.typeSpecPath(el.typeSpec), node, context, el.info);
+
+            if SCodeUtil.isConnector(SCodeUtil.getClassRestriction(InstNode.definition(ty_node))) then
+              ty_node := Inst.expand(ty_node, context);
+              e := JSON.addPair("$kind", JSON.STRING("component"), JSON.makeNull());
+              e := JSON.addPair("name", JSON.makeString(el.name), e);
+              e := dumpJSONAnnotationOpt(el.comment.annotation_, node, {"Placement"}, false, e);
+              e := JSON.addPair("type",
+                dumpJSONInstanceAnnotation(ty_node, {"Icon"}, dumpDerivedBase = true), e);
+              json := JSON.addElement(e, json);
+              any := true;
+            end if;
+          else
+          end try;
+        then ();
+
+      else ();
+    end match;
+  end for;
+end dumpJSONInstanceAnnotationConnectors;
+
 function dumpJSONInstanceAnnotationExtends
   input InstNode ext;
   input list<String> filter;
+  input Boolean dumpDerivedBase = false;
   output JSON json = JSON.makeNull();
 algorithm
   json := JSON.addPair("$kind", JSON.STRING("extends"), json);
-  json := JSON.addPair("baseClass", dumpJSONInstanceAnnotation(ext, filter), json);
+  json := JSON.addPair("baseClass",
+    dumpJSONInstanceAnnotation(ext, filter, dumpDerivedBase = dumpDerivedBase), json);
 end dumpJSONInstanceAnnotationExtends;
 
 function dumpJSONNodePath


### PR DESCRIPTION
`generateFMI3GraphicalRepresentation` asked for a *full* model instance (`getModelInstanceReference`) and read its Icon out of it. That means instantiating the model a second time, typing it, and serialising every component in it to JSON, all to render one icon and the placed connectors' port symbols. On `Buildings.DHC.Examples.Combined. SeriesConstantFlow` that was 28 s of a 4 minute FMI 3.0 export, and it grows with the model.

An icon renderer reads only the class' Icon annotation with its extends chain, and the locally declared connector components' Placement plus their type's Icon. `NFApi.getModelInstanceIconReference` builds exactly that, by lookup and expand -- no instantiation, no typing, no full tree. The structure it stores has the same shape the renderer already walks, so `OMGraphics` is unchanged.

`dumpJSONInstanceAnnotation` grew two defaulted flags for it:

| flag              | adds                                                |
| ----------------- | --------------------------------------------------- |
| `dumpConnectors`  | the class' own connector components (name,           |
|                   | Placement, and the type's icon annotation)           |
| `dumpDerivedBase` | a short class definition's base class, which a full  |
|                   | model instance lists as an extends                   |

`Class.classTree` looks through a derived class to its base, so the two must not both contribute or the base's chain is counted twice. `getModelInstanceAnnotation` passes neither and is unchanged.

`createFMIModelDerivativesForInitialization` deep-copied the whole simulation DAE and collapsed its partitions, then read only the state variables from the result. Walking the systems gives the same list. The state finders cons, and collapsing folds the systems in reverse, so reading them forwards restores both orders.

Verified by exporting 13 FMI 3.0 FMUs before and after: all 3360 generated files, `modelDescription.xml` and `terminalsAndIcons/` included, are byte-identical apart from the GUID and the timestamp. Comparing the icon a renderer would draw from the new structure against the one from a full model instance over 997 MSL and Buildings classes agrees for every model, block and connector (347/123/87, with 802 placed-connector elements); it differs only for media functions and three partial `BaseProperties` models inside partial interface packages, none of which can be an FMU root or a connector type.

rtest: openmodelica/fmi/ModelExchange/{2.0,3.0} (70 + 29) and openmodelica/instance-API (99) pass on the Rust omc; the same 3.0 suite passes on the bootstrapped C omc except the four `fmi3_wasm_*` cases, which need the wasm-jit target that build does not have.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
