### PR TITLE
NB: cut SimCode allocations, dedupe upgrade rows

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
@@ -1086,8 +1086,9 @@ public
 
         case FULL() algorithm
           // empty matrices can have a strictness if we want to expand them, in this case ignore and overwrite
+          // min is the rank the matrix already contains, -1 for an empty one
           if isEmpty(adj) then
-            min := 0;
+            min := -1;
             adj := initialize(full.mapping, st);
           else
             min := Solvability.rank(Solvability.fromStrictness(getStrictness(adj)));
@@ -1113,7 +1114,7 @@ public
                 indices := UnorderedMap.valueList(eqns_map);
                 builder := IntMatrix.toBuilder(adj.m, estimateEntries(occ, adj.mapping, indices), true);
                 for index in indices loop
-                  filtered := Solvability.filter(UnorderedSet.toList(occ[index]), sol[index], vars_map, min, max);
+                  filtered := Solvability.filter(UnorderedSet.toList(occ[index]), sol[index], vars_map, min + 1, max);
                   // upgrade the row and all meta data
                   upgradeRow(EquationPointers.getEqnAt(eqns, index), index, filtered, dep[index], rep[index], vars_map, vars_map, builder, adj.mapping, adj.modes, iter);
                 end for;

--- a/OMCompiler/Compiler/NSimCode/NSimCode.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimCode.mo
@@ -91,7 +91,7 @@ protected
   import SimGenericCall = NSimGenericCall;
   import SimPartition = NSimPartition;
   import SimStrongComponent = NSimStrongComponent;
-  import NSimVar.{SimVar, SimVars, VarInfo, ExtObjInfo};
+  import NSimVar.{SimVar, SimVars, VarInfo, ExtObjInfo, ConvertMemo};
 
   // Old SimCode imports
   import HashTableCrIListArray;
@@ -523,12 +523,14 @@ public
       OldSimCode.HashTableCrefToSimVar crefToSimVarHT "hidden from typeview - used by cref2simvar() for cref -> SIMVAR lookup available in templates.";
       HashTable.HashTable crefToClockIndexHT "map variables to clock indices";
       list<SimVar> residualVars;
+      ConvertMemo memo;
     algorithm
-      modelInfo := ModelInfo.convert(simCode.modelInfo);
+      memo := SimVar.newConvertMemo(UnorderedMap.size(simCode.simcode_map));
+      modelInfo := ModelInfo.convert(simCode.modelInfo, memo);
       (zeroCrossings, relations, timeEvents, spatialInfo) := EventInfo.convert(simCode.eventInfo, simCode.equation_map);
 
       (varToArrayIndexMapping, varToIndexMapping) := SimCodeUtilShared.createVarToArrayIndexMapping(modelInfo);
-      crefToSimVarHT := SimCodeUtil.convertSimCodeMap(simCode.simcode_map);
+      crefToSimVarHT := SimCodeUtil.convertSimCodeMap(simCode.simcode_map, memo);
       // do we still need the following for DAE mode?
       if isSome(simCode.daeModeData) then
         SOME(DAE_MODE_DATA(residualVars = residualVars)) := simCode.daeModeData;
@@ -725,6 +727,7 @@ public
 
     function convert
       input ModelInfo modelInfo;
+      input ConvertMemo memo;
       output OldSimCode.ModelInfo oldModelInfo;
     protected
       OldSimCode.VarInfo varInfo;
@@ -740,7 +743,7 @@ public
         directory                       = modelInfo.directory,
         fileName                        = modelInfo.fileName,
         varInfo                         = VarInfo.convert(modelInfo.varInfo),
-        vars                            = SimVar.SimVars.convert(modelInfo.vars),
+        vars                            = SimVar.SimVars.convert(modelInfo.vars, memo),
         functions                       = modelInfo.functions,
         labels                          = modelInfo.labels,
         resourcePaths                   = modelInfo.resourcePaths,

