### PR TITLE
[FMI-CS] Locate state events by bisection instead of applying them at the end of step

### DIFF
--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
@@ -45,12 +45,15 @@
 #endif
 #include "../simulation/solver/delay.h"
 #include "../simulation/solver/discrete_changes.h"
+#include "../simulation/solver/epsilon.h"
 #include "../simulation/simulation_info_json.h"
 #include "../simulation/simulation_input_xml.h"
 #include "../simulation/solver/synchronous.h"
 #include "../simulation/options.h"
 #include "../util/simulation_options.h"
 #include "../util/omc_error.h"
+
+#include <math.h>
 
 #include "fmu2_dummy_model_defines.h" // get's replaced in SimCodeMain.mo
 
@@ -2333,6 +2336,105 @@ fmi2Status fmi2GetRealOutputDerivatives(fmi2Component c, const fmi2ValueReferenc
   return fmi2OK;
 }
 
+#if NUMBER_OF_STATES > 0 && NUMBER_OF_EVENT_INDICATORS > 0
+/**
+ * @brief Locate a state event within [t_left, t_right] by bisection.
+ *
+ * fmi2DoStep integrates over an entire sub-step before it can check the
+ * event indicators, so a zero crossing occurring inside that sub-step would
+ * otherwise only be noticed (and applied) at the sub-step's end instead of
+ * where it actually happens. For models with fast switching (e.g. ideal
+ * diodes), that timing error is visible in the results (see issue #16093).
+ * This mirrors the bisection root-finding events.c uses for the standalone
+ * simulation runtime, but works directly through fmi2DoStep's own
+ * get/set-state calls so it applies regardless of which internal solver
+ * (S_EULER or S_CVODE) produced the bracket.
+ *
+ * States at an intermediate time are approximated by linear interpolation
+ * between the bracket ends, consistent with the accuracy already assumed by
+ * the explicit-Euler / macro CVODE step that produced them.
+ *
+ * On return, *eventTime and states_event hold the right bracket bound, i.e.
+ * just past the crossing, so that the indicators there differ in sign from
+ * indicators_left -- matching what fmi2DoStep's own zero-crossing check
+ * expects to see in order to trigger event iteration.
+ *
+ * @param c                 FMU component.
+ * @param t_left            Start time of the bracket (no crossing yet).
+ * @param states_left       States at t_left.
+ * @param indicators_left   Event indicators at t_left.
+ * @param t_right           End time of the bracket (crossing already happened).
+ * @param states_right      States at t_right.
+ * @param states_event      Output: states just past the located crossing.
+ * @param eventTime         Output: time just past the located crossing.
+ * @return fmi2Status       fmi2OK, or an error propagated from a get/set call.
+ */
+static fmi2Status internalLocateStateEvent(fmi2Component c,
+                                            fmi2Real t_left, const fmi2Real* states_left, const fmi2Real* indicators_left,
+                                            fmi2Real t_right, const fmi2Real* states_right,
+                                            fmi2Real* states_event, fmi2Real* eventTime)
+{
+  ModelInstance *comp = (ModelInstance *)c;
+  fmi2Status status = fmi2OK;
+  fmi2Real states_a[NUMBER_OF_STATES];
+  fmi2Real states_b[NUMBER_OF_STATES];
+  fmi2Real states_mid[NUMBER_OF_STATES];
+  fmi2Real indicators_a[NUMBER_OF_EVENT_INDICATORS];
+  fmi2Real indicators_mid[NUMBER_OF_EVENT_INDICATORS];
+  fmi2Real a = t_left, b = t_right, tmid, tol;
+  int i, crossed_left_half;
+
+  memcpy(states_a, states_left, NUMBER_OF_STATES * sizeof(fmi2Real));
+  memcpy(states_b, states_right, NUMBER_OF_STATES * sizeof(fmi2Real));
+  memcpy(indicators_a, indicators_left, NUMBER_OF_EVENT_INDICATORS * sizeof(fmi2Real));
+
+  tol = MINIMAL_STEP_SIZE + MINIMAL_STEP_SIZE * fabs(b - a);
+
+  while (fabs(b - a) > tol)
+  {
+    tmid = 0.5 * (a + b);
+    for (i = 0; i < NUMBER_OF_STATES; i++) {
+      states_mid[i] = 0.5 * (states_a[i] + states_b[i]);
+    }
+
+    comp->fmuData->localData[0]->timeValue = tmid;
+    status = internalSetContinuousStates(c, states_mid, NUMBER_OF_STATES);
+    if (status != fmi2OK) return status;
+    status = internalGetEventIndicators(c, "fmi2DoStep", indicators_mid, NUMBER_OF_EVENT_INDICATORS);
+    if (status != fmi2OK) return status;
+
+    crossed_left_half = 0;
+    for (i = 0; i < NUMBER_OF_EVENT_INDICATORS; i++)
+    {
+      if (indicators_a[i] * indicators_mid[i] < 0)
+      {
+        crossed_left_half = 1;
+        break;
+      }
+    }
+
+    if (crossed_left_half)
+    {
+      b = tmid;
+      memcpy(states_b, states_mid, NUMBER_OF_STATES * sizeof(fmi2Real));
+    }
+    else
+    {
+      a = tmid;
+      memcpy(states_a, states_mid, NUMBER_OF_STATES * sizeof(fmi2Real));
+      memcpy(indicators_a, indicators_mid, NUMBER_OF_EVENT_INDICATORS * sizeof(fmi2Real));
+    }
+  }
+
+  *eventTime = b;
+  memcpy(states_event, states_b, NUMBER_OF_STATES * sizeof(fmi2Real));
+
+  /* Leave the FMU state consistent with the returned (time, states). */
+  comp->fmuData->localData[0]->timeValue = b;
+  return internalSetContinuousStates(c, states_b, NUMBER_OF_STATES);
+}
+#endif
+
 /**
  * @brief FMI 2 doStep function.
  *
@@ -2463,6 +2565,11 @@ fmi2Status fmi2DoStep(fmi2Component c, fmi2Real currentCommunicationPoint, fmi2R
     }
 
     /* integrate */
