### PR TITLE
NB: cut SimCode scalarization allocations

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBackendExtension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBackendExtension.mo
@@ -70,6 +70,7 @@ protected
   // Util imports
   import Pointer;
   import UnorderedMap;
+  import MetaModelica.Dangerous.listReverseInPlace;
 
 public
   uniontype BackendInfo
@@ -192,10 +193,15 @@ public
       binfo_list := match binfo.varKind
         local
           list<VariableAttributes> scalar_attributes;
+          Boolean uniform;
         case VariableKind.FRONTEND_DUMMY() then List.fill(binfo, length);
         else algorithm
-          scalar_attributes := VariableAttributes.scalarize(binfo.attributes, length);
-        then list(BACKEND_INFO(binfo.varKind, attr, binfo.annotations, binfo.var_pre, binfo.var_seed, binfo.var_pder_res, binfo.var_pder_tmp, binfo.var_start, binfo.parent) for attr in scalar_attributes);
+          (scalar_attributes, uniform) := VariableAttributes.scalarize(binfo.attributes, length);
+          if uniform then
+            binfo.attributes := listHead(scalar_attributes);
+          end if;
+        then if uniform then List.fill(binfo, length) else
+          list(BACKEND_INFO(binfo.varKind, attr, binfo.annotations, binfo.var_pre, binfo.var_seed, binfo.var_pder_res, binfo.var_pder_tmp, binfo.var_start, binfo.parent) for attr in scalar_attributes);
       end match;
     end scalarize;
   end BackendInfo;
@@ -908,11 +914,13 @@ public
       input Option<Boolean>           finalPrefix "Defined as final";
       input Integer                   length "length of result";
       output list<VariableAttributes> scalar_attributes = {};
+      output Boolean uniform;
     protected
       Option<Expression> quantity_e, unit_e, displayUnit_e, min_e, max_e, start_e, fixed_e, nominal_e, binding_e;
       ExpressionIterator quantity_loc = quantity_iter, unit_loc = unit_iter, displayUnit_loc = displayUnit_iter, min_loc = min_iter, max_loc = max_iter, start_loc = start_iter, fixed_loc = fixed_iter, nominal_loc = nominal_iter, binding_loc = binding_iter;
     algorithm
-      for i in 1:length loop
+      uniform := length > 1 and List.all({quantity_iter, unit_iter, displayUnit_iter, min_iter, max_iter, start_iter, fixed_iter, nominal_iter, binding_iter}, ExpressionIterator.isUniform);
+      for i in 1:(if uniform then 1 else length) loop
         (quantity_loc, quantity_e)     := ExpressionIterator.nextOpt(quantity_loc);
         (unit_loc, unit_e)             := ExpressionIterator.nextOpt(unit_loc);
         (displayUnit_loc, displayUnit_e) := ExpressionIterator.nextOpt(displayUnit_loc);
@@ -935,7 +943,7 @@ public
           Util.applyOption(binding_e,      expToGeneratedBinding),
           isProtected, finalPrefix) :: scalar_attributes;
       end for;
-      scalar_attributes := listReverse(scalar_attributes);
+      scalar_attributes := if uniform then List.fill(listHead(scalar_attributes), length) else listReverseInPlace(scalar_attributes);
     end scalarizeReal;
 
     function scalarizeInt
@@ -951,11 +959,13 @@ public
       input Option<Boolean>           finalPrefix "Defined as final";
       input Integer                   length "length of result";
       output list<VariableAttributes> scalar_attributes = {};
+      output Boolean uniform;
     protected
       Option<Expression> quantity_e, min_e, max_e, start_e, fixed_e, binding_e;
       ExpressionIterator quantity_loc = quantity_iter, min_loc = min_iter, max_loc = max_iter, start_loc = start_iter, fixed_loc = fixed_iter, binding_loc = binding_iter;
     algorithm
-      for i in 1:length loop
+      uniform := length > 1 and List.all({quantity_iter, min_iter, max_iter, start_iter, fixed_iter, binding_iter}, ExpressionIterator.isUniform);
+      for i in 1:(if uniform then 1 else length) loop
         (quantity_loc, quantity_e) := ExpressionIterator.nextOpt(quantity_loc);
         (min_loc, min_e)           := ExpressionIterator.nextOpt(min_loc);
         (max_loc, max_e)           := ExpressionIterator.nextOpt(max_loc);
@@ -972,7 +982,7 @@ public
           Util.applyOption(binding_e,  expToGeneratedBinding),
           isProtected, finalPrefix) :: scalar_attributes;
       end for;
-      scalar_attributes := listReverse(scalar_attributes);
+      scalar_attributes := if uniform then List.fill(listHead(scalar_attributes), length) else listReverseInPlace(scalar_attributes);
     end scalarizeInt;
 
     function scalarizeBool
@@ -984,11 +994,13 @@ public
       input Option<Boolean>           finalPrefix "Defined as final";
       input Integer                   length "length of result";
       output list<VariableAttributes> scalar_attributes = {};
+      output Boolean uniform;
     protected
       Option<Expression> quantity_e, start_e, fixed_e, binding_e;
       ExpressionIterator quantity_loc = quantity_iter, start_loc = start_iter, fixed_loc = fixed_iter, binding_loc = binding_iter;
     algorithm