--- a/OMCompiler/Compiler/NSimCode/NSimCodeUtil.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimCodeUtil.mo
@@ -43,7 +43,7 @@ encapsulated package NSimCodeUtil
 import ComponentRef = NFComponentRef;
 
 // SimCode imports
-import NSimVar.{SimVar, SimVars, ExtObjInfo};
+import NSimVar.{SimVar, SimVars, ExtObjInfo, ConvertMemo};
 
 // Old SimCode imports
 import HashTableCrefSimVar;
@@ -104,12 +104,13 @@ public
 
   function convertSimCodeMap
     input UnorderedMap<ComponentRef, SimVar> simcode_map;
+    input ConvertMemo memo;
     output HashTableCrefSimVar.HashTable old_ht;
-  protected
-    list<SimVar> vars = UnorderedMap.valueList(simcode_map);
   algorithm
     old_ht := HashTableCrefSimVar.emptyHashTableSized(UnorderedMap.size(simcode_map));
-    old_ht := List.fold(SimVar.convertList(vars), HashTableCrefSimVar.addSimVarToHashTable, old_ht);
+    for var in UnorderedMap.valueList(simcode_map) loop
+      old_ht := HashTableCrefSimVar.addSimVarToHashTable(SimVar.convertMemoized(var, memo), old_ht);
+    end for;
   end convertSimCodeMap;
 
 annotation(__OpenModelica_Interface="nbackend");

--- a/OMCompiler/Compiler/NSimCode/NSimJacobian.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimJacobian.mo
@@ -65,7 +65,7 @@ public
   import SimGenericCall = NSimGenericCall;
   import NSimCode.Identifier;
   import SimStrongComponent = NSimStrongComponent;
-  import NSimVar.{SimVar, SimVars, VarType};
+  import NSimVar.{SimVar, SimVars, VarType, ConvertMemo};
 
   // Old SimCode imports
   import OldSimCode = SimCode;
@@ -688,17 +688,20 @@ public
       OldSimCode.JacobianColumn oldJacCol;
     algorithm
       oldJac := match simJac
+        local
+          ConvertMemo memo;
         case SIM_JAC() algorithm