+#if NUMBER_OF_STATES > 0
+    fmi2Real states_t0[NUMBER_OF_STATES];
+    memcpy(states_t0, states, NUMBER_OF_STATES * sizeof(fmi2Real));
+    fmi2Real t0 = comp->fmuData->localData[0]->timeValue;
+#endif
     switch(comp->solverInfo->solverMethod)
     {
       case S_EULER:
@@ -2491,6 +2598,42 @@ fmi2Status fmi2DoStep(fmi2Component c, fmi2Real currentCommunicationPoint, fmi2R
         status = fmi2Fatal;
         goto doStep_cleanup;
     }
+
+#if NUMBER_OF_STATES > 0 && NUMBER_OF_EVENT_INDICATORS > 0
+    /* Check whether a state event occurred within this sub-step, and if so
+     * shrink the step to the precise crossing time by bisection instead of
+     * applying it at the sub-step's end (see internalLocateStateEvent). */
+    {
+      fmi2Real trial_indicators[NUMBER_OF_EVENT_INDICATORS];
+      int trial_zc = 0;
+
+      comp->fmuData->localData[0]->timeValue = tNext;
+      status = internalSetContinuousStates(c, states, NUMBER_OF_STATES);
+      if (status != fmi2OK) goto doStep_cleanup;
+      status = internalGetEventIndicators(c, "fmi2DoStep", trial_indicators, NUMBER_OF_EVENT_INDICATORS);
+      if (status != fmi2OK) goto doStep_cleanup;
+
+      for (i = 0; i < NUMBER_OF_EVENT_INDICATORS; i++)
+      {
+        if (trial_indicators[i]*event_indicators_prev[i] < 0)
+        {
+          trial_zc = 1;
+          break;
+        }
+      }
+
+      if (trial_zc)
+      {
+        fmi2Real eventTime;
+        fmi2Real states_event[NUMBER_OF_STATES];
+        status = internalLocateStateEvent(c, t0, states_t0, event_indicators_prev, tNext, states, states_event, &eventTime);
+        if (status != fmi2OK) goto doStep_cleanup;
+
+        tNext = eventTime;
+        memcpy(states, states_event, NUMBER_OF_STATES * sizeof(fmi2Real));
+      }
+    }
+#endif
 
     // update time
     comp->fmuData->localData[0]->timeValue = tNext;


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/16093

### Purpose

Add a self-contained bisection helper that mirrors `events.c's` approach but works through fmi2DoStep's own get/set-state calls, so it applies to both S_EULER and S_CVODE.