-      for i in 1:length loop
+      uniform := length > 1 and List.all({quantity_iter, start_iter, fixed_iter, binding_iter}, ExpressionIterator.isUniform);
+      for i in 1:(if uniform then 1 else length) loop
         (quantity_loc, quantity_e) := ExpressionIterator.nextOpt(quantity_loc);
         (start_loc, start_e)       := ExpressionIterator.nextOpt(start_loc);
         (fixed_loc, fixed_e)       := ExpressionIterator.nextOpt(fixed_loc);
@@ -1000,7 +1012,7 @@ public
           Util.applyOption(binding_e,  expToGeneratedBinding),
           isProtected, finalPrefix) :: scalar_attributes;
       end for;
-      scalar_attributes := listReverse(scalar_attributes);
+      scalar_attributes := if uniform then List.fill(listHead(scalar_attributes), length) else listReverseInPlace(scalar_attributes);
     end scalarizeBool;
 
     function scalarizeClock
@@ -1008,6 +1020,7 @@ public
       input Option<Boolean>               finalPrefix "Defined as final";
       input Integer                       length "length of result";
       output list<VariableAttributes>     scalar_attributes = List.fill(VAR_ATTR_CLOCK(isProtected, finalPrefix), length);
+      output Boolean uniform = true;
     end scalarizeClock;
 
     function scalarizeString
@@ -1019,11 +1032,13 @@ public
       input Option<Boolean>           finalPrefix "Defined as final";
       input Integer                   length "length of result";
       output list<VariableAttributes> scalar_attributes = {};
+      output Boolean uniform;
     protected
       Option<Expression> quantity_e, start_e, fixed_e, binding_e;
       ExpressionIterator quantity_loc = quantity_iter, start_loc = start_iter, fixed_loc = fixed_iter, binding_loc = binding_iter;
     algorithm
-      for i in 1:length loop
+      uniform := length > 1 and List.all({quantity_iter, start_iter, fixed_iter, binding_iter}, ExpressionIterator.isUniform);
+      for i in 1:(if uniform then 1 else length) loop
         (quantity_loc, quantity_e) := ExpressionIterator.nextOpt(quantity_loc);
         (start_loc, start_e)       := ExpressionIterator.nextOpt(start_loc);
         (fixed_loc, fixed_e)       := ExpressionIterator.nextOpt(fixed_loc);
@@ -1035,7 +1050,7 @@ public
           Util.applyOption(binding_e,  expToGeneratedBinding),
           isProtected, finalPrefix) :: scalar_attributes;
       end for;
-      scalar_attributes := listReverse(scalar_attributes);
+      scalar_attributes := if uniform then List.fill(listHead(scalar_attributes), length) else listReverseInPlace(scalar_attributes);
     end scalarizeString;
 
     function scalarizeEnumeration
@@ -1049,11 +1064,13 @@ public
       input Option<Boolean>           finalPrefix "Defined as final";
       input Integer                   length "length of result";
       output list<VariableAttributes> scalar_attributes = {};
+      output Boolean uniform;
     protected
       Option<Expression> quantity_e, min_e, max_e, start_e, fixed_e, binding_e;
       ExpressionIterator quantity_loc = quantity_iter, min_loc = min_iter, max_loc = max_iter, start_loc = start_iter, fixed_loc = fixed_iter, binding_loc = binding_iter;
     algorithm
-      for i in 1:length loop
+      uniform := length > 1 and List.all({quantity_iter, min_iter, max_iter, start_iter, fixed_iter, binding_iter}, ExpressionIterator.isUniform);
+      for i in 1:(if uniform then 1 else length) loop
         (quantity_loc, quantity_e) := ExpressionIterator.nextOpt(quantity_loc);
         (min_loc, min_e)           := ExpressionIterator.nextOpt(min_loc);
         (max_loc, max_e)           := ExpressionIterator.nextOpt(max_loc);
@@ -1069,15 +1086,16 @@ public
           Util.applyOption(binding_e,  expToGeneratedBinding),
           isProtected, finalPrefix) :: scalar_attributes;
       end for;
-      scalar_attributes := listReverse(scalar_attributes);
+      scalar_attributes := if uniform then List.fill(listHead(scalar_attributes), length) else listReverseInPlace(scalar_attributes);
     end scalarizeEnumeration;
 
     function scalarize
       input VariableAttributes attributes;
       input Integer length;
       output list<VariableAttributes> scalar_attributes = {};
+      output Boolean uniform "every element got the same attribute record";
     algorithm
-      scalar_attributes := match attributes
+      (scalar_attributes, uniform) := match attributes
         case VAR_ATTR_REAL() then scalarizeReal(
           quantity_iter       = ExpressionIterator.fromExpOpt(Util.applyOption(attributes.quantity,    Binding.getTypedExp)),
           unit_iter           = ExpressionIterator.fromExpOpt(Util.applyOption(attributes.unit,        Binding.getTypedExp)),
@@ -1150,7 +1168,7 @@ public
         );
 
         // kabdelhak: ToDo: need to discuss this case
-        case VAR_ATTR_RECORD() then {attributes};
+        case VAR_ATTR_RECORD() then ({attributes}, false);
 
         else algorithm
           Error.terminate(getInstanceName() + "failed. Not yet handled: " + toString(attributes), sourceInfo());

--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -1524,12 +1524,35 @@ public
           false;
 
       case TYPED_CALL() then Expression.listContains(call.arguments, func);
