### PR TITLE
Update fmi-ls-dae to its 1.0.0-alpha.1 draft

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
+++ b/OMCompiler/Compiler/OpenModelica.rs/Cargo.lock
@@ -58,6 +58,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -256,6 +257,83 @@ name = "arrayvec"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+
+[[package]]
+name = "arrow-array"
+version = "59.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e5f6adeffdf587d7a31db5d2266189624b526730cd3627f9ff9fedae97ad584"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "59.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "097d193003ce7995d5d087089069ec2a6e0187faf5a6f8c9f38af2645d987182"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint 0.5.1",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-data"
+version = "59.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba2f832eaeca24b8f26143dba750e42ee4ab51cf7d65e701ca9607cfda9f358"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "59.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcc41681ea80f521df14c36725b74d4c60702c47f0793af2be469c04527e2599"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "59.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10fab8d4563491417ba801fab29d205104d20d4bdf37bda6cd1cf425cff598cd"
+
+[[package]]
+name = "arrow-select"
+version = "59.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc58569193c2525915f3cc6310edba3792f1200f65d6e9ed330aa33e691493b8"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
 
 [[package]]
 name = "as-raw-xcb-connection"
@@ -1170,6 +1248,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,6 +1402,26 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "const-serialize"
@@ -3294,6 +3403,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags 2.13.0",
+ "rustc_version",
+]
 
 [[package]]
 name = "flate2"
@@ -5952,6 +6071,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5993,7 +6122,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
 ]
