### PR TITLE
wasm-jit: take the math builtins from the host

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -68,6 +68,63 @@ fn alarm_secs() -> u32 {
     ALARM_SECS.load(std::sync::atomic::Ordering::Relaxed)
 }
 
+/// The model's math builtins from the host's libm, as the C target has them,
+/// rather than the runtime's in-wasm `libm` crate. Only this engine can: the
+/// browser, the wasip1 session and the standalone command module have no host
+/// libm. `OMC_WASM_HOST_LIBM=0` restores the in-wasm one here too.
+fn host_libm() -> bool {
+    !matches!(std::env::var("OMC_WASM_HOST_LIBM").as_deref(), Ok("0"))
+}
+
+fn shadow_math_with_host_libm(
+    linker: &mut wasmtime::Linker<WasiCtx>,
+    store: &mut wasmtime::Store<WasiCtx>,
+    rt_inst: &wasmtime::Instance,
+) -> std::result::Result<(), wasmtime::Error> {
+    // `^` lowers to `rt_real_pow`, which owns C's negative-base and odd-root
+    // cases: take the ordinary branch here and leave the rest to the runtime.
+    let rt_pow = rt_inst.get_typed_func::<(f64, f64, u32), f64>(&mut *store, "rt_real_pow")?;
+    linker.allow_shadowing(true);
+    linker.func_wrap(
+        "rt",
+        "rt_real_pow",
+        move |mut caller: wasmtime::Caller<'_, WasiCtx>, base: f64, exp: f64, loc: u32| {
+            if base >= 0.0 || exp == 0.0 {
+                let r = base.powf(exp);
+                if r.is_finite() {
+                    return Ok(r);
+                }
+            }
+            rt_pow.call(&mut caller, (base, exp, loc))
+        },
+    )?;
+    macro_rules! m1 {
+        ($($n:literal => $f:expr),* $(,)?) => {$(
+            linker.func_wrap("rt", $n, |x: f64| -> f64 { $f(x) })?;
+        )*};
+    }
+    macro_rules! m2 {
+        ($($n:literal => $f:expr),* $(,)?) => {$(
+            linker.func_wrap("rt", $n, |x: f64, y: f64| -> f64 { $f(x, y) })?;
+        )*};
+    }
+    m1! {
+        "sin" => f64::sin, "cos" => f64::cos, "tan" => f64::tan,
+        "asin" => f64::asin, "acos" => f64::acos, "atan" => f64::atan,
+        "sinh" => f64::sinh, "cosh" => f64::cosh, "tanh" => f64::tanh,
+        "exp" => f64::exp, "log" => f64::ln, "log10" => f64::log10,
+        "cbrt" => f64::cbrt, "expm1" => f64::exp_m1, "log1p" => f64::ln_1p,
+        "exp2" => f64::exp2, "log2" => f64::log2,
+        "asinh" => f64::asinh, "acosh" => f64::acosh, "atanh" => f64::atanh,
+    }
+    m2! {
+        "pow" => f64::powf, "atan2" => f64::atan2, "hypot" => f64::hypot,
+        "fmod" => |x: f64, y: f64| x % y,
+    }
+    linker.allow_shadowing(false);
+    Ok(())
+}
+
 /// Report an expired alarm as the driver's own deadline does; the trap it unwinds
 /// as no longer says. The engine detail stays: its backtrace is where it stuck.
 fn map_alarm(e: String) -> String {
@@ -1382,6 +1439,9 @@ fn instantiate_modules(model: &SimModel, meta: &SimMeta) -> std::result::Result<
     let rt_inst = wts(linker.instantiate(&mut store, runtime_module))?;
     // The generated module imports the runtime's exports under module name "rt".
     wts(linker.instance(&mut store, "rt", rt_inst))?;
+    if host_libm() {
+        wts(shadow_math_with_host_libm(&mut linker, &mut store, &rt_inst))?;
+    }
     let memory = rt_inst
         .get_memory(&mut store, "memory")
         .ok_or_else(|| "CodegenWasmJit: runtime has no `memory` export")?;


### PR DESCRIPTION
The runtime implements the math builtins in wasm, from the musl-derived `libm` crate; the C target compiles generated C against glibc. They disagree by up to an ulp. Measured over 20000 arguments per function, both targets from one omc:

| function | args differing | function | args differing |
| -------- | -------------: | -------- | -------------: |
| `exp`    |          9.85% | `sin`    |          3.10% |
| `pow`    |          9.88% | `tanh`   |          2.55% |
| `asin`   |          5.31% | `log`    |          0.75% |
| `cos`    |          3.19% | `atan`   |          0.03% |

Pure arithmetic is bit-identical, so this is the whole of it.

A numerical Jacobian divides by h ~ 6.7e-8*|x|, so a last-bit difference lands in the fourth digit of the difference quotient. On `ThermoPower.Examples.CISE.Simulators.CISESim180503` that put two entries of the first 14x14 initialization Jacobian 1.9e-4 apart and sent Newton to another root of a bistable system - C to saturated liquid, wasm-jit to superheated steam, "Reverse flow not allowed", and a failed run. (C itself lands on the bad root at `-ils=4`.)

Shadow the 24 math imports under "rt" with host functions over glibc. All eight measured functions become bit-identical to C and that model now matches it on every variable.

`^` lowers to the runtime's own `rt_real_pow`, which holds C's negative-base, odd-root and invalid-root cases - the ones `CodegenCFunctions.tpl` inlines. Rather than duplicate those on the host, the shadow takes only the branch C reaches for an ordinary base and delegates every special case back to `rt_real_pow`, which keeps the reporting.

It is also faster, because the host call costs less than that crate run through cranelift. 200 states, 1.8M `functionODE` calls, minimum of three runs:

| residual per state              | in-wasm | host   | ratio |
| ------------------------------- | ------: | -----: | ----: |
| 7 fns (exp sin log tanh atan..) |  183.9s | 176.5s | 0.96x |
| 1 fn (sin)                      |  119.4s | 115.8s | 0.97x |
| 3 `^` + 1 sin                   |  205.7s | 148.3s | 0.72x |

Only the host-driven wasmtime engine can do this; the browser, the wasip1 session and the standalone command module have no host libm and keep the in-wasm one, so web and native now differ from each other where they used to agree. `OMC_WASM_HOST_LIBM=0` restores the in-wasm libm here too.

Baselines whose last digits came from the in-wasm libm will move, towards the C target's values.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
