### PR TITLE
wasm-jit: release String args of external calls

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -2755,6 +2755,9 @@ fn emit_shared_external_call(
         F77Array { handle: u32, ptr: u32, is_out: bool },
         /// C's `<record>_external`: copy its fields into `out`, then free it.
         CRecord { ptr: u32, fields: Arc<Vec<(ArcStr, SigTy)>>, out: Target },
+        /// A String argument: the callee got a `rt_str_data` pointer into it, so
+        /// this side still owns the handle and releases it once the call is done.
+        Owned { handle: u32 },
     }
     let fortran = sig.lang == ExtLang::Fortran77;
     let native = is_native_external(&sig.name);
@@ -2853,6 +2856,9 @@ fn emit_shared_external_call(
             }
             SigTy::Str if !is_out => {
                 push_value(ctx, "a String", WTy::I32)?;
+                let handle = ctx.alloc_temp(WTy::I32);
+                ctx.emit(we::Instruction::LocalTee(handle));
+                cleanups.push(Cleanup::Owned { handle });
                 if !native {
                     ctx.emit(we::Instruction::Call(rt_index("rt_str_data")?));
                 }
@@ -2942,6 +2948,10 @@ fn emit_shared_external_call(
                 Cleanup::CRecord { ptr, .. } => {
                     ctx.emit(we::Instruction::LocalGet(*ptr));
                     ctx.emit(we::Instruction::Call(rt_index("rt_free")?));
+                }
+                Cleanup::Owned { handle } => {
+                    ctx.emit(we::Instruction::LocalGet(*handle));
+                    ctx.emit(we::Instruction::Call(rt_index("rt_release")?));
                 }
             }
         }
@@ -3036,6 +3046,10 @@ fn emit_shared_external_call(
                 }
                 ctx.emit(we::Instruction::LocalGet(*ptr));
                 ctx.emit(we::Instruction::Call(rt_index("rt_free")?));
+            }
+            Cleanup::Owned { handle } => {
+                ctx.emit(we::Instruction::LocalGet(*handle));
+                ctx.emit(we::Instruction::Call(rt_index("rt_release")?));
             }
         }
     }
@@ -3203,17 +3217,38 @@ fn emit_general_external_call(ctx: &mut FnCtx, ext_name: &str, args: &[Arc<DAE::
         ));
     }
 
