### PR TITLE
CS FMU: fire clock activations, one Sync

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -963,7 +963,7 @@ macro_rules! shared_instance_methods {
         let mut e = Engine;
         match set_zc_tolerance(&mut e, sim_data, &layout, tolerance.unwrap_or(0.0)) {
             Ok(()) => Status::Ok,
-            Err(_) => Status::Error,
+            Err(err) => err_status(err),
         }
     }
 
@@ -980,7 +980,7 @@ macro_rules! shared_instance_methods {
             let start_time = st.read_f64(TIME_OFF);
             match Samples::load(&Engine, st.sim_data, &st.layout, start_time) {
                 Ok(s) => st.samples = Some(s),
-                Err(_) => return Status::Error,
+                Err(err) => return err_status(err),
             }
         }
         // The CS driver is built lazily on the first `do-step` (see there): a me_cs
@@ -992,9 +992,10 @@ macro_rules! shared_instance_methods {
         if st.defer != CsDefer::None {
             let (sim_data, t) = (st.sim_data, st.read_f64(TIME_OFF));
             let (meta, defer) = (st.meta.clone(), st.defer);
-            match CsDriver::new(&mut Engine, &meta, sim_data, t, defer) {
+            let sync = st.sync.take();
+            match CsDriver::new(&mut Engine, &meta, sim_data, t, defer, sync) {
                 Ok(d) => st.cs = Some(d),
-                Err(_) => return Status::Error,
+                Err(err) => return err_status(err),
             }
         }
         Status::Ok
@@ -1014,27 +1015,28 @@ macro_rules! shared_instance_methods {
         let time = st.read_f64(TIME_OFF);
         let mut e = Engine;
 
+        // The CS driver owns the instance's clock schedule and fires the timers
+        // itself, so `fmi_handle_timers` below must not fire them a second time.
         #[cfg(feature = "cs")]
-        let up = if st.defer != CsDefer::None {
-            // Route through the driver so its sample schedule advances in step with
-            // the integrator (see `CsDriver::do_event_update`).
+        let (up, clocks_handled) = if let Some(mut d) = st.cs.take() {
+            // Route through the driver so its sample and clock schedules advance in
+            // step with the integrator (see `CsDriver::do_event_update`).
             let meta = st.meta.clone();
-            let mut d = st.cs.take().ok_or(Status::Error)?;
             let r = d.do_event_update(&mut e, &meta, time);
             st.cs = Some(d);
             match r {
-                Ok(up) => up,
+                Ok(up) => (up, true),
                 Err(err) => return Err(err_status(err)),
             }
         } else {
             match event_update(&mut e, sim_data, &layout, st.samples.as_mut(), time) {
-                Ok(up) => up,
+                Ok(up) => (up, false),
                 Err(err) => return Err(err_status(err)),
             }
         };
         #[cfg(not(feature = "cs"))]
-        let up = match event_update(&mut e, sim_data, &layout, st.samples.as_mut(), time) {
-            Ok(up) => up,
+        let (up, clocks_handled) = match event_update(&mut e, sim_data, &layout, st.samples.as_mut(), time) {
+            Ok(up) => (up, false),
             Err(err) => return Err(err_status(err)),
         };
 
@@ -1060,7 +1062,8 @@ macro_rules! shared_instance_methods {
         // sample and the next activation.
         let mut next = up.next_event_time;
         let mut ticked = false;
-        if let Some(mut sync) = st.sync.take() {
+        let pending_sync = if clocks_handled { None } else { st.sync.take() };
+        if let Some(mut sync) = pending_sync {
             let r = driver::fmi_handle_timers(&mut e, &mut sync, &st.meta, sim_data, time);
             let tc = sync.next_time();
             st.sync = Some(sync);
@@ -1703,7 +1706,8 @@ impl GuestCoSimulationInstance for Instance {
         // Event Mode already built it in exit-initialization-mode.
         if st.cs.is_none() {
             let (sim_data, t) = (st.sim_data, st.read_f64(TIME_OFF));
-            match CsDriver::new(&mut e, &meta, sim_data, t, defer) {
+            let sync = st.sync.take();
+            match CsDriver::new(&mut e, &meta, sim_data, t, defer, sync) {
                 Ok(d) => st.cs = Some(d),
                 Err(e) => return Err(err_status(e)),
             }

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/driver.rs
@@ -8288,6 +8288,9 @@ impl CsDriver {
     /// Build over an already-initialized model at time `t`, integrating with the
     /// method the FMU was exported with ([`SimMeta::cs_method`]).
     ///
+    /// The driver takes over `sync` so the instance has exactly one clock schedule,
+    /// and builds its own only for a caller with none.
+    ///
     /// The integrator watches event indicators only under [`CsDefer::Any`], the one
     /// mode whose master can be handed the crossing time (Event Mode with early
     /// return). Otherwise the FMU resolves the event itself, and does it as C's
@@ -8299,6 +8302,7 @@ impl CsDriver {
         sim_data: u32,
         t: f64,
         defer: CsDefer,
+        sync: Option<crate::sync::Sync>,
     ) -> Result<Self> {
         daskr::auxiliary::xsetf(0);
         let layout = &model.layout;
@@ -8310,8 +8314,14 @@ impl CsDriver {
         }
         store_relations(e, sim_data, layout)?;
         let samp = Samples::load(e, sim_data, layout, t)?;
-        let mut sync = crate::sync::Sync::new(e, model, sim_data)?;
-        sync.take_fired(e, t)?;
+        let sync = match sync {
+            Some(s) => s,
+            None => {
+                let mut s = crate::sync::Sync::new(e, model, sim_data)?;
+                s.take_fired(e, t)?;
+                s
+            }
+        };
         let mut core = SolverCore::new(&*e, model, sim_data, t, method, alloc_gbode(model, method)?)?;
         core.fmi_cs_solver_setup(defer);
         if core.n_states > 0 {
@@ -8344,8 +8354,9 @@ impl CsDriver {
     ) -> Result<CsStep> {
         let layout = &model.layout;
         let sim_data = self.core.sim_data;
-        // No continuous states: samples, and zero crossings on `time` bracketed and
-        // bisected between the communication points as `EventsDriver` does.
+        // No continuous states: samples, clock activations, and zero crossings on
+        // `time` bracketed and bisected between the communication points as
+        // `EventsDriver` does.
         if self.core.n_states == 0 {
             self.resume = None;
             let eps = reached_eps(t_target, model.stop_time - model.start_time);
@@ -8358,7 +8369,14 @@ impl CsDriver {
             loop {
                 rotate_old_real(e, sim_data, layout)?;
                 let te = self.samp.next_time();
-                let subtarget = if te >= self.core.t && te <= t_target + SAMPLE_EPS { te } else { t_target };
+                let tc = self.sync.next_time();
+                let mut subtarget = t_target;
+                if tc >= self.core.t && tc <= subtarget + SYNC_EPS {
+                    subtarget = tc;
+                }
+                if te >= self.core.t && te <= subtarget + SAMPLE_EPS {
+                    subtarget = te;
+                }
                 let mut troot = None;
                 if layout.n_zc > 0 && subtarget - self.core.t > eps {
                     update_zero_crossings(e, sim_data, layout, subtarget, &mut scratch, false)?;
@@ -8399,9 +8417,29 @@ impl CsDriver {
                         return Ok(CsStep::Terminated);
                     }
                     self.after_walk_event(e, layout)?;
-                    continue;
                 }
-                break;
+                // C's `handleTimers`, plus any event clock the update above fired.
+                if !self.sync.is_empty() {
+                    write_time(e, sim_data, subtarget)?;
+                    self.sync.take_fired(e, subtarget)?;
+                }
+                if self.sync.next_time() <= subtarget + SYNC_EPS {
+                    self.core.t = subtarget;
+                    if defers(subtarget) {
+                        write_time(e, sim_data, subtarget)?;
+                        return Ok(CsStep::Event { time: subtarget });
+                    }
+                    write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
+                    eval_continuous(e, sim_data, layout)?;
+                    if fire_clocks(e, &mut self.sync, model, sim_data, subtarget, SYNC_EPS, None)? {
+                        if terminated(e, sim_data, layout)? {
+                            return Ok(CsStep::Terminated);
+                        }
+                        self.after_walk_event(e, layout)?;
+                    }
+                } else if te > subtarget + SAMPLE_EPS {
+                    break;
+                }
             }
             self.core.t = t_target;
             write_i32(e, sim_data + layout.rel_fresh_off, 0)?;
@@ -8459,6 +8497,9 @@ impl CsDriver {
     /// The master's `update-discrete-states` at the event `step_to` stopped on: the
     /// discrete update and bookkeeping [`integrate_to`](SolverCore::integrate_to)
     /// runs for an event it resolves itself, the restart left to the next step.
+    ///
+    /// C's `internalEventUpdate` runs `handleTimersFMI` here too, and on this
+    /// schedule: it is the one `step_to` cut its step onto.
     pub fn do_event_update(
         &mut self,
         e: &mut (dyn SimEngine + 'static),
@@ -8467,20 +8508,28 @@ impl CsDriver {
     ) -> Result<EventUpdate> {
         let layout = &model.layout;
         let sim_data = self.core.sim_data;
-        let time_event = self.samp.next_time() <= time + SAMPLE_EPS;
-        if time_event {
+        let sample_due = self.samp.next_time() <= time + SAMPLE_EPS;
+        let clock_due = self.sync.next_time() <= time + SYNC_EPS;
+        if sample_due {
             self.core.time_events += 1;
-        } else {
+        } else if !clock_due {
             self.core.state_events += 1;
         }
-        let up = event_update(e, sim_data, layout, Some(&mut self.samp), time)?;
+        let mut up = event_update(e, sim_data, layout, Some(&mut self.samp), time)?;
+        let ticked = fire_clocks(e, &mut self.sync, model, sim_data, time, SYNC_EPS, None)?;
+        up.states_changed |= ticked;
+        let tc = self.sync.next_time();
+        if tc.is_finite() {
+            up.next_event_time = Some(up.next_event_time.map_or(tc, |n: f64| n.min(tc)));
+        }
         save_zero_crossings_after_event(e, sim_data, layout)?;
         store_operators(e, sim_data, layout)?;
         if self.core.n_states == 0 && layout.n_zc > 0 {
             read_zero_crossings(e, sim_data, layout, &mut self.zc0)?;
         }
         omclog::close(omclog::EVENTS);
-        self.resume = Some(if time_event { MasterEvent::Time } else { MasterEvent::State });
+        self.resume =
+            Some(if sample_due || clock_due { MasterEvent::Time } else { MasterEvent::State });
         Ok(up)
     }
 


### PR DESCRIPTION
The FMI 3.0 Co-Simulation face left every clocked partition frozen at its start value. `CsDriver::step_to`'s no-continuous-states walk interleaved sample events and zero crossings but never consulted the clock schedule, so a stateless clocked model reported `0 events` and held its clocked outputs for the whole run. `EventsDriver`'s walk and `SolverCore::integrate_to` both fold `sync.next_time()` into their sub-target; this one now does too, and reports the activation to the master under `CsDefer` rather than resolving it.

The instance also carried two independent `sync::Sync` objects: one built by the component's `run_init`, one built again inside `CsDriver::new`. `Sync` owns its timer list, so the two drifted - in Event Mode `update-discrete-states` fired one while the integrator advanced the other, and the base-clock count that drives the sub-clock formula ran ahead. `CsDriver::new` now takes the component's `Sync`, `update-discrete-states` routes through the driver whenever one exists, and `do_event_update` runs C's `handleTimersFMI` on that single schedule and folds the next activation into `next_event_time`.

Three `exit-initialization-mode` failure paths discarded the error text, so a failed CS instantiation reported nothing but `fmi3ExitInitializationMode returned error`; they now use `err_status`.

Verified on all 77 `Modelica.Clocked.Examples` models, each exported once and run as a plain simulation, as ME and as CS:

| face | models differing from the standalone |
| ---- | ------------------------------------ |
| ME   | 20 of 77                             |
| CS   | 19 of 77                             |

Every remaining CS difference is identical, variable for variable, to the ME difference on the same model, so the two faces now agree. What is left is the pre-existing event ordering at a clock tick coincident with a time event, which C's own FMU export shares.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