-      case UNTYPED_ARRAY_CONSTRUCTOR() then Expression.contains(call.exp, func);
-      case TYPED_ARRAY_CONSTRUCTOR() then Expression.contains(call.exp, func);
-      case UNTYPED_REDUCTION() then Expression.contains(call.exp, func);
-      case TYPED_REDUCTION() then Expression.contains(call.exp, func);
+      case UNTYPED_ARRAY_CONSTRUCTOR()
+        then Expression.contains(call.exp, func) or itersContainExp(call.iters, func);
+      case TYPED_ARRAY_CONSTRUCTOR()
+        then Expression.contains(call.exp, func) or itersContainExp(call.iters, func);
+      case UNTYPED_REDUCTION()
+        then Expression.contains(call.exp, func) or itersContainExp(call.iters, func);
+      case TYPED_REDUCTION()
+        then Expression.contains(call.exp, func) or itersContainExp(call.iters, func);
     end match;
   end containsExp;
+
+  function itersContainExp
+    "An iterator range is a subexpression too: `sum(x[k] for k in i:n)` uses `i`."
+    input list<tuple<InstNode, Expression>> iters;
+    input ContainsPred func;
+    output Boolean res = false;
+
+    partial function ContainsPred
+      input Expression exp;
+      output Boolean res;
+    end ContainsPred;
+  algorithm
+    for iter in iters loop
+      if Expression.contains(Util.tuple22(iter), func) then
+        res := true;
+        return;
+      end if;
+    end for;
+  end itersContainExp;
 
   function containsExpShallow
     input Call call;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
@@ -55,6 +55,8 @@ protected
   import Absyn;
   import EvalTarget = NFCeval.EvalTarget;
   import Array;
+  import Util;
+  import List;
 
 public
   function expand
@@ -462,6 +464,11 @@ public
     Mutable<Expression> iter;
     list<Mutable<Expression>> iters = {};
   algorithm
+    if Type.hasKnownSize(ty) and not List.any(iterators, function usesIterator(exp = exp)) then
+      result := fillArrayConstructor(expand(SimplifyExp.simplify(exp)), ty, listLength(iterators));
+      return;
+    end if;
+
     for i in iterators loop
       (node, range) := i;
       iter := Mutable.create(Expression.EMPTY(InstNode.getType(node)));
@@ -473,6 +480,24 @@ public
 
     result := expandArrayConstructor2(e, ty, ranges, iters);
   end expandArrayConstructor;
+
+  function usesIterator
+    input tuple<InstNode, Expression> iterator;
+    input Expression exp;
+    output Boolean used = Expression.containsIterator(exp, Util.tuple21(iterator));
+  end usesIterator;
+
+  function fillArrayConstructor
+    "The body does not depend on the iterators: every element is the same expression."
+    input Expression value;
+    input Type ty;
+    input Integer levels;
+    output Expression result;
+  algorithm
+    result := if levels == 0 then value else
+      Expression.makeArray(ty, arrayCreate(Dimension.size(Type.nthDimension(ty, 1)),
+        fillArrayConstructor(value, Type.unliftArray(ty), levels - 1)));
+  end fillArrayConstructor;
 
   function expandArrayConstructor2
     input Expression exp;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -2072,11 +2072,8 @@ public
       output Boolean res;
     algorithm
       res := match exp
-        local
-          InstNode node;
-
-        case CREF(cref = ComponentRef.CREF(node = node))
-          then InstNode.refEqual(node, iterator);
+        // Only the first (last in stored order) part of a cref can be an iterator: `i.x`.
+        case CREF() then InstNode.refEqual(ComponentRef.node(ComponentRef.last(exp.cref)), iterator);
         else false;
       end match;
     end containsIterator2;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpressionIterator.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpressionIterator.mo
@@ -46,6 +46,7 @@ protected
 public
   import Expression = NFExpression;
   import Binding = NFBinding;
+  import Util;
 
   record ARRAY_ITERATOR
     array<Expression> arr;
@@ -166,6 +167,38 @@ public
         then EACH_ITERATOR(binding.bindingExp);
     end match;
   end fromBinding;
+
+  function isUniform
+    "Whether every element the iterator yields is the same expression object,
+     so one element stands for all of them."
+    input ExpressionIterator iterator;
+    output Boolean uniform;
+  algorithm
+    uniform := match iterator
+      case ARRAY_ITERATOR() then isUniformArrays(iterator.arr :: iterator.arrays);
+      case EACH_ITERATOR() then true;
+      case NONE_ITERATOR() then true;
+      else false;
+    end match;
+  end isUniform;
+
+  function isUniformArrays
+    input list<array<Expression>> arrays;
+    output Boolean uniform = true;
+  protected
+    Option<Expression> first = NONE();
+  algorithm
+    for arr in arrays loop
+      for e in arr loop
+        if isNone(first) then
+          first := SOME(e);
+        elseif not referenceEq(e, Util.getOption(first)) then
+          uniform := false;
+          return;
+        end if;
+      end for;
+    end for;
+  end isUniformArrays;
 
   function hasNext
     input ExpressionIterator iterator;

--- a/OMCompiler/Compiler/NSimCode/NSimJacobian.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimJacobian.mo
@@ -56,6 +56,7 @@ public
   import BEquation = NBEquation;
   import NBVariable.{VariablePointers, VarData};
   import BVariable = NBVariable;
+  import Variable = NFVariable;
   import Jacobian = NBJacobian;
   import Partition = NBPartition;
 