+    // A heap argument reaches the host as an owned reference (reading a String
+    // local retains), and the trampoline only copies out of it — so this side
+    // owns it still and must release it after the call, as `str_binop` does.
+    // `Strings.compare` takes two per call, which is why `Strings.find` leaked one
+    // substring per position it tried.
+    let mut arg_temps: Vec<(u32, &'static str)> = Vec::new();
     for (a, p) in args.iter().zip(params.iter()) {
         let w = compile_exp(ctx, a)?;
         coerce(ctx, w, p.wty());
+        if let Some(release_fn) = p.release_fn() {
+            let t = ctx.alloc_temp(p.wty());
+            ctx.emit(we::Instruction::LocalTee(t));
+            arg_temps.push((t, release_fn));
+        }
     }
     ctx.emit(we::Instruction::Call(index));
+    // The results sit on the stack (or in `temps`); `rt_release` leaves nothing
+    // behind, so releasing here does not disturb them.
+    let release_args = |ctx: &mut FnCtx| -> Result<()> {
+        for (t, release_fn) in &arg_temps {
+            ctx.emit(we::Instruction::LocalGet(*t));
+            ctx.emit(we::Instruction::Call(rt_index(release_fn)?));
+        }
+        Ok(())
+    };
     if catch.is_some() {
         // Out of the `try_table` region: the results travel through locals so every
         // block here is empty-typed but the one the caught `exnref` lands in.
         for t in temps.iter().rev() {
             ctx.emit(we::Instruction::LocalSet(*t));
         }
+        release_args(ctx)?;
         ctx.emit(we::Instruction::End); // try_table
         ctx.emit(we::Instruction::Br(1)); // done
         ctx.emit(we::Instruction::End); // handler: the exception is on the stack
@@ -3222,6 +3257,7 @@ fn emit_general_external_call(ctx: &mut FnCtx, ext_name: &str, args: &[Arc<DAE::
         ctx.emit(we::Instruction::LocalGet(saved_stack));
         ctx.emit(we::Instruction::Call(env_extra_index("rt_ext_stack_restore")?));
         ctx.emit(we::Instruction::Call(rt_index("rt_nls_note_assert")?));
+        release_args(ctx)?;
         release_heap_locals(ctx)?;
         push_outputs(ctx);
         ctx.emit(we::Instruction::Return);
@@ -3232,6 +3268,8 @@ fn emit_general_external_call(ctx: &mut FnCtx, ext_name: &str, args: &[Arc<DAE::
         for t in &temps {
             ctx.emit(we::Instruction::LocalGet(*t));
         }
+    } else {
+        release_args(ctx)?;
     }
     Ok(results)
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/Cargo.lock
@@ -529,6 +529,7 @@ name = "openmodelica_sim_meta"
 version = "0.1.0"
 dependencies = [
  "daskr",
+ "libc",
  "libm",
  "openmodelica_lapack",
  "openmodelica_mat_writer",

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/Cargo.toml
@@ -33,6 +33,10 @@ standalone = ["dep:daskr", "dep:openmodelica_plt_writer", "inwasm_solve"]
 inwasm_solve = ["dep:rsparse"]
 # Delegate the sparse solve to the host (`env.rt_host_lin_solve`); native interactive only.
 host_lin_solve = []
+# Count `rt_free` and the bytes either side of the allocator passes, so a run's
+# live heap shows up in the bench line. Two extra atomics on every allocation, so
+# it is off unless a leak is being chased; rebuild the runtime wasm to use it.
+heap_stats = []
 # `cfg(sundials)` without linking anything: the FMI3 adapter's PIC build leaves the
 # CVODE/IDA/KINSOL/KLU/UMFPACK/Lis calls undefined, as imports the FMU's SUNDIALS
 # side module resolves.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -455,7 +455,58 @@ pub use openmodelica_solvers::counters::*;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_stat(kind: u32) -> u64 {
+    // The live-block histogram is only knowable by walking the list, and the
+    // reader asks for `live_rc1` first (slot order), so scan there.
+    #[cfg(feature = "heap_stats")]
+    if kind == STAT_LIVE_RC1 {
+        scan_live();
+    }
     openmodelica_solvers::counters::stat(kind)
+}
+
+/// Walk the live-block list, bucketing each object by its reference count (the
+/// first word of every object). Idempotent: the slots are set, not added to.
+#[cfg(feature = "heap_stats")]
+fn scan_live() {
+    let (mut rc1, mut rc2, mut rcn, mut maxrc) = (0u64, 0u64, 0u64, 0u64);
+    let mut raw = unsafe { *LIVE.0.get() };
+    while raw != 0 {
+        let rc = unsafe { load_u32(raw + HEADER as u32) } as u64;
+        match rc {
+            1 => rc1 += 1,
+            2 => rc2 += 1,
+            _ => rcn += 1,
+        }
+        if rc > maxrc {
+            maxrc = rc;
+        }
+        raw = unsafe { load_u32(raw + LIVE_NEXT) };
+    }
+    for (slot, v) in [(STAT_LIVE_RC1, rc1), (STAT_LIVE_RC2, rc2), (STAT_LIVE_RCN, rcn), (STAT_LIVE_MAXRC, maxrc)] {
+        openmodelica_solvers::counters::stat_set(slot, v);
+    }
+    // What the survivors *are*: the first few that read as `[rc][len][utf8]`.
+    let mut shown = 0;
+    let mut raw = unsafe { *LIVE.0.get() };
+    while raw != 0 && shown < 8 {
+        let obj = raw + HEADER as u32;
+        let (total, rc, len) =
+            unsafe { (load_u32(raw) as usize, load_u32(obj), load_u32(obj + STR_LEN_OFF) as usize) };
+        if rc == 1 && len > 0 && len + HEADER + STR_DATA_OFF as usize + 1 <= total + 8 {
+            let bytes = unsafe {
+                core::slice::from_raw_parts((obj + STR_DATA_OFF) as *const u8, len.min(60))
+            };
+            if bytes.iter().all(|b| *b >= 0x20 && *b < 0x7f) {
+                omclog::info(
+                    omclog::STDOUT,
+                    false,
+                    &alloc::format!("live string rc=1 len={len}: {}", core::str::from_utf8(bytes).unwrap_or("?")),
+                );
+                shown += 1;
+            }
+        }
+        raw = unsafe { load_u32(raw + LIVE_NEXT) };
+    }
 }
 
 /// Called per run (`rt_sim_start`), so the counters are per-run.
@@ -470,8 +521,55 @@ pub fn reset_stats() {
 /// Bytes reserved before every object for the allocation size (used by
 /// `rt_free`). 8 rather than 4 so the returned object is 8-byte aligned, which
 /// keeps `f64` array/record elements naturally aligned.
+/// `[size:u32][spare:u32]` before every object. With `heap_stats` the spare pair
+/// grows to `[size][pad][prev][next]` so every live block is on one list and the
+/// run can be asked what is still holding memory, and at what reference count.
+#[cfg(not(feature = "heap_stats"))]
 const HEADER: usize = 8;
+#[cfg(feature = "heap_stats")]
+const HEADER: usize = 16;
 const ALIGN: usize = 8;
+#[cfg(feature = "heap_stats")]
+const LIVE_PREV: u32 = 8;
+#[cfg(feature = "heap_stats")]
+const LIVE_NEXT: u32 = 12;
+
+/// Head of the live-block list (`raw` pointers), newest first.
+#[cfg(feature = "heap_stats")]
+struct LiveHead(core::cell::UnsafeCell<u32>);
+#[cfg(feature = "heap_stats")]
+unsafe impl Sync for LiveHead {}
+#[cfg(feature = "heap_stats")]
+static LIVE: LiveHead = LiveHead(core::cell::UnsafeCell::new(0));
+
+#[cfg(feature = "heap_stats")]
+fn live_link(raw: u32) {
+    let head = unsafe { &mut *LIVE.0.get() };
+    unsafe {
+        store_u32(raw + LIVE_PREV, 0);
+        store_u32(raw + LIVE_NEXT, *head);
+        if *head != 0 {
+            store_u32(*head + LIVE_PREV, raw);
+        }
+    }
+    *head = raw;
+}
+
+#[cfg(feature = "heap_stats")]
+fn live_unlink(raw: u32) {
+    let head = unsafe { &mut *LIVE.0.get() };
+    let (prev, next) = unsafe { (load_u32(raw + LIVE_PREV), load_u32(raw + LIVE_NEXT)) };
+    unsafe {
+        if prev != 0 {
+            store_u32(prev + LIVE_NEXT, next);
+        } else if *head == raw {
+            *head = next;
+        }
+        if next != 0 {
+            store_u32(next + LIVE_PREV, prev);
+        }
+    }
+}
 
 /// Recycling free lists in front of `dlmalloc`. Generated code allocates and frees
 /// one array/record per array/record-typed function local on every call (an IF97
@@ -503,12 +601,16 @@ pub extern "C" fn rt_alloc(size: u32) -> u32 {
     if total <= CACHE_MAX {
         total = (total + ALIGN - 1) & !(ALIGN - 1);
     }
+    #[cfg(feature = "heap_stats")]
+    stat_add(STAT_ALLOC_BYTES, total as u64);
     if let Some(class) = cache_class(total) {
         let lists = unsafe { &mut *FREE.0.get() };
         let head = lists[class];
         if head != 0 {
             lists[class] = unsafe { load_u32(head + HEADER as u32) };
             unsafe { store_u32(head, total as u32) };
+            #[cfg(feature = "heap_stats")]
+            live_link(head);
             return head + HEADER as u32;
         }
     }
@@ -519,6 +621,8 @@ pub extern "C" fn rt_alloc(size: u32) -> u32 {
         trap();
     }
     unsafe { store_u32(raw, total as u32) };
+    #[cfg(feature = "heap_stats")]
+    live_link(raw);
     raw + HEADER as u32
 }
 
@@ -530,6 +634,12 @@ pub extern "C" fn rt_free(obj: u32) {
     }
     let raw = obj - HEADER as u32;
     let total = unsafe { load_u32(raw) } as usize;
+    #[cfg(feature = "heap_stats")]
+    {
+        stat_inc(STAT_FREE);
+        stat_add(STAT_FREE_BYTES, total as u64);
+        live_unlink(raw);
+    }
     if let Some(class) = cache_class(total) {
         let lists = unsafe { &mut *FREE.0.get() };
         unsafe { store_u32(raw + HEADER as u32, lists[class]) };

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/build.rs
@@ -1520,7 +1520,16 @@ fn standalone_features(sundials_dir: Option<&Path>) -> String {
     if has_primme(sundials_dir) {
         f.push_str(",primme");
     }
+    f.push_str(&heap_stats_feature());
     f
+}
+
+/// `,heap_stats` when `OMC_WASM_HEAP_STATS` is set, else nothing. The runtime
+/// blobs below are built `--no-default-features`, so a feature that is only in
+/// the crate's `default` never reaches them.
+fn heap_stats_feature() -> String {
+    println!("cargo:rerun-if-env-changed=OMC_WASM_HEAP_STATS");
+    if std::env::var_os("OMC_WASM_HEAP_STATS").is_some() { ",heap_stats".to_string() } else { String::new() }
 }
 
 /// Returns `Some((dir, key))` when `OMC_SUNDIALS_WASM_DIR` is set (the key is
@@ -1741,6 +1750,10 @@ fn build_wasip1_interactive_runtime(
     if has_primme(sundials_dir) {
         features.push_str(",primme");
     }
+    // This blob is built `--no-default-features`, so the runtime's `heap_stats`
+    // has to be asked for by name; an in-session simulation runs *this* runtime,
+    // not the JIT one, so without it the live-heap counters read zero.
+    features.push_str(&heap_stats_feature());
     // The feature set is part of the cache key: toggling the engine must rebuild.
     let stamp_val = format!("{hash}:{features}");
 

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/driver.rs
@@ -824,13 +824,14 @@ impl StepRetry {
 }
 
 /// Must match the runtime's `N_STATS`.
-pub const RT_STATS: usize = 25;
+pub const RT_STATS: usize = 32;
 
 pub const RT_STAT_NAMES: [&str; RT_STATS] = [
     "alloc", "array_new", "record_new", "str_new", "nls_solve", "nls_res", "nls_jac", "nls_fail", "nls_retry",
     "elem_ptr", "nls_iter", "nls_newton_fail", "nls_guess_hit", "nls_accept", "nls_store_back",
     "nls_vary_start", "nls_stale", "newton_irregular", "newton_lambda", "newton_negstep",
     "newton_maxiter", "newton_stuck", "newton_jac", "newton_singular", "homotopy_steps",
+    "free", "alloc_bytes", "free_bytes", "live_rc1", "live_rc2", "live_rcn", "live_maxrc",
 ];
 
 /// Lambda steps the runtime's locally-continued systems took, part of the same

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/counters.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/counters.rs
@@ -36,7 +36,18 @@ pub const STAT_NEWTON_SINGULAR: u32 = 23;
 /// Not a diagnostic: C's `homotopySteps`, which the driver folds into the
 /// initialization success line.
 pub const STAT_HOMOTOPY_STEPS: u32 = 24;
-pub const N_STATS: usize = 25;
+/// `rt_free` calls and the bytes either side passed, so a run's live heap is
+/// `alloc_bytes - free_bytes`: churn keeps the two close, a leak separates them.
+pub const STAT_FREE: u32 = 25;
+pub const STAT_ALLOC_BYTES: u32 = 26;
+pub const STAT_FREE_BYTES: u32 = 27;
+/// Live objects at the end of the run, by reference count: all at 1 means they
+/// were simply never released, 2 or more means a retain has no matching release.
+pub const STAT_LIVE_RC1: u32 = 28;
+pub const STAT_LIVE_RC2: u32 = 29;
+pub const STAT_LIVE_RCN: u32 = 30;
+pub const STAT_LIVE_MAXRC: u32 = 31;
+pub const N_STATS: usize = 32;
 
 static STATS: [AtomicU64; N_STATS] = [const { AtomicU64::new(0) }; N_STATS];
 
@@ -48,6 +59,11 @@ pub fn stat_inc(kind: u32) {
 #[inline]
 pub fn stat_add(kind: u32, n: u64) {
     STATS[kind as usize].fetch_add(n, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn stat_set(kind: u32, n: u64) {
+    STATS[kind as usize].store(n, Ordering::Relaxed);
 }
 
 #[inline]


### PR DESCRIPTION
A heap argument to an `external "C"` call reaches the host as an *owned* reference -- reading a String local retains -- and the trampoline only copies out of it, so the emitted code still owns the handle once the call returns and has to release it. Neither external emitter did, so every such argument leaked.

`Modelica.Utilities.Strings.compare` is a general external taking two Strings, and `Strings.find` reaches it through `isEqual` once per position it tries, on a fresh `substring`. Every window of every line scanned was leaked at reference count 1. Buildings' `DHC.Loads.BaseClasses.getPeakLoad` runs `find` over a load file, so `BenchmarkFlowDistribution2` allocated 78.9M strings and held 3.5GB of them -- the 4GiB a 32-bit wasm memory can address -- and died with "out of memory" partway through the run.

Released as `str_binop` already did it: tee the argument into a temp and release it after the call. Both emitters, and the `rt_nls_recovering` early return of each:

  * `emit_general_external_call`, the host trampoline
  * `emit_shared_external_call`, shared linear memory, via a new `Cleanup::Owned` handled in both of its cleanup loops

|                                   | before      | after |
|-----------------------------------|-------------|-------|
| `Strings.find` x17M, live objects  | 17,044,201  |     2 |
| BenchmarkFlowDistribution2, live   | 72,330,046  |   461 |
| BenchmarkFlowDistribution2, peak   | 6.5GB, OOM  | 2.8GB |

The 18 enabled tests of simulation/modelica/external_functions pass under --simCodeTarget=wasm-jit; arrays, records and external objects are covered there, so the release is right for every heap argument type rather than String alone.

Also adds the instrumentation that found it, behind the runtime's `heap_stats` feature (off by default -- it costs two atomics per allocation). It extends the OMC_WASM_SIM_BENCH line with `free`, `alloc_bytes`, `free_bytes` and, from a list of live blocks, `live_rc1`/`live_rc2`/`live_rcn`/`live_maxrc` plus a sample of the surviving strings. Survivors at reference count exactly 1 say nothing released them rather than that something over-retained, and the sample then names the allocation site. The runtime blobs are built --no-default-features, and an in-session simulation runs the wasip1 interactive runtime rather than the JIT one, so build.rs appends the feature from OMC_WASM_HEAP_STATS.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
