### PR TITLE
Key the runtime's per-system tables by system

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -2924,8 +2924,12 @@ fn ls_print_matrix(name: &str, a: &[f64], n: usize) {
     omclog::close(omclog::LS_V);
 }
 
-/// C's per-solver `Start solving Linear System …` line.
+/// C's per-solver `Start solving Linear System …` line. `format_g` allocates, so
+/// check the stream before the arguments are built.
 fn ls_start_log(eq_index: i32, size: usize, time: f64, solver: &str) {
+    if !omclog::active(omclog::LS) {
+        return;
+    }
     omclog::info!(
         omclog::LS,
         false,
@@ -2983,7 +2987,7 @@ pub extern "C" fn rt_ls_check_step(res_ptr: u32, b_ptr: u32, n: u32, eq_index: i
     if dense != 0 && matches!(openmodelica_solvers::solverflags::ls(), openmodelica_solvers::solverflags::Ls::TotalPivot) {
         return 0;
     }
-    if core::mem::replace(&mut ls_failure_entry(eq_index).fell_back, false) {
+    if ls_took_fallback(eq_index) {
         return 0;
     }
     let n = n as usize;
@@ -3014,28 +3018,37 @@ pub extern "C" fn rt_ls_check_step(res_ptr: u32, b_ptr: u32, n: u32, eq_index: i
 
 /// C's per-system `linsys->failed` / `numberOfFailures`: the first failure after
 /// a success warns on stdout, a run of them only on `LOG_LS`.
+#[derive(Default)]
 struct LsFailure {
-    eq_index: i32,
     failed: bool,
     failures: u64,
     /// The last solve was the total-pivot fallback, whose step C takes unchecked.
     fell_back: bool,
 }
-struct LsFailures(core::cell::UnsafeCell<alloc::vec::Vec<LsFailure>>);
+/// Keyed, not scanned: [`ls_solved`] runs per solve, and a model can solve O(n)
+/// systems per `functionODE`.
+struct LsFailures(core::cell::UnsafeCell<alloc::collections::BTreeMap<i32, LsFailure>>);
 unsafe impl Sync for LsFailures {}
-static LS_FAILURES: LsFailures = LsFailures(core::cell::UnsafeCell::new(alloc::vec::Vec::new()));
+static LS_FAILURES: LsFailures =
+    LsFailures(core::cell::UnsafeCell::new(alloc::collections::BTreeMap::new()));
 
 fn ls_failure_entry(eq_index: i32) -> &'static mut LsFailure {
-    let v = unsafe { &mut *LS_FAILURES.0.get() };
-    if let Some(i) = v.iter().position(|e| e.eq_index == eq_index) {
-        return &mut v[i];
-    }
-    v.push(LsFailure { eq_index, failed: false, failures: 0, fell_back: false });
-    v.last_mut().unwrap()
+    unsafe { &mut *LS_FAILURES.0.get() }.entry(eq_index).or_default()
 }
 
+/// No entry means the system never failed, so `failed` is already clear.
 fn ls_solved(eq_index: i32) {
-    ls_failure_entry(eq_index).failed = false;
+    if let Some(e) = unsafe { &mut *LS_FAILURES.0.get() }.get_mut(&eq_index) {
+        e.failed = false;
+    }
+}
+
+/// Takes the total-pivot-fallback flag: C's step after it goes unchecked.
+fn ls_took_fallback(eq_index: i32) -> bool {
+    match unsafe { &mut *LS_FAILURES.0.get() }.get_mut(&eq_index) {
+        Some(e) => core::mem::replace(&mut e.fell_back, false),
+        None => false,
+    }
 }
 
 /// C's `++systemData->numberOfFailures`, shared by both warnings of one failure.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/nls.rs
@@ -428,25 +428,34 @@ impl History for MemHistory {
 }
 
 /// C's `simulationInfo->nonlinearSystemData`: each system's (state address, size),
-/// filled by the module `start`.
-struct RosterCell(UnsafeCell<alloc::vec::Vec<(u32, usize)>>);
+/// filled by the module `start`. `index` is the reverse map, wanted per solve.
+struct Roster {
+    sys: alloc::vec::Vec<(u32, usize)>,
+    index: alloc::collections::BTreeMap<u32, u32>,
+}
+struct RosterCell(UnsafeCell<Roster>);
 // Single-threaded wasm: no concurrent access.
 unsafe impl Sync for RosterCell {}
-static ROSTER: RosterCell = RosterCell(UnsafeCell::new(alloc::vec::Vec::new()));
+static ROSTER: RosterCell =
+    RosterCell(UnsafeCell::new(Roster { sys: alloc::vec::Vec::new(), index: alloc::collections::BTreeMap::new() }));
 
 /// `k == 0` starts a fresh roster, so a second model replaces the first.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_nls_register(k: u32, hist_addr: u32, n: u32) {
     let roster = unsafe { &mut *ROSTER.0.get() };
-    roster.truncate(k as usize);
-    roster.push((hist_addr, n as usize));
+    let keep = roster.sys.len().min(k as usize);
+    for (addr, _) in roster.sys.drain(keep..) {
+        roster.index.remove(&addr);
+    }
+    roster.index.insert(hist_addr, roster.sys.len() as u32);
+    roster.sys.push((hist_addr, n as usize));
 }
 
 /// C's `sysNumber`: the index in `nonlinearSystemData` the homotopy messages quote
 /// (not the equation index). The roster is registered in that order.
 fn nls_sys_number(hist_addr: u32) -> u32 {
     let roster = unsafe { &*ROSTER.0.get() };
-    roster.iter().position(|(h, _)| *h == hist_addr).unwrap_or(0) as u32
+    roster.index.get(&hist_addr).copied().unwrap_or(0)
 }
 
 /// [`set_var_names`] across the module boundary: `ptr`/`len` are a NUL-separated
@@ -504,7 +513,7 @@ pub(crate) fn set_diag(systems: &[openmodelica_sim_meta::NlsVars]) {
 /// C's `cleanUpOldValueListAfterEvent`, called once per event.
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_nls_clean_history(time: f64) {
-    for &(addr, n) in unsafe { &*ROSTER.0.get() } {
+    for &(addr, n) in &unsafe { &*ROSTER.0.get() }.sys {
         let mut hist = MemHistory { count_addr: addr, base: addr + 16 + 2 * (n * 8) as u32, n };
         history_clean(&mut hist, time);
     }

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_nls/src/kinsol.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_nls/src/kinsol.rs
@@ -1041,13 +1041,15 @@ pub mod sun {
             };
             unsafe { KINSetUserData(self.kin, &mut ud as *mut BUd as *mut c_void) };
             let v = openmodelica_solvers::omclog::NLS_V;
-            openmodelica_solvers::omclog::info!(
-                v,
-                true,
-                "Start solving Non-Linear System {eq_index} (size {}) at time {} with Kinsol Solver",
-                self.n,
-                openmodelica_solvers::format_g(time, 6),
-            );
+            if openmodelica_solvers::omclog::active(v) {
+                openmodelica_solvers::omclog::info!(
+                    v,
+                    true,
+                    "Start solving Non-Linear System {eq_index} (size {}) at time {} with Kinsol Solver",
+                    self.n,
+                    openmodelica_solvers::format_g(time, 6),
+                );
+            }
             let mut success = false;
             let mut retries = 0;
             let mut passes = 0;
@@ -1169,10 +1171,10 @@ pub mod sun {
 pub const AVAILABLE: bool = cfg!(sundials);
 
 /// One solver per system `handle`, kept for the run so KINSOL and KLU reuse their
-/// setup. A list rather than a map: a model has a handful of nonlinear systems, and
-/// the runtime is single-threaded (as the rest of this crate's rosters are).
+/// setup. Keyed, not scanned: a model can have one system per discretization
+/// volume. Single-threaded, as the rest of this crate's rosters are.
 #[cfg(sundials)]
-struct Cache<T>(core::cell::UnsafeCell<alloc::vec::Vec<(u32, T)>>);
+struct Cache<T>(core::cell::UnsafeCell<alloc::collections::BTreeMap<u32, T>>);
 #[cfg(sundials)]
 unsafe impl<T> Sync for Cache<T> {}
 
@@ -1181,25 +1183,26 @@ impl<T> Cache<T> {
     /// Detach the solver for `handle` so a model callback can re-enter for a nested
     /// system, run `f`, then put it back.
     fn with(&self, handle: u32, new: impl FnOnce() -> Option<T>, f: impl FnOnce(&mut T) -> bool) -> bool {
-        let list = unsafe { &mut *self.0.get() };
-        let mut solver = match list.iter().position(|(h, _)| *h == handle) {
-            Some(i) => list.swap_remove(i).1,
+        let mut solver = match unsafe { &mut *self.0.get() }.remove(&handle) {
+            Some(s) => s,
             None => match new() {
                 Some(s) => s,
                 None => return false,
             },
         };
         let ok = f(&mut solver);
-        unsafe { &mut *self.0.get() }.push((handle, solver));
+        unsafe { &mut *self.0.get() }.insert(handle, solver);
         ok
     }
 }
 
 #[cfg(sundials)]
-static KIN_CACHE: Cache<sun::Solver> = Cache(core::cell::UnsafeCell::new(alloc::vec::Vec::new()));
+static KIN_CACHE: Cache<sun::Solver> =
+    Cache(core::cell::UnsafeCell::new(alloc::collections::BTreeMap::new()));
 /// [`KIN_CACHE`] for `-nls=kinsol_b`.
 #[cfg(sundials)]
-static KIN_B_CACHE: Cache<sun::BSolver> = Cache(core::cell::UnsafeCell::new(alloc::vec::Vec::new()));
+static KIN_B_CACHE: Cache<sun::BSolver> =
+    Cache(core::cell::UnsafeCell::new(alloc::collections::BTreeMap::new()));
 
 /// Drop every per-system KINSOL/KLU memory; they belong to one run.
 #[cfg(sundials)]

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_nls/src/lib.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_nls/src/lib.rs
@@ -1893,7 +1893,8 @@ fn hybrd_c(
 ) -> bool {
     use omclog;
     let log_v = omclog::active(omclog::NLS_V);
-    let names = var_names(t.eq_index);
+    // The first lookup parses `<Model>_info.json` on the native runtime.
+    let names = if log_v { var_names(t.eq_index) } else { &[] };
     // C's `printVector`.
     let print_vector = |name: &str, v: &[f64]| {
         omclog::info(omclog::NLS_V, true, name);
@@ -1902,11 +1903,15 @@ fn hybrd_c(
         }
         omclog::close(omclog::NLS_V);
     };
-    let log_rung = |msg: &str| {
-        if log_v {
-            omclog::info(omclog::NLS_V, false, msg);
-        }
-    };
+    // A macro, not a `fn(&str)`: the rung messages format their arguments, and a
+    // function call would do that before `log_v` is ever tested.
+    macro_rules! log_rung {
+        ($($arg:tt)*) => {
+            if log_v {
+                omclog::info!(omclog::NLS_V, false, $($arg)*);
+            }
+        };
+    }
     if log_v {
         omclog::info!(
             omclog::NLS_V,
@@ -2116,36 +2121,36 @@ fn hybrd_c(
                 xv[assert_retries - 1] += 0.01 * nominal[assert_retries - 1];
             }
             assert_retries += 1;
-            log_rung(&alloc::format!(" - try to handle a problem with a called assert vary initial value a bit. (Retry: {assert_retries})"));
+            log_rung!(" - try to handle a problem with a called assert vary initial value a bit. (Retry: {assert_retries})");
         } else if retries < 3 {
             restart(&mut xv, &nlsx);
             factor /= 10.0;
             retries += 1;
-            log_rung(&alloc::format!(" - iteration making no progress:\t decreasing initial step bound to {}.", omclog::f(factor, 0, 6)));
+            log_rung!(" - iteration making no progress:\t decreasing initial step bound to {}.", omclog::f(factor, 0, 6));
         } else if retries < 4 {
             for i in 0..n {
                 xv[i] += nominal[i] * 0.1;
             }
             factor = initial_factor;
             retries += 1;
-            log_rung("iteration making no progress:\t vary solution point by 1%.");
+            log_rung!("iteration making no progress:\t vary solution point by 1%.");
         } else if retries < 5 {
             // C's "try old values as x-scaling factors"; the constrain-x block above
             // overwrites them again, in C too, so this is a plain restart.
             restart(&mut xv, &nlsx);
             retries += 1;
-            log_rung("iteration making no progress:\t try old values as scaling factors.");
+            log_rung!("iteration making no progress:\t try old values as scaling factors.");
         } else if retries < 6 {
             restart(&mut xv, &nlsx);
             *use_xscaling = false;
             retries += 1;
-            log_rung("iteration making no progress:\t try without scaling at all.");
+            log_rung!("iteration making no progress:\t try without scaling at all.");
         } else if retries < 7 && discrete_call {
             xv.copy_from_slice(&warm);
             continuous = false;
             non_continuous = true;
             retries += 1;
-            log_rung(" - iteration making no progress:\t try to solve a discontinuous system.");
+            log_rung!(" - iteration making no progress:\t try to solve a discontinuous system.");
         } else if retries2 < 1 {
             xv.copy_from_slice(&warm);
             *use_xscaling = true;
@@ -2153,7 +2158,7 @@ fn hybrd_c(
             factor = initial_factor;
             retries = 0;
             retries2 += 1;
-            log_rung(" - iteration making no progress:\t use old values instead extrapolated.");
+            log_rung!(" - iteration making no progress:\t use old values instead extrapolated.");
         } else if retries2 < 2 {
             restart(&mut xv, &nlsx);
             for v in xv.iter_mut() {
@@ -2161,7 +2166,7 @@ fn hybrd_c(
             }
             retries = 0;
             retries2 += 1;
-            log_rung(" - iteration making no progress:\t vary initial point by adding 1%.");
+            log_rung!(" - iteration making no progress:\t vary initial point by adding 1%.");
         } else if retries2 < 3 {
             restart(&mut xv, &nlsx);
             for v in xv.iter_mut() {
@@ -2169,18 +2174,18 @@ fn hybrd_c(
             }
             retries = 0;
             retries2 += 1;
-            log_rung(" - iteration making no progress:\t vary initial point by -1%.");
+            log_rung!(" - iteration making no progress:\t vary initial point by -1%.");
         } else if retries2 < 4 {
             xv.copy_from_slice(nominal);
             retries = 0;
             retries2 += 1;
-            log_rung(" - iteration making no progress:\t try scaling factor as initial point.");
+            log_rung!(" - iteration making no progress:\t try scaling factor as initial point.");
         } else if retries2 < 5 && !assert_called {
             restart(&mut xv, &nlsx);
             diag = Some(res_scaling.iter().map(|v| libm::fabs(*v).max(1e-16)).collect());
             retries = 0;
             retries2 += 1;
-            log_rung(" - iteration making no progress:\t try with own scaling factors.");
+            log_rung!(" - iteration making no progress:\t try with own scaling factors.");
         } else if retries3 < 1 {
             restart(&mut xv, &nlsx);
             diag = Some(vec![1.0f64; n]);
@@ -2188,7 +2193,7 @@ fn hybrd_c(
             retries = 0;
             retries2 = 0;
             retries3 += 1;
-            log_rung(" - iteration making no progress:\t disable solver internal scaling.");
+            log_rung!(" - iteration making no progress:\t disable solver internal scaling.");
         } else if retries3 < 6 {
             restart(&mut xv, &nlsx);
             local_tol *= 10.0;
@@ -2197,9 +2202,9 @@ fn hybrd_c(
             retries = 0;
             retries2 = 0;
             retries3 += 1;
-            log_rung(&alloc::format!(" - iteration making no progress:\t reduce the tolerance slightly to {}.", omclog::e(local_tol, 0, 6)));
+            log_rung!(" - iteration making no progress:\t reduce the tolerance slightly to {}.", omclog::e(local_tol, 0, 6));
         } else {
-            log_rung(&alloc::format!("### No Solution! ###\n after {} restarts", retries * retries2 * retries3));
+            log_rung!("### No Solution! ###\n after {} restarts", retries * retries2 * retries3);
             x.copy_from_slice(&xv);
             set_continuous(true);
             return false;
@@ -2409,9 +2414,9 @@ pub fn history_clean(h: &mut dyn History, time: f64) {
 
 /// C's `NONLINEAR_SYSTEM_DATA::numberOf{Iterations,FEval,JEval}`: per system,
 /// cumulative over the run, keyed by equation index.
-struct CountersCell(UnsafeCell<alloc::vec::Vec<(u32, [u64; 3])>>);
+struct CountersCell(UnsafeCell<alloc::collections::BTreeMap<u32, [u64; 3]>>);
 unsafe impl Sync for CountersCell {}
-static COUNTERS: CountersCell = CountersCell(UnsafeCell::new(alloc::vec::Vec::new()));
+static COUNTERS: CountersCell = CountersCell(UnsafeCell::new(alloc::collections::BTreeMap::new()));
 
 /// Nonzero while a Jacobian is being formed: C counts `numberOfFEval` in
 /// `wrapper_fvec`, which the FD Jacobian does not go through.
@@ -2436,26 +2441,18 @@ fn sys_counts() -> [u64; 3] {
 }
 
 fn counters_of(eq_index: u32) -> &'static mut [u64; 3] {
-    let v = unsafe { &mut *COUNTERS.0.get() };
-    let pos = match v.iter().position(|(i, _)| *i == eq_index) {
-        Some(p) => p,
-        None => {
-            v.push((eq_index, [0; 3]));
-            v.len() - 1
-        }
-    };
-    &mut v[pos].1
+    unsafe { &mut *COUNTERS.0.get() }.entry(eq_index).or_default()
 }
 
 /// C's `modelInfoGetEquation(...).vars[i]`, keyed by `equationIndex`. Pushed in
 /// from the decoded `SimMeta`, and only when the stream is on.
-struct NamesCell(UnsafeCell<alloc::vec::Vec<(u32, alloc::vec::Vec<alloc::string::String>)>>);
+struct NamesCell(UnsafeCell<alloc::collections::BTreeMap<u32, alloc::vec::Vec<alloc::string::String>>>);
 unsafe impl Sync for NamesCell {}
-static NAMES: NamesCell = NamesCell(UnsafeCell::new(alloc::vec::Vec::new()));
+static NAMES: NamesCell = NamesCell(UnsafeCell::new(alloc::collections::BTreeMap::new()));
 
 /// `eq_index`'s iteration-variable names, or `[]` when they were not pushed in.
 pub fn var_names(eq_index: u32) -> &'static [alloc::string::String] {
-    if let Some((_, v)) = unsafe { &*NAMES.0.get() }.iter().find(|(i, _)| *i == eq_index) {
+    if let Some(v) = unsafe { &*NAMES.0.get() }.get(&eq_index) {
         return v.as_slice();
     }
     // Not shipped ahead of time: ask the host, which reads the model's equation
@@ -2475,29 +2472,29 @@ fn var_label(names: &[alloc::string::String], i: usize) -> alloc::string::String
 
 /// Replace the name roster. `set` is `(eq_index, names)` in any order.
 pub fn set_var_names(set: alloc::vec::Vec<(u32, alloc::vec::Vec<alloc::string::String>)>) {
-    *unsafe { &mut *NAMES.0.get() } = set;
+    *unsafe { &mut *NAMES.0.get() } = set.into_iter().collect();
 }
 
 /// What `-lv=LOG_NLS_NEWTON_DIAGNOSTICS` needs per system beyond the names, keyed
 /// by equation index; pushed in from the model's metadata.
-struct DiagCell(UnsafeCell<alloc::vec::Vec<(u32, newton_diagnostics::DiagInfo)>>);
+struct DiagCell(UnsafeCell<alloc::collections::BTreeMap<u32, newton_diagnostics::DiagInfo>>);
 unsafe impl Sync for DiagCell {}
-static DIAG: DiagCell = DiagCell(UnsafeCell::new(alloc::vec::Vec::new()));
+static DIAG: DiagCell = DiagCell(UnsafeCell::new(alloc::collections::BTreeMap::new()));
 
 /// Replace the `LOG_NLS_NEWTON_DIAGNOSTICS` roster. `set` is `(eq_index, info)`
 /// in any order.
 pub fn set_diag(set: alloc::vec::Vec<(u32, newton_diagnostics::DiagInfo)>) {
-    *unsafe { &mut *DIAG.0.get() } = set;
+    *unsafe { &mut *DIAG.0.get() } = set.into_iter().collect();
 }
 
 /// Add one system to it, for a host that ships the roster a system at a time.
 pub fn push_diag(eq_index: u32, info: newton_diagnostics::DiagInfo) {
-    unsafe { &mut *DIAG.0.get() }.push((eq_index, info));
+    unsafe { &mut *DIAG.0.get() }.insert(eq_index, info);
 }
 
 /// [`set_var_names`] one system at a time.
 pub fn push_var_names(eq_index: u32, names: alloc::vec::Vec<alloc::string::String>) {
-    unsafe { &mut *NAMES.0.get() }.push((eq_index, names));
+    unsafe { &mut *NAMES.0.get() }.insert(eq_index, names);
 }
 
 /// The SimCode equation index of each residual, as the Newton-diagnostics roster
@@ -2518,7 +2515,7 @@ pub fn clear_diag() {
 }
 
 fn diag_info(eq_index: u32) -> Option<&'static newton_diagnostics::DiagInfo> {
-    unsafe { &*DIAG.0.get() }.iter().find(|(e, _)| *e == eq_index).map(|(_, d)| d)
+    unsafe { &*DIAG.0.get() }.get(&eq_index)
 }
 
 /// C's `printNonLinearInitialInfo`, under the `solve_nonlinear_system` header.

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/systems.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/systems.rs
@@ -350,12 +350,14 @@ fn solve_total_pivot(
     let size = ls.size.max(0) as usize;
     let time = unsafe { (**(*data).localData).timeValue };
     let eq = ls.equationIndex;
-    omclog::info!(
-        omclog::LS,
-        false,
-        "Start solving Linear System {eq} (size {size}) at time {} with Total Pivot Solver",
-        openmodelica_sim_meta::driver::format_g(time, 6),
-    );
+    if omclog::active(omclog::LS) {
+        omclog::info!(
+            omclog::LS,
+            false,
+            "Start solving Linear System {eq} (size {size}) at time {} with Total Pivot Solver",
+            openmodelica_sim_meta::driver::format_g(time, 6),
+        );
+    }
     let mut a = vec![0.0f64; (size * size).max(1)];
     let mut b = vec![0.0f64; size.max(1)];
     if ls.method == 0 {

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/delay.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_solvers/src/delay.rs
@@ -143,15 +143,17 @@ impl DelayState {
                 buf.pop_front();
             }
         }
-        omclog::info!(
-            omclog::DELAY,
-            false,
-            "storeDelayed[{idx}] ({},{}) position={}",
-            format_g(time, 6),
-            format_g(value, 6),
-            buf.len(),
-        );
-        print_buffer(omclog::DELAY, buf);
+        if omclog::active(omclog::DELAY) {
+            omclog::info!(
+                omclog::DELAY,
+                false,
+                "storeDelayed[{idx}] ({},{}) position={}",
+                format_g(time, 6),
+                format_g(value, 6),
+                buf.len(),
+            );
+            print_buffer(omclog::DELAY, buf);
+        }
     }
 
     /// C `delayImpl`: `expr(time - delay_time)` by linear interpolation, with the
@@ -159,14 +161,16 @@ impl DelayState {
     pub fn eval(&self, idx: usize, time: f64, value: f64, delay_time: f64, delay_max: f64) -> f64 {
         let buf = &self.buffers[idx];
         let length = buf.len();
-        omclog::info!(
-            omclog::DELAY,
-            false,
-            "delayImpl: exprNumber = {idx}, exprValue = {}, time = {}, delayTime = {}",
-            format_g(value, 6),
-            format_g(time, 6),
-            format_g(delay_time, 6),
-        );
+        if omclog::active(omclog::DELAY) {
+            omclog::info!(
+                omclog::DELAY,
+                false,
+                "delayImpl: exprNumber = {idx}, exprValue = {}, time = {}, delayTime = {}",
+                format_g(value, 6),
+                format_g(time, 6),
+                format_g(delay_time, 6),
+            );
+        }
         // C's `assertStreamPrint` guards, `DASSL_STEP_EPS` being 1e-13. Each one
         // throws in C, so at most one is reported and the caller's value stands in
         // for the interpolation the jump skipped.


### PR DESCRIPTION
A `Vec` with one entry per linear or nonlinear system, looked up by a scan on every solve, makes the run quadratic in the model: a discretized model has one system **per volume**, not the handful these tables were written for.  `IBPSA…Aquifer.SimulationTest` has `6 * nVol` linear systems — 2088 of them at nVol=348 — and solves all of them per `functionODE`.

The one that mattered was `ls_failure_entry`, which `ls_solved` calls on every *successful* linear solve, so it was on the default path of every wasm-jit run.  `simulation` seconds, same commit with only that file reverted:

| nVol | before | after | C    | before / C | after / C |
| ---: | -----: | ----: | ---: | ---------: | --------: |
|   58 |   0.99 |  0.35 | 0.41 |       2.41 |      0.90 |
|  116 |   2.34 |  0.69 | 0.87 |       2.68 |      0.84 |
|  232 |   7.09 |  1.60 | 1.80 |       3.93 |      0.83 |
|  348 |  21.30 |  3.12 | 3.50 |       6.09 |      0.81 |

The ratio to C was climbing with model size; it is flat now, and under one.  `diffSimulationResults` against the C target at nVol=116 reports no differing variables.  Past ~2000 entries even the constant degrades — the scanned `Vec` leaves L1 — which is why the before column grows faster than n².

The same construct, keyed here too but not separately measured: `KIN_CACHE`/`KIN_B_CACHE` (per KINSOL solve, and it `swap_remove`d and re-pushed, so the list never settled), `ROSTER` behind `sysNumber`, and `NAMES`, `COUNTERS`, `DIAG`.  A system that has never failed now gets no entry at all, so the hot path is a lookup miss rather than an insert.

The native runtime reaches these through the indexed `LINEAR_SYSTEM_DATA` / `NONLINEAR_SYSTEM_DATA`, which is why C+Rust stayed linear and the gap read as a wasm-jit codegen problem.

Second, log lines built for a stream that is off.  `format_args!` defers the *formatting*, not its arguments, so a `format_g(time, 6)` argument allocates before the sink checks the stream:

* `ls_start_log`, per linear solve, and the native total-pivot line beside it — the Lapack path already had the check.
* KINSOL's `Start solving Non-Linear System` line, per solve.
* `delay`'s `store` and `eval`, per call.
* `hybrd_c` looked up the iteration-variable names before testing `LOG_NLS_V`, and on the native runtime the first lookup of a system parses the model's `info.json` for names nothing goes on to print.

`hybrd_c`'s `log_rung` was a `fn(&str)` whose callers passed `&alloc::format!(…)`, so the message was built and only then discarded. It is a macro now, with the `log_v` test outside it, which is the one form that keeps the arguments unevaluated too.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