@@ -362,10 +363,7 @@ public
           SimStrongComponent.Block columnEqn;
           list<SimStrongComponent.Block> columnEqns = {};
           VarData varData;
-          VariablePointers seed_vec, res_vec, tmp_vec;
-          Pointer<list<SimVar>> seedVars_ptr = Pointer.create({});
-          Pointer<list<SimVar>> resVars_ptr = Pointer.create({});
-          Pointer<list<SimVar>> tmpVars_ptr = Pointer.create({});
+          list<Pointer<Variable>> seed_lst, res_lst, tmp_lst;
           list<SimVar> seedVars, resVars, tmpVars;
           UnorderedMap<ComponentRef, SimVar> jac_map;
           SimJacobian jac;
@@ -388,24 +386,20 @@ public
           generic_loop_calls := list(SimGenericCall.fromIdentifier(tpl) for tpl in UnorderedMap.toList(indices.generic_call_map));
           indices.generic_call_map := sim_map;
 
-          // scalarize variables for sim code
           if Flags.getConfigBool(Flags.SIM_CODE_SCALARIZE) then
-            seed_vec := VariablePointers.scalarize(varData.seedVars);
-            res_vec  := VariablePointers.scalarize(varData.resultVars);
-            tmp_vec  := VariablePointers.scalarize(varData.tmpVars);
+            seed_lst := VariablePointers.toList(VariablePointers.scalarize(varData.seedVars));
+            res_lst  := VariablePointers.toList(VariablePointers.scalarize(varData.resultVars));
+            tmp_lst  := VariablePointers.toList(VariablePointers.scalarize(varData.tmpVars));
           else
-            seed_vec := varData.seedVars;
-            res_vec  := varData.resultVars;
-            tmp_vec  := varData.tmpVars;
+            seed_lst := VariablePointers.toList(varData.seedVars);
+            res_lst  := VariablePointers.toList(varData.resultVars);
+            tmp_lst  := VariablePointers.toList(varData.tmpVars);
           end if;
 
-          // use dummy simcode indices to always start at 0 for column and seed vars
-          VariablePointers.map(seed_vec,  function SimVar.traverseCreate(acc = seedVars_ptr, indices_ptr = Pointer.create(NSimCode.EMPTY_SIM_CODE_INDICES()), varType = VarType.SIMULATION));
-          VariablePointers.map(res_vec,   function SimVar.traverseCreate(acc = resVars_ptr,  indices_ptr = Pointer.create(NSimCode.EMPTY_SIM_CODE_INDICES()), varType = VarType.SIMULATION));
-          VariablePointers.map(tmp_vec,   function SimVar.traverseCreate(acc = tmpVars_ptr,  indices_ptr = Pointer.create(NSimCode.EMPTY_SIM_CODE_INDICES()), varType = VarType.SIMULATION));
-          seedVars  := listReverse(Pointer.access(seedVars_ptr));
-          resVars   := listReverse(Pointer.access(resVars_ptr));
-          tmpVars   := listReverse(Pointer.access(tmpVars_ptr));
+          // column and seed var indices always start at 0
+          seedVars := SimVar.createList(seed_lst, VarType.SIMULATION, NSimCode.EMPTY_SIM_CODE_INDICES());
+          resVars  := SimVar.createList(res_lst,  VarType.SIMULATION, NSimCode.EMPTY_SIM_CODE_INDICES());
+          tmpVars  := SimVar.createList(tmp_lst,  VarType.SIMULATION, NSimCode.EMPTY_SIM_CODE_INDICES());
 
           jac_map := UnorderedMap.new<SimVar>(ComponentRef.hash, ComponentRef.isEqual, listLength(seedVars) + listLength(resVars) + listLength(tmpVars));
           SimCodeUtil.addListSimCodeMap(seedVars, jac_map);

--- a/OMCompiler/Compiler/NSimCode/NSimVar.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimVar.mo
@@ -56,6 +56,7 @@ protected
   import SimplifyExp = NFSimplifyExp;
   import Type = NFType;
   import Variable = NFVariable;
+  import MetaModelica.Dangerous.listReverseInPlace;
   import NBVariable.VariablePointers;
 
   // Old Backend imports
@@ -265,6 +266,172 @@ public
       end match;
       Pointer.update(indices_ptr, simCodeIndices);
     end traverseCreate;