+          memo := SimVar.newConvertMemo(listLength(simJac.seedVars) + listLength(simJac.columnVars));
           oldJacCol := OldSimCode.JAC_COLUMN(
             columnEqns          = list(SimStrongComponent.Block.convert(blck) for blck in simJac.columnEqns),
-            columnVars          = list(SimVar.convert(var) for var in simJac.columnVars),
+            columnVars          = SimVar.convertListMemo(simJac.columnVars, memo),
             numberOfResultVars  = simJac.numberOfResultVars,
             constantEqns        = list(SimStrongComponent.Block.convert(blck) for blck in simJac.constantEqns)
           );
 
           oldJac := OldSimCode.JAC_MATRIX(
             columns             = {oldJacCol},
-            seedVars            = SimVar.convertList(simJac.seedVars),
+            seedVars            = SimVar.convertListMemo(simJac.seedVars, memo),
             matrixName          = simJac.name,
             sparsityMatrix      = Sparsity.convert(simJac.sparsityMatrix),
             sparsity            = {},
@@ -711,7 +714,7 @@ public
             jacobianIndex       = simJac.jacobianIndex,
             partitionIndex      = simJac.partitionIndex,
             generic_loop_calls  = list(SimGenericCall.convert(gc) for gc in simJac.generic_loop_calls),
-            crefsHT             = Util.applyOption(simJac.jac_map, SimCodeUtil.convertSimCodeMap),
+            crefsHT             = Util.applyOption(simJac.jac_map, function SimCodeUtil.convertSimCodeMap(memo = memo)),
             isAdjoint           = simJac.isAdjoint,
             isBidirectional     = simJac.isBidirectional,
             adjointJacobianIndex = simJac.adjointJacobianIndex,

--- a/OMCompiler/Compiler/NSimCode/NSimVar.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimVar.mo
@@ -85,6 +85,9 @@ protected
   import Util;
 
 public
+  type ConvertEntry = tuple<SimVar, OldSimCodeVar.SimVar>;
+  type ConvertMemo = UnorderedMap<ComponentRef, ConvertEntry> "SimVar -> old SimVar conversions already made";
+
   uniontype SimVar "Information about a variable in a Modelica model."
     record SIMVAR
       ComponentRef name;
@@ -435,6 +438,39 @@ public
       input list<SimVar> simVar_lst;
       output list<OldSimCodeVar.SimVar> oldSimVar_lst = list(convert(simVar) for simVar in simVar_lst);
     end convertList;
+
+    function newConvertMemo
+      input Integer size;
+      output ConvertMemo memo = UnorderedMap.new<ConvertEntry>(ComponentRef.hash, ComponentRef.isEqual, Util.nextPrime(size));
+    end newConvertMemo;
+
+    function convertMemo
+      input SimVar simVar;
+      input ConvertMemo memo;
+      output OldSimCodeVar.SimVar oldSimVar = convert(simVar);
+    algorithm
+      UnorderedMap.add(simVar.name, (simVar, oldSimVar), memo);
+    end convertMemo;
+
+    function convertListMemo
+      input list<SimVar> simVar_lst;
+      input ConvertMemo memo;
+      output list<OldSimCodeVar.SimVar> oldSimVar_lst = list(convertMemo(simVar, memo) for simVar in simVar_lst);
+    end convertListMemo;
+
+    function convertMemoized
+      "the remembered conversion of exactly this record, or a fresh one"
+      input SimVar simVar;
+      input ConvertMemo memo;
+      output OldSimCodeVar.SimVar oldSimVar;
+    protected
+      SimVar orig;
+    algorithm
+      oldSimVar := match UnorderedMap.get(simVar.name, memo)
+        case SOME((orig, oldSimVar)) guard referenceEq(orig, simVar) then oldSimVar;
+        else convert(simVar);
+      end match;
+    end convertMemoized;
 
     function convertTpl
       input tuple<SimVar, Boolean> tpl;
@@ -1055,39 +1091,40 @@ public
 
     function convert
       input SimVars simVars;
+      input ConvertMemo memo;
       output OldSimCodeVar.SimVars oldSimVars;
     algorithm
       oldSimVars := OldSimCodeVar.SIMVARS(
-        stateVars                         = SimVar.convertList(simVars.stateVars),
-        derivativeVars                    = SimVar.convertList(simVars.derivativeVars),
-        algVars                           = SimVar.convertList(simVars.algVars),
-        discreteAlgVars                   = SimVar.convertList(simVars.discreteAlgVars),
-        intAlgVars                        = SimVar.convertList(simVars.intAlgVars),
-        boolAlgVars                       = SimVar.convertList(simVars.boolAlgVars),
-        inputVars                         = SimVar.convertList(simVars.inputVars),
-        outputVars                        = SimVar.convertList(simVars.outputVars),
-        aliasVars                         = SimVar.convertList(simVars.aliasVars),
-        intAliasVars                      = SimVar.convertList(simVars.intAliasVars),
-        boolAliasVars                     = SimVar.convertList(simVars.boolAliasVars),
-        paramVars                         = SimVar.convertList(simVars.paramVars),
-        intParamVars                      = SimVar.convertList(simVars.intParamVars),
-        boolParamVars                     = SimVar.convertList(simVars.boolParamVars),
-        stringAlgVars                     = SimVar.convertList(simVars.stringAlgVars),
-        stringParamVars                   = SimVar.convertList(simVars.stringParamVars),
-        stringAliasVars                   = SimVar.convertList(simVars.stringAliasVars),
-        extObjVars                        = SimVar.convertList(simVars.extObjVars),
-        constVars                         = SimVar.convertList(simVars.constVars),
-        intConstVars                      = SimVar.convertList(simVars.intConstVars),
-        boolConstVars                     = SimVar.convertList(simVars.boolConstVars),
-        stringConstVars                   = SimVar.convertList(simVars.stringConstVars),
-        jacobianVars                      = SimVar.convertList(simVars.jacobianVars),
-        seedVars                          = SimVar.convertList(simVars.seedVars),
-        realOptimizeConstraintsVars       = SimVar.convertList(simVars.realOptimizeConstraintsVars),
-        realOptimizeFinalConstraintsVars  = SimVar.convertList(simVars.realOptimizeFinalConstraintsVars),
-        sensitivityVars                   = SimVar.convertList(simVars.sensitivityVars),
-        dataReconSetcVars                 = SimVar.convertList(simVars.dataReconSetcVars),
-        dataReconinputVars                = SimVar.convertList(simVars.dataReconinputVars),
-        dataReconSetBVars                 = SimVar.convertList(simVars.dataReconSetBVars));
+        stateVars                         = SimVar.convertListMemo(simVars.stateVars, memo),
+        derivativeVars                    = SimVar.convertListMemo(simVars.derivativeVars, memo),
+        algVars                           = SimVar.convertListMemo(simVars.algVars, memo),
+        discreteAlgVars                   = SimVar.convertListMemo(simVars.discreteAlgVars, memo),
+        intAlgVars                        = SimVar.convertListMemo(simVars.intAlgVars, memo),
+        boolAlgVars                       = SimVar.convertListMemo(simVars.boolAlgVars, memo),
+        inputVars                         = SimVar.convertListMemo(simVars.inputVars, memo),
+        outputVars                        = SimVar.convertListMemo(simVars.outputVars, memo),
+        aliasVars                         = SimVar.convertListMemo(simVars.aliasVars, memo),
+        intAliasVars                      = SimVar.convertListMemo(simVars.intAliasVars, memo),
+        boolAliasVars                     = SimVar.convertListMemo(simVars.boolAliasVars, memo),
+        paramVars                         = SimVar.convertListMemo(simVars.paramVars, memo),
+        intParamVars                      = SimVar.convertListMemo(simVars.intParamVars, memo),
+        boolParamVars                     = SimVar.convertListMemo(simVars.boolParamVars, memo),
+        stringAlgVars                     = SimVar.convertListMemo(simVars.stringAlgVars, memo),
+        stringParamVars                   = SimVar.convertListMemo(simVars.stringParamVars, memo),
+        stringAliasVars                   = SimVar.convertListMemo(simVars.stringAliasVars, memo),
+        extObjVars                        = SimVar.convertListMemo(simVars.extObjVars, memo),
+        constVars                         = SimVar.convertListMemo(simVars.constVars, memo),
+        intConstVars                      = SimVar.convertListMemo(simVars.intConstVars, memo),
+        boolConstVars                     = SimVar.convertListMemo(simVars.boolConstVars, memo),
+        stringConstVars                   = SimVar.convertListMemo(simVars.stringConstVars, memo),
+        jacobianVars                      = SimVar.convertListMemo(simVars.jacobianVars, memo),
+        seedVars                          = SimVar.convertListMemo(simVars.seedVars, memo),
+        realOptimizeConstraintsVars       = SimVar.convertListMemo(simVars.realOptimizeConstraintsVars, memo),
+        realOptimizeFinalConstraintsVars  = SimVar.convertListMemo(simVars.realOptimizeFinalConstraintsVars, memo),
+        sensitivityVars                   = SimVar.convertListMemo(simVars.sensitivityVars, memo),
+        dataReconSetcVars                 = SimVar.convertListMemo(simVars.dataReconSetcVars, memo),
+        dataReconinputVars                = SimVar.convertListMemo(simVars.dataReconinputVars, memo),
+        dataReconSetBVars                 = SimVar.convertListMemo(simVars.dataReconSetBVars, memo));
     end convert;
 
     function createSimVarLists