@@ -6527,6 +6656,15 @@ dependencies = [
  "js-sys",
  "openmodelica_animation",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "openmodelica_arrow_writer"
+version = "0.1.0"
+dependencies = [
+ "arrow-array",
+ "arrow-ipc",
+ "arrow-schema",
 ]
 
 [[package]]
@@ -7284,18 +7422,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "openmodelica_result_capi"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "openmodelica_arrow_writer",
+ "openmodelica_mat_writer",
+ "openmodelica_plt_writer",
+ "openmodelica_result_files",
+]
+
+[[package]]
+name = "openmodelica_result_cli"
+version = "0.1.0"
+dependencies = [
+ "openmodelica_result_files",
+]
+
+[[package]]
 name = "openmodelica_result_files"
 version = "0.1.0"
 dependencies = [
+ "arrow-array",
+ "arrow-ipc",
+ "arrow-schema",
+ "openmodelica_arrow_writer",
  "openmodelica_mat_reader",
+ "openmodelica_mat_writer",
  "openmodelica_wasi",
+ "serde_json",
 ]
 
 [[package]]
 name = "openmodelica_result_web"
 version = "0.1.0"
 dependencies = [
- "openmodelica_mat_writer",
  "openmodelica_result_files",
  "openmodelica_wasi",
  "wasm-bindgen",
@@ -7315,6 +7476,7 @@ dependencies = [
  "loop_unwrap",
  "match_deref",
  "metamodelica",
+ "openmodelica_arrow_writer",
  "openmodelica_ast",
  "openmodelica_error",
  "openmodelica_frontend_dump",
@@ -7353,6 +7515,7 @@ dependencies = [
  "daskr",
  "libc",
  "libm",
+ "openmodelica_arrow_writer",
  "openmodelica_lapack",
  "openmodelica_mat_writer",
  "openmodelica_plt_writer",
@@ -10331,6 +10494,15 @@ checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -2782,7 +2782,7 @@ fn link_err(e: impl core::fmt::Debug) -> &'static str {
 /// The value references are `getFMI3ValueReference`'s, the ones `CodegenFMU3`
 /// writes into `modelDescription.xml`. Variables with no slot are skipped; the
 /// adapter reports an unresolvable vr as an error.
-/// Also the fmi-ls-dae `EnableDAE` value reference, 0 for a model without a DAE
+/// Also the fmi-ls-dae `EnableDAEParameter` value reference, 0 for a model without a DAE
 /// formulation. The synthetic variables follow `CodegenFMU3`: time, then the event
 /// indicators, then (`--daeMode`) the DAE-mode switch and the residuals.
 fn build_fmi_vrs(sim_code: &SimCode::SimCode, map: &SimVarMap, layout: &SimLayout) -> Result<(Vec<FmiVr>, u32)> {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/lsdae.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/lsdae.rs
@@ -3,29 +3,12 @@
 //! variables the importer then solves for beside the states, and the residuals it
 //! drives to zero, with a `<ModelStructure>` that replaces the model description's.
 
-use crate::description::{DependenciesKind, Unknown};
-use crate::parse::{child, children, list_attr, u32_attr};
+use crate::description::Unknown;
+use crate::parse::{child, children, u32_attr};
 use crate::{Error, Result};
 
 pub const MANIFEST_PATH: &str = "extra/org.fmi-standard.fmi-ls-dae/fmi-ls-manifest.xml";
 pub const LS_NAME: &str = "org.fmi-standard.fmi-ls-dae";
-
-/// One `<Formulation>`: a residual variable, and how many times the constraint
-/// it came from was differentiated to get it.
-#[derive(Clone, Debug)]
-pub struct Formulation {
-    pub value_reference: u32,
-    pub index: Option<u32>,
-    /// `None`: depends on every known.
-    pub dependencies: Option<Vec<u32>>,
-    pub dependencies_kind: Vec<DependenciesKind>,
-}
-
-/// A `<Residual>`: one constraint, in one or more differentiated forms.
-#[derive(Clone, Debug)]
-pub struct Residual {
-    pub formulations: Vec<Formulation>,
-}
 
 #[derive(Clone, Debug)]
 pub struct Manifest {
@@ -34,7 +17,8 @@ pub struct Manifest {
     pub enable_vr: u32,
     /// The algebraic unknowns, in the order the residual Jacobian's columns follow the states.
     pub algebraic_variables: Vec<u32>,
-    pub residuals: Vec<Residual>,
+    /// The `<Residual>` constraints the importer drives to zero, in row order.
+    pub residuals: Vec<Unknown>,
     /// The `<ModelStructure>` overriding the model description's; each list is
     /// empty when the manifest leaves it out.
     pub outputs: Vec<Unknown>,
@@ -47,34 +31,17 @@ impl Manifest {
     pub fn parse(xml: &str) -> Result<Manifest> {
         let doc = roxmltree::Document::parse(xml).map_err(|e| Error::Xml(e.to_string()))?;
         let root = doc.root_element();
-        if root.tag_name().name() != "fmi-ls-dae" {
-            return Err(Error::Xml(format!("root element is <{}>, not <fmi-ls-dae>", root.tag_name().name())));
+        if root.tag_name().name() != "fmiDAEManifest" {
+            return Err(Error::Xml(format!("root element is <{}>, not <fmiDAEManifest>", root.tag_name().name())));
         }
-        let enable = child(root, "EnableDAE").ok_or_else(|| Error::Xml("<fmi-ls-dae> has no <EnableDAE>".into()))?;
+        let enable = child(root, "EnableDAEParameter")
+            .ok_or_else(|| Error::Xml("<fmiDAEManifest> has no <EnableDAEParameter>".into()))?;
         let enable_vr = u32_attr(enable, "valueReference")
-            .ok_or_else(|| Error::Xml("<EnableDAE> has no valueReference".into()))?;
+            .ok_or_else(|| Error::Xml("<EnableDAEParameter> has no valueReference".into()))?;
         let algebraic_variables = child(root, "AlgebraicVariables")
             .map(|a| children(a, "AlgebraicVariable").filter_map(|v| u32_attr(v, "valueReference")).collect())
             .unwrap_or_default();
         let ms = child(root, "ModelStructure");
-        let residuals = ms
-            .map(|ms| {
-                children(ms, "Residual")
-                    .map(|r| Residual {
-                        formulations: children(r, "Formulation")
-                            .filter_map(|f| {
-                                Some(Formulation {
-                                    value_reference: u32_attr(f, "valueReference")?,
-                                    index: u32_attr(f, "index"),
-                                    dependencies: list_attr(f, "dependencies"),
-                                    dependencies_kind: crate::parse::dependencies_kind(f),
-                                })
-                            })
-                            .collect(),
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
         let unknowns = |tag| ms.map(|ms| crate::parse::unknowns3(ms, tag)).unwrap_or_default();
         Ok(Manifest {
             version: root.attribute(("http://fmi-standard.org/fmi-ls-manifest", "fmi-ls-version"))
@@ -83,7 +50,7 @@ impl Manifest {
                 .to_string(),
             enable_vr,
             algebraic_variables,
-            residuals,
+            residuals: unknowns("Residual"),
             outputs: unknowns("Output"),
             continuous_state_derivatives: unknowns("ContinuousStateDerivative"),
             initial_unknowns: unknowns("InitialUnknown"),
@@ -91,8 +58,8 @@ impl Manifest {
         })
     }
 
-    /// The residual variables in row order, every formulation of every residual.
+    /// The residual variables in row order.
     pub fn residual_vrs(&self) -> Vec<u32> {
-        self.residuals.iter().flat_map(|r| r.formulations.iter().map(|f| f.value_reference)).collect()
+        self.residuals.iter().map(|r| r.value_reference).collect()
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi3_wasm/src/lib.rs
@@ -557,7 +557,7 @@ struct MeState {
     mode: Mode,
     /// C's `model_state_me_continuous_time_mode`.
     continuous_time: bool,
-    /// fmi-ls-dae: the `EnableDAE` structural parameter's value reference (0 when
+    /// fmi-ls-dae: the `EnableDAEParameter` structural parameter's value reference (0 when
     /// the model has no DAE formulation), whether it is set, and whether the
     /// importer is in Configuration Mode, the only place it may be set.
     dae_enable_vr: u32,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/me.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/me.rs
@@ -10,11 +10,12 @@
 //! `fmi3UpdateDiscreteStates` announces.
 //!
 //! An FMU with an fmi-ls-dae manifest can instead be run in DAE mode
-//! ([`Options::dae`]): the master sets the states, their derivatives and the
-//! algebraic variables, reads the residuals back, and IDA drives them to zero over
+//! ([`Options::dae`]): the master sets the states and the algebraic variables,
+//! reads the residuals back, and IDA drives them to zero over
 //! `y = [states | algebraic variables]` — with `IDACalcIC` making the point
 //! consistent at the start and after every event, as a `--daeMode` model's own
-//! runtime does.
+//! runtime does. The manifest states the DAE in one of two forms (`DaeForm`),
+//! which decides whether the derivatives go in as knowns as well.
 
 use crate::api::{Fmi3, Fmi3ModelExchange};
 use crate::common::{Inputs, event_iteration, initialize};
@@ -48,14 +49,28 @@ pub struct Run {
     pub retries: u64,
 }
 
+/// The two shapes fmi-ls-dae's `<ModelStructure>` can state a DAE in.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DaeForm {
+    /// No `<ContinuousStateDerivative>`: the residuals cover every unknown, and
+    /// `der(x)` goes into the FMU as a known of theirs.
+    Implicit,
+    /// One per state: the FMU answers with `der(x)`, the residuals constrain the
+    /// algebraic variables alone, and the master closes the state rows itself.
+    SemiExplicit,
+}
+
 /// The value references DAE mode works through, out of the fmi-ls-dae manifest.
 struct DaeVrs {
     nx: usize,
+    form: DaeForm,
     /// The algebraic variables, which follow the states in `y`.
     alg_vrs: Vec<u32>,
-    /// The state derivatives, set as knowns of the residuals.
+    /// The state derivatives in the FMU's own order: knowns of the residuals in
+    /// the implicit form, and in the semi-explicit one the name of the column
+    /// each belongs to.
     der_vrs: Vec<u32>,
-    /// The residuals, one per row of `F`.
+    /// The residuals the FMU exposes, one per `<Residual>`.
     res_vrs: Vec<u32>,
     /// The residual Jacobian's sparsity, out of the manifest's `dependencies`;
     /// `None` when the manifest states none, which means a dense Jacobian.
@@ -63,8 +78,8 @@ struct DaeVrs {
 }
 
 /// The FMU as an ODE: set the time and the states, then read the derivatives or
-/// the event indicators back. In DAE mode the derivatives and the algebraic
-/// variables are set too, and the residuals are what is read.
+/// the event indicators back. In DAE mode the algebraic variables are set too —
+/// and the derivatives, in the implicit form — and the residuals are read.
 struct FmuOde<'a> {
     inst: &'a mut dyn Fmi3ModelExchange,
     inputs: &'a mut Inputs,
@@ -85,7 +100,7 @@ struct FmuOde<'a> {
     /// FMU treats every `fmi3SetContinuousStates` as a move and throws away what
     /// it cached for the old point — including its Jacobian, which a colour-by-
     /// colour assembly would then pay for again per colour. The derivatives are
-    /// part of the point in DAE mode only.
+    /// part of the point in the implicit DAE form only.
     committed: Option<(f64, Vec<f64>, Vec<f64>)>,
     dae: Option<DaeVrs>,
     /// What the FMU actually said, behind the static message the solvers carry.
@@ -107,8 +122,8 @@ impl FmuOde<'_> {
         self.commit_point(t, y, &[])
     }
 
-    /// [`commit`](Self::commit), with the derivatives too in DAE mode: the
-    /// residuals are a function of `(t, y, y')`.
+    /// [`commit`](Self::commit), with the derivatives too where the FMU takes
+    /// them: the implicit form's residuals are a function of `(t, y, y')`.
     fn commit_point(&mut self, t: f64, y: &[f64], yp: &[f64]) -> Result<()> {
         let Some(dae) = self.dae.as_ref() else {
             if self.committed.as_ref().is_some_and(|(ct, cy, _)| *ct == t && cy == y) {
@@ -124,7 +139,10 @@ impl FmuOde<'_> {
             return Ok(());
         };
         let nx = dae.nx;
-        let ders = &yp[..nx.min(yp.len())];
+        // A semi-explicit FMU is not told its derivatives, so they are no part
+        // of the point it stands at.
+        let implicit = dae.form == DaeForm::Implicit;
+        let ders = if implicit { &yp[..nx.min(yp.len())] } else { &[][..] };
         if self.committed.as_ref().is_some_and(|(ct, cy, cp)| *ct == t && cy == y && cp == ders) {
             return Ok(());
         }
@@ -134,7 +152,7 @@ impl FmuOde<'_> {
             let inst: &mut dyn Fmi3 = self.inst;
             inst.set_numeric(VarType::Float64, &dae.alg_vrs, &y[nx..])?;
         }
-        if ders.len() == nx && nx > 0 {
+        if implicit && ders.len() == nx && nx > 0 {
             let inst: &mut dyn Fmi3 = self.inst;
             inst.set_numeric(VarType::Float64, &dae.der_vrs, ders)?;
         }
@@ -270,8 +288,26 @@ impl Dae for FmuOde<'_> {
         }
         self.commit_point(t, y, yp).map_err(|e| self.note(e))?;
         let Some(d) = self.dae.as_ref() else { return Ok(()) };
+        let (form, nx) = (d.form, d.nx);
+        if form == DaeForm::Implicit {
+            let inst: &mut dyn Fmi3 = self.inst;
+            let r = inst.get_numeric(VarType::Float64, &d.res_vrs, res);
+            return r.map_err(|e| self.note(e));
+        }
+        // The state rows close der(x) = f(x, a, t) over y'; the FMU's residuals
+        // are the constraints below them.
+        if nx > 0 {
+            self.inst.get_continuous_state_derivatives(&mut res[..nx]).map_err(|e| self.note(e))?;
+            for (r, p) in res[..nx].iter_mut().zip(yp) {
+                *r = *p - *r;
+            }
+        }
+        let d = self.dae.as_ref().expect("checked above");
+        if d.res_vrs.is_empty() {
+            return Ok(());
+        }
         let inst: &mut dyn Fmi3 = self.inst;
-        let r = inst.get_numeric(VarType::Float64, &d.res_vrs, res);
+        let r = inst.get_numeric(VarType::Float64, &d.res_vrs, &mut res[nx..]);
         r.map_err(|e| self.note(e))
     }
 
@@ -311,45 +347,67 @@ fn dae_vrs(md: &ModelDescription, m: &openmodelica_fmi::lsdae::Manifest, nx: usi
             ))),
         }
     };
-    let der_vrs: Vec<u32> = md
-        .model_structure
-        .continuous_state_derivatives
-        .iter()
-        .map(|u| u.value_reference)
-        .collect();
+    // The manifest's <ModelStructure> replaces the model description's, so its
+    // <ContinuousStateDerivative> list decides the form; naming none states the
+    // implicit one, whose derivatives the model description still has to name.
+    let form = if m.continuous_state_derivatives.is_empty() { DaeForm::Implicit } else { DaeForm::SemiExplicit };
+    // From the model description in either form: `continuous_states` and
+    // `fmi3GetContinuousStates` follow this order, which is what pairs `y[i]`
+    // with `y'[i]`. The manifest's own order does not get to decide that.
+    let der_vrs: Vec<u32> =
+        md.model_structure.continuous_state_derivatives.iter().map(|u| u.value_reference).collect();
     if der_vrs.len() != nx {
         return Err(Error::Unsupported(format!(
             "fmi-ls-dae: the FMU has {nx} continuous states but <ModelStructure> lists {} derivatives",
             der_vrs.len()
         )));
     }
-    let alg_vrs = m.algebraic_variables.iter().map(|&vr| float64(vr, "algebraic variable")).collect::<Result<Vec<_>>>()?;
-    let res_vrs = m.residual_vrs().into_iter().map(|vr| float64(vr, "residual")).collect::<Result<Vec<_>>>()?;
-    if res_vrs.len() != nx + alg_vrs.len() {
+    if form == DaeForm::SemiExplicit && m.continuous_state_derivatives.len() != nx {
         return Err(Error::Unsupported(format!(
-            "fmi-ls-dae: {} residuals for {} states and {} algebraic variables; only a square system can be integrated",
-            res_vrs.len(),
-            nx,
-            alg_vrs.len()
+            "fmi-ls-dae: the manifest states a semi-explicit DAE but gives {} of the FMU's {nx} state derivatives",
+            m.continuous_state_derivatives.len()
         )));
     }
-    let sparsity = dae_sparsity(md, m, nx, &alg_vrs, &der_vrs);
-    Ok(DaeVrs { nx, alg_vrs, der_vrs, res_vrs, sparsity })
+    let alg_vrs = m.algebraic_variables.iter().map(|&vr| float64(vr, "algebraic variable")).collect::<Result<Vec<_>>>()?;
+    let res_vrs = m.residual_vrs().into_iter().map(|vr| float64(vr, "residual")).collect::<Result<Vec<_>>>()?;
+    let wanted = match form {
+        DaeForm::Implicit => nx + alg_vrs.len(),
+        DaeForm::SemiExplicit => alg_vrs.len(),
+    };
+    if res_vrs.len() != wanted {
+        let form = match form {
+            DaeForm::Implicit => "implicit",
+            DaeForm::SemiExplicit => "semi-explicit",
+        };
+        return Err(Error::Unsupported(format!(
+            "fmi-ls-dae: the manifest states a {form} DAE with {} states and {} algebraic variables, which wants {wanted} residuals, but lists {}; only a square system can be integrated",
+            nx,
+            alg_vrs.len(),
+            res_vrs.len()
+        )));
+    }
+    let sparsity = dae_sparsity(md, m, nx, form, &alg_vrs, &der_vrs);
+    Ok(DaeVrs { nx, form, alg_vrs, der_vrs, res_vrs, sparsity })
 }
 
-/// The residual Jacobian's sparsity out of the manifest's `<Formulation
-/// dependencies=…>`: for each residual, which of `y = [states | algebraic]` it
-/// reaches. A state's column collects the rows reached through either `x` or
-/// `der(x)`, since one difference quotient carries `∂F/∂x + cj·∂F/∂der(x)`
-/// together — which is why the exporter lists both for a state column.
+/// The residual Jacobian's sparsity out of the manifest's `dependencies`: for
+/// each row of `F`, which of `y = [states | algebraic]` it reaches. A state's
+/// column collects the rows reached through either `x` or `der(x)`, since one
+/// difference quotient carries `∂F/∂x + cj·∂F/∂der(x)` together — which is why
+/// the exporter lists both for a state column.
 ///
-/// `None` unless every residual states its dependencies: one that does not means
+/// The semi-explicit form's state rows reach their own column through `y'`
+/// whatever the manifest says, plus what the `<ContinuousStateDerivative>`
+/// depends on.
+///
+/// `None` unless every row states its dependencies: one that does not means
 /// "all of them", and a Jacobian with a dense row is no cheaper to difference
 /// sparsely than to let IDA build itself.
 fn dae_sparsity(
     md: &ModelDescription,
     m: &openmodelica_fmi::lsdae::Manifest,
     nx: usize,
+    form: DaeForm,
     alg_vrs: &[u32],
     der_vrs: &[u32],
 ) -> Option<DaeSparsity> {
@@ -368,12 +426,29 @@ fn dae_sparsity(
         return None; // a state without a value reference of its own
     }
     let mut rows_by_col: Vec<Vec<u32>> = vec![Vec::new(); n];
-    // The same flattening `Manifest::residual_vrs` uses, so the rows line up.
-    for (row, f) in m.residuals.iter().flat_map(|r| r.formulations.iter()).enumerate() {
-        let deps = f.dependencies.as_ref()?;
+    let mark = |rows_by_col: &mut Vec<Vec<u32>>, row: usize, u: &openmodelica_fmi::description::Unknown| {
+        let deps = u.dependencies.as_ref()?;
         for col in deps.iter().filter_map(|vr| column_of.get(vr)) {
             rows_by_col[*col].push(row as u32);
         }
+        Some(())
+    };
+    let first_residual = if form == DaeForm::SemiExplicit {
+        let row_of: std::collections::HashMap<u32, usize> =
+            der_vrs.iter().enumerate().map(|(row, vr)| (*vr, row)).collect();
+        for row in 0..nx {
+            rows_by_col[row].push(row as u32);
+        }
+        for u in &m.continuous_state_derivatives {
+            mark(&mut rows_by_col, *row_of.get(&u.value_reference)?, u)?;
+        }
+        nx
+    } else {
+        0
+    };
+    // The same order `Manifest::residual_vrs` uses, so the rows line up.
+    for (i, u) in m.residuals.iter().enumerate() {
+        mark(&mut rows_by_col, first_residual + i, u)?;
     }
     for rows in &mut rows_by_col {
         rows.sort_unstable();

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/tests/reference_fmus.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/tests/reference_fmus.rs
@@ -1,7 +1,8 @@
 //! The masters against the Modelica Association's Reference FMUs, which are not
 //! in this repository: point `OMC_FMI_REFERENCE_FMUS` at an unpacked
 //! `Reference-FMUs-<version>.zip` (the directory holding `3.0/`) and these run;
-//! without it they skip.
+//! without it they skip. `OMC_FMI_LS_DAE_FMUS` does the same for the fmi-ls-dae
+//! repository's own FMUs (its `reference-FMUs/build/fmus`).
 //!
 //! What is checked is what a master can be wrong about on its own: the solution
 //! an FMU's equations have, the time an event happens at, and the values around
@@ -18,6 +19,12 @@ use std::path::PathBuf;
 fn reference_fmu(name: &str) -> Option<PathBuf> {
     let root = std::env::var_os("OMC_FMI_REFERENCE_FMUS")?;
     let path = PathBuf::from(root).join("3.0").join(format!("{name}.fmu"));
+    path.exists().then_some(path)
+}
+
+fn ls_dae_fmu(name: &str) -> Option<PathBuf> {
+    let root = std::env::var_os("OMC_FMI_LS_DAE_FMUS")?;
+    let path = PathBuf::from(root).join(format!("{name}.fmu"));
     path.exists().then_some(path)
 }
 
@@ -49,10 +56,29 @@ impl Sim {
 }
 
 fn simulate(name: &str, kind: InterfaceKind, with: impl FnOnce(&mut Options)) -> Option<Sim> {
-    let path = reference_fmu(name)?;
-    let fmu = Fmu::from_path(&path).expect("read the FMU");
+    run(&reference_fmu(name)?, name, kind, false, with)
+}
+
+/// The same, in fmi-ls-dae's DAE mode: the manifest out of the FMU decides the
+/// unknowns and the residuals, so nothing about the form is written down here.
+fn simulate_dae(name: &str, with: impl FnOnce(&mut Options)) -> Option<Sim> {
+    run(&ls_dae_fmu(name)?, name, InterfaceKind::ModelExchange, true, with)
+}
+
+fn run(
+    path: &std::path::Path,
+    name: &str,
+    kind: InterfaceKind,
+    dae: bool,
+    with: impl FnOnce(&mut Options),
+) -> Option<Sim> {
+    let fmu = Fmu::from_path(path).expect("read the FMU");
     let md = &fmu.model_description;
     let mut opts = Options::from_model_description(md);
+    if dae {
+        opts.solver = openmodelica_fmi_driver::Solver::Ida;
+        opts.dae = Some(fmu.ls_dae_manifest().expect("no fmi-ls-dae manifest").expect("parse the manifest"));
+    }
     with(&mut opts);
 
     // A directory of its own per run: the tests run in parallel, and two of them
@@ -204,4 +230,26 @@ fn co_simulation_handles_events_at_the_time_they_happen() {
     let v = sim.at("v", handled + 1e-9);
     assert!(v > 0.0, "the ball is still falling after the bounce (v = {v})");
     assert!(sim.rec.times().last().unwrap_or(0.0) >= 1.0 - 1e-9, "the run stopped early");
+}
+
+/// fmi-ls-dae's own reference FMU states a *semi-explicit* DAE, so the master
+/// closes the system itself over `y = [x1 x2 z1 z2]`. With both inputs left at
+/// zero the constraints come out as `tanh(3*z1) = 0` and `1/3 = sin(z2*x2)`, and
+/// `der(x1) = sin(x1)` integrates to `x1 = 2*atan(tan(x1(0)/2)*e^t)`.
+#[test]
+fn dae_mode_solves_a_semi_explicit_dae() {
+    let Some(sim) = simulate_dae("SimpleDAE", |o| {
+        o.tolerance = Some(1e-10);
+        o.stop_time = 2.0;
+    }) else {
+        return;
+    };
+    for t in [0.5, 1.0, 2.0] {
+        let (x1, x2, z1, z2) = (sim.at("x1", t), sim.at("x2", t), sim.at("z1", t), sim.at("z2", t));
+        let want_x1 = 2.0 * ((0.25f64).tan() * t.exp()).atan();
+        assert!((x1 - want_x1).abs() < 1e-6, "x1({t}) = {x1}, not {want_x1}");
+        assert!(z1.abs() < 1e-6, "z1({t}) = {z1}, not 0 — the first constraint is not held");
+        let g = (z2 * x2).sin() - 1.0 / 3.0;
+        assert!(g.abs() < 1e-6, "the second constraint is off by {g} at t = {t}");
+    }
 }

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -1008,6 +1008,8 @@ algorithm
     if isSome(simCode.daeModeData) and FMI.isFMIMEType(FMUType) then
       lsDaeManifestStr := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + Tpl.textString(
         CodegenFMU3.fmiLsDaeManifest(Tpl.emptyTxt, simCode));
+      Error.addMessage(Error.FMU_EXPORT_FMI_LS_DAE_DRAFT,
+        {SimCodeUtil.FMI_LS_DAE_VERSION, SimCodeUtil.FMI_LS_DAE_DRAFT_DATE, SimCodeUtil.FMI_LS_DAE_DRAFT_COMMIT});
       ExecStat.execStat("FMU fmi-ls-manifest.xml");
     end if;
     // terminalsAndIcons/ by the C target's route: SimCode writes the XML, then the

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -15155,6 +15155,18 @@ algorithm
   end if;
 end exportIfAlgebraicState;
 
+public constant String FMI_LS_DAE_VERSION = "1.0.0-alpha.1";
+public constant String FMI_LS_DAE_DRAFT_DATE = "2026-09-02";
+public constant String FMI_LS_DAE_DRAFT_COMMIT = "78313f4";
+
+public function fmiLsDaeVersion
+  "The version of fmi-ls-dae the manifest declares. FMI_LS_DAE_DRAFT_DATE and
+   FMI_LS_DAE_DRAFT_COMMIT name the revision of github.com/modelica/fmi-ls-dae
+   the export was written against, which the export reports since the layered
+   standard is still a draft."
+  output String version = FMI_LS_DAE_VERSION;
+end fmiLsDaeVersion;
+
 public function getFMI3DaeModeValueReference
   "fmi-ls-dae: the value reference of the structural parameter that switches a
    --daeMode FMU into DAE mode, the first one past the event indicators. The
@@ -15169,7 +15181,7 @@ end getFMI3DaeModeValueReference;
 public function fmi3DaeResiduals
   "fmi-ls-dae: the residuals of a --daeMode model as (valueReference, dependency
    attributes): the value references follow the DAE-mode switch's, and the
-   dependencies and dependenciesKind attributes of each <Formulation> are read
+   dependencies and dependenciesKind attributes of each <Residual> are read
    off the rows of the DAE-mode Jacobian's transposed sparsity. A state column
    stands for the state and its derivative both, since DAE-mode differentiation
    folds der(x) into x ($cj * x.Seed); the other columns are the algebraic

--- a/OMCompiler/Compiler/Template/CodegenFMU3.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU3.tpl
@@ -529,7 +529,7 @@ template fmiLsDaeManifest(SimCode simCode)
   for a --daeMode Model Exchange FMU: the switch, the algebraic variables the
   importer solves for beside the states, and a ModelStructure that restates the
   model description's and adds the residuals — the fully implicit form
-  F(der(x), x, z, t) = 0, so no ContinuousStateDerivative entries."
+  F(der(x), x, a, t) = 0, so no ContinuousStateDerivative entries."
 ::=
 match simCode
 case SIMCODE(daeModeData=SOME(dmd as DAEMODEDATA(__)), modelStructure=modelStructure) then
@@ -545,13 +545,12 @@ case SIMCODE(daeModeData=SOME(dmd as DAEMODEDATA(__)), modelStructure=modelStruc
   let residuals = (SimCodeUtil.fmi3DaeResiduals(simCode) |> (vr, dependencyAttributes) => DaeResidual3(vr, dependencyAttributes) ;separator="\n")
   let _ = SimCodeUtil.clearFMI3ValueReferences()
   <<
-  <fmi-ls-dae
-    xmlns="http://fmi-standard.org/fmi-ls-manifest"
+  <fmiDAEManifest
     xmlns:fmi-ls="http://fmi-standard.org/fmi-ls-manifest"
     fmi-ls:fmi-ls-name="org.fmi-standard.fmi-ls-dae"
-    fmi-ls:fmi-ls-version="0.1.0"
+    fmi-ls:fmi-ls-version="<%SimCodeUtil.fmiLsDaeVersion()%>"
     fmi-ls:fmi-ls-description="Layered standard for DAE support in FMI.">
-    <EnableDAE valueReference="<%SimCodeUtil.getFMI3DaeModeValueReference(simCode)%>"/>
+    <EnableDAEParameter valueReference="<%SimCodeUtil.getFMI3DaeModeValueReference(simCode)%>"/>
     <AlgebraicVariables>
       <%dmd.algebraicVars |> var => '<AlgebraicVariable valueReference="<%SimCodeUtil.getFMI3ValueReference(var, simCode)%>"/>' ;separator="\n"%>
     </AlgebraicVariables>
@@ -560,17 +559,13 @@ case SIMCODE(daeModeData=SOME(dmd as DAEMODEDATA(__)), modelStructure=modelStruc
       <%indicators%>
       <%residuals%>
     </ModelStructure>
-  </fmi-ls-dae>
+  </fmiDAEManifest>
   >>
 end fmiLsDaeManifest;
 
 template DaeResidual3(String vr, String dependencyAttributes)
 ::=
-  <<
-  <Residual>
-    <Formulation valueReference="<%vr%>"<%dependencyAttributes%>/>
-  </Residual>
-  >>
+  '<Residual valueReference="<%vr%>"<%dependencyAttributes%>/>'
 end DaeResidual3;
 
 template EventIndicatorVariables3(SimCode simCode)

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -1586,6 +1586,10 @@ package SimCodeUtil
     output list<tuple<String, String>> residuals;
   end fmi3DaeResiduals;
 
+  function fmiLsDaeVersion
+    output String version;
+  end fmiLsDaeVersion;
+
   function getLocalValueReference
     input SimCodeVar.SimVar inSimVar;
     input SimCode.SimCode inSimCode;

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -1349,6 +1349,8 @@ public constant ErrorTypes.Message FMU_EXPORT_DAE_MODE_C_CS = ErrorTypes.MESSAGE
   "DAE mode (--daeMode) is not supported by the C simulation runtime, so it cannot build a Co-Simulation FMU either. Export with platforms={\"wasm\"}, whose runtime does support it, or remove the --daeMode flag.");
 public constant ErrorTypes.Message ALARM_EXPIRED = ErrorTypes.MESSAGE(7031, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   "Operation aborted: the time limit set by the alarm ran out.");
+public constant ErrorTypes.Message FMU_EXPORT_FMI_LS_DAE_DRAFT = ErrorTypes.MESSAGE(7032, ErrorTypes.SCRIPTING(), ErrorTypes.NOTIFICATION(),
+  "The Model Exchange FMU carries a DAE formulation as fmi-ls-dae %s, implemented against the draft of %s (commit %s). fmi-ls-dae is not a released layered standard yet, so an importer written against another revision of the draft may not read the manifest.");
 public constant ErrorTypes.Message FMU_EXPORT_WASM_FMI1 = ErrorTypes.MESSAGE(7029, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   "The wasm FMU export does not serve the deprecated FMI 1.0. Ask for version=\"2.0\" or version=\"3.0\", or drop \"wasm\" from platforms to export a C FMU.");
 

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/lib.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/lib.rs
@@ -1113,7 +1113,7 @@ pub struct SimMeta {
     /// FMI value reference -> `SimData` slot, sorted by `vr`. Only filled for the
     /// FMU export; empty for a plain simulation.
     pub fmi_vrs: Vec<FmiVr>,
-    /// fmi-ls-dae's `EnableDAE` structural parameter, the value reference that
+    /// fmi-ls-dae's `EnableDAEParameter` structural parameter, the value reference that
     /// switches a `--daeMode` FMU into DAE mode; 0 for an FMU without one.
     pub fmi_dae_enable_vr: u32,
     /// Per-zero-crossing description (Modelica source of the relation, e.g.

--- a/doc/UsersGuide/source/fmitlm.rst
+++ b/doc/UsersGuide/source/fmitlm.rst
@@ -46,7 +46,9 @@ specifications.
    * - `FMI-LS-REF <https://github.com/modelica/fmi-ls-ref>`_
      - Planned
    * - `FMI-LS-DAE <https://github.com/modelica/fmi-ls-dae>`_
-     - Planned (demonstrator in progress)
+     - Planned (demonstrator in progress). Export and import follow the
+       ``1.0.0-alpha.1`` draft as of its commit ``78313f4`` (2026-09-02); the
+       revision is also reported as a notification when an FMU is exported.
 
 Supported Capability Flags
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_daemode.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_daemode.mos
@@ -48,7 +48,8 @@ diffSimulationResults("daemode_cs.mat", "daemode_plain_res.mat", "diff_daemode_c
 // true
 // ""
 // "DaeModeWhenLoop.fmu"
-// "Notification: Building FMU for platform 'wasm' (1/1).
+// "Notification: The Model Exchange FMU carries a DAE formulation as fmi-ls-dae 1.0.0-alpha.1, implemented against the draft of 2026-09-02 (commit 78313f4). fmi-ls-dae is not a released layered standard yet, so an importer written against another revision of the draft may not read the manifest.
+// Notification: Building FMU for platform 'wasm' (1/1).
 // Notification: Finished FMU for platform 'wasm' (1/1).
 // "
 // record SimulationResult

--- a/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_wasm_daemode_me.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_wasm_daemode_me.mos
@@ -52,7 +52,8 @@ simulate(DaeModeMe, simflags="-s fmi3:me:dassl -daeMode", resimulateExecutable="
 // end SimulationResult;
 // ""
 // "DaeModeMe.fmu"
-// "Notification: Building FMU for platform 'wasm' (1/1).
+// "Notification: The Model Exchange FMU carries a DAE formulation as fmi-ls-dae 1.0.0-alpha.1, implemented against the draft of 2026-09-02 (commit 78313f4). fmi-ls-dae is not a released layered standard yet, so an importer written against another revision of the draft may not read the manifest.
+// Notification: Building FMU for platform 'wasm' (1/1).
 // Notification: Finished FMU for platform 'wasm' (1/1).
 // "
 // record SimulationResult
@@ -69,17 +70,17 @@ simulate(DaeModeMe, simflags="-s fmi3:me:dassl -daeMode", resimulateExecutable="
 // true
 // ""
 // "DaeModeMeDir.fmu"
-// "Notification: Building FMU for platform 'wasm' (1/1).
+// "Notification: The Model Exchange FMU carries a DAE formulation as fmi-ls-dae 1.0.0-alpha.1, implemented against the draft of 2026-09-02 (commit 78313f4). fmi-ls-dae is not a released layered standard yet, so an importer written against another revision of the draft may not read the manifest.
+// Notification: Building FMU for platform 'wasm' (1/1).
 // Notification: Finished FMU for platform 'wasm' (1/1).
 // "
 // "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-// <fmi-ls-dae
-//   xmlns=\"http://fmi-standard.org/fmi-ls-manifest\"
+// <fmiDAEManifest
 //   xmlns:fmi-ls=\"http://fmi-standard.org/fmi-ls-manifest\"
 //   fmi-ls:fmi-ls-name=\"org.fmi-standard.fmi-ls-dae\"
-//   fmi-ls:fmi-ls-version=\"0.1.0\"
+//   fmi-ls:fmi-ls-version=\"1.0.0-alpha.1\"
 //   fmi-ls:fmi-ls-description=\"Layered standard for DAE support in FMI.\">
-//   <EnableDAE valueReference=\"9\"/>
+//   <EnableDAEParameter valueReference=\"9\"/>
 //   <AlgebraicVariables>
 //     <AlgebraicVariable valueReference=\"3\"/>
 //     <AlgebraicVariable valueReference=\"4\"/>
@@ -87,17 +88,11 @@ simulate(DaeModeMe, simflags="-s fmi3:me:dassl -daeMode", resimulateExecutable="
 //   <ModelStructure>
 //     <InitialUnknown valueReference=\"1\"/>
 //     <EventIndicator valueReference=\"8\"/>
-//     <Residual>
-//       <Formulation valueReference=\"10\" dependencies=\"0 1 3 4\" dependenciesKind=\"dependent dependent dependent dependent\"/>
-//     </Residual>
-//     <Residual>
-//       <Formulation valueReference=\"11\" dependencies=\"0 1 3 4\" dependenciesKind=\"dependent dependent dependent dependent\"/>
-//     </Residual>
-//     <Residual>
-//       <Formulation valueReference=\"12\" dependencies=\"0 1 3\" dependenciesKind=\"dependent dependent dependent\"/>
-//     </Residual>
+//     <Residual valueReference=\"10\" dependencies=\"0 1 3 4\" dependenciesKind=\"dependent dependent dependent dependent\"/>
+//     <Residual valueReference=\"11\" dependencies=\"0 1 3 4\" dependenciesKind=\"dependent dependent dependent dependent\"/>
+//     <Residual valueReference=\"12\" dependencies=\"0 1 3\" dependenciesKind=\"dependent dependent dependent\"/>
 //   </ModelStructure>
-// </fmi-ls-dae>"
+// </fmiDAEManifest>"
 // ""
 // true
 // record SimulationResult


### PR DESCRIPTION
fmi-ls-dae commit 78313f4 (2026-09-02) reshaped the manifest, so what we exported no longer validates against the layered standard's schema:

| Was                                   | Is                               |
| ------------------------------------- | -------------------------------- |
| `<fmi-ls-dae>`, in the ls namespace   | `<fmiDAEManifest>`, unnamespaced |
| `<EnableDAE>`                         | `<EnableDAEParameter>`           |
| `<Residual><Formulation/></Residual>` | `<Residual/>`                    |
| `index` on the formulation            | removed                          |
| `fmi-ls-version="0.1.0"`              | `"1.0.0-alpha.1"`                |

Exporting such an FMU now reports the draft it was built against — version, date and short commit hash — so it is visible from a `.fmu` which revision of a moving target it implements, and so the gap to the next one can be found rather than guessed. `SimCodeUtil.FMI_LS_DAE_*` holds the three, and `fmiLsDaeVersion()` feeds the manifest attribute from the same constant, so the XML and the notification cannot drift.

Flattening `<Formulation>` is what makes the draft's semi-explicit form reachable, so the importer now reads both shapes the standard defines. The manifest's `<ModelStructure>` replaces the model description's, and its `<ContinuousStateDerivative>` list decides which:

* implicit, which is what OpenModelica exports: `der(x)` goes in as a known and the FMU owes a residual per unknown, as before.
* semi-explicit: the FMU is never told its derivatives, it answers with them, and the master closes the state rows itself as `y'[i] - f_i(x, a, t)` above the FMU's own constraints.

The state rows follow the FMU's state order rather than the manifest's, so a manifest listing the derivatives in some other order cannot silently misplace a Jacobian row.

`dae_mode_solves_a_semi_explicit_dae` runs the draft's own SimpleDAE reference FMU against its closed form — `tanh(3*z1) = 0`, `sin(z2*x2) = 1/3`, `x1 = 2*atan(tan(x1(0)/2)*e^t)` — all solutions of the residuals rather than of anything the FMU computes for itself. It skips without `OMC_FMI_LS_DAE_FMUS`, as the Reference-FMU tests skip without theirs.

Directional derivatives stay off in DAE mode: that part of the draft is older than this commit, and no FMU here advertises them to check an exact residual Jacobian against.

Cargo.lock picks up the Arrow crates this branch's result writers already pull in; the lockfile had not been regenerated for them.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