+
+    function createList
+      "SimVars for scalar variables in list order, with running indices."
+      input list<Pointer<Variable>> vars;
+      input VarType varType;
+      output list<SimVar> simVars = {};
+      input output SimCode.SimCodeIndices indices;
+    protected
+      Integer uniq = indices.uniqueIndex;
+      Integer idx = getTypeIndex(indices, varType);
+      Variable var;
+    algorithm
+      for var_ptr in vars loop
+        var := Pointer.access(var_ptr);
+        simVars := create(var, uniq, idx, if varType == VarType.ALIAS then Alias.fromBinding(var.binding) else Alias.NO_ALIAS()) :: simVars;
+        uniq := uniq + 1;
+        idx := idx + 1;
+      end for;
+      simVars := listReverseInPlace(simVars);
+      indices.uniqueIndex := uniq;
+      indices := setTypeIndex(indices, varType, idx);
+    end createList;
+
+    function createListsByType
+      "One SimVar list per basic type (real, integer, boolean, string, enumeration),
+      each with its own running index."
+      input list<Pointer<Variable>> vars;
+      input VarType varType;
+      output list<list<SimVar>> simVars;
+      input output SimCode.SimCodeIndices indices;
+    protected
+      Integer uniq = indices.uniqueIndex;
+      Integer real_idx, int_idx, bool_idx, string_idx, enum_idx;
+      list<SimVar> real_lst = {}, int_lst = {}, bool_lst = {}, string_lst = {}, enum_lst = {};
+      Variable var;
+      Alias alias;
+    algorithm
+      (real_idx, int_idx, bool_idx, string_idx, enum_idx) := getTypeIndices(indices, varType);
+      for var_ptr in vars loop
+        var := Pointer.access(var_ptr);
+        alias := if varType == VarType.ALIAS then Alias.fromBinding(var.binding) else Alias.NO_ALIAS();
+        () := match Type.arrayElementType(var.ty)
+          case Type.REAL() algorithm
+            real_lst := create(var, uniq, real_idx, alias) :: real_lst;
+            real_idx := real_idx + 1;
+            uniq := uniq + 1;
+          then ();
+
+          case Type.INTEGER() algorithm
+            int_lst := create(var, uniq, int_idx, alias) :: int_lst;
+            int_idx := int_idx + 1;
+            uniq := uniq + 1;
+          then ();
+
+          case Type.BOOLEAN() algorithm
+            bool_lst := create(var, uniq, bool_idx, alias) :: bool_lst;
+            bool_idx := bool_idx + 1;
+            uniq := uniq + 1;
+          then ();
+
+          case Type.STRING() algorithm
+            string_lst := create(var, uniq, string_idx, alias) :: string_lst;
+            string_idx := string_idx + 1;
+            uniq := uniq + 1;
+          then ();
+
+          case Type.ENUMERATION() algorithm
+            enum_lst := create(var, uniq, enum_idx, alias) :: enum_lst;
+            enum_idx := enum_idx + 1;
+            uniq := uniq + 1;
+          then ();
+
+          // clock variables do not exist anymore
+          case Type.CLOCK() then ();
+
+          else algorithm
+            Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed because of unhandled Variable " + ComponentRef.toString(var.name) + "."});
+          then fail();
+        end match;
+      end for;
+      simVars := {listReverseInPlace(real_lst), listReverseInPlace(int_lst), listReverseInPlace(bool_lst),
+                  listReverseInPlace(string_lst), listReverseInPlace(enum_lst)};
+      indices.uniqueIndex := uniq;
+      indices := setTypeIndices(indices, varType, real_idx, int_idx, bool_idx, string_idx, enum_idx);
+    end createListsByType;
+
+    function getTypeIndex
+      input SimCode.SimCodeIndices indices;
+      input VarType varType;
+      output Integer idx;
+    algorithm
+      idx := match varType
+        case VarType.SIMULATION       then indices.realVarIndex;
+        case VarType.PARAMETER        then indices.realParamIndex;
+        case VarType.ALIAS            then indices.realAliasIndex;
+        case VarType.RESIDUAL         then indices.residualIndex;
+        case VarType.EXTERNAL_OBJECT  then indices.extObjIndex;
+      end match;
+    end getTypeIndex;
+
+    function setTypeIndex
+      input output SimCode.SimCodeIndices indices;
+      input VarType varType;
+      input Integer idx;
+    algorithm
+      () := match varType
+        case VarType.SIMULATION       algorithm indices.realVarIndex := idx;   then ();
+        case VarType.PARAMETER        algorithm indices.realParamIndex := idx; then ();
+        case VarType.ALIAS            algorithm indices.realAliasIndex := idx; then ();
+        case VarType.RESIDUAL         algorithm indices.residualIndex := idx;  then ();
+        case VarType.EXTERNAL_OBJECT  algorithm indices.extObjIndex := idx;    then ();
+      end match;
+    end setTypeIndex;
+
+    function getTypeIndices
+      input SimCode.SimCodeIndices indices;
+      input VarType varType;
+      output Integer real_idx;
+      output Integer int_idx;
+      output Integer bool_idx;
+      output Integer string_idx;
+      output Integer enum_idx;
+    algorithm
+      (real_idx, int_idx, bool_idx, string_idx, enum_idx) := match varType
+        case VarType.SIMULATION then (indices.realVarIndex, indices.integerVarIndex, indices.booleanVarIndex, indices.stringVarIndex, indices.enumerationVarIndex);
+        case VarType.PARAMETER  then (indices.realParamIndex, indices.integerParamIndex, indices.booleanParamIndex, indices.stringParamIndex, indices.enumerationParamIndex);
+        case VarType.ALIAS      then (indices.realAliasIndex, indices.integerAliasIndex, indices.booleanAliasIndex, indices.stringAliasIndex, indices.enumerationAliasIndex);
+        else algorithm
+          Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed because of unhandled VarType."});
+        then fail();
+      end match;
+    end getTypeIndices;
+
+    function setTypeIndices
+      input output SimCode.SimCodeIndices indices;
+      input VarType varType;
+      input Integer real_idx;
+      input Integer int_idx;
+      input Integer bool_idx;
+      input Integer string_idx;
+      input Integer enum_idx;
+    algorithm
+      () := match varType
+        case VarType.SIMULATION algorithm
+          indices.realVarIndex := real_idx;
+          indices.integerVarIndex := int_idx;
+          indices.booleanVarIndex := bool_idx;
+          indices.stringVarIndex := string_idx;
+          indices.enumerationVarIndex := enum_idx;
+        then ();
+        case VarType.PARAMETER algorithm
+          indices.realParamIndex := real_idx;
+          indices.integerParamIndex := int_idx;
+          indices.booleanParamIndex := bool_idx;
+          indices.stringParamIndex := string_idx;
+          indices.enumerationParamIndex := enum_idx;
+        then ();
+        case VarType.ALIAS algorithm
+          indices.realAliasIndex := real_idx;
+          indices.integerAliasIndex := int_idx;
+          indices.booleanAliasIndex := bool_idx;
+          indices.stringAliasIndex := string_idx;
+          indices.enumerationAliasIndex := enum_idx;
+        then ();
+      end match;
+    end setTypeIndices;
 
     function createFromResidualComponent
       input output StrongComponent comp;
