### PR TITLE
wasm-jit: homotopy arithmetic and extern protos

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -8252,6 +8252,7 @@ fn build_chunks(
 ) -> Result<Vec<usize>> {
     let first = pool.len();
     let mut i = 0usize;
+    let _fg = crate::CodegenWasmJitFunctions::FnNameGuard::new(name);
     while i < units.len() || (pool.len() == first && !(stateset_diag.is_empty() && save_pre.is_empty()))
     {
         let mut ctx = FnCtx::new_sim_params(sim_ctx(var_map), by_name, &mut *literals, n_params);
@@ -8856,6 +8857,7 @@ pub(crate) fn lower_equation(
             ctx.emit(we::Instruction::Call(rt_index("rt_prof_add_ncall")?));
         }
     }
+    let _g = crate::CodegenWasmJitFunctions::PartGuard::new(format!("equation {}", eq_index_of(eq)));
     lower_equation_inner(ctx, eq, eq_index)?;
     crate::CodegenWasmJitFunctions::emit_prof(ctx, clock, "rt_prof_acc")
 }
@@ -9883,6 +9885,9 @@ pub(crate) fn iteration_var_slot(
     match vars.get(&key) {
         None => Ok(None),
         Some(slot) if slot.wty != WTy::F64 => {
+            record_error(format!(
+                "CodegenWasmJit: torn-system unknown `{key}` is not a Real variable"
+            ));
             Err("CodegenWasmJit: torn-system unknown is not a Real variable")
         }
         Some(slot) => Ok(Some(slot.off)),
@@ -10667,6 +10672,10 @@ fn build_nls_fns(
     jac_info: Option<&NlsJacInfo>,
     strict: Option<NlsJob>,
 ) -> Result<(we::Function, we::Function, Option<we::Function>, Option<we::Function>)> {
+    let _fg = crate::CodegenWasmJitFunctions::FnNameGuard::new(&format!(
+        "nonlinear system {}",
+        nlsystem.index
+    ));
     let (inner, residuals, iter_vars) = nls_parts(nlsystem)?;
     // Resolve each unknown to its (real) SimData slot offset.
     let mut slots: Vec<u32> = Vec::with_capacity(iter_vars.len());

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -98,10 +98,10 @@ fn fn_context() -> String {
 }
 
 /// Sets `CURRENT_PART` until it drops, restoring the previous value.
-struct PartGuard(String);
+pub(crate) struct PartGuard(String);
 
 impl PartGuard {
-    fn new(part: String) -> Self {
+    pub(crate) fn new(part: String) -> Self {
         PartGuard(CURRENT_PART.with(|p| p.replace(part)))
     }
 }
@@ -109,6 +109,22 @@ impl PartGuard {
 impl Drop for PartGuard {
     fn drop(&mut self) {
         CURRENT_PART.with(|p| *p.borrow_mut() = std::mem::take(&mut self.0));
+    }
+}
+
+/// [`PartGuard`] for `CURRENT_FN`, which the equation functions have no
+/// `SimCodeFunction` to take a name from.
+pub(crate) struct FnNameGuard(String);
+
+impl FnNameGuard {
+    pub(crate) fn new(name: &str) -> Self {
+        FnNameGuard(CURRENT_FN.with(|f| f.replace(name.to_owned())))
+    }
+}
+
+impl Drop for FnNameGuard {
+    fn drop(&mut self) {
+        CURRENT_FN.with(|f| *f.borrow_mut() = std::mem::take(&mut self.0));
     }
 }
 
@@ -621,6 +637,7 @@ pub(crate) fn parse_ext_sig(line: &str) -> Result<ExtCallSig> {
         lang: if lang == "F" { ExtLang::Fortran77 } else { ExtLang::C },
         args: tys.into_iter().zip(outs.chars()).map(|(t, o)| (t, o == '1')).collect(),
         ret: if ret == "-" { None } else { parse_sig_types(ret)?.into_iter().next() },
+        declare: f.next() == Some("1"),
     })
 }
 
@@ -640,7 +657,8 @@ fn write_ext_sig(e: &ExtCallSig) -> String {
         None => ret.push('-'),
     }
     let lang = if e.lang == ExtLang::Fortran77 { 'F' } else { 'C' };
-    format!("{}\t{lang}\t{ret}\t{args}\t{outs}", e.name)
+    let declare = if e.declare { '1' } else { '0' };
+    format!("{}\t{lang}\t{ret}\t{args}\t{outs}\t{declare}", e.name)
 }
 
 /// A lowered function module and what its sidecar has to record: the main
@@ -1075,7 +1093,9 @@ pub(crate) fn external_general_why(f: &SimCodeFunction::Function::Function) -> s
 /// wrapper's own signature).
 pub(crate) fn external_import_sig(f: &SimCodeFunction::Function::Function) -> Result<ExtCallSig> {
     use SimCodeFunction::SimExtArg::SimExtArg as A;
-    let SimCodeFunction::Function::Function::EXTERNAL_FUNCTION { extName, extArgs, extReturn, language, .. } = f else {
+    let SimCodeFunction::Function::Function::EXTERNAL_FUNCTION { extName, extArgs, extReturn, language, includes, .. } =
+        f
+    else {
         return Err("CodegenWasmJit: external_import_sig on a non-external function");
     };
     let lang = ext_lang(language).ok_or("CodegenWasmJit: unsupported external language")?;
@@ -1099,7 +1119,7 @@ pub(crate) fn external_import_sig(f: &SimCodeFunction::Function::Function) -> Re
         ExtLang::C => extName.to_string(),
         ExtLang::Fortran77 => format!("{extName}_"),
     };
-    Ok(ExtCallSig { name, lang, args, ret })
+    Ok(ExtCallSig { name, lang, args, ret, declare: includes.is_empty() })
 }
 
 /// The input/output scalar `SigTy`s of the main function, for the sidecar.
@@ -6183,8 +6203,15 @@ fn clkpre_cref(cr: &DAE::ComponentRef) -> Arc<DAE::ComponentRef> {
 }
 
 /// Address of the sub-clock block `interval()`/`firstTick()` read.
-fn sub_clock_off(sim: &SimCtx) -> Result<u32> {
-    sim.sub_clock_off.ok_or("CodegenWasmJit: clock builtin outside a clocked partition")
+fn sub_clock_off(sim: &SimCtx, name: &str) -> Result<u32> {
+    sim.sub_clock_off.ok_or_else(|| {
+        crate::CodegenWasmJit::record_error(format!(
+            "CodegenWasmJit: `{name}()` reads the active sub-clock, but the equation is not in a \
+             clocked partition{}",
+            fn_context()
+        ));
+        "CodegenWasmJit: clock builtin outside a clocked partition"
+    })
 }
 
 /// The `der(cr)` component reference: `cr` wrapped in a `$DER` qualifier, as the
@@ -6879,7 +6906,8 @@ fn compile_sim_cref_read(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Op
                 return Ok(Some(wty));
             }
             crate::CodegenWasmJit::record_error(format!(
-                "CodegenWasmJit: simulation reference to unknown variable `{key}`"
+                "CodegenWasmJit: simulation reference to unknown variable `{key}`{}",
+                fn_context()
             ));
             return Err("CodegenWasmJit: simulation reference to unknown variable")
         }
@@ -9459,10 +9487,9 @@ fn compile_math_builtin(
             let w = compile_exp(ctx, argv[0])?;
             Ok(if w == WTy::F64 { SigTy::Real } else { SigTy::Int })
         }
-        // `homotopy(actual, simplified)` = `simplified + lambda*(actual-simplified)`
-        // (C's `homotopy_` with `data->simulationInfo->lambda`). lambda is 1.0
-        // outside the continuation, so this is `actual` for the normal init and the
-        // non-initial partitions; the init driver sweeps lambda 0->1 on fallback.
+        // C's macro, and not interchangeable with the algebraically equal
+        // `s + lambda*(a - s)`: that rounds `a - s` to the ulp of the larger operand,
+        // quantizing a residual whose simplified branch is much bigger than itself.
         "homotopy" => {
             need_args(&argv, 2, name)?;
             let (data, lambda_off) = { let s = ctx.sim()?; (s.data_local, s.lambda_off) };
@@ -9474,13 +9501,17 @@ fn compile_math_builtin(
             coerce(ctx, s, WTy::F64);
             let st = ctx.alloc_temp(WTy::F64);
             ctx.emit(we::Instruction::LocalSet(st));
-            // simplified + lambda*(actual - simplified)
-            ctx.emit(we::Instruction::LocalGet(st));
+            let lam = ctx.alloc_temp(WTy::F64);
             ctx.emit(we::Instruction::LocalGet(data));
             ctx.emit(we::Instruction::F64Load(mem_arg(lambda_off, 3)));
-            ctx.emit(we::Instruction::LocalGet(at));
+            ctx.emit(we::Instruction::LocalSet(lam));
             ctx.emit(we::Instruction::LocalGet(st));
+            ctx.emit(we::Instruction::F64Const(1.0.into()));
+            ctx.emit(we::Instruction::LocalGet(lam));
             ctx.emit(we::Instruction::F64Sub);
+            ctx.emit(we::Instruction::F64Mul);
+            ctx.emit(we::Instruction::LocalGet(at));
+            ctx.emit(we::Instruction::LocalGet(lam));
             ctx.emit(we::Instruction::F64Mul);
             ctx.emit(we::Instruction::F64Add);
             Ok(SigTy::Real)
@@ -9610,13 +9641,13 @@ fn compile_math_builtin(
         // `interval()` and `interval(clk)` alike read the active sub-clock, as C's
         // `daeExpCall` does: the backend already put the reference in that partition.
         "interval" if argv.len() <= 1 => {
-            let (data, off) = { let s = ctx.sim()?; (s.data_local, sub_clock_off(s)?) };
+            let (data, off) = { let s = ctx.sim()?; (s.data_local, sub_clock_off(s, "interval")?) };
             ctx.emit(we::Instruction::LocalGet(data));
             ctx.emit(we::Instruction::F64Load(mem_arg(off + clock_field::SUB_PREV_INTERVAL, 3)));
             Ok(SigTy::Real)
         }
         "firstTick" if argv.len() <= 1 => {
-            let (data, off) = { let s = ctx.sim()?; (s.data_local, sub_clock_off(s)?) };
+            let (data, off) = { let s = ctx.sim()?; (s.data_local, sub_clock_off(s, "firstTick")?) };
             ctx.emit(we::Instruction::LocalGet(data));
             ctx.emit(we::Instruction::I32Load(mem_arg(off + clock_field::SUB_COUNT, 2)));
             ctx.emit(we::Instruction::I32Const(1));
@@ -10765,12 +10796,45 @@ const OP_POW: i32 = 4;
 const OP_AND: i32 = 5;
 const OP_OR: i32 = 6;
 
+/// The element type of an array operation: the operator's own type, else an
+/// operand's, since both frontends leave arithmetic operators `T_UNKNOWN`. A
+/// *definite* scalar operator type over array operands is an inconsistent DAE, so
+/// that case is named rather than lowered.
+fn array_op_elem(ty: &DAE::Type, operands: [&DAE::Exp; 2]) -> Result<Arc<SigTy>> {
+    match sig_ty(ty) {
+        Ok(SigTy::Array { elem, .. }) => return Ok(elem),
+        Ok(_) => {}
+        Err(_) => {
+            for e in operands {
+                if let Ok(Some(elem)) = array_elem(e) {
+                    return Ok(elem);
+                }
+            }
+        }
+    }
+    let show = |x: &DAE::Exp| {
+        openmodelica_frontend_dump::ExpressionBasics::printExpStr(Arc::new(x.clone()))
+            .map(|s| s.to_string())
+            .unwrap_or_default()
+    };
+    crate::CodegenWasmJit::record_error(format!(
+        "CodegenWasmJit: array operator between `{}` and `{}` types neither as an array{}",
+        show(operands[0]),
+        show(operands[1]),
+        fn_context()
+    ));
+    Err("CodegenWasmJit: array operator with non-array type")
+}
+
+/// `exp_sigty` is best-effort: an `Err` means "unknown", not "not an array".
+fn is_array_exp(e: &DAE::Exp) -> bool {
+    matches!(exp_sigty(e), Ok(SigTy::Array { .. }))
+}
+
 /// Element-wise `a op b` over two same-shape arrays: produces a fresh array; the
 /// operand arrays are released after.
 fn compile_array_ew(ctx: &mut FnCtx, e1: &DAE::Exp, e2: &DAE::Exp, op_code: i32, ty: &DAE::Type) -> Result<WTy> {
-    let SigTy::Array { elem, .. } = sig_ty(ty)? else {
-        return Err("CodegenWasmJit: element-wise array op with non-array type");
-    };
+    let elem = array_op_elem(ty, [e1, e2])?;
     let rt = if elem.wty() == WTy::F64 { "rt_array_ew_f64" } else { "rt_array_ew_i32" };
     compile_exp(ctx, e1)?;
     let at = ctx.alloc_temp(WTy::I32);
@@ -10834,12 +10898,16 @@ fn compile_matmul(ctx: &mut FnCtx, e1: &DAE::Exp, e2: &DAE::Exp) -> Result<WTy> 
 /// and scalar operands are found by type (so commutative forms accept either
 /// order); the array operand is released after.
 fn compile_array_scalar(ctx: &mut FnCtx, e1: &DAE::Exp, e2: &DAE::Exp, op_code: i32, rev: bool, ty: &DAE::Type) -> Result<WTy> {
-    let SigTy::Array { elem, .. } = sig_ty(ty)? else {
-        return Err("CodegenWasmJit: array-scalar op with non-array type");
-    };
+    let elem = array_op_elem(ty, [e1, e2])?;
     let elem_wty = elem.wty();
     let rt = if elem_wty == WTy::F64 { "rt_array_scalar_f64" } else { "rt_array_scalar_i32" };
-    let (arr_e, scal_e) = if matches!(exp_sigty(e1)?, SigTy::Array { .. }) { (e1, e2) } else { (e2, e1) };
+    // By type where the frontend typed one, else by the operator's own convention:
+    // `rev` marks the scalar-first forms.
+    let arr_first = match (is_array_exp(e1), is_array_exp(e2)) {
+        (a, b) if a != b => a,
+        _ => !rev,
+    };
+    let (arr_e, scal_e) = if arr_first { (e1, e2) } else { (e2, e1) };
     compile_exp(ctx, arr_e)?;
     let at = ctx.alloc_temp(WTy::I32);
     ctx.emit(we::Instruction::LocalSet(at));

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/dylink_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/dylink_wasmtime.rs
@@ -636,6 +636,7 @@ mod tests {
             lang: ExtLang::C,
             args: vec![(SigTy::Real, false)],
             ret: Some(SigTy::Real),
+            declare: false,
         };
         let functype = wasmtime::FuncType::new(
             &engine,
@@ -697,6 +698,7 @@ mod tests {
             lang: ExtLang::C,
             args: vec![(ints.clone(), false), (ints, true), (SigTy::Real, true)],
             ret: None,
+            declare: false,
         };
         let export = loaded.func("xorshift").unwrap().ty(&store);
         assert!(same_type(&export, &functype(&engine, &xorshift.wasm_sig_c_shared())));
@@ -707,6 +709,7 @@ mod tests {
             lang: ExtLang::C,
             args: vec![(SigTy::Str, false), (SigTy::Int, false)],
             ret: Some(SigTy::Str),
+            declare: false,
         };
         let export = loaded.func("greet").unwrap().ty(&store);
         assert!(same_type(&export, &functype(&engine, &greet.wasm_sig_c_shared())));

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -338,6 +338,12 @@ pub fn ext_wrappers(sigs: &[ExtCallSig]) -> String {
     let mut out = String::new();
     for sig in sigs {
         let name = &sig.name;
+        // C's `extFunDef`.
+        if sig.declare {
+            if let Some(decl) = ext_prototype(sig) {
+                out.push_str(&decl);
+            }
+        }
         match ext_call_wrapper(sig) {
             // A macro has no address to hand back.
             Some(call) => out.push_str(&format!("{call}#ifndef {name}\n{}#endif\n", ext_addr_wrapper(name))),
@@ -351,20 +357,38 @@ fn ext_addr_wrapper(name: &str) -> String {
     format!("void (*{EXT_ADDR_PREFIX}{name}(void))(void) {{ return (void (*)(void)) {name}; }}\n")
 }
 
+/// `extern T f(A, …);` in the types [`ext_call_wrapper`] hands the call.
+fn ext_prototype(sig: &ExtCallSig) -> Option<String> {
+    let params = ext_param_types(sig)?.join(", ");
+    let ret = match &sig.ret {
+        Some(ty) => ext_c_type(ty)?.to_owned(),
+        None => "void".to_owned(),
+    };
+    Some(format!("extern {ret} {}({});\n", sig.name, if params.is_empty() { "void".to_owned() } else { params }))
+}
+
+/// Fortran passes everything by reference, and so does an `_Out_` scalar; an array
+/// or record is a pointer either way.
+fn ext_param_types(sig: &ExtCallSig) -> Option<Vec<String>> {
+    let byref = sig.lang == crate::sig::ExtLang::Fortran77;
+    sig.args
+        .iter()
+        .map(|(ty, is_out)| {
+            let ptr = *is_out || byref || matches!(ty, crate::sig::SigTy::Array { .. } | crate::sig::SigTy::Record { .. });
+            Some(format!("{}{}", ext_c_arg_type(ty)?, if ptr { "*" } else { "" }))
+        })
+        .collect()
+}
+
 /// `T omc_ext_call_f(A a0, …) { return f(a0, …); }`. `None` when the result has no
 /// C spelling the declaration alone fixes (a record returned by value).
 fn ext_call_wrapper(sig: &ExtCallSig) -> Option<String> {
-    let byref = sig.lang == crate::sig::ExtLang::Fortran77;
-    let mut params = String::new();
-    for (i, (ty, is_out)) in sig.args.iter().enumerate() {
-        let ptr = *is_out || byref || matches!(ty, crate::sig::SigTy::Array { .. } | crate::sig::SigTy::Record { .. });
-        params.push_str(&format!(
-            "{}{}{} a{i}",
-            if i == 0 { "" } else { ", " },
-            ext_c_arg_type(ty)?,
-            if ptr { "*" } else { "" }
-        ));
-    }
+    let params = ext_param_types(sig)?
+        .into_iter()
+        .enumerate()
+        .map(|(i, ty)| format!("{ty} a{i}"))
+        .collect::<Vec<_>>()
+        .join(", ");
     let args: Vec<String> = (0..sig.args.len()).map(|i| format!("a{i}")).collect();
     let (ret, call) = match &sig.ret {
         Some(ty) => (ext_c_type(ty)?.to_owned(), "return "),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sig.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sig.rs
@@ -177,6 +177,9 @@ pub struct ExtCallSig {
     pub lang: ExtLang,
     pub args: Vec<(SigTy, bool)>,
     pub ret: Option<SigTy>,
+    /// The function carried no `Include`, so a unit calling it must declare it
+    /// itself (C's `extFunDef`).
+    pub declare: bool,
 }
 
 impl ExtCallSig {
@@ -318,6 +321,7 @@ mod tests {
             lang: ExtLang::C,
             args: vec![(ints.clone(), false), (ints.clone(), true), (SigTy::Real, true)],
             ret: None,
+            declare: false,
         };
         let host = sig.wasm_sig();
         assert_eq!(host.params, vec![ints.clone(), ints.clone()]);
@@ -331,6 +335,7 @@ mod tests {
             lang: ExtLang::C,
             args: vec![(SigTy::Str, false), (SigTy::Int, false), (SigTy::Int, false)],
             ret: Some(SigTy::Str),
+            declare: false,
         };
         assert_eq!(ret.wasm_sig_c_shared().params, vec![SigTy::Str, SigTy::Int, SigTy::Int]);
         assert_eq!(ret.wasm_sig_c_shared().results, vec![SigTy::Str]);


### PR DESCRIPTION
Three fixes from triaging the OMLT rows where master passes more phases than wasm-jit.

**`homotopy(actual, simplified)` follows C's macro.** It was lowered as `s + lambda*(a - s)`; `openmodelica.h` uses `s*(1-lambda) + a*lambda`. Algebraically equal, but the first computes `s + (a - s)` at lambda = 1, rounding `a - s` to the ulp of the larger operand, so a residual much smaller than its own simplified branch comes back quantized. ThermoPower's TestGasValve has a simplified valve characteristic of ~4e9 against a residual of ~0.2: every residual of nonlinear system 125 was a multiple of 2^-20, where the finite-difference signal its numeric Jacobian measures is ~3e-7. Whole Jacobian columns came out zero, the initial-point total-pivot search reported rank 1, the guess was varied by 1% and 10%, and Newton left the domain of a sqrt(). The model now initializes with no homotopy at all.

**An `external` with no `Include` is declared by the unit that calls it** -- C's `extFunDef` rule. Without it the native fallback translation unit called `dgesv_`, `dgesvd_`, `dtrsen_` and the rest with no prototype in scope, failed to compile, and was dropped whole, so ModelicaTest.Math.TestMatrices2 had no LAPACK to call. `ExtCallSig` carries the flag from SimCode's `includes` through the `.wasm.sig` sidecar; the prototype uses `ext_call_wrapper`'s own parameter types, so the declaration and the call agree. Should one ever clash with a header's own declaration, the existing wrapper-less retry still compiles the unit as it did before.

**Codegen errors name the variable and the equation.** The equation index and the equation function join every recorded message, as do the torn-system variable, the clock builtin, and an array operator's operands. An array operator whose own type is unknown now takes its element type from an operand, the way `compile_binary`'s scalar path already did; a definite scalar type over array operands stays an error, since that is an inconsistent DAE rather than a missing annotation.

Verified from one omc against `--simCodeTarget=C`, with `diffSimulationResults` returning `(true, {})`:

  - `ThermoPower.Test.GasComponents.TestGasValve`, which C initializes in 3 homotopy steps and wasm-jit could not initialize at all
  - `OpenIPSL.Tests.Controls.PSSE.ES.EXST1`
  - Buildings' `BuriedPipes.Examples.TwoBuriedPipes`
  - `external_functions/LapackInverse`, whose `external "FORTRAN 77"` with no `Include` is the prototype change's own surface

`ModelicaTest.Math.TestMatrices2` cannot be compared that way: it now runs to completion under wasm-jit, with every self-check residual at ~1e-15, while the C target segfaults inside `liblapack`'s `dgesvx_` called from `continuousRiccati`.

`homotopy()` is used across most fluid and power libraries, so the whole wasm-jit lane wants re-measuring rather than these models alone.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
