### PR TITLE
FMU flags: keep a valueless --fmiFlags entry

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -13675,7 +13675,7 @@ protected
   String pathToFile;
   String msg;
   String tmpName, tmpValue;
-  list<String> tmpSplitted;
+  list<String> tmpSplitted, tmpRest;
   list<tuple<String,String>> nameValueTuples = {} ;
 algorithm
   fmiFlagsList := Flags.getConfigStringList(Flags.FMI_FLAGS);
@@ -13715,17 +13715,18 @@ algorithm
   // --fmiFlags=s:cvode,nls:homotopy
   else
     for flag in fmiFlagsList loop
-      // Check each flag
+      // A flag that takes no value is its name alone (`noRestart`); a value may
+      // itself contain a colon.
       tmpSplitted := Util.stringSplitAtChar(flag,":");
-      if not listLength(tmpSplitted) == 2 then
+      if listEmpty(tmpSplitted) then
         if printWarning then
-          msg := "Can't process flag \"" + flag + "\".\nSeperate flag name and flag value with \":\".\n";
+          msg := "Can't process flag \"" + flag + "\".\nIt names no simulation flag.\n";
           Error.addCompilerWarning(msg);
         end if;
-        fmiSimulationFlags := SOME(SimCode.defaultFmiSimulationFlags);
-        return;
+        continue;
       end if;
-      {tmpName, tmpValue} := tmpSplitted;
+      tmpName :: tmpRest := tmpSplitted;
+      tmpValue := stringDelimitList(tmpRest, ":");
 
       // Save value
       if stringEqual(tmpName, "s") then

--- a/testsuite/openmodelica/fmi/CoSimulation/3.0/Makefile
+++ b/testsuite/openmodelica/fmi/CoSimulation/3.0/Makefile
@@ -3,6 +3,7 @@ TEST = ../../../../rtest -v
 TESTFILES = \
 fmi3_cs_01.mos \
 fmi3_msl_clocked_drive.mos \
+fmi3_wasm_annotation_flags.mos \
 fmi3_wasm_arrays.mos \
 fmi3_wasm_daemode.mos \
 fmi3_wasm_solver_absent.mos \

--- a/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_annotation_flags.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_annotation_flags.mos
@@ -1,0 +1,41 @@
+// name: fmi3_wasm_annotation_flags.mos
+// keywords: FMI 3.0 export wasm Co-Simulation simulation flags annotation
+// status: correct
+// suite: wasm
+// teardown_command: rm -rf M_annflags* om-wasm-include-*
+//
+// A wasm FMU folds the class's __OpenModelica_simulationFlags into its
+// `_flags.json`, which is what its Co-Simulation face integrates with. A flag
+// that takes no value is an entry with an empty value; it used to be rejected,
+// and the rejection dropped the whole set for the `s:euler` default -- putting
+// the FMU on explicit Euler where the model asked for dassl.
+
+setCommandLineOptions("--simCodeTarget=wasm-jit --fmuDirectory=true"); getErrorString();
+loadString("model AnnFlags
+  Real x(start = 1, fixed = true);
+equation
+  der(x) = -x;
+  annotation(experiment(StopTime = 1),
+    __OpenModelica_simulationFlags(s = \"dassl\", nls = \"kinsol\", noRestart = \"()\"));
+end AnnFlags;"); getErrorString();
+
+buildModelFMU(AnnFlags, fileNamePrefix="M_annflags", fmuType="cs", version="3.0", platforms={"wasm"}); getErrorString();
+readFile("M_annflags.fmu/resources/M_annflags_flags.json"); getErrorString();
+// Result:
+// true
+// ""
+// true
+// ""
+// "M_annflags.fmu"
+// "Warning: Adding unknown FMU simulation flag \"nls\" .
+// Warning: Adding unknown FMU simulation flag \"noRestart\" .
+// Notification: Building FMU for platform 'wasm' (1/1).
+// Notification: Finished FMU for platform 'wasm' (1/1).
+// "
+// "{
+//   \"s\" : \"dassl\",
+//   \"nls\" : \"kinsol\",
+//   \"noRestart\" : \"\"
+// }"
+// ""
+// endResult


### PR DESCRIPTION
`createFMISimulationFlags` split every `--fmiFlags` entry at `:` and, unless the split gave exactly two parts, warned and returned `SimCode.defaultFmiSimulationFlags` -- which is `{("s","euler")}`. One unparseable entry therefore discarded every other flag *and* rewrote the solver.

A flag that takes no value arrives as `name:`, which splits into one part. `fmuAnnotationSimulationFlags` produces exactly that for `__OpenModelica_simulationFlags(emit_protected = "()")`, so a class carrying one lost its whole flag set. Every Dynawo example does:

    __OpenModelica_simulationFlags(initialStepSize = "0.001",
      nls = "kinsol", s = "ida", nlsLS = "klu",
      maxIntegrationOrder = "2", maxStepSize = "10",
      emit_protected = "()")

exported `{"s" : "euler"}` and nothing else, so the FMU's Co-Simulation face integrated with explicit Euler at the communication step size while the same artifact's Model Exchange face and `simulate()` ran IDA with KINSOL/KLU. `SMIBStepPm` died at t=5.22 on `Solving non-linear system 389 failed`; the ones that survived disagreed with the reference.

A name alone is now a flag with an empty value, a value may itself contain a colon, and an entry that still names nothing is skipped with a warning instead of taking the others down with it. Everything downstream already handled the empty value: `fmu_solver_flags` maps it to `-name`, `fmu_accepts_flag` takes `("noRestart", "")`, and C's `parseFlags` only reacts to names it knows.

Measured on the nine `Dynawo_dev` models the library testing has verifying under `wasm-jit` but not `wasm-jit-cs`, comparing each face of one artifact against the standalone run within an event envelope:

| model                        | vars | CS before | CS after | ME |
| ---------------------------- | ---: | --------: | -------: | -: |
| BESSCurrentSourceExternalPCS | 1534 |         5 |        0 |  1 |
| BESSCurrentSourceNoPPC       |  930 |         1 |        0 |  0 |
| GovCt2St4b                   |  986 |         1 |        0 |  1 |
| GovSteam1St4bPss2b1          | 1174 |         1 |        0 |  0 |
| PVCurrentSource              | 1353 |         1 |        0 |  0 |
| PVVoltageSource2             | 1466 |         2 |        0 |  0 |
| PVVoltageSource4             | 1575 |         3 |        0 |  1 |
| SMIBStepPm                   |  398 |         1 |        0 |  0 |
| TestCase1                    |  861 |         2 |        0 |  0 |

("before" is the count the library testing reports; the local CS run of `SMIBStepPm` does not reach the end at all.) Two models the CS lane could not simulate at all, `GovSteam1St4b2` and `GovSteamEuSt4b`, now run and agree with Model Exchange variable for variable.

43 models in `Dynawo master`, 34 in `Dynawo 1.7.0`, 13 in `PowerGrids 1.0.3`, 7 in `PowerGrids 2.0.0-develop`, 3 in `PhotoVoltaics_TGM` and 2 in `AES` carry a valueless entry.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