@@ -1136,179 +1303,20 @@ public
       input SplitType splitType;
       input VarType varType;
     protected
-      VariablePointers sim_vars = if Flags.getConfigBool(Flags.SIM_CODE_SCALARIZE) then VariablePointers.scalarize(vars) else vars;
-      Pointer<list<SimVar>> acc = Pointer.create({});
-      Pointer<list<SimVar>> real_lst = Pointer.create({});
-      Pointer<list<SimVar>> int_lst = Pointer.create({});
-      Pointer<list<SimVar>> bool_lst = Pointer.create({});
-      Pointer<list<SimVar>> string_lst = Pointer.create({});
-      Pointer<list<SimVar>> enum_lst = Pointer.create({});
-      Pointer<SimCode.SimCodeIndices> indices_ptr = Pointer.create(simCodeIndices);
+      // scalarize goes through fromList, whose cref dedupe a record and its elements rely on
+      list<Pointer<Variable>> sim_vars = VariablePointers.toList(if Flags.getConfigBool(Flags.SIM_CODE_SCALARIZE) then VariablePointers.scalarize(vars) else vars);
+      list<SimVar> lst;
     algorithm
+
       if splitType == SplitType.NONE then
-        // Do not split and return everything as one single list
-        VariablePointers.map(sim_vars, function SimVar.traverseCreate(acc = acc, indices_ptr = indices_ptr, varType = varType));
-        simVars := {listReverse(Pointer.access(acc))};
-        simCodeIndices := Pointer.access(indices_ptr);
+        (lst, simCodeIndices) := SimVar.createList(sim_vars, varType, simCodeIndices);
+        simVars := {lst};
       elseif splitType == SplitType.TYPE then
-        // Split the variables by basic type (real, integer, boolean, string)
-        // and return a list for each type
-        VariablePointers.map(sim_vars, function splitByType(real_lst = real_lst, int_lst = int_lst, bool_lst = bool_lst, string_lst = string_lst, enum_lst = enum_lst, indices_ptr = indices_ptr, varType = varType));
-        simVars := {listReverse(Pointer.access(real_lst)),
-                    listReverse(Pointer.access(int_lst)),
-                    listReverse(Pointer.access(bool_lst)),
-                    listReverse(Pointer.access(string_lst)),
-                    listReverse(Pointer.access(enum_lst))};
-        simCodeIndices := Pointer.access(indices_ptr);
+        (simVars, simCodeIndices) := SimVar.createListsByType(sim_vars, varType, simCodeIndices);
       else
         Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed because of invalid splitType."});
       end if;
     end createSimVarLists;
