### PR TITLE
Write .arrow result files from the web pages

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/wasm_api.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/wasm_api.rs
@@ -409,12 +409,15 @@ pub fn omc_sim_units() -> JsValue {
     map.into()
 }
 
-/// `{ model, start, stop, rows }` for the last run, or `null` if none.
+/// `{ model, file, start, stop, rows }` for the last run, or `null` if none.
+/// `file` is the result file the run actually wrote, whose suffix is the format
+/// it was written in (`-outputFormat` can have moved it off the requested one).
 #[wasm_bindgen]
 pub fn omc_sim_info() -> JsValue {
     openmodelica_codegen_wasm_jit::CodegenWasmJit::with_last_sim(|sim| {
         let o = js_sys::Object::new();
         let _ = js_sys::Reflect::set(&o, &JsValue::from_str("model"), &JsValue::from_str(&sim.model_name));
+        let _ = js_sys::Reflect::set(&o, &JsValue::from_str("file"), &JsValue::from_str(&sim.result_file));
         let _ = js_sys::Reflect::set(&o, &JsValue::from_str("start"), &JsValue::from_f64(sim.start_time));
         let _ = js_sys::Reflect::set(&o, &JsValue::from_str("stop"), &JsValue::from_f64(sim.stop_time));
         let _ = js_sys::Reflect::set(&o, &JsValue::from_str("rows"), &JsValue::from_f64(sim.n_rows() as f64));
@@ -429,6 +432,15 @@ pub fn omc_sim_info() -> JsValue {
         o.into()
     })
     .unwrap_or(JsValue::NULL)
+}
+
+/// The last run's result file as `format` (`arrow`, `mat` or `csv`), for a
+/// download in a format other than the one the run wrote. The file's own format
+/// is returned unconverted; converting to `mat`/`csv` drops the String variables
+/// they cannot hold. `None` on failure — read `getErrorString()`.
+#[wasm_bindgen]
+pub fn omc_sim_result_as(format: &str) -> Option<Vec<u8>> {
+    openmodelica_codegen_wasm_jit::CodegenWasmJit::last_sim_result_as(format)
 }
 
 /// The independent `time` column of the last run as a `Float64Array`, or `None`.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/Cargo.toml
@@ -16,6 +16,9 @@ openmodelica_plt_writer.workspace = true
 # `-iif=<file>`: C's `importStartValues` reads the initialization file with the
 # MATLAB v4 reader.
 openmodelica_mat_reader.workspace = true
+# Reading a finished run's result file back by variable name, whatever format it
+# was written in (the web simulator's plot data).
+openmodelica_result_files.workspace = true
 openmodelica_sim_meta.workspace = true
 metamodelica.workspace = true
 openmodelica_ast.workspace = true

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -86,7 +86,6 @@ use openmodelica_sim_meta::{
 // guards). The `SimModel` below stores compiled modules as `sim_runtime::Module`.
 // Engine, model data and driver flags live in `openmodelica_wasm_jit`; the
 // orchestration below keeps its `sim_runtime::`/`SimModel` paths via these.
-use openmodelica_sim_meta::result::MatLayout;
 use openmodelica_wasm_jit::result_sink::{ResultTarget, Written};
 use openmodelica_wasm_jit::{sim_driver, sim_runtime};
 #[cfg(feature = "jit")]
@@ -167,11 +166,11 @@ fn fmu_kernels() -> &'static Mutex<HashMap<String, Arc<FmuKernel>>> {
     KERNELS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// Where a captured signal's values live: a `data_2` column of the result file
-/// (negated for a `-v` alias), or one time-invariant value.
+/// Where a captured signal's values come from: the result file under the
+/// signal's own name, or one time-invariant value.
 #[derive(Clone, Copy)]
 pub enum SeriesData {
-    Column { col: usize, negate: bool },
+    File,
     Scalar(f64),
 }
 
@@ -208,16 +207,17 @@ pub struct CapturedParam {
     pub enum_names: Vec<String>,
 }
 
-/// The last run's results: the per-signal metadata plus where each kept signal
-/// sits in the `.mat` the run wrote, so a host (the web simulator) reads a column
-/// straight out of that file. `series` excludes `time`.
+/// The last run's results: the per-signal metadata over the result file the run
+/// wrote, which a host (the web simulator) reads a signal out of by name.
+/// `series` excludes `time`.
 pub struct CapturedSim {
     pub model_name: String,
     pub start_time: f64,
     pub stop_time: f64,
     pub result_file: String,
     n_rows: usize,
-    layout: Option<MatLayout>,
+    /// Opened on the first read and kept for the rest.
+    reader: Mutex<Option<openmodelica_result_files::ResultFile>>,
     pub series: Vec<SimSeries>,
     pub params: Vec<CapturedParam>,
     /// The units the signals and parameters name, defined: what a host needs to
@@ -233,21 +233,40 @@ impl CapturedSim {
         self.n_rows
     }
 
-    fn column(&self, col: usize, negate: bool) -> Vec<f64> {
-        let Some(l) = &self.layout else { return Vec::new() };
-        openmodelica_wasi::fs::with_bytes(&self.result_file, |b| l.column(b, col, negate)).unwrap_or_default()
+    /// Run `f` over the result file, opening it the first time.
+    fn with_file<R>(&self, f: impl FnOnce(&mut openmodelica_result_files::ResultFile) -> R) -> Option<R> {
+        let mut cell = self.reader.lock().unwrap_or_else(|e| e.into_inner());
+        if cell.is_none() {
+            *cell = openmodelica_result_files::ResultFile::open(&self.result_file).ok();
+        }
+        cell.as_mut().map(f)
     }
 
     /// The independent `time` column.
     pub fn time(&self) -> Vec<f64> {
-        self.column(0, false)
+        self.with_file(|r| r.time().map(<[f64]>::to_vec).unwrap_or_default()).unwrap_or_default()
+    }
+
+    /// The result file as `format`. Its own format is handed back unconverted,
+    /// so that download loses nothing; the others drop the String variables they
+    /// cannot hold.
+    pub fn result_as(&self, format: &str) -> std::result::Result<Vec<u8>, String> {
+        if self.result_file.rsplit_once('.').is_some_and(|(_, s)| s == format) {
+            return openmodelica_wasi::fs::read(&self.result_file).map_err(|e| e.to_string());
+        }
+        self.with_file(|r| r.write(format, Vec::new(), 0, false))
+            .unwrap_or_else(|| Err(format!("cannot read the result file {}", self.result_file)))
     }
 
     /// The values of `series[index]` over the run (length 1 for a time-invariant
     /// signal), or `None` when out of range.
     pub fn values(&self, index: usize) -> Option<Vec<f64>> {
-        Some(match self.series.get(index)?.data {
-            SeriesData::Column { col, negate } => self.column(col, negate),
+        let v = self.series.get(index)?;
+        Some(match v.data {
+            SeriesData::File => {
+                let name = v.name.clone();
+                self.with_file(|r| r.trajectory(&name).unwrap_or_default()).unwrap_or_default()
+            }
             SeriesData::Scalar(v) => vec![v],
         })
     }
@@ -268,13 +287,10 @@ fn capture_last_sim(
     keep: &[bool],
     result_file: &str,
 ) {
-    let Written { n_rows, layout } = written;
-    let first_row: &[f64] = layout.as_ref().map_or(&[], |l| &l.first_row);
+    let Written { n_rows, first_row } = written;
     let unit_of = |name: &str| model.var_units.get(name).cloned().unwrap_or_default();
     let mut series = Vec::new();
     let mut param_idx = 0usize;
-    // The kept signals are the file's, in order; `file_ix` is the next one's index.
-    let mut file_ix = 0usize;
     // A signal aliases an earlier one when it reads the same underlying data: the
     // same result column, or the same parameter slot (the `.mat`'s `dataInfo`
     // aliasing — several names, one stored column). Distinct columns are distinct
@@ -286,19 +302,14 @@ fn capture_last_sim(
     // Row 0 of every signal, for the start values of the editable parameters.
     let mut row0_by_name: HashMap<&str, f64> = HashMap::new();
     for (v, &kept) in model.result_vars.iter().zip(keep) {
-        let k = kept.then(|| {
-            file_ix += 1;
-            file_ix - 1
-        });
         let (alias, row0, data) = match &v.kind {
             ResultKind::Time => continue,
             ResultKind::Column { col, negate } => {
                 let col = *col as usize;
                 let row0 = negate.apply_f64(first_row.get(col).copied().unwrap_or(0.0));
-                let data = k.zip(layout.as_ref()).and_then(|(k, l)| match l.data2_col(k) {
-                    Some((col, negate)) => Some(SeriesData::Column { col, negate }),
-                    None => l.data1_value(k).map(SeriesData::Scalar),
-                });
+                // Both writers store an `unvarying` column as a parameter, so it
+                // is its row-0 value rather than a trajectory.
+                let data = Some(if v.unvarying { SeriesData::Scalar(row0) } else { SeriesData::File });
                 (!seen_cols.insert(col), row0, data)
             }
             ResultKind::Param { off, negate, .. } => {
@@ -349,7 +360,7 @@ fn capture_last_sim(
         stop_time: model.stop_time,
         result_file: result_file.to_string(),
         n_rows,
-        layout,
+        reader: Mutex::new(None),
         series,
         params,
         units: model.meta.units.iter().cloned().map(|mut u| {
@@ -358,6 +369,18 @@ fn capture_last_sim(
         }).collect(),
         stats: stats.clone(),
     });
+}
+
+/// [`CapturedSim::result_as`] for a host, recording a failure for
+/// `getErrorString()`.
+pub fn last_sim_result_as(format: &str) -> Option<Vec<u8>> {
+    match with_last_sim(|sim| sim.result_as(format))? {
+        Ok(bytes) => Some(bytes),
+        Err(e) => {
+            record_error(format!("wasm-jit: {e}"));
+            None
+        }
+    }
 }
 
 /// Run `f` with the last captured simulation results, if any. Lets a host read
@@ -923,15 +946,14 @@ fn run_experiment(model: &SimModel, flags: &simflags::SimFlags) -> (SimMeta, Str
     (meta, openmodelica_wasi::wasi::take_stdout_capture())
 }
 
-/// C's `initializeResultData`: the formats this runtime has a writer for, over the
-/// model's own `outputFormat` as `-outputFormat` may have replaced it.
-fn check_output_format(meta: &SimMeta) -> std::result::Result<(), String> {
-    match meta.output_format.as_str() {
-        f if openmodelica_sim_meta::result::known(f) => Ok(()),
-        other => Err(format!(
-            "CodegenWasmJit: this runtime writes `mat`/`csv`/`plt` results, or `empty` for none (got `{other}`)"
-        )),
+/// C's `initializeResultData`: the formats this runtime has a writer for.
+fn check_output_format(format: &str) -> std::result::Result<(), String> {
+    if openmodelica_sim_meta::result::known(format) {
+        return Ok(());
     }
+    Err(format!(
+        "CodegenWasmJit: this runtime writes `mat`/`csv`/`plt`/`arrow` results, or `empty` for none (got `{format}`)"
+    ))
 }
 
 /// C's result-file resolution (`simulation_runtime.cpp`): `-r` outright, else
@@ -953,14 +975,12 @@ fn result_path(flags: &simflags::SimFlags, meta: &SimMeta, derived: &str) -> Str
     }
 }
 
-/// The result file of a run: its resolved path, the `-variableFilter` decision
-/// per signal, and `-single`.
+/// The result file of a run: its resolved path, the writer that name asks for,
+/// the `-variableFilter` decision per signal, and `-single`.
 fn result_target(model: &SimModel, meta: &SimMeta, flags: &simflags::SimFlags, derived: &str) -> ResultTarget {
-    ResultTarget {
-        path: result_path(flags, meta, derived),
-        keep: output_selection(model),
-        single: flags.single_precision,
-    }
+    let path = result_path(flags, meta, derived);
+    let format = openmodelica_sim_meta::result::format_of(&path, &meta.output_format).to_string();
+    ResultTarget { path, format, keep: output_selection(model), single: flags.single_precision }
 }
 
 /// Resolve each `-override=name=value` to its editable parameter's `SimData` slot.
@@ -1232,8 +1252,8 @@ fn run_simulation_inner(prefix: &str, result_file: &str, simflags: &str) -> (std
     let res = (|| -> std::result::Result<(), String> {
         // `empty` (and `-noemit`) runs the integration but writes no result file —
         // useful for benchmarking the solver in isolation from the `.mat` writer.
-        check_output_format(&meta)?;
         let target = result_target(&model, &meta, &flags, result_file);
+        check_output_format(&target.format)?;
         let (path, keep) = (target.path.clone(), target.keep.clone());
         let (run, written) = sim_runtime::run(&model, &meta, target)?;
         // The driver already printed the `-output` line that precedes this block.
@@ -1439,7 +1459,8 @@ mod session {
         sim_driver::init_host_hooks();
         sim_driver::set_result_file_reader(read_result_values);
         let (meta, experiment_log) = run_experiment(&model, &flags);
-        check_output_format(&meta).map_err(|e| {
+        let target = result_target(&model, &meta, &flags, result_file);
+        check_output_format(&target.format).map_err(|e| {
             record_error(e);
             "CodegenWasmJit: unsupported output format"
         })?;
@@ -1450,7 +1471,6 @@ mod session {
         // Build the backend (instantiate, init, emit row 0). An init trap is usually
         // a failed `assert()`; the host driver routes it via `enrich_trap`.
         let inwasm = inwasm_driver_enabled();
-        let target = result_target(&model, &meta, &flags, result_file);
         let (path, keep) = (target.path.clone(), target.keep.clone());
         let built = (|| -> std::result::Result<SessionBackend, String> {
             if inwasm {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/artifact.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/artifact.rs
@@ -732,7 +732,7 @@ fn run_fmi(
         return Ok(());
     }
     recorder
-        .write_mat(Path::new(out), opts.start_time, opts.stop_time)
+        .write(Path::new(out), opts.start_time, opts.stop_time, &md.units)
         .map_err(|e| format!("cannot write {out}: {e}"))
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/session.rs
@@ -228,8 +228,9 @@ struct Session {
     /// `+profiling`'s collected state (`profiling::snapshot`), for the host to
     /// render into the report once it has written the result file.
     prof: Vec<u8>,
-    /// The written `.mat`'s [`openmodelica_sim_meta::result::MatLayout`].
-    layout: Vec<u8>,
+    /// The initial result row, encoded for the host
+    /// ([`openmodelica_sim_meta::result::decode_first_row`]).
+    first_row: Vec<u8>,
 }
 
 /// The result file the next [`rt_sim_start`] writes.
@@ -364,7 +365,8 @@ fn open_result_stream(engine: &mut InWasmEngine, model: &SimMeta, sim_data: u32)
         driver::set_row_sink(None, None);
         return 0;
     };
-    match openmodelica_sim_meta::result::open_stream(engine, model, sim_data, &cfg.keep, cfg.precision, || {
+    let format = openmodelica_sim_meta::result::format_of(&cfg.path, &model.output_format);
+    match openmodelica_sim_meta::result::open_stream(engine, model, sim_data, format, &cfg.keep, cfg.precision, || {
         open_result(&cfg.path)
     }) {
         Ok(st) => *result_stream() = Some(st),
@@ -557,7 +559,7 @@ pub extern "C" fn rt_sim_start(meta_ptr: u32, meta_len: u32, fn_base: u32, prese
         stats: SolveStats::default(),
         lin: Vec::new(),
         prof: Vec::new(),
-        layout: Vec::new(),
+        first_row: Vec::new(),
     });
     // What C's `NLS_USERDATA` carries as `DATA*`: the run's model and `SimData`,
     // for the analyses the nonlinear solver runs from inside a solve.
@@ -629,7 +631,7 @@ fn finish(s: &mut Session) {
     openmodelica_sim_meta::parmod::finish();
     driver::finish_rows(&mut s.rows);
     if let Some(st) = result_stream().take() {
-        s.layout = st.layout_blob();
+        s.first_row = st.first_row_blob();
         s.rows_written = st.n_rows() as u32;
     }
     rtclock::accumulate(rtclock::TOTAL);
@@ -671,15 +673,15 @@ pub extern "C" fn rt_sim_n_reals() -> u32 {
 pub extern "C" fn rt_sim_n_rows() -> u32 {
     session().as_ref().map_or(0, |s| s.rows_written + (s.rows.len() as u32) / s.n_reals.max(1))
 }
-/// The written `.mat`'s layout blob (`result::MatLayout::decode`); empty when this
-/// run wrote no `.mat`.
+/// The initial result row (`result::decode_first_row`); empty when the run was
+/// given no result file to write.
 #[unsafe(no_mangle)]
-pub extern "C" fn rt_sim_layout_ptr() -> u32 {
-    session().as_ref().map_or(0, |s| s.layout.as_ptr() as u32)
+pub extern "C" fn rt_sim_first_row_ptr() -> u32 {
+    session().as_ref().map_or(0, |s| s.first_row.as_ptr() as u32)
 }
 #[unsafe(no_mangle)]
-pub extern "C" fn rt_sim_layout_len() -> u32 {
-    session().as_ref().map_or(0, |s| s.layout.len() as u32)
+pub extern "C" fn rt_sim_first_row_len() -> u32 {
+    session().as_ref().map_or(0, |s| s.first_row.len() as u32)
 }
 /// `-l`'s linearized model as `<file name>\0<content>`; the host writes the file
 /// (this runtime's WASI is the browser's VFS).

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/standalone.rs
@@ -282,8 +282,10 @@ fn arm_result(m: &SimMeta) {
 
 fn open_result(e: &mut dyn driver::SimEngine, m: &SimMeta, sim_data: u32) -> driver::Result<()> {
     let Some((keep, precision)) = (unsafe { (*RESULT.0.get()).0.take() }) else { return Ok(()) };
-    let st = openmodelica_sim_meta::result::open_stream(e, m, sim_data, &keep, precision, || {
-        crate::result_out::open(&m.result_file())
+    let path = m.result_file();
+    let format = openmodelica_sim_meta::result::format_of(&path, &m.output_format);
+    let st = openmodelica_sim_meta::result::open_stream(e, m, sim_data, format, &keep, precision, || {
+        crate::result_out::open(&path)
     })?;
     *result_stream() = Some(st);
     Ok(())

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/Cargo.toml
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/Cargo.toml
@@ -26,6 +26,9 @@ openmodelica_solvers = { path = "../../../SimulationRuntime/rust/openmodelica_so
 # The result file: the same `.mat` a simulated model writes, so OMPlot and
 # omc-diff read an FMU run like any other.
 openmodelica_mat_writer = { path = "../../../SimulationRuntime/rust/openmodelica_mat_writer" }
+# The Arrow result file, which keeps the column types, the discrete-time encoding
+# and the FMU's own unit definitions that a `.mat` has nowhere to put.
+openmodelica_arrow_writer = { path = "../../../SimulationRuntime/rust/openmodelica_arrow_writer" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libloading = { version = "0.8", optional = true }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/examples/fmusim.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/examples/fmusim.rs
@@ -193,7 +193,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let output = args
         .output
         .unwrap_or_else(|| PathBuf::from(format!("{}_res.mat", md.model_name)));
-    rec.write_mat(&output, opts.start_time, opts.stop_time)?;
+    rec.write(&output, opts.start_time, opts.stop_time, &md.units)?;
     println!("wrote {}", output.display());
     for (i, c) in rec.columns.iter().enumerate() {
         let last = rec.values(i).last().unwrap_or(f64::NAN);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/record.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/record.rs
@@ -2,17 +2,20 @@
 //!
 //! The columns are chosen the way a plot wants them: every numeric variable
 //! that can change, grouped by type so one `fmi3Get*` call fetches a whole
-//! group. Parameters and constants are read once, after initialization, and go
-//! into the `.mat`'s time-invariant half — the same layout a simulated
-//! OpenModelica model writes, so OMPlot and `omc-diff` read an FMU run
-//! unchanged. An alias (an FMI 3.0 `<Alias>` child, or an FMI 1.0 `alias`
-//! variable) shares its variable's column.
+//! group. Parameters and constants are read once, after initialization, and are
+//! stored as the time-invariant values a simulated OpenModelica model writes, so
+//! OMPlot and `omc-diff` read an FMU run unchanged. An alias (an FMI 3.0
+//! `<Alias>` child, or an FMI 1.0 `alias` variable) shares its variable's
+//! column. `.mat` and `.arrow` are written from the same columns; only the
+//! latter has anywhere to put their types, units and `relativeQuantity`.
 
 use crate::api::Fmi3;
 use crate::{Error, Result};
 use openmodelica_fmi::{
     Alias, Causality, Dimension, ModelDescription, VarType, Variability, Variable,
 };
+use openmodelica_arrow_writer as arrow;
+use openmodelica_fmi::description as fmi_unit;
 use openmodelica_mat_writer as mat;
 use std::collections::HashMap;
 
@@ -20,9 +23,34 @@ pub struct Column {
     pub name: String,
     pub description: String,
     pub unit: Option<String>,
+    /// The unit it is preferably shown in, a display unit of `unit`.
+    pub display_unit: Option<String>,
+    /// FMI's `relativeQuantity`: a difference in the unit, so a conversion to a
+    /// display unit scales it but adds no offset.
+    pub relative_quantity: bool,
+    pub ty: VarType,
+    /// Changes only at events, so the Arrow file run-end encodes it.
+    pub discrete: bool,
     pub causality: Causality,
     /// A continuous state (something differentiates it).
     pub is_state: bool,
+}
+
+/// A name that is not a column of its own: a time-invariant value, or an affine
+/// function of a column. It carries the same metadata a column does, because the
+/// result file records it per name.
+pub struct Entry {
+    pub name: String,
+    pub description: String,
+    pub unit: Option<String>,
+    pub display_unit: Option<String>,
+    pub relative_quantity: bool,
+    pub ty: VarType,
+    /// For an alias, the column (or parameter slot) it reads; unused otherwise.
+    pub target: usize,
+    pub negated: bool,
+    /// A parameter's value, read once after initialization; 0 for an alias.
+    pub value: f64,
 }
 
 /// Variables of one type, fetched together. An array variable is one value
@@ -43,12 +71,12 @@ pub struct Recorder {
     /// Row-major, `1 + columns.len()` values per row, starting with the time.
     rows: Vec<f64>,
     /// The time-invariant signals, and their values once initialization is over.
-    parameters: Vec<(String, String, f64)>,
+    parameters: Vec<Entry>,
     param_groups: Vec<Group>,
-    /// Aliases: `(name, description, column of the variable it aliases, negated)`.
-    aliases: Vec<(String, String, usize, bool)>,
-    /// Aliases of parameters: `(name, description, index into `parameters`, negated)`.
-    param_aliases: Vec<(String, String, usize, bool)>,
+    /// Aliases, each naming the column it reads.
+    aliases: Vec<Entry>,
+    /// Aliases of parameters, each naming its slot in `parameters`.
+    param_aliases: Vec<Entry>,
     scratch: Vec<f64>,
 }
 
@@ -165,6 +193,21 @@ fn element_names(name: &str, dimensions: &[usize]) -> Vec<String> {
     out.into_iter().map(|index| format!("{name}[{index}]")).collect()
 }
 
+/// One non-column name, taking its metadata from the variable it belongs to.
+fn entry(name: String, description: &str, v: &Variable, target: usize, negated: bool, value: f64) -> Entry {
+    Entry {
+        name,
+        description: description.to_string(),
+        unit: v.unit.clone(),
+        display_unit: v.display_unit.clone(),
+        relative_quantity: v.relative_quantity,
+        ty: v.ty,
+        target,
+        negated,
+        value,
+    }
+}
+
 impl Recorder {
     pub fn new(md: &ModelDescription, keep: Option<&dyn Fn(&str) -> bool>) -> Recorder {
         // Dropped here, not at write time: the sampling is the cost.
@@ -184,13 +227,17 @@ impl Recorder {
                     name: element,
                     description: description.to_string(),
                     unit: v.unit.clone(),
+                    display_unit: v.display_unit.clone(),
+                    relative_quantity: v.relative_quantity,
+                    ty: v.ty,
+                    discrete: v.variability == Variability::Discrete,
                     causality: v.causality,
                     is_state: states.contains(&v.value_reference),
                 });
             }
             for (alias, description, negated) in &names[1..] {
                 for (k, element) in element_names(alias, &extents).into_iter().enumerate() {
-                    aliases.push((element, description.to_string(), first + k, *negated));
+                    aliases.push(entry(element, description, v, first + k, *negated, 0.0));
                 }
             }
             recorded.push((v, first, columns.len() + 1 - first));
@@ -212,11 +259,12 @@ impl Recorder {
                 _ => Vec::new(),
             };
             for (k, element) in element_names(name, &extents).into_iter().enumerate() {
-                parameters.push((element, description.to_string(), starts.get(k).copied().unwrap_or(0.0)));
+                let start = starts.get(k).copied().unwrap_or(0.0);
+                parameters.push(entry(element, description, v, 0, false, start));
             }
             for (alias, description, negated) in &names[1..] {
                 for (k, element) in element_names(alias, &extents).into_iter().enumerate() {
-                    param_aliases.push((element, description.to_string(), first + k, *negated));
+                    param_aliases.push(entry(element, description, v, first + k, *negated, 0.0));
                 }
             }
             params.push((v, first, parameters.len() - first));
@@ -246,7 +294,7 @@ impl Recorder {
     /// The time-invariant signals and the values they were read with, for a
     /// host that shows them beside the plot.
     pub fn parameters(&self) -> impl Iterator<Item = (&str, f64)> {
-        self.parameters.iter().map(|(name, _, value)| (name.as_str(), *value))
+        self.parameters.iter().map(|p| (p.name.as_str(), p.value))
     }
 
     /// The samples as they are stored: `stride()` values per row, the time
@@ -297,7 +345,7 @@ impl Recorder {
             let mut k = 0;
             for (slot, len) in &g.spans {
                 for j in 0..*len {
-                    self.parameters[slot + j].2 = out[k + j];
+                    self.parameters[slot + j].value = out[k + j];
                 }
                 k += len;
             }
@@ -321,35 +369,35 @@ impl Recorder {
                 unvarying: false,
             });
         }
-        for (name, description, col, negated) in &self.aliases {
+        for a in &self.aliases {
             signals.push(mat::MatVar {
-                name,
-                comment: description,
+                name: &a.name,
+                comment: &a.description,
                 kind: mat::MatKind::Column {
-                    col: *col as u32,
-                    negate: if *negated { mat::Neg::Arith } else { mat::Neg::None },
+                    col: a.target as u32,
+                    negate: if a.negated { mat::Neg::Arith } else { mat::Neg::None },
                 },
                 unvarying: false,
             });
         }
         let mut params: Vec<f64> = Vec::with_capacity(self.parameters.len() + self.param_aliases.len());
-        for (name, description, value) in &self.parameters {
+        for p in &self.parameters {
             signals.push(mat::MatVar {
-                name,
-                comment: description,
+                name: &p.name,
+                comment: &p.description,
                 kind: mat::MatKind::Param { negate: mat::Neg::None },
                 unvarying: false,
             });
-            params.push(*value);
+            params.push(p.value);
         }
-        for (name, description, index, negated) in &self.param_aliases {
+        for a in &self.param_aliases {
             signals.push(mat::MatVar {
-                name,
-                comment: description,
-                kind: mat::MatKind::Param { negate: if *negated { mat::Neg::Arith } else { mat::Neg::None } },
+                name: &a.name,
+                comment: &a.description,
+                kind: mat::MatKind::Param { negate: if a.negated { mat::Neg::Arith } else { mat::Neg::None } },
                 unvarying: false,
             });
-            params.push(self.parameters[*index].2);
+            params.push(self.parameters[a.target].value);
         }
         mat::write_mat4(
             &signals,
@@ -362,10 +410,132 @@ impl Recorder {
         )
     }
 
-    /// Write the result file. On the web this goes through WASI like every other
-    /// file the simulation writes.
-    pub fn write_mat(&self, path: &std::path::Path, start_time: f64, stop_time: f64) -> Result<()> {
-        std::fs::write(path, self.to_mat(start_time, stop_time))
-            .map_err(|e| Error::Io(format!("{}: {e}", path.display())))
+    /// Serialize as the Arrow result file, which unlike the `.mat` keeps the
+    /// column types, the discrete-time encoding, the units the FMU defines and
+    /// `relativeQuantity`. `units` are the FMU's `<UnitDefinitions>`.
+    pub fn to_arrow(&self, start_time: f64, stop_time: f64, units: &[fmi_unit::Unit]) -> Vec<u8> {
+        let n_reals = self.columns.len() as u32 + 1;
+        let mut vars = vec![arrow::ArrowVar {
+            name: "time",
+            comment: "Simulation time [s]",
+            unit: "s",
+            display_unit: "",
+            relative_quantity: false,
+            ty: arrow::VarTy::Real,
+            discrete: false,
+            kind: arrow::ArrowKind::Time,
+            unvarying: false,
+            enumeration: None,
+        }];
+        for (i, c) in self.columns.iter().enumerate() {
+            vars.push(arrow::ArrowVar {
+                name: &c.name,
+                comment: &c.description,
+                unit: c.unit.as_deref().unwrap_or_default(),
+                display_unit: c.display_unit.as_deref().unwrap_or_default(),
+                relative_quantity: c.relative_quantity,
+                ty: arrow_ty(c.ty),
+                discrete: c.discrete,
+                kind: arrow::ArrowKind::Column { col: i as u32 + 1, affine: arrow::Affine::IDENTITY },
+                unvarying: false,
+                enumeration: None,
+            });
+        }
+        let affine = |e: &Entry| {
+            if !e.negated {
+                arrow::Affine::IDENTITY
+            } else if arrow_ty(e.ty) == arrow::VarTy::Boolean {
+                arrow::Affine::NOT
+            } else {
+                arrow::Affine::NEGATE
+            }
+        };
+        for a in &self.aliases {
+            vars.push(entry_var(a, arrow::ArrowKind::Column { col: a.target as u32, affine: affine(a) }));
+        }
+        let mut params: Vec<f64> = Vec::with_capacity(self.parameters.len() + self.param_aliases.len());
+        for p in &self.parameters {
+            vars.push(entry_var(p, arrow::ArrowKind::Param { affine: arrow::Affine::IDENTITY }));
+            params.push(p.value);
+        }
+        for a in &self.param_aliases {
+            vars.push(entry_var(a, arrow::ArrowKind::Param { affine: affine(a) }));
+            params.push(self.parameters[a.target].value);
+        }
+        let mut col_types = vec![arrow::ColTy::F64];
+        col_types.extend(self.columns.iter().map(|c| match arrow_ty(c.ty) {
+            arrow::VarTy::Integer => arrow::ColTy::I32,
+            arrow::VarTy::Boolean => arrow::ColTy::Bool,
+            _ => arrow::ColTy::F64,
+        }));
+        let defs = arrow::units::declared(units.iter().map(unit_def));
+        arrow::write_arrow(
+            &vars,
+            &self.rows,
+            n_reals,
+            &params,
+            &col_types,
+            arrow::no_strings(),
+            &arrow::FileMeta { span: Some((start_time, stop_time)), units: &defs },
+        )
+    }
+
+    /// Write the result file as its name's suffix asks (`.arrow` or `.mat`). On
+    /// the web this goes through WASI like every other file the simulation writes.
+    pub fn write(&self, path: &std::path::Path, start_time: f64, stop_time: f64, units: &[fmi_unit::Unit]) -> Result<()> {
+        let bytes = match path.extension().and_then(|e| e.to_str()) {
+            Some("arrow") => self.to_arrow(start_time, stop_time, units),
+            _ => self.to_mat(start_time, stop_time),
+        };
+        std::fs::write(path, bytes).map_err(|e| Error::Io(format!("{}: {e}", path.display())))
+    }
+}
+
+fn entry_var<'a>(e: &'a Entry, kind: arrow::ArrowKind) -> arrow::ArrowVar<'a> {
+    arrow::ArrowVar {
+        name: &e.name,
+        comment: &e.description,
+        unit: e.unit.as_deref().unwrap_or_default(),
+        display_unit: e.display_unit.as_deref().unwrap_or_default(),
+        relative_quantity: e.relative_quantity,
+        ty: arrow_ty(e.ty),
+        discrete: false,
+        kind,
+        unvarying: false,
+        enumeration: None,
+    }
+}
+
+/// An FMI variable type as the result file's Modelica type. An enumeration is
+/// stored as its Integer value; the FMU's literal names are not carried.
+fn arrow_ty(ty: VarType) -> arrow::VarTy {
+    match ty {
+        VarType::Boolean => arrow::VarTy::Boolean,
+        VarType::String | VarType::Binary => arrow::VarTy::String,
+        VarType::Float32 | VarType::Float64 => arrow::VarTy::Real,
+        _ => arrow::VarTy::Integer,
+    }
+}
+
+/// An FMU's `<Unit>` as a `modelica.units` entry; the two are FMI 3.0's own
+/// definitions, so this only reshapes the base exponents into their array.
+fn unit_def(u: &fmi_unit::Unit) -> arrow::units::UnitDef {
+    arrow::units::UnitDef {
+        name: u.name.clone(),
+        base: u.base_unit.as_ref().map(|b| arrow::units::BaseUnit {
+            exponents: [b.kg, b.m, b.s, b.a, b.k, b.mol, b.cd, b.rad],
+            factor: b.factor,
+            offset: b.offset,
+        }),
+        display_units: u
+            .display_units
+            .iter()
+            .map(|d| arrow::units::DisplayUnit {
+                name: d.name.clone(),
+                factor: d.factor,
+                offset: d.offset,
+                inverse: d.inverse,
+            })
+            .collect(),
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_web/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_web/src/lib.rs
@@ -275,17 +275,19 @@ pub extern "C" fn om_fmi_rows_len() -> usize {
 }
 
 /// Write the result file, through WASI like every other file a simulation
-/// writes.
+/// writes. The name's suffix picks the format (`.arrow` or `.mat`).
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn om_fmi_write_mat(ptr: *const u8, len: usize) -> i32 {
+pub unsafe extern "C" fn om_fmi_write_result(ptr: *const u8, len: usize) -> i32 {
     let path = String::from_utf8_lossy(unsafe { std::slice::from_raw_parts(ptr, len) }).into_owned();
     with(|s| {
+        let Some(fmu) = s.fmu.as_ref() else { return fail("no FMU is loaded") };
+        let units = fmu.model_description.units.clone();
         let Some(run) = s.run.as_ref() else { return fail("nothing has been simulated") };
         let (start, stop) = (
             run.summary["startTime"].as_f64().unwrap_or(0.0),
             run.summary["stopTime"].as_f64().unwrap_or(0.0),
         );
-        match run.recorder.write_mat(std::path::Path::new(&path), start, stop) {
+        match run.recorder.write(std::path::Path::new(&path), start, stop, &units) {
             Ok(()) => 1,
             Err(e) => fail(e),
         }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_result_web/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_result_web/src/lib.rs
@@ -21,6 +21,19 @@ impl Drop for ResultFile {
     }
 }
 
+fn json_str(out: &mut String, s: &str) {
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+}
+
 fn js_err(msg: String) -> JsError {
     JsError::new(&msg)
 }
@@ -64,6 +77,45 @@ impl ResultFile {
     /// The variable's unit (`.arrow` files carry one; the others give "").
     pub fn unit(&self, var: &str) -> String {
         self.inner.unit(var)
+    }
+
+    /// The unit it is preferably plotted in, a display unit of [`Self::unit`].
+    pub fn display_unit(&self, var: &str) -> String {
+        self.inner.display_unit(var)
+    }
+
+    /// FMI's `relativeQuantity`: a difference in the unit, so a conversion to a
+    /// display unit scales it but adds no offset.
+    pub fn relative_quantity(&self, var: &str) -> bool {
+        self.inner.relative_quantity(var)
+    }
+
+    /// The display units of every unit the file names, as the JSON object
+    /// `{"K":[{"name","factor","offset","inverse"}],...}` — the shape
+    /// `omc_sim_units()` hands the simulator. `JSON.parse` it.
+    pub fn unit_defs_json(&self) -> String {
+        let mut o = String::from("{");
+        for (i, u) in self.inner.unit_defs().iter().enumerate() {
+            if i > 0 {
+                o.push(',');
+            }
+            json_str(&mut o, &u.name);
+            o.push_str(":[");
+            for (j, d) in u.display_units.iter().enumerate() {
+                if j > 0 {
+                    o.push(',');
+                }
+                o.push_str("{\"name\":");
+                json_str(&mut o, &d.name);
+                o.push_str(&format!(
+                    ",\"factor\":{},\"offset\":{},\"inverse\":{}}}",
+                    d.factor, d.offset, d.inverse
+                ));
+            }
+            o.push(']');
+        }
+        o.push('}');
+        o
     }
 
     pub fn is_parameter(&self, var: &str) -> bool {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/result_sink.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/result_sink.rs
@@ -4,15 +4,16 @@
 
 use std::cell::RefCell;
 
-use openmodelica_sim_meta::result::{MatLayout, Precision, ResultOut, ResultStream};
+use openmodelica_sim_meta::result::{Precision, ResultOut, ResultStream};
 use openmodelica_sim_meta::{SimMeta, driver};
 use openmodelica_wasi::fs;
 
-/// The result file of the next run: the resolved path, the `-variableFilter`
-/// decision per result signal, and `-single`.
+/// The result file of the next run: the resolved path, the writer its name asks
+/// for, the `-variableFilter` decision per result signal, and `-single`.
 #[derive(Clone)]
 pub struct ResultTarget {
     pub path: String,
+    pub format: String,
     pub keep: Vec<bool>,
     pub single: bool,
 }
@@ -23,11 +24,11 @@ impl ResultTarget {
     }
 }
 
-/// What a run wrote: how many rows, and where the kept signals sit in a `.mat`.
+/// What a run wrote: how many rows, and the initial result row.
 #[derive(Default)]
 pub struct Written {
     pub n_rows: usize,
-    pub layout: Option<MatLayout>,
+    pub first_row: Vec<f64>,
 }
 
 struct FileOut(fs::Writer);
@@ -54,7 +55,7 @@ thread_local! {
 
 fn open(e: &mut dyn driver::SimEngine, model: &SimMeta, sim_data: u32) -> driver::Result<()> {
     let Some(t) = TARGET.with(|c| c.borrow_mut().take()) else { return Ok(()) };
-    let st = openmodelica_sim_meta::result::open_stream(e, model, sim_data, &t.keep, t.precision(), || {
+    let st = openmodelica_sim_meta::result::open_stream(e, model, sim_data, &t.format, &t.keep, t.precision(), || {
         fs::Writer::create(&t.path).ok().map(|w| Box::new(FileOut(w)) as Box<dyn ResultOut>)
     })?;
     STREAM.with(|c| *c.borrow_mut() = Some(st));
@@ -96,7 +97,7 @@ pub fn take() -> Written {
     match STREAM.with(|c| c.borrow_mut().take()) {
         Some(mut st) => {
             st.finish();
-            Written { n_rows: st.n_rows(), layout: MatLayout::decode(&st.layout_blob()) }
+            Written { n_rows: st.n_rows(), first_row: st.first_row().to_vec() }
         }
         None => Written::default(),
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmer.rs
@@ -1323,8 +1323,8 @@ pub struct InWasmSession {
     rows_ptr: wasmer::TypedFunction<(), u32>,
     rows_len: wasmer::TypedFunction<(), u32>,
     n_rows_f: wasmer::TypedFunction<(), u32>,
-    layout_ptr: wasmer::TypedFunction<(), u32>,
-    layout_len: wasmer::TypedFunction<(), u32>,
+    first_row_ptr: wasmer::TypedFunction<(), u32>,
+    first_row_len: wasmer::TypedFunction<(), u32>,
     n_reals_f: wasmer::TypedFunction<(), u32>,
     params_ptr: wasmer::TypedFunction<(), u32>,
     params_len: wasmer::TypedFunction<(), u32>,
@@ -1411,8 +1411,8 @@ pub fn build_inwasm_session(
         rows_ptr: gf(&store, "rt_sim_rows_ptr")?,
         rows_len: gf(&store, "rt_sim_rows_len")?,
         n_rows_f: gf(&store, "rt_sim_n_rows")?,
-        layout_ptr: gf(&store, "rt_sim_layout_ptr")?,
-        layout_len: gf(&store, "rt_sim_layout_len")?,
+        first_row_ptr: gf(&store, "rt_sim_first_row_ptr")?,
+        first_row_len: gf(&store, "rt_sim_first_row_len")?,
         n_reals_f: gf(&store, "rt_sim_n_reals")?,
         params_ptr: gf(&store, "rt_sim_params_ptr")?,
         params_len: gf(&store, "rt_sim_params_len")?,
@@ -1525,15 +1525,15 @@ impl InWasmSession {
     /// What the runtime wrote to the result file it was given.
     pub fn take_written(&mut self) -> Result<crate::result_sink::Written> {
         let n_rows = wt(self.n_rows_f.call(&mut self.store))? as usize;
-        let p = wt(self.layout_ptr.call(&mut self.store))?;
-        let n = wt(self.layout_len.call(&mut self.store))? as usize;
+        let p = wt(self.first_row_ptr.call(&mut self.store))?;
+        let n = wt(self.first_row_len.call(&mut self.store))? as usize;
         let mut bytes = vec![0u8; n];
         if n > 0 {
-            self.memory.view(&self.store).read(p as u64, &mut bytes).map_err(|_| "CodegenWasmJit: layout read")?;
+            self.memory.view(&self.store).read(p as u64, &mut bytes).map_err(|_| "CodegenWasmJit: first-row read")?;
         }
         Ok(crate::result_sink::Written {
             n_rows,
-            layout: openmodelica_sim_meta::result::MatLayout::decode(&bytes),
+            first_row: openmodelica_sim_meta::result::decode_first_row(&bytes),
         })
     }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/sim_runtime_wasmtime.rs
@@ -1739,8 +1739,8 @@ pub struct InWasmSession {
     rows_ptr: wasmtime::TypedFunc<(), u32>,
     rows_len: wasmtime::TypedFunc<(), u32>,
     n_rows_f: wasmtime::TypedFunc<(), u32>,
-    layout_ptr: wasmtime::TypedFunc<(), u32>,
-    layout_len: wasmtime::TypedFunc<(), u32>,
+    first_row_ptr: wasmtime::TypedFunc<(), u32>,
+    first_row_len: wasmtime::TypedFunc<(), u32>,
     n_reals_f: wasmtime::TypedFunc<(), u32>,
     params_ptr: wasmtime::TypedFunc<(), u32>,
     params_len: wasmtime::TypedFunc<(), u32>,
@@ -1831,8 +1831,8 @@ pub fn build_inwasm_session(
         rows_ptr: gf(&mut store, "rt_sim_rows_ptr")?,
         rows_len: gf(&mut store, "rt_sim_rows_len")?,
         n_rows_f: gf(&mut store, "rt_sim_n_rows")?,
-        layout_ptr: gf(&mut store, "rt_sim_layout_ptr")?,
-        layout_len: gf(&mut store, "rt_sim_layout_len")?,
+        first_row_ptr: gf(&mut store, "rt_sim_first_row_ptr")?,
+        first_row_len: gf(&mut store, "rt_sim_first_row_len")?,
         n_reals_f: gf(&mut store, "rt_sim_n_reals")?,
         params_ptr: gf(&mut store, "rt_sim_params_ptr")?,
         params_len: gf(&mut store, "rt_sim_params_len")?,
@@ -1957,15 +1957,11 @@ impl InWasmSession {
     /// What the runtime wrote to the result file it was given.
     pub fn take_written(&mut self) -> Result<crate::result_sink::Written> {
         let n_rows = wt(self.n_rows_f.call(&mut self.store, ()))? as usize;
-        let p = wt(self.layout_ptr.call(&mut self.store, ()))? as usize;
-        let n = wt(self.layout_len.call(&mut self.store, ()))? as usize;
-        let layout = match n {
-            0 => None,
-            _ => openmodelica_sim_meta::result::MatLayout::decode(
-                self.memory.data(&self.store).get(p..p + n).ok_or("CodegenWasmJit: layout read")?,
-            ),
-        };
-        Ok(crate::result_sink::Written { n_rows, layout })
+        let p = wt(self.first_row_ptr.call(&mut self.store, ()))? as usize;
+        let n = wt(self.first_row_len.call(&mut self.store, ()))? as usize;
+        let blob = self.memory.data(&self.store).get(p..p + n).ok_or("CodegenWasmJit: first-row read")?;
+        let first_row = openmodelica_sim_meta::result::decode_first_row(blob);
+        Ok(crate::result_sink::Written { n_rows, first_row })
     }
 
     /// The runtime's `-l` blob (`<file name>\0<content>`), empty when unasked.

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/README.md
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/README.md
@@ -100,11 +100,13 @@ lose their href rather than pretend to work.
 
 ## Results
 
-Samples are recorded for every numeric variable that can change. The download
-button in the header writes the usual OpenModelica `.mat` through WASI and hands
-it over — the same file OMPlot and `omc-diff` read for a simulated model. It is
-written when asked for rather than after every run, since serialising the whole
-result is the expensive part and most runs are only ever plotted.
+Samples are recorded for every numeric variable that can change, and the plot
+reads them straight out of the recorder as the run produces them. They become a
+file only when the download button asks for one — serialising the whole result
+is the expensive part, and most runs are only ever plotted. The picker beside
+the button chooses the format: `.arrow` keeps the column types, the
+discrete-time encoding, `relativeQuantity` and the FMU's own unit definitions,
+while `.mat` is the file OMPlot and `omc-diff` have always read.
 
 A cref in a figure or in the 3D scene often names an FMI 3.0 `<Alias>` rather
 than the variable holding the data — an alias shares its base variable's

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/driver.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/driver.js
@@ -267,11 +267,12 @@ export class Driver {
     return result;
   }
 
-  // Write the result file through WASI, and hand back what landed there.
-  writeMat(path) {
+  // Write the result file through WASI, and hand back what landed there. The
+  // name's suffix picks the format.
+  writeResult(path) {
     const bytes = this.encoder.encode(path);
     const ptr = this.pass(bytes);
-    const ok = this.exports.om_fmi_write_mat(ptr, bytes.length);
+    const ok = this.exports.om_fmi_write_result(ptr, bytes.length);
     this.exports.om_fmi_free(ptr, bytes.length);
     if (!ok) throw new Error(this.lastError());
     return this.wasi.read(path);

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/fmi-worker.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/fmi-worker.js
@@ -51,9 +51,9 @@ async function handle(kind, args) {
       delete result.values;
       return { ...result, values };
     }
-    case 'mat': {
+    case 'result': {
       if (!driver) throw new Error('no FMU is loaded');
-      return driver.writeMat(args.path);
+      return driver.writeResult(args.path);
     }
     default:
       throw new Error(`the worker does not know how to ${kind}`);

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/index.html
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/index.html
@@ -77,7 +77,13 @@
   .doc-body h1, .doc-body h2, .doc-body h3, .doc-body h4 { color:var(--fg); font-size:1.05em; margin:.8em 0 .3em; }
   .doc-body .svgiconhead { width:24px; height:24px; object-fit:contain; vertical-align:middle; }
 
-  @media (max-width:820px), (orientation:portrait) {
+  .dl { display:inline-flex; align-items:stretch; }
+  .dl[hidden] { display:none; }
+  .dl button.ghost { border-top-right-radius:0; border-bottom-right-radius:0; }
+  .dl select { background:transparent; color:var(--muted); border:1px solid var(--border); border-left:0;
+    border-top-left-radius:0; border-bottom-left-radius:0; font-size:12px; padding:0 4px; }
+
+@media (max-width:820px), (orientation:portrait) {
     main { grid-template-columns:1fr; }
     .left { border-right:0; border-bottom:1px solid var(--border); overflow:visible; }
     .grid2 .wide { grid-column:2; }
@@ -128,7 +134,10 @@
   <button class="ghost" id="nativeBtn" title="Compile this FMU's component for native platforms and repack it" hidden disabled>Native binaries…</button>
   <button class="ghost" id="figToggle" title="Switch between the FMU's figures and all recorded variables" hidden>All variables</button>
   <button id="run" disabled>Simulate</button>
-  <button class="ghost icon-only" id="download" hidden><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12"/><path d="M7 10l5 5 5-5"/><path d="M3 20h18"/></svg></button>
+  <span class="dl" id="downloadWrap" hidden>
+    <button class="ghost icon-only" id="download"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12"/><path d="M7 10l5 5 5-5"/><path d="M3 20h18"/></svg></button>
+    <select id="resFormat" title="Result format to download"><option value="arrow" selected>.arrow</option><option value="mat">.mat</option></select>
+  </span>
 </header>
 
 <main>
@@ -226,6 +235,7 @@ import { buildAnimData, attachCadMeshes } from '../anim/anim-core.js';
 const el = (id) => document.getElementById(id);
 const statusEl = el('status'), runBtn = el('run'), openBtn = el('open'), fileEl = el('file');
 const downloadEl = el('download');
+const downloadWrap = el('downloadWrap'), resFormatEl = el('resFormat');
 const infoEl = el('info'), dropEl = el('drop'), icGrid = el('icGrid'), icEmpty = el('icEmpty');
 const docBody = el('docBody');
 const chartsEl = el('charts'), chartsEmpty = el('chartsEmpty'), logEl = el('log');
@@ -244,6 +254,7 @@ let lastRec = null;     // the most recent simulation record, for re-rendering
 let viewMode = 'auto';  // 'auto' -> figures when the FMU has them, else all vars
 let animView = null;    // shared 3D animation panel, if the FMU carries a <Visualization>
 let resultName = null;  // the last run's result file, or null when there is none
+let resultStem = null;  // its name without the format suffix
 let archive = null;     // the .fmu bytes, kept only for the native repack
 
 const setStatus = (text, cls = '') => { statusEl.textContent = text; statusEl.className = 'status ' + cls; };
@@ -636,23 +647,33 @@ function toRecord(result) {
   };
 }
 
-// Written on demand: serialising the whole result is the expensive part.
+// The plot reads the recorder's rows directly, so this is the only place the
+// result becomes a file — written on demand, since serialising it is the
+// expensive part.
+function resultFileName() {
+  return `${resultStem}_res.${resFormatEl.value}`;
+}
+
 function offerResultFile() {
-  resultName = `${(fmu.md.modelName || 'result').replace(/[^\w.-]+/g, '_')}_res.mat`;
-  downloadEl.hidden = false;
+  resultStem = (fmu.md.modelName || 'result').replace(/[^\w.-]+/g, '_');
+  resultName = resultFileName();
+  downloadWrap.hidden = false;
   downloadEl.title = downloadEl.ariaLabel = `Download ${resultName}`;
 }
 
 function hideResultFile() {
   resultName = null;
-  downloadEl.hidden = true;
+  resultStem = null;
+  downloadWrap.hidden = true;
 }
+
+resFormatEl.addEventListener('change', () => { if (resultStem) offerResultFile(); });
 
 downloadEl.onclick = async () => {
   if (!resultName || downloadEl.disabled) return;
   downloadEl.disabled = true;
   try {
-    const bytes = await session.mat(`/${resultName}`);
+    const bytes = await session.result(`/${resultName}`);
     if (!bytes || !bytes.length) throw new Error('the driver wrote no result file');
     downloadBlob(resultName, bytes);
     setStatus(`${resultName} — ${bytes.length} bytes.`, 'ok');

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/selftest.html
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/selftest.html
@@ -78,7 +78,7 @@ try {
     if (!again.rows) throw new Error('the FMU was lost when the run was cancelled');
   }
 
-  const mat = await session.mat('/selftest_res.mat');
+  const mat = await session.result('/selftest_res.mat');
   say(`result file: ${mat ? mat.length + ' bytes' : 'not written'}`);
   if (!result.rows) throw new Error('the run produced no samples');
   if (!mat || mat.length < 100) throw new Error('the result file is missing or too small');

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/session.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/session.js
@@ -71,9 +71,10 @@ export class Session {
     return this.send('warm', { kind });
   }
 
-  // Write the result file inside the driver's WASI filesystem and read it back.
-  mat(path) {
-    return this.send('mat', { path });
+  // Write the result file inside the driver's WASI filesystem and read it back;
+  // the name's suffix picks the format.
+  result(path) {
+    return this.send('result', { path });
   }
 
   // Ask a running simulation to stop at its next output point, which keeps the

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/omplot/index.html
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/omplot/index.html
@@ -32,6 +32,7 @@
   .var input { width:auto; margin:0; }
   .var .nm { flex:1 1 auto; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
   .var .p { color:var(--muted); font-size:11px; }
+  .var .u { color:var(--muted); font-size:11px; flex:0 0 auto; }
   .var .diff { width:8px; height:8px; border-radius:50%; background:var(--err); flex:0 0 auto; }
   .vars-note { color:var(--muted); font-size:12px; padding:4px 12px; }
 
@@ -125,7 +126,8 @@
 
 <script type="module">
 import init, { ResultFile, diff_all, diff_variable } from './openmodelica_result_web.js';
-import { COLORS, createCharts } from '../plot.js';
+import { COLORS, createCharts, unitHTML, unitLabel } from '../plot.js';
+import { scale, relative } from '../units.js';
 import { bindModal, downloadBlob } from '../ui.js';
 
 const $ = (id) => document.getElementById(id);
@@ -139,11 +141,12 @@ const charts = createCharts(chartsEl);
 const DEFAULTS = { relTol: 1e-3, relTolDiffMinMax: 1e-4, rangeDelta: 0.002 };
 
 // --- state -----------------------------------------------------------------
-const files = [];       // { id, name, rf, vars, params:Set, nrows, selected:Set }
+const files = [];       // { id, name, rf, vars, params:Set, units, nrows, selected:Set }
 let active = null;      // the file whose variables are listed
 let mode = 'plot';      // 'plot' | 'compare'
 let cmp = null;         // { actual, reference, opts, diffVars:Set, compared, current }
 let nextId = 1;
+const unitPick = new Map();  // unit -> the display unit the reader chose for that axis
 
 function setStatus(text, cls = '') { statusEl.textContent = text; statusEl.className = 'status ' + cls; }
 function fail(e) { console.error(e); setStatus(String(e && e.message || e), 'err'); }
@@ -154,7 +157,11 @@ function addFile(name, bytes) {
   const vars = rf.variables();
   const timeName = rf.time_name();
   const params = new Set(vars.filter((v) => rf.is_parameter(v)));
-  const f = { id: nextId++, name, rf, vars, params, timeName, nrows: rf.nrows(), selected: new Set() };
+  // The file's own display units, keyed by unit name — `.arrow` carries them,
+  // the other formats define none and leave every unit alone.
+  let units = {};
+  try { units = JSON.parse(rf.unit_defs_json()); } catch (e) { console.warn('unit table', e); }
+  const f = { id: nextId++, name, rf, vars, params, units, timeName, nrows: rf.nrows(), selected: new Set() };
   files.push(f);
   active = f;
   return f;
@@ -261,6 +268,13 @@ function renderVars() {
       row.appendChild(cb);
     }
     const nm = document.createElement('span'); nm.className = 'nm'; nm.textContent = v; row.appendChild(nm);
+    if (u) {
+      const us = document.createElement('span'); us.className = 'u';
+      const du = f.rf.display_unit(v);
+      us.innerHTML = unitHTML(du || u);
+      us.title = du && du !== u ? 'displayUnit ' + unitLabel(du) + ', unit ' + unitLabel(u) : 'unit ' + unitLabel(u);
+      row.appendChild(us);
+    }
     if (f.params.has(v)) { const p = document.createElement('span'); p.className = 'p'; p.textContent = 'param'; row.appendChild(p); }
     varsEl.appendChild(row);
   }
@@ -274,6 +288,18 @@ filterEl.oninput = renderVars;
 
 function showEmpty(text) { chartsEl.appendChild(chartsEmpty); chartsEmpty.textContent = text; }
 
+// The display unit named `to`, or null for the unit itself. A relative quantity
+// is a difference, so its conversion keeps the factor and drops the offset.
+function displayUnitDef(f, base, to, rel) {
+  if (!base || !to || to === base) return null;
+  const d = ((f.units && f.units[base]) || []).find((u) => u.name === to) || null;
+  return rel ? relative(d) : d;
+}
+
+function unitAlternatives(f, base) {
+  return base ? [base, ...((f.units && f.units[base]) || []).map((d) => d.name)] : [];
+}
+
 function renderCharts() {
   charts.clear();
   if (mode === 'compare') { renderDiffChart(); return; }
@@ -286,11 +312,40 @@ function renderCharts() {
       const ys = f.rf.trajectory(v); if (!ys) continue;
       const n = Math.min(time.length, ys.length);
       curves.push({ label: multi ? v + ' @ ' + f.name : v, color: COLORS[curves.length % COLORS.length],
-        xs: time.subarray(0, n), ys: ys.subarray(0, n) });
+        xs: time.subarray(0, n), ys: ys.subarray(0, n),
+        file: f, unit: f.rf.unit(v), displayUnit: f.rf.display_unit(v), relative: f.rf.relative_quantity(v) });
     }
   }
   if (!curves.length) { showEmpty(files.length ? 'Tick variables to plot them.' : 'Open a result file to plot it.'); return; }
-  charts.add({ curves, xText: 'time', xUnit: 's', solo: true, xIsTime: true }, 'plot');
+  const spec = { curves, xText: 'time', xUnit: 's', solo: true, xIsTime: true };
+  // One unit across the plotted curves makes the y-axis a unit the reader can
+  // switch; mixed units leave the axis unlabelled.
+  const bases = [...new Set(curves.map((c) => c.unit).filter(Boolean))];
+  if (bases.length === 1 && curves.every((c) => c.unit)) applyUnit(spec, bases[0]);
+  charts.add(spec, 'plot');
+}
+
+// Draw the curves in `unitPick`'s unit (else the declared displayUnit), and let
+// the axis switch between the alternatives the files define. Two files can
+// define different display units for one unit, so the choices are their union.
+function applyUnit(spec, base) {
+  const alternatives = [base];
+  for (const f of new Set(spec.curves.map((c) => c.file))) {
+    for (const u of unitAlternatives(f, base)) if (!alternatives.includes(u)) alternatives.push(u);
+  }
+  const declared = spec.curves[0].displayUnit;
+  const shown = unitPick.has(base) ? unitPick.get(base)
+              : (declared && alternatives.includes(declared) ? declared : base);
+  for (const c of spec.curves) {
+    const d = displayUnitDef(c.file, base, shown, c.relative);
+    if (!d) continue;
+    const fn = scale(d), out = new Float64Array(c.ys.length);
+    for (let i = 0; i < c.ys.length; i++) out[i] = fn(c.ys[i]);
+    c.ys = out; c.unit = shown;
+  }
+  spec.yUnit = shown;
+  spec.unitChoices = alternatives;
+  spec.onUnit = (u) => { unitPick.set(base, u); renderCharts(); };
 }
 
 // --- comparison ------------------------------------------------------------

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/index.html
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/index.html
@@ -67,7 +67,13 @@
   /* charts area: one card per plot, scrollable */
   /* Modelica units: superscript exponents and stacked (num-over-den) fractions */
 
-  @media (max-width:820px), (orientation:portrait) {
+  .dl { display:inline-flex; align-items:stretch; }
+  .dl[hidden] { display:none; }
+  .dl button.ghost { border-top-right-radius:0; border-bottom-right-radius:0; }
+  .dl select { background:transparent; color:var(--muted); border:1px solid var(--border); border-left:0;
+    border-top-left-radius:0; border-bottom-left-radius:0; font-size:12px; padding:0 4px; }
+
+@media (max-width:820px), (orientation:portrait) {
     body { overflow:auto; height:auto; min-height:100vh; }
     main { grid-template-columns:1fr; }
     .left { border-right:0; border-bottom:1px solid var(--border); }
@@ -114,7 +120,10 @@
   </button>
   <button id="exportFmu" class="ghost" disabled title="Export an FMI 3.0 wasm FMU of the active model">Export FMU</button>
   <button id="run" disabled>Run</button>
-  <button id="downloadRes" class="ghost icon-only" hidden><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12"/><path d="M7 10l5 5 5-5"/><path d="M3 20h18"/></svg></button>
+  <span class="dl" id="downloadWrap" hidden>
+    <button id="downloadRes" class="ghost icon-only"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12"/><path d="M7 10l5 5 5-5"/><path d="M3 20h18"/></svg></button>
+    <select id="resFormat" title="Result format to download"><option value="arrow" selected>.arrow</option><option value="mat">.mat</option><option value="csv">.csv</option></select>
+  </span>
 </header>
 
 <main>
@@ -252,6 +261,7 @@ const charts = createCharts(chartsEl);
 const icGrid = el('icGrid'), icEmpty = el('icEmpty'), tolEl = el('tol'), toggleBtn = el('viewToggle');
 const exSel = el('examples'), docBody = el('docBody');
 const settingsBtn = el('settingsBtn'), downloadResBtn = el('downloadRes');
+const downloadWrap = el('downloadWrap'), resFormatEl = el('resFormat');
 const rightEl = el('right');
 
 // Documentation collapse/expand, driven from inside the widget: a chevron in the
@@ -452,7 +462,7 @@ let copyName = null;          // top-level name of the current library copy (cop
 let preloaded = null;         // a class already loaded by copyClass (skip the first redundant loadSource)
 let freshModel = true;        // true until a model's own experiment settings have been read back from a run
 let animView = null;          // the shared 3D animation panel (lazily created on first use)
-let resultReady = false;      // the built worker's VFS holds a complete `<model>_res.mat`
+let resultReady = false;      // the built worker's VFS holds a complete `<model>_res.arrow`
 let resultCache = null;       // { name, bytes } — kept when the worker holding it had to go
 
 // Only the parameters the user actually edited. Sending the whole grid back would
@@ -663,23 +673,51 @@ async function run(kind) {                       // 'full' | 'resim'
 // gone. Offered only for a run that finished: a failed one leaves a truncated file.
 function syncResultDownload() {
   const name = resultCache ? resultCache.name
-             : (resultReady && builtModel && builtWorker) ? `${builtModel}_res.mat` : null;
-  downloadResBtn.hidden = !name;
-  if (name) downloadResBtn.title = downloadResBtn.ariaLabel = `Download ${name}`;
+             : (resultReady && builtModel && builtWorker)
+               ? ((snap && snap.info && snap.info.file) || `${builtModel}_res.arrow`) : null;
+  downloadWrap.hidden = !name;
+  if (name) syncResultTitle(name);
 }
 
-async function fetchResultFile(worker, model) {
+function syncResultTitle(name) {
+  const fmt = resFormatEl.value;
+  const shown = name.replace(/\.[^.]*$/, '') + '.' + fmt;
+  downloadResBtn.title = downloadResBtn.ariaLabel = `Download ${shown}`;
+}
+
+async function fetchResultFile(worker, model, format) {
   if (!worker || !model) return null;
-  const r = await call(worker, 'resultFile', { name: model });
+  const r = await call(worker, 'resultFile', { name: model, format });
   if (!r.ok) throw new Error(r.error);
   return { name: r.filename, bytes: r.bytes };
 }
 
+// The retired worker's copy is the run's own format, and converting it needs a
+// reader. The OMPlot module is one: the same `ResultFile::write`, without omc.
+async function convertCached(cached, format) {
+  if (cached.name.endsWith('.' + format)) return cached;
+  const mod = await import('../omplot/openmodelica_result_web.js');
+  await mod.default();
+  const rf = new mod.ResultFile(cached.name, new Uint8Array(cached.bytes));
+  try {
+    const out = format === 'csv' ? new TextEncoder().encode(rf.write_csv([], 0))
+              : format === 'mat' ? rf.write_mat([], 0) : rf.write_arrow([], 0);
+    return { name: cached.name.replace(/\.[^.]*$/, '') + '.' + format, bytes: out };
+  } finally { rf.free(); }
+}
+
+resFormatEl.addEventListener('change', () => {
+  const name = resultCache ? resultCache.name : (snap && snap.info && snap.info.file);
+  if (name) syncResultTitle(name);
+});
+
 downloadResBtn.addEventListener('click', async () => {
   if (downloadResBtn.disabled) return;
   downloadResBtn.disabled = true;
+  const format = resFormatEl.value;
   try {
-    const r = resultCache || await fetchResultFile(builtWorker, builtModel);
+    const r = resultCache ? await convertCached(resultCache, format)
+                          : await fetchResultFile(builtWorker, builtModel, format);
     if (!r) return;
     downloadBlob(r.name, r.bytes);
     setStatus(`${r.name} — ${r.bytes.length} bytes.`);

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/omc-worker.js
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/simulator/omc-worker.js
@@ -14,6 +14,7 @@ import init, {
   omc_take_pending_downloads, wasi_write_file,
   wasi_path_open, wasi_fd_read, wasi_fd_close,
   omc_sim_info, omc_sim_series, omc_sim_time, omc_sim_column, omc_sim_parameters, omc_sim_units,
+  omc_sim_result_as,
 } from '../omc/OpenModelicaCompiler.js';
 // Shared MultiBody animation core (standalone wasm), the same module the FMI
 // simulator uses; fed here from the omc result store rather than an FMU.
@@ -185,6 +186,10 @@ function logCompilerMessages(what) {
   if (msg) console.warn('[omc ' + what + ']\n' + msg);
 }
 
+// `omc_sim_start` takes the writer from the name's suffix, so this is where the
+// page's result format is chosen.
+const RESULT_SUFFIX = '_res.arrow';
+
 // Chunked, cancellable integration of a prepared model. Each `omc_sim_advance`
 // runs ~BUDGET_MS of wall-clock (it times itself), then we yield to the message
 // loop so a queued {cmd:'cancelSim'} can set `simCancel`. A run that finishes in
@@ -192,7 +197,7 @@ function logCompilerMessages(what) {
 async function runResumable(prefix, simflags, onStatus) {
   simCancel = false;   // discard a cancel that raced in after the previous run
   const _t0 = performance.now();
-  if (!omc_sim_start(prefix, prefix + '_res.mat', simflags)) { logModelOutput(prefix); return -1; }
+  if (!omc_sim_start(prefix, prefix + RESULT_SUFFIX, simflags)) { logModelOutput(prefix); return -1; }
   // Split off `omc_sim_start` (compile lookup, instantiate, init, row 0) and count
   // the chunks: a run that suddenly costs more is either paying instantiation again
   // or being yielded far more often than its budget should need.
@@ -383,7 +388,7 @@ self.onmessage = async (ev) => {
       }
       case 'simulate': {
         // translateModelFMU (translate + JIT) then runResumable (a cancellable
-        // chunked run + `.mat`). The kernel it lowers is the very module an Export
+        // chunked run + result file). The kernel it lowers is the very module an Export
         // FMU links its adapter onto, so pressing Export costs a link and an XML
         // render rather than a second translation. The experiment travels in the
         // simflags rather than being baked in, so changing it needs no rebuild.
@@ -485,15 +490,18 @@ self.onmessage = async (ev) => {
       }
       case 'resultFile': {
         // runResumable already wrote it, so this is a read, not a re-simulation.
+        // The file's own format is handed back unconverted.
         const info = omc_sim_info();
         const model = (info && info.model) || a.name;
         if (!model) return reply({ ok: false, error: 'no simulation has been run' });
-        const file = model + '_res.mat';
-        const bytes = wasiReadFile(file);
-        if (!bytes || !bytes.length) return reply({ ok: false, error: 'no result file at ' + file });
-        // Copy out of wasm memory before transferring (wasiReadFile may view it).
-        const buf = bytes.slice();
-        reply({ ok: true, filename: file, bytes: buf }, [buf.buffer]);
+        const file = (info && info.file) || model + RESULT_SUFFIX;
+        const format = a.format || (file.split('.').pop() || 'arrow');
+        const bytes = omc_sim_result_as(format);
+        if (!bytes || !bytes.length) {
+          return reply({ ok: false, error: unquote(omc_eval('getErrorString()')).trim() || 'no result file at ' + file });
+        }
+        const name = file.replace(/\.[^.]*$/, '') + '.' + format;
+        reply({ ok: true, filename: name, bytes }, [bytes.buffer]);
         break;
       }
       case 'eval':

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_result_files/src/file.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_result_files/src/file.rs
@@ -277,6 +277,12 @@ impl ResultFile {
                 Some((st, u, du, ty, en)) => (Some(st), u, du, ty, en),
                 None => (None, String::new(), String::new(), "Real".to_owned(), None),
             };
+            // A String variable has no numeric trajectory, and none of the
+            // formats this plan feeds can hold one: drop it rather than fail the
+            // whole conversion.
+            if ty == "String" {
+                continue;
+            }
             let read = |me: &mut Self| me.reader.trajectory(var).ok_or_else(|| format!("Could not read variable {var}"));
             let kind = match storage {
                 Some((true, _)) => {

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/result.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_sim_meta/src/result.rs
@@ -25,6 +25,16 @@ pub fn known(format: &str) -> bool {
     matches!(format, "mat" | "csv" | "plt" | "arrow" | "empty")
 }
 
+/// The writer a result file's name asks for: its suffix when this runtime has
+/// that writer, else `fallback` (the model's `outputFormat`). Diverges from C,
+/// which always writes the `outputFormat` under whatever name it was given.
+pub fn format_of<'a>(path: &'a str, fallback: &'a str) -> &'a str {
+    match path.rsplit_once('.') {
+        Some((_, suffix)) if known(suffix) => suffix,
+        _ => fallback,
+    }
+}
+
 /// Where a streamed result file's bytes go: a file, the web store, or a host
 /// import from inside wasm. `false` reports a failed write.
 pub trait ResultOut {
@@ -62,11 +72,11 @@ pub fn open_stream(
     e: &mut dyn crate::driver::SimEngine,
     model: &SimMeta,
     sim_data: u32,
+    format: &str,
     keep: &[bool],
     precision: Precision,
     out: impl FnOnce() -> Option<Box<dyn ResultOut>>,
 ) -> crate::driver::Result<ResultStream> {
-    let format = model.output_format.as_str();
     let out: Box<dyn ResultOut> = match format {
         "mat" | "csv" | "plt" | "arrow" => out().ok_or("CodegenWasmJit: cannot open the result file")?,
         _ => Box::new(NullOut),
@@ -262,124 +272,30 @@ impl ResultStream {
         self.n_rows
     }
 
-    /// The `.mat` layout, for a reader of the file being written; `None` for the
-    /// other formats.
-    pub fn mat(&self) -> Option<&Mat4Stream> {
-        match &self.kind {
-            Kind::Mat(s) => Some(s),
-            _ => None,
-        }
-    }
-
     /// The initial result row (`n_reals` values).
     pub fn first_row(&self) -> &[f64] {
         &self.first_row
     }
 
-    /// [`MatLayout`] of the written `.mat`, encoded for a host across the wasm
-    /// boundary ([`MatLayout::decode`]); empty for the other formats.
-    pub fn layout_blob(&self) -> Vec<u8> {
-        let Some(m) = self.mat() else { return Vec::new() };
-        let mut o = Vec::new();
-        o.extend_from_slice(&(m.n_rows() as u32).to_le_bytes());
-        o.extend_from_slice(&(m.n_reals2() as u32).to_le_bytes());
-        o.extend_from_slice(&m.data2_pos().to_le_bytes());
-        o.push(m.precision().size() as u8);
-        o.extend_from_slice(&(m.data_info().len() as u32).to_le_bytes());
-        for info in m.data_info() {
-            for v in info {
-                o.extend_from_slice(&v.to_le_bytes());
-            }
-        }
-        for values in [m.data_1(), &self.first_row] {
-            o.extend_from_slice(&(values.len() as u32).to_le_bytes());
-            for v in values {
-                o.extend_from_slice(&v.to_le_bytes());
-            }
+    /// The initial result row encoded for a host across the wasm boundary
+    /// ([`decode_first_row`]).
+    pub fn first_row_blob(&self) -> Vec<u8> {
+        let mut o = Vec::with_capacity(4 + self.first_row.len() * 8);
+        o.extend_from_slice(&(self.first_row.len() as u32).to_le_bytes());
+        for v in &self.first_row {
+            o.extend_from_slice(&v.to_le_bytes());
         }
         o
     }
 }
 
-/// Where each kept signal lives in a written `.mat`, enough to read a column
-/// back out of the file without parsing it.
-pub struct MatLayout {
-    pub n_rows: usize,
-    /// Columns per `data_2` row, time included.
-    pub n_reals2: usize,
-    /// Absolute byte position of the first `data_2` element.
-    pub data2_pos: u64,
-    pub precision: Precision,
-    /// Per kept signal: `[channel, index, interp, extrap]`.
-    pub data_info: Vec<[i32; 4]>,
-    /// `data_1`'s first column.
-    pub data_1: Vec<f64>,
-    /// The initial result row, every column.
-    pub first_row: Vec<f64>,
-}
-
-impl MatLayout {
-    pub fn decode(b: &[u8]) -> Option<MatLayout> {
-        let u32_at = |p: usize| Some(u32::from_le_bytes(b.get(p..p + 4)?.try_into().ok()?));
-        let n_rows = u32_at(0)? as usize;
-        let n_reals2 = u32_at(4)? as usize;
-        let data2_pos = u64::from_le_bytes(b.get(8..16)?.try_into().ok()?);
-        let precision = if *b.get(16)? == 4 { Precision::Single } else { Precision::Double };
-        let n = u32_at(17)? as usize;
-        let mut data_info = Vec::with_capacity(n);
-        for i in 0..n {
-            let base = 21 + i * 16;
-            let at = |k: usize| Some(i32::from_le_bytes(b.get(base + k * 4..base + k * 4 + 4)?.try_into().ok()?));
-            data_info.push([at(0)?, at(1)?, at(2)?, at(3)?]);
-        }
-        let mut p = 21 + n * 16;
-        let mut f64s = || -> Option<Vec<f64>> {
-            let n = u32_at(p)? as usize;
-            p += 4;
-            let mut v = Vec::with_capacity(n);
-            for _ in 0..n {
-                v.push(f64::from_le_bytes(b.get(p..p + 8)?.try_into().ok()?));
-                p += 8;
-            }
-            Some(v)
-        };
-        let data_1 = f64s()?;
-        let first_row = f64s()?;
-        Some(MatLayout { n_rows, n_reals2, data2_pos, precision, data_info, data_1, first_row })
-    }
-
-    /// The `data_2` column (0-based) `data_info` entry `i` reads, with its sign.
-    pub fn data2_col(&self, i: usize) -> Option<(usize, bool)> {
-        let [ch, ix, ..] = *self.data_info.get(i)?;
-        ((ch == 2 || ch == 0) && ix != 0).then(|| ((ix.unsigned_abs() - 1) as usize, ix < 0))
-    }
-
-    /// The time-invariant value `data_info` entry `i` holds in `data_1`.
-    pub fn data1_value(&self, i: usize) -> Option<f64> {
-        let [ch, ix, ..] = *self.data_info.get(i)?;
-        if ch != 1 || ix == 0 {
-            return None;
-        }
-        let v = *self.data_1.get(ix.unsigned_abs() as usize - 1)?;
-        Some(if ix < 0 { -v } else { v })
-    }
-
-    /// Read `data_2` column `col` of `file` (the whole `.mat`), negated if `neg`.
-    pub fn column(&self, file: &[u8], col: usize, neg: bool) -> Vec<f64> {
-        let w = self.precision.size();
-        let stride = self.n_reals2 * w;
-        let start = self.data2_pos as usize + col * w;
-        let mut out = Vec::with_capacity(self.n_rows);
-        for r in 0..self.n_rows {
-            let Some(b) = file.get(start + r * stride..start + r * stride + w) else { break };
-            let v = match self.precision {
-                Precision::Double => f64::from_le_bytes(b.try_into().unwrap()),
-                Precision::Single => f32::from_le_bytes(b.try_into().unwrap()) as f64,
-            };
-            out.push(if neg { -v } else { v });
-        }
-        out
-    }
+/// Decode what [`ResultStream::first_row_blob`] wrote.
+pub fn decode_first_row(b: &[u8]) -> Vec<f64> {
+    let Some(head) = b.get(..4) else { return Vec::new() };
+    let n = u32::from_le_bytes(head.try_into().expect("4 bytes")) as usize;
+    (0..n)
+        .map_while(|i| b.get(4 + i * 8..12 + i * 8).map(|w| f64::from_le_bytes(w.try_into().expect("8 bytes"))))
+        .collect()
 }
 
 /// The file for `format`, or `None` for `empty`. `rows` is row-major


### PR DESCRIPTION
The result format was the model's compile-time `outputFormat`, so naming a file `_res.arrow` wrote a `.mat` under an arrow name. It now comes from the file name: `result::format_of` reads the writer off the suffix and falls back to `outputFormat`, `open_stream` takes that format as an argument, and `ResultTarget` carries it.

This diverges from the C runtime, which writes the `outputFormat` under whatever name `-r` gave it. No test in the suite names a suffix that disagrees with its format, and doing what the name says is the more useful of the two readings.

`CapturedSim` no longer strides the `.mat` by byte offset. It reads a signal by name through `ResultFile`, so it serves whatever format the run wrote. That deletes `MatLayout` and its blob; the only thing left to cross the wasm boundary is the initial result row. A signal is `constant` when `MetaVar::unvarying` says so, which is exactly what both writers use to store a column as a parameter.

Arrow keeps what a `.mat` cannot: the discrete-time encoding, the unit table, the enumeration literals and `relativeQuantity`.

## The pages

The simulator names its file `_res.arrow` and the download button grew a format picker beside it. Converting is `ResultFile::write`, the same call `filterSimulationResults` makes: through omc while the worker that ran the model is alive, and through the OMPlot module for the copy kept from a retired worker.

The FMI simulator streams the recorder's rows straight into the plot and only ever serialises for the download, so that is where its format is chosen. `Recorder` had thrown away everything an arrow file records — the display unit, `relativeQuantity`, the type, the variability, and the parameters and aliases carried no unit at all — so those become an `Entry` alongside the widened `Column`, and `to_arrow` maps the FMU's own `<UnitDefinitions>` into `modelica.units`. A run written from an FMU now loses nothing.

OMPlot lists each variable's unit, marks the ones that declare a display unit, and lets the y-axis switch between them.

## Fixes on the way

* `plan_columns` failed the whole conversion on a String variable, which no format it feeds can hold; it drops them instead.
* `omc_sim_info()` reports the file the run actually wrote, so a download follows `-outputFormat` wherever it moves it.

Assisted-by: Claude Fable 5.1

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
