### PR TITLE
wasm FMU: report the model's own assertions

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -2471,6 +2471,16 @@ impl DylinkFmu {
         let str_new = wts(fused_inst.get_typed_func::<u32, u32>(&mut store, "rt_str_new"))?;
         let str_data = wts(fused_inst.get_typed_func::<u32, u32>(&mut store, "rt_str_data"))?;
         crate::host::define_uri_import(&mut linker, memory, str_new, str_data)?;
+        // The artifact reports its own assertions: `add_host_builtins` binds these
+        // to omc's simulation-path recorder, which only the host driver drains.
+        linker.allow_shadowing(true);
+        for name in ["rt_assert", "rt_assert_warning"] {
+            let f = fused_inst
+                .get_func(&mut store, name)
+                .ok_or_else(|| format!("CodegenWasmJit: the fused runtime has no `{name}` export"))?;
+            wts(linker.define(&store, "rt", name, f))?;
+        }
+        linker.allow_shadowing(false);
         // `rt` for the model, one export at a time rather than `Linker::instance`,
         // which would collide with those.
         let exports: Vec<(String, wasmtime::Extern)> = fused_inst

--- a/testsuite/openmodelica/fmi/CoSimulation/3.0/Makefile
+++ b/testsuite/openmodelica/fmi/CoSimulation/3.0/Makefile
@@ -6,6 +6,7 @@ fmi3_msl_clocked_drive.mos \
 fmi3_wasm_annotation_flags.mos \
 fmi3_wasm_arrays.mos \
 fmi3_wasm_daemode.mos \
+fmi3_wasm_error_reason.mos \
 fmi3_wasm_solver_absent.mos \
 fmi3_wasm_solver_libraries.mos \
 fmi3_wasm_solver_me.mos

--- a/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_error_reason.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_error_reason.mos
@@ -1,0 +1,22 @@
+// name: fmi3_wasm_error_reason.mos
+// keywords: FMI 3.0 export wasm Co-Simulation error reporting assert
+// status: correct
+// suite: wasm
+// depends: fmi3_wasm_error_reason_sub.mos
+// teardown_command: rm -rf M_reason* reason.log count.log om-wasm-include-*
+//
+// A model error inside an artifact FMU has to reach the log; the FMI status alone
+// tells the importer nothing. The message names the library function that raised
+// it by absolute path, so grep the sub-run's log instead of comparing it.
+
+system(getInstallationDirectoryPath() + "/bin/omc fmi3_wasm_error_reason_sub.mos > reason.log 2>&1"); getErrorString();
+system("grep -c 'logStatusError.*boom from ModelicaError' reason.log > count.log"); getErrorString();
+readFile("count.log");
+// Result:
+// 0
+// ""
+// 0
+// ""
+// "1
+// "
+// endResult

--- a/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_error_reason_sub.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_error_reason_sub.mos
@@ -1,0 +1,15 @@
+// The failing run fmi3_wasm_error_reason.mos greps.
+setCommandLineOptions("--simCodeTarget=wasm-jit --fmuDirectory=true"); getErrorString();
+loadModel(Modelica); getErrorString();
+loadString("model Boom
+  Real x(start = 0, fixed = true);
+equation
+  der(x) = 1;
+algorithm
+  when time > 0.5 then
+    Modelica.Utilities.Streams.error(\"boom from ModelicaError\");
+  end when;
+  annotation(experiment(StopTime = 1));
+end Boom;"); getErrorString();
+buildModelFMU(Boom, fileNamePrefix="M_reason", fmuType="cs", version="3.0", platforms={"wasm"}); getErrorString();
+simulate(Boom, simflags="-lv LOG_STATS -s fmi3:cs", resimulateExecutable="M_reason.fmu"); getErrorString();


### PR DESCRIPTION
`DylinkFmu::load_fused` calls `add_host_builtins`, which defines `rt.rt_assert` and `rt.rt_assert_warning` as omc's *simulation-path* recorder: `host::assert_failed` stores the violation in a thread-local that only the host driver and the `-d=gen` function-eval path drain. The loop that then publishes the fused module's own exports under `rt` skips a name the linker already has, so the artifact's own reporter -- the adapter's `rt_assert`, which is C's `omc_assert_fmi` and `omc_assert_simulation_withEquationIndexes` -- was never reached.

Nothing on the FMI path drains that recorder, so **every model error inside an artifact FMU failed its call with no reason in the log**. The model traps, `enrich_trap` labels the trap `ASSERT_ERR`, and `err_status` suppresses its own message because `ASSERT_ERR` is documented as having reported already. Nothing had.

One `Modelica.Utilities.Streams.error` in a `when` body, exported twice from the same source:

    --fmuDirectory=true (the linked form, what the library testing uses)
      LOG_ERROR | error | fmi3UpdateDiscreteStates returned error

    zipped (the component form, unaffected)
      LOG_STDOUT | info  | logStatusError: Streams.mo:113: boom from …
      LOG_ERROR  | error | fmi3UpdateDiscreteStates returned error

Rebinding the two names from the fused instance is control-flow neutral. The model-error call sites pass `cond = 0` and drop the result; the one site that uses it unwinds unless the driver suppressed the assertion, and suppression is the host's `NO_THROW`, a host-driver thread-local that is never set on the FMI path -- so the host's `rt_assert` already always returned 1 there, exactly as the adapter's does. Suppression on this path is `rt_assert_common`'s, untouched. `rt_print`, `rt_uri_to_filename`, `rt_row_asserts` and `rt_ext_stack_save` stay the host's, which genuinely owns them.

This is the largest cluster of opaque failures in the library testing's `wasm-jit-cs` lane -- of 133 sampled `.sim` logs at dev-566, `fmi3ExitInitializationMode returned error` (29),
`fmi3DoStep returned error` (21), `om_fmi3GetFloat64 returned error` (10) and `fmi3UpdateDiscreteStates returned error` (2) carried no reason at all. It also hid assertions on the artifact's own simulation face, which loads through the same function. The reasons it uncovers are separate bugs, now diagnosable: `TestReadFile`, for one, turns out to be `Streams.readFile failed (at least one of the lines is wrongly read)`.

The non-fused fallback (`OMC_WASM_FUSED_ARTIFACT=0`) loads the adapter after the model, so binding the model's import to it needs a trampoline; that path is still silent.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