-
-    function splitByType
-      "Traverser function for splitting process. Target for SplitType.TYPE"
-      input output Variable var;
-      input Pointer<list<SimVar>> real_lst;
-      input Pointer<list<SimVar>> int_lst;
-      input Pointer<list<SimVar>> bool_lst;
-      input Pointer<list<SimVar>> string_lst;
-      input Pointer<list<SimVar>> enum_lst;
-      input Pointer<SimCode.SimCodeIndices> indices_ptr;
-      input VarType varType;
-    protected
-      SimCode.SimCodeIndices simCodeIndices = Pointer.access(indices_ptr);
-    algorithm
-      () := match (Type.arrayElementType(var.ty), varType)
-
-        case (Type.REAL(), VarType.SIMULATION)
-          algorithm
-            Pointer.update(real_lst, SimVar.create(var, simCodeIndices.uniqueIndex, simCodeIndices.realVarIndex) :: Pointer.access(real_lst));
-            simCodeIndices.realVarIndex := simCodeIndices.realVarIndex + 1;
-            simCodeIndices.uniqueIndex := simCodeIndices.uniqueIndex + 1;
-            Pointer.update(indices_ptr, simCodeIndices);
-        then ();
-
-        case (Type.INTEGER(), VarType.SIMULATION)
-          algorithm
-            Pointer.update(int_lst, SimVar.create(var, simCodeIndices.uniqueIndex, simCodeIndices.integerVarIndex) :: Pointer.access(int_lst));
-            simCodeIndices.integerVarIndex := simCodeIndices.integerVarIndex + 1;
-            simCodeIndices.uniqueIndex := simCodeIndices.uniqueIndex + 1;
-            Pointer.update(indices_ptr, simCodeIndices);
-        then ();
-
-        case (Type.BOOLEAN(), VarType.SIMULATION)
-          algorithm
-            Pointer.update(bool_lst, SimVar.create(var, simCodeIndices.uniqueIndex, simCodeIndices.booleanVarIndex) :: Pointer.access(bool_lst));
-            simCodeIndices.booleanVarIndex := simCodeIndices.booleanVarIndex + 1;
-            simCodeIndices.uniqueIndex := simCodeIndices.uniqueIndex + 1;
-            Pointer.update(indices_ptr, simCodeIndices);
-        then ();
-
-        case (Type.STRING(), VarType.SIMULATION)
-          algorithm
-            Pointer.update(string_lst, SimVar.create(var, simCodeIndices.uniqueIndex, simCodeIndices.stringVarIndex) :: Pointer.access(string_lst));
-            simCodeIndices.stringVarIndex := simCodeIndices.stringVarIndex + 1;
-            simCodeIndices.uniqueIndex := simCodeIndices.uniqueIndex + 1;
-            Pointer.update(indices_ptr, simCodeIndices);
-        then ();
-
-        case (Type.ENUMERATION(), VarType.SIMULATION)
-          algorithm
-            Pointer.update(enum_lst, SimVar.create(var, simCodeIndices.uniqueIndex, simCodeIndices.enumerationVarIndex) :: Pointer.access(enum_lst));
-            simCodeIndices.enumerationVarIndex := simCodeIndices.enumerationVarIndex + 1;
-            simCodeIndices.uniqueIndex := simCodeIndices.uniqueIndex + 1;
-            Pointer.update(indices_ptr, simCodeIndices);
-        then ();
-
-        case (Type.REAL(), VarType.PARAMETER)
-          algorithm
-            Pointer.update(real_lst, SimVar.create(var, simCodeIndices.uniqueIndex, simCodeIndices.realParamIndex) :: Pointer.access(real_lst));
-            simCodeIndices.realParamIndex := simCodeIndices.realParamIndex + 1;
-            simCodeIndices.uniqueIndex := simCodeIndices.uniqueIndex + 1;
-            Pointer.update(indices_ptr, simCodeIndices);
-        then ();
-
-        case (Type.INTEGER(), VarType.PARAMETER)
-          algorithm
-            Pointer.update(int_lst, SimVar.create(var, simCodeIndices.uniqueIndex, simCodeIndices.integerParamIndex) :: Pointer.access(int_lst));
-            simCodeIndices.integerParamIndex := simCodeIndices.integerParamIndex + 1;
-            simCodeIndices.uniqueIndex := simCodeIndices.uniqueIndex + 1;
-            Pointer.update(indices_ptr, simCodeIndices);
-        then ();
-
-        case (Type.BOOLEAN(), VarType.PARAMETER)
-          algorithm
-            Pointer.update(bool_lst, SimVar.create(var, simCodeIndices.uniqueIndex, simCodeIndices.booleanParamIndex) :: Pointer.access(bool_lst));
-            simCodeIndices.booleanParamIndex := simCodeIndices.booleanParamIndex + 1;
-            simCodeIndices.uniqueIndex := simCodeIndices.uniqueIndex + 1;
-            Pointer.update(indices_ptr, simCodeIndices);
-        then ();
-
-        case (Type.STRING(), VarType.PARAMETER)
-          algorithm
-            Pointer.update(string_lst, SimVar.create(var, simCodeIndices.uniqueIndex, simCodeIndices.stringParamIndex) :: Pointer.access(string_lst));
-            simCodeIndices.stringParamIndex := simCodeIndices.stringParamIndex + 1;
-            simCodeIndices.uniqueIndex := simCodeIndices.uniqueIndex + 1;
-            Pointer.update(indices_ptr, simCodeIndices);
-        then ();
-
-        case (Type.ENUMERATION(), VarType.PARAMETER)
-          algorithm
-            Pointer.update(enum_lst, SimVar.create(var, simCodeIndices.uniqueIndex, simCodeIndices.enumerationParamIndex) :: Pointer.access(enum_lst));
-            simCodeIndices.enumerationParamIndex := simCodeIndices.enumerationParamIndex + 1;
-            simCodeIndices.uniqueIndex := simCodeIndices.uniqueIndex + 1;
-            Pointer.update(indices_ptr, simCodeIndices);
-        then ();
-
-        case (Type.REAL(), VarType.ALIAS)
-          algorithm
-            Pointer.update(real_lst, SimVar.create(var, simCodeIndices.uniqueIndex, simCodeIndices.realAliasIndex, Alias.fromBinding(var.binding)) :: Pointer.access(real_lst));
-            simCodeIndices.realAliasIndex := simCodeIndices.realAliasIndex + 1;
-            simCodeIndices.uniqueIndex := simCodeIndices.uniqueIndex + 1;
-            Pointer.update(indices_ptr, simCodeIndices);
-        then ();
-
-        case (Type.INTEGER(), VarType.ALIAS)
-          algorithm
-            Pointer.update(int_lst, SimVar.create(var, simCodeIndices.uniqueIndex, simCodeIndices.integerAliasIndex, Alias.fromBinding(var.binding)) :: Pointer.access(int_lst));
-            simCodeIndices.integerAliasIndex := simCodeIndices.integerAliasIndex + 1;
-            simCodeIndices.uniqueIndex := simCodeIndices.uniqueIndex + 1;
-            Pointer.update(indices_ptr, simCodeIndices);
-        then ();
-
-        case (Type.BOOLEAN(), VarType.ALIAS)
-          algorithm
-            Pointer.update(bool_lst, SimVar.create(var, simCodeIndices.uniqueIndex, simCodeIndices.booleanAliasIndex, Alias.fromBinding(var.binding)) :: Pointer.access(bool_lst));
-            simCodeIndices.booleanAliasIndex := simCodeIndices.booleanAliasIndex + 1;
-            simCodeIndices.uniqueIndex := simCodeIndices.uniqueIndex + 1;
-            Pointer.update(indices_ptr, simCodeIndices);
-        then ();
-
-        case (Type.STRING(), VarType.ALIAS)
-          algorithm
-            Pointer.update(string_lst, SimVar.create(var, simCodeIndices.uniqueIndex, simCodeIndices.stringAliasIndex, Alias.fromBinding(var.binding)) :: Pointer.access(string_lst));
-            simCodeIndices.stringAliasIndex := simCodeIndices.stringAliasIndex + 1;
-            simCodeIndices.uniqueIndex := simCodeIndices.uniqueIndex + 1;
-            Pointer.update(indices_ptr, simCodeIndices);
-        then ();
-
-        case (Type.ENUMERATION(), VarType.ALIAS)
-          algorithm
-            Pointer.update(enum_lst, SimVar.create(var, simCodeIndices.uniqueIndex, simCodeIndices.enumerationAliasIndex, Alias.fromBinding(var.binding)) :: Pointer.access(enum_lst));
-            simCodeIndices.enumerationAliasIndex := simCodeIndices.enumerationAliasIndex + 1;
-            simCodeIndices.uniqueIndex := simCodeIndices.uniqueIndex + 1;
-            Pointer.update(indices_ptr, simCodeIndices);
-        then ();
-
-        // clock variables do not exist anymore
-        case (Type.CLOCK(), _) then ();
-
-        else algorithm
-          Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed because of unhandled Variable " + ComponentRef.toString(var.name) + "."});
-        then fail();
-
-      end match;
-    end splitByType;
 
     function getPartitionVars
       input Partition partition;