--- a/OMCompiler/Compiler/SimCode/SimCodeUtilShared.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtilShared.mo
@@ -63,8 +63,10 @@ protected
 import BaseHashTable;
 import ComponentReference;
 import ComponentReferenceBasics;
+import Config;
 import DAEUtil;
 import Error;
+import Flags;
 import List;
 
 public
@@ -109,7 +111,8 @@ algorithm
 end createFunctions;
 
 public function createVarToArrayIndexMapping
-  "Creates a mapping for each array-cref to the array dimensions (int list) and to the indices (for the code generation) used to store the array content."
+  "Creates a mapping for each array-cref to the array dimensions (int list) and to the indices (for the code generation) used to store the array content.
+   Only the Cpp/OMSI templates and HpcOm read the mappings, other targets get empty tables."
   input SimCode.ModelInfo iModelInfo;
   output HashTableCrIListArray.HashTable oVarToArrayIndexMapping;
   output HashTableCrILst.HashTable oVarToIndexMapping; //same as oVarToArrayIndexMapping, but does not merge array variables into one list
@@ -121,6 +124,12 @@ protected
   Integer var_type;
   array<Integer> currentVarIndices; //current variable index real,int,bool,string
 algorithm
+  if not (Flags.isSet(Flags.HPCOM) or listMember(Config.simCodeTarget(), {"Cpp", "omsic", "omsicpp"})) then
+    oVarToArrayIndexMapping := HashTableCrIListArray.emptyHashTableSized(1);
+    oVarToIndexMapping := HashTableCrILst.emptyHashTableSized(1);
+    return;
+  end if;
+
   // Collect the variable lists into a list for easier handling.
   sim_vars := iModelInfo.vars;
   vars := {


### PR DESCRIPTION
Three independent cuts to the new backend's SimCode phase, measured on `OneDHeatTransferTI_Modelica_N_20480` with `-d=execstat`: SimCode allocations 3.04 GB -> 2.60 GB, whole translate 4.62 GB -> 4.17 GB.

* `createVarToArrayIndexMapping` built two `BaseHashTable`s over every SimVar, but only the Cpp/OMSI templates and HpcOm read `varToArrayIndexMapping` / `varToIndexMapping`, and `SimCodeMain.generateModelCodeDAE` already skipped them for other targets. The old-backend `createSimCode` and `NSimCode.convert` now get empty tables unless the target is Cpp/omsic/omsicpp or `-d=hpcom` is set (-150 MB).

* `NSimCode.convert` converted every SimVar twice: once for `modelInfo.vars` and again in `convertSimCodeMap` for the old cref -> SimVar hash table; `SimJacobian.convert` did the same for a Jacobian's seed and column vars and its `jac_map`. `SimVars.convert` now records `(SimVar, old SimVar)` per cref in a `ConvertMemo` and `convertSimCodeMap` reuses the old SimVar when the map holds exactly that record (`referenceEq`), converting afresh otherwise. It still iterates `UnorderedMap.valueList(simcode_map)`, so which SimVar wins an `arrayCref` key in the hash table is unchanged (-300 MB).

* `Adjacency.Matrix.upgrade` seeds the builder with the rows the matrix already has and then filtered the full matrix for occurrences with rank in `[min, max]`, `min` being the rank of the existing matrix, so every rank-`min` occurrence (IMPLICIT ones for MATCHING -> SORTING) was added a second time. Filter `(min, max]`; an empty matrix starts at -1 so that rank 0 is still included.

The first two leave the generated C byte identical apart from the GUID. The duplicates were harmless for Tarjan, but they fed the size of the `UnorderedSet` in `SuperNode.mergeRows`, whose bucket count decides the order of a merged row: models with IMPLICIT occurrences in an algebraic loop (e.g. `CoupledClutches`) get a different, equally valid order of the loop's unknowns and equations. `simulation/modelica/NBackend` results are unchanged.

Assisted-by: Claude Fable 5.1

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
