### PR TITLE
wasm-jit: a model throw in ida_jac is recoverable

### DIFF
--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/driver.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/driver.rs
@@ -10137,7 +10137,14 @@ unsafe extern "C" fn ida_jac(
             let mut gp = core::mem::take(&mut ctx.jac_gp);
             let r = unsafe { ida_residual(ctx, t, y, ypv, gp.as_mut_ptr()) };
             ctx.jac_gp = gp;
-            r?;
+            // C's `jacoColoredNumericalSparse` ignores what the probe returns:
+            // `residualFunctionIDA` catches a model throw itself, leaving
+            // `newdelta` at the previous colour's values.
+            if let Err(err) = r
+                && !residual_model_throw(e, err, t)
+            {
+                return Err(err);
+            }
             for &col in color {
                 let ci = col as usize;
                 let del = ctx.jac_del[ci];


### PR DESCRIPTION
`ida_jac` called `ida_residual` directly and turned any `Err` into -1, IDA's unrecoverable Jacobian failure. C probes through `residualFunctionIDA`, whose `MMC_TRY` catches a model throw and returns the recoverable 1, and `jacoColoredNumericalSparse` then ignores the return value entirely, carrying on with `newdelta` at the previous colour's values.

So one domain error at one finite-difference probe ended the whole `IDACalcIC` where C keeps going. Classify the failure the way `ida_res` already does: a model throw is swallowed and the colour loop continues, and only an error of ours ends the evaluation. The symbolic branch is left alone - C has no `MMC_TRY` there either, and a throw escapes SUNDIALS entirely.

Found on `PowerGrids.Examples.IEEE14bus.IEEE14busShort4`, which dies at its t=1 fault event under `--daeMode`. That model needs more than this, but it no longer fails on the unrecoverable return.

`simulation/modelica/daemode` 13/13 and `simulation/modelica/events` 35/35 under `--simCodeTarget=wasm-jit`.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