@@ -1546,14 +1554,9 @@ public
       input output SimVars vars;
       input output SimCodeIndices simCodeIndices;
     protected
-      Pointer<SimCodeIndices> indices_ptr = Pointer.create(simCodeIndices);
-      Pointer<list<SimVar>> acc = Pointer.create({});
-      VarType varType = VarType.EXTERNAL_OBJECT;
       list<SimVar> var_lst;
     algorithm
-      VariablePointers.map(external_objects, function SimVar.traverseCreate(acc = acc, indices_ptr = indices_ptr, varType = varType));
-      simCodeIndices := Pointer.access(indices_ptr);
-      var_lst := listReverse(Pointer.access(acc));
+      (var_lst, simCodeIndices) := SimVar.createList(VariablePointers.toList(external_objects), VarType.EXTERNAL_OBJECT, simCodeIndices);
       vars.extObjVars := var_lst;
       // todo: alias
       info := EXT_OBJ_INFO(var_lst, {});


### PR DESCRIPTION
Three independent cuts in the path from array variables to SimVars, measured on `OneDHeatTransferTI_Modelica_N_20480` with `--newBackend -d=arrayConnect -d=execstat`: SimCode allocations 2.60 GB -> 1.73 GB, whole translate 4.17 GB -> 3.30 GB. Causalize is unchanged.

* `ExpandExp.expandArrayConstructor2` ran `expand(SimplifyExp.simplify(body))` once per element even when the body never mentions an iterator, which is what an `each` modifier or a scalar attribute on an array component becomes (`{cp * m / 9.0 for $i1 in 1:9}`). Every element got a fresh, structurally equal copy and the `1:N` range was evaluated into N integer expressions for nothing. When no iterator occurs in the body and the type has known size, simplify and expand it once and build the array from that single expression.

* `SimVar.traverseCreate` read the 23-field `SimCodeIndices` record out of a `Pointer`, updated two fields (two record copies) and wrote it back for every scalar variable; `splitByType` did the same, ~190 MB on a 350k-variable model. `SimVar.createList` and `createListsByType` walk the scalar list with Integer counters and write the record back once per list. `SimVars.createSimVarLists`, `SimJacobian.create` and `ExtObjInfo.create` use them; `traverseCreate` stays for the per-component residual path. The lists still come from `VariablePointers.scalarize`: `fromList` deduplicates by cref, and a record variable and its scalarized elements can both be in the list (`RecordCausality` fails without it).

* `VariableAttributes.scalarize*` built a `VAR_ATTR_*` record, and `BackendInfo.scalarize` a `BACKEND_INFO`, for every element even when every element gets the same attributes. With the first cut the array constructors for `each` attributes expand into one shared element, so that is the common case: `ExpressionIterator.isUniform` says whether an iterator yields the same expression object for every element (`EACH`, `NONE`, or an array whose elements are all `referenceEq`; a `SCALAR` iterator yields once and then nothing, so it is not uniform). When every attribute iterator is uniform the scalarizers build the record once and `List.fill` it. Mixed attributes still take the per-element path, so nothing carries an array expression downstream.

Generated C is byte identical apart from the GUID for the models in the comparison set (LTS N_5120, CoupledClutches, CauerLowPassAnalog and the four that fail identically before and after);
`simulation/modelica/NBackend` stays at 1 failure of 224 (`guruTearing1`, unchanged) and `simulation/modelica/{equations,arrays, records,initialization}` plus `flattening/modelica/scodeinst` are unchanged. The Rust omc builds.

Assisted-by: Claude Fable 5.1

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
