### PR TITLE
Arrow: slim the result variable table

### DIFF
--- a/OMCompiler/SimulationRuntime/rust/openmodelica_arrow_writer/src/lib.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_arrow_writer/src/lib.rs
@@ -15,17 +15,20 @@
 //! a JSON array with one object per result variable,
 //!
 //! ```text
-//! {"name": "a.b", "kind": "variable",  "column": 3, "scale": -1.0, "type": "Real",
+//! {"name": "a.b", "column": 3, "scale": -1.0,
 //!  "description": "...", "unit": "m", "displayUnit": "mm",
 //!  "relativeQuantity": true}
-//! {"name": "p",   "kind": "parameter", "value": 2.5, ...}
-//! {"name": "time","kind": "time",      "column": 0, ...}
+//! {"name": "p",   "value": 2.5, ...}
+//! {"name": "time","column": 0, ...}
 //! ```
 //!
-//! `column` is the schema field index. An alias is `scale * column + offset`
-//! (each key omitted when it is the identity's 1 or 0); a negated Real is
-//! `scale: -1`, a negated Boolean `scale: -1, offset: 1` over the 0/1 encoding,
-//! which is its logical negation. Only the keys with content are written.
+//! `column` is the schema field index and column 0 is `time`. An entry without
+//! one is time-invariant and carries its `value` instead, typed by the JSON: a
+//! boolean, a string, or a number that `type` widens beyond the default
+//! `Float64`. An alias is `scale * column + offset` (each key omitted when it is
+//! the identity's 1 or 0); a negated Real is `scale: -1`, a negated Boolean
+//! `scale: -1, offset: 1` over the 0/1 encoding, which is its logical negation.
+//! Only the keys with content are written.
 //!
 //! `unit` and `displayUnit` are names into the [`UNITS_KEY`] table, as in FMI,
 //! because a model has far more variables than units; see [`units`].
@@ -338,6 +341,9 @@ fn field_metadata(v: &ArrowVar) -> HashMap<String, String> {
     md
 }
 
+/// The type a variable has when its entry names none.
+const DEFAULT_TYPE: &str = "Float64";
+
 /// The declared type as its Arrow name — the file is an Arrow file, so it names
 /// types the way Arrow does. It is the *declared* type, which the storage may
 /// narrow: a `Float64` variable is a `Float32` column under `-single`, and a
@@ -382,31 +388,31 @@ fn plan(vars: &[ArrowVar], params: &[f64], first_row: &[f64], col_types: &[ColTy
     let time_field = match time_var {
         Some(v) => Field::new("time", DataType::Float64, false).with_metadata(field_metadata(v)),
         None => Field::new("time", DataType::Float64, false)
-            .with_metadata(HashMap::from([("unit".to_owned(), "s".to_owned()), ("type".to_owned(), "Real".to_owned())])),
+            .with_metadata(HashMap::from([("unit".to_owned(), "s".to_owned()), ("type".to_owned(), DEFAULT_TYPE.to_owned())])),
     };
     fields.push(time_field);
     owner.insert(0, (0, Affine::IDENTITY));
 
     for v in vars {
-        // (kind, column, alias transform, value)
-        let (kind, column, affine, value): (&str, Option<usize>, Affine, Option<f64>) = match v.kind {
-            ArrowKind::Time => ("time", Some(0), Affine::IDENTITY, None),
+        // (column, alias transform, time-invariant value)
+        let (column, affine, value): (Option<usize>, Affine, Option<f64>) = match v.kind {
+            ArrowKind::Time => (Some(0), Affine::IDENTITY, None),
             ArrowKind::Param { affine } => {
                 let p = params.get(param_ix).copied().unwrap_or(0.0);
                 param_ix += 1;
-                ("parameter", None, Affine::IDENTITY, Some(affine.apply(p)))
+                (None, Affine::IDENTITY, Some(affine.apply(p)))
             }
-            ArrowKind::Const { value } => ("parameter", None, Affine::IDENTITY, Some(value)),
+            ArrowKind::Const { value } => (None, Affine::IDENTITY, Some(value)),
             ArrowKind::Column { col, affine } if v.unvarying => {
                 let raw = first_row.get(col as usize).copied().unwrap_or(0.0);
-                ("parameter", None, Affine::IDENTITY, Some(affine.apply(raw)))
+                (None, Affine::IDENTITY, Some(affine.apply(raw)))
             }
             ArrowKind::Column { col, affine } => match owner.get(&col) {
-                Some(&(f, base)) => ("variable", Some(f), affine.relative_to(base), None),
+                Some(&(f, base)) => (Some(f), affine.relative_to(base), None),
                 None => {
                     let f = field_for(&mut fields, &mut stored, &mut enumerations, v, col, affine);
                     owner.insert(col, (f, affine));
-                    ("variable", Some(f), Affine::IDENTITY, None)
+                    (Some(f), Affine::IDENTITY, None)
                 }
             },
         };
@@ -416,9 +422,6 @@ fn plan(vars: &[ArrowVar], params: &[f64], first_row: &[f64], col_types: &[ColTy
         first = false;
         json.push_str("{\"name\":");
         json_str(&mut json, v.name);
-        json.push_str(",\"kind\":\"");
-        json.push_str(kind);
-        json.push('"');
         if let Some(c) = column {
             json.push_str(&format!(",\"column\":{c}"));
         }
@@ -430,19 +433,23 @@ fn plan(vars: &[ArrowVar], params: &[f64], first_row: &[f64], col_types: &[ColTy
             json.push_str(",\"offset\":");
             json_f64(&mut json, affine.offset);
         }
+        // Only a parameter has no column to carry its type and enumeration.
         if let Some(val) = value {
             json.push_str(",\"value\":");
-            if v.ty == VarTy::String {
-                json_str(&mut json, &resolve(val as u32));
-            } else {
-                json_f64(&mut json, val);
+            match v.ty {
+                VarTy::String => json_str(&mut json, &resolve(val as u32)),
+                VarTy::Boolean => json.push_str(if val != 0.0 { "true" } else { "false" }),
+                VarTy::Integer if val.is_finite() => json.push_str(&(val as i64).to_string()),
+                _ => json_f64(&mut json, val),
             }
-        }
-        json.push_str(",\"type\":\"");
-        json.push_str(type_name(v));
-        json.push('"');
-        if let Some(e) = v.enumeration {
-            json.push_str(&format!(",\"enumeration\":{}", enumerations.index(e)));
+            if type_name(v) != DEFAULT_TYPE {
+                json.push_str(",\"type\":\"");
+                json.push_str(type_name(v));
+                json.push('"');
+            }
+            if let Some(e) = v.enumeration {
+                json.push_str(&format!(",\"enumeration\":{}", enumerations.index(e)));
+            }
         }
         if !v.comment.is_empty() {
             json.push_str(",\"description\":");
@@ -668,8 +675,8 @@ mod tests {
         assert_eq!(*f.data_type(), ree_type(DataType::Int32));
         assert_eq!(schema.metadata()[ENUMERATIONS_KEY], r#"[["one","two","three"],["on","off"]]"#);
         let json = &schema.metadata()[VARIABLES_KEY];
-        assert!(json.contains(r#""name":"ep","kind":"parameter","value":2.0,"type":"Int32","enumeration":0"#), "{json}");
-        assert!(json.contains(r#""name":"fp","kind":"parameter","value":1.0,"type":"Int32","enumeration":1"#), "{json}");
+        assert!(json.contains(r#""name":"ep","value":2,"type":"Int32","enumeration":0"#), "{json}");
+        assert!(json.contains(r#""name":"fp","value":1,"type":"Int32","enumeration":1"#), "{json}");
         let batch = reader.into_iter().next().expect("a batch").expect("ok");
         let ree = batch.column(1).as_any().downcast_ref::<RunArray<Int32Type>>().expect("run-end encoded");
         assert_eq!(ree.values().as_any().downcast_ref::<Int32Array>().expect("int32").values(), &[1, 3]);
@@ -694,10 +701,10 @@ mod tests {
         assert_eq!(schema.field(1).metadata()["unit"], "m");
         assert_eq!(schema.metadata()[STOP_TIME_KEY], "1.0");
         let json = &schema.metadata()[VARIABLES_KEY];
-        assert!(json.contains(r#"{"name":"mx","kind":"variable","column":1,"scale":-1.0,"type":"Float64"}"#), "{json}");
-        assert!(json.contains(r#"{"name":"nb","kind":"variable","column":2,"scale":-1.0,"offset":1.0,"type":"Boolean"}"#), "{json}");
-        assert!(json.contains(r#"{"name":"p","kind":"parameter","value":-2.5,"type":"Float64"}"#), "{json}");
-        assert!(json.contains(r#"{"name":"u","kind":"parameter","value":7.0,"type":"Float64"}"#), "{json}");
+        assert!(json.contains(r#"{"name":"mx","column":1,"scale":-1.0}"#), "{json}");
+        assert!(json.contains(r#"{"name":"nb","column":2,"scale":-1.0,"offset":1.0}"#), "{json}");
+        assert!(json.contains(r#"{"name":"p","value":-2.5}"#), "{json}");
+        assert!(json.contains(r#"{"name":"u","value":7.0}"#), "{json}");
         let batches: Vec<RecordBatch> = r.map(|b| b.unwrap()).collect();
         assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 3);
         // `b` is discrete: run-end encoded, [true, false, true] in three runs.
@@ -705,6 +712,37 @@ mod tests {
         assert_eq!(b.run_ends().values(), &[1, 2, 3]);
         let bv = b.values().as_any().downcast_ref::<BooleanArray>().unwrap();
         assert_eq!((0..3).map(|i| bv.value(i)).collect::<Vec<_>>(), [true, false, true]);
+    }
+
+    /// A time-invariant value is written in the JSON type its own type calls for.
+    #[test]
+    fn parameter_values_are_typed_json() {
+        let param = |name, ty, affine| ArrowVar {
+            name,
+            comment: "",
+            unit: "",
+            display_unit: "",
+            relative_quantity: false,
+            ty,
+            discrete: false,
+            kind: ArrowKind::Param { affine },
+            unvarying: false,
+            enumeration: None,
+        };
+        let vars = [
+            ArrowVar { name: "time", comment: "", unit: "s", display_unit: "", relative_quantity: false, ty: VarTy::Real, discrete: false, kind: ArrowKind::Time, unvarying: false, enumeration: None },
+            param("b", VarTy::Boolean, Affine::IDENTITY),
+            param("nb", VarTy::Boolean, Affine::NOT),
+            param("n", VarTy::Integer, Affine::NEGATE),
+            param("x", VarTy::Real, Affine::IDENTITY),
+        ];
+        let bytes = write_arrow(&vars, &[0.0, 1.0], 1, &[1.0, 1.0, 3.0, 2.5], &[ColTy::F64], no_strings(), &FileMeta::default());
+        let schema = FileReader::try_new(std::io::Cursor::new(bytes), None).unwrap().schema();
+        let json = &schema.metadata()[VARIABLES_KEY];
+        assert!(json.contains(r#"{"name":"b","value":true,"type":"Boolean"}"#), "{json}");
+        assert!(json.contains(r#"{"name":"nb","value":false,"type":"Boolean"}"#), "{json}");
+        assert!(json.contains(r#"{"name":"n","value":-3,"type":"Int32"}"#), "{json}");
+        assert!(json.contains(r#"{"name":"x","value":2.5}"#), "{json}");
     }
 
     /// The first variable to reach a column decides how it is stored; the others
@@ -722,9 +760,9 @@ mod tests {
         let r = FileReader::try_new(std::io::Cursor::new(bytes), None).unwrap();
         let schema = r.schema();
         let json = &schema.metadata()[VARIABLES_KEY];
-        assert!(json.contains(r#"{"name":"mx","kind":"variable","column":1,"type":"Float64"}"#), "{json}");
-        assert!(json.contains(r#"{"name":"x","kind":"variable","column":1,"scale":-1.0,"type":"Float64"}"#), "{json}");
-        assert!(json.contains(r#"{"name":"y","kind":"variable","column":1,"scale":-2.0,"offset":3.0,"type":"Float64"}"#), "{json}");
+        assert!(json.contains(r#"{"name":"mx","column":1}"#), "{json}");
+        assert!(json.contains(r#"{"name":"x","column":1,"scale":-1.0}"#), "{json}");
+        assert!(json.contains(r#"{"name":"y","column":1,"scale":-2.0,"offset":3.0}"#), "{json}");
         let b = r.map(|b| b.unwrap()).next().unwrap();
         let mx = b.column(1).as_any().downcast_ref::<Float32Array>().unwrap();
         assert_eq!(mx.values(), &[-1.0f32, -2.0]);
@@ -746,7 +784,7 @@ mod tests {
         let r = FileReader::try_new(std::io::Cursor::new(bytes), None).unwrap();
         let schema = r.schema();
         assert!(matches!(schema.field(1).data_type(), DataType::RunEndEncoded(_, v) if *v.data_type() == DataType::Utf8));
-        assert!(schema.metadata()[VARIABLES_KEY].contains(r#"{"name":"sp","kind":"parameter","value":"on","type":"Utf8"}"#));
+        assert!(schema.metadata()[VARIABLES_KEY].contains(r#"{"name":"sp","value":"on","type":"Utf8"}"#));
         let b = r.map(|b| b.unwrap()).next().unwrap();
         let s = b.column(1).as_any().downcast_ref::<RunArray<Int32Type>>().unwrap();
         assert_eq!(s.run_ends().values(), &[2, 4]);

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_result_files/src/arrow.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_result_files/src/arrow.rs
@@ -225,21 +225,41 @@ impl ArrowReader {
                     if name.is_empty() {
                         continue;
                     }
-                    let (isParam, index) = match e.get("kind").and_then(|v| v.as_str()).unwrap_or("variable") {
-                        "parameter" => {
-                            params.push(e.get("value").and_then(|v| v.as_f64()).unwrap_or(f64::NAN));
-                            if let Some(text) = e.get("value").and_then(|v| v.as_str()) {
+                    // A stored variable's type and enumeration are its column's
+                    // field metadata; only a time-invariant value carries its own.
+                    let mut ty = String::new();
+                    let mut enum_ix = None;
+                    let (isParam, index) = match e.get("column").and_then(|v| v.as_u64()) {
+                        None => {
+                            let value = e.get("value");
+                            params.push(match value {
+                                Some(serde_json::Value::Bool(b)) => f64::from(u8::from(*b)),
+                                Some(v) => v.as_f64().unwrap_or(f64::NAN),
+                                None => f64::NAN,
+                            });
+                            if let Some(text) = value.and_then(|v| v.as_str()) {
                                 string_params.insert(params.len() - 1, text.to_owned());
                             }
+                            ty = match (str_of("type"), value) {
+                                (t, _) if !t.is_empty() => t,
+                                (_, Some(serde_json::Value::Bool(_))) => "Boolean".to_owned(),
+                                (_, Some(serde_json::Value::String(_))) => "Utf8".to_owned(),
+                                _ => String::new(),
+                            };
+                            enum_ix = e.get("enumeration").and_then(|v| v.as_u64());
                             (true, params.len() as i32)
                         }
-                        _ => {
-                            let field = e.get("column").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+                        Some(col) => {
+                            let col = col as usize;
+                            if let Some(md) = schema.fields().get(col).map(|f| f.metadata()) {
+                                ty = md.get("type").cloned().unwrap_or_default();
+                                enum_ix = md.get("enumeration").and_then(|s| s.parse().ok());
+                            }
                             // The time column was moved to 0 above.
-                            let field = match schema.fields().get(field) {
+                            let field = match schema.fields().get(col) {
                                 Some(f) if f.name() == "time" || f.name() == "Time" => 0,
-                                _ if field == 0 => field_pos("time").or_else(|| field_pos("Time")).unwrap_or(0),
-                                _ => field,
+                                _ if col == 0 => field_pos("time").or_else(|| field_pos("Time")).unwrap_or(0),
+                                _ => col,
                             };
                             let num = |k: &str, dflt: f64| e.get(k).and_then(|v| v.as_f64()).unwrap_or(dflt);
                             let (scale, offset) = (num("scale", 1.0), num("offset", 0.0));
@@ -259,11 +279,8 @@ impl ArrowReader {
                         }
                     };
                     allInfo.push(MatVariable { name, descr: str_of("description"), isParam, index });
-                    meta.push((str_of("unit"), str_of("displayUnit"), {
-                        let t = str_of("type");
-                        if t.is_empty() { "Real".to_owned() } else { t }
-                    }, e.get("relativeQuantity").and_then(|v| v.as_bool()).unwrap_or(false)));
-                    enums.push(e.get("enumeration").and_then(|v| v.as_u64()).and_then(|i| enum_types.get(i as usize).cloned()));
+                    meta.push((str_of("unit"), str_of("displayUnit"), if ty.is_empty() { "Real".to_owned() } else { ty }, e.get("relativeQuantity").and_then(|v| v.as_bool()).unwrap_or(false)));
+                    enums.push(enum_ix.and_then(|i| enum_types.get(i as usize).cloned()));
                 }
             }
             Some(Err(e)) => return Err(format!("bad {VARIABLES_KEY} metadata: {e}")),
@@ -440,7 +457,7 @@ mod tests {
         let schema = Schema::new_with_metadata(
             vec![Field::new("time", DataType::Float64, false), Field::new("e", dict_type, false).with_metadata(e_md)],
             HashMap::from([
-                (VARIABLES_KEY.to_owned(), r#"[{"name":"time","kind":"time","column":0},{"name":"e","kind":"variable","column":1,"type":"enumeration","enumeration":0}]"#.to_owned()),
+                (VARIABLES_KEY.to_owned(), r#"[{"name":"time","column":0},{"name":"e","column":1}]"#.to_owned()),
                 (ENUMERATIONS_KEY.to_owned(), r#"[["one","two","three"]]"#.to_owned()),
             ]),
         );
@@ -479,6 +496,37 @@ mod tests {
         assert_eq!(r.read_strings(index), None, "an Int32 column carries no texts; ResultFile::strings maps the literals");
         let p = r.find_var("ep").expect("ep");
         assert_eq!(r.val(p, 0.0), Some(2.0));
+    }
+
+    /// A `Boolean` parameter's JSON boolean and an `Integer` one's JSON integer
+    /// read back as the 0/1 and the value `ResultTable` hands out.
+    #[test]
+    fn typed_parameters_read_back() {
+        let param = |name, ty| ArrowVar {
+            name,
+            comment: "",
+            unit: "",
+            display_unit: "",
+            relative_quantity: false,
+            ty,
+            discrete: false,
+            kind: ArrowKind::Param { affine: Affine::IDENTITY },
+            unvarying: false,
+            enumeration: None,
+        };
+        let vars = [
+            ArrowVar { name: "time", comment: "", unit: "s", display_unit: "", relative_quantity: false, ty: VarTy::Real, discrete: false, kind: ArrowKind::Time, unvarying: false, enumeration: None },
+            param("b", VarTy::Boolean),
+            param("n", VarTy::Integer),
+        ];
+        let bytes = write_arrow(&vars, &[0.0, 1.0], 1, &[1.0, -3.0], &[ColTy::F64], no_strings(), &FileMeta::default());
+        let mut r = ArrowReader::from_bytes(bytes).expect("readable");
+        let b = r.find_var("b").expect("b");
+        assert_eq!(r.var_type(b), "Boolean");
+        assert_eq!(r.val(b, 0.0), Some(1.0));
+        let n = r.find_var("n").expect("n");
+        assert_eq!(r.var_type(n), "Integer");
+        assert_eq!(r.val(n, 0.0), Some(-3.0));
     }
 
     #[test]

--- a/doc/UsersGuide/source/technical_details.rst
+++ b/doc/UsersGuide/source/technical_details.rst
@@ -168,10 +168,10 @@ Discrete-time variables
   that can disagree with it. In FMI's terms a ``discrete`` or ``tunable``
   variable is stored this way — the two are indistinguishable once the run is
   over — while ``constant`` and ``fixed`` variables have no column at all and
-  appear as a ``parameter`` in the variable table.
+  appear in the variable table as a parameter: a ``value`` and no ``column``.
 
   A variable that *could* change but did not — one the run computes once during
-  initialization and never writes again — is also stored as a ``parameter``,
+  initialization and never writes again — is also stored as a parameter,
   holding the value it took. Its variability in the model it came from may well
   have been continuous; the file records the trajectory, not the declaration.
 
@@ -184,10 +184,10 @@ Discrete-time variables
   ``omc_result_string_at``).
 
 Enumerations
-  An enumeration variable is typed ``enumeration`` and names its type by index
-  into ``modelica.enumerations``, a table of ordered literal names. A type is
-  identified by that ordered list alone, so two variables listing the same
-  literals share one entry.
+  An enumeration variable is an ``Int32`` that names its type by index into
+  ``modelica.enumerations``, a table of ordered literal names, in an
+  ``enumeration`` key. A type is identified by that ordered list alone, so two
+  variables listing the same literals share one entry.
 
   The column is either an ``Int32`` holding the value (``1`` for the first
   literal), or a ``Dictionary<Int32, Utf8>`` whose dictionary is the same
@@ -204,6 +204,11 @@ Field metadata
   variables share a column, the field metadata is that of the variable owning
   the column; the variable table carries each variable's own.
 
+  ``type`` and ``enumeration`` are the exception: they belong to the column
+  rather than to the variable, so the variable table does not repeat them and an
+  alias has the type of the column it reads. Only a variable with no column at
+  all — a parameter — carries them there.
+
 Schema metadata
   The keys carry a tool-neutral ``modelica.`` prefix, so another tool can write
   and read the same layout. Every value is a string, as Arrow schema metadata
@@ -219,7 +224,10 @@ Schema metadata
     A JSON array with one object per result variable, in the order the writer
     lists them, holding what ``dataInfo`` holds in the MATv4 file together with
     each variable's own metadata. Only keys with content are written, so a
-    reader must apply the default of every key it does not find:
+    reader must apply the default of every key it does not find.
+
+    An entry either names a ``column`` or carries a ``value``, and that alone
+    tells a time-variant variable from a parameter.
 
     .. list-table::
        :header-rows: 1
@@ -231,19 +239,12 @@ Schema metadata
        * - ``name``
          - string
          - The variable's name. Required.
-       * - ``kind``
-         - string
-         - ``"time"``, ``"variable"`` or ``"parameter"`` — a string, not an
-           index. Required. A ``parameter`` carries ``value`` and no ``column``;
-           the other two carry ``column`` and no ``value``, so the kinds are
-           also told apart structurally. ``time`` marks the run's time variable,
-           which an alias of it (``column: 0``, kind ``variable``) does not.
        * - ``column``
          - integer
-         - For ``time`` and ``variable``, the schema field index holding the
-           values. Several variables may name the same column: they are
-           aliases and the data is stored once; an alias of ``time`` names
-           column 0.
+         - The schema field index holding the values, for a time-variant
+           variable. Several variables may name the same column: they are
+           aliases and the data is stored once. Column 0 is ``time``, so the
+           time variable and any alias of it name it.
        * - ``scale``
          - number
          - The variable is ``scale * column + offset``. Default ``1``.
@@ -255,14 +256,19 @@ Schema metadata
            OpenModelica detects only these, but a reader must apply any
            ``scale`` and ``offset`` it finds.
        * - ``value``
-         - number or string
-         - For ``parameter``, the value; a string for a ``String`` parameter.
-           Values computed once during initialization are parameters here, as
-           in ``data_1``.
+         - number, string or boolean
+         - The value of a variable that has no column: a parameter. Its JSON
+           type is the one ``type`` calls for — a JSON boolean for a
+           ``Boolean``, a string for a ``Utf8``, a number otherwise, ``null``
+           for a value JSON cannot write (an infinity or a NaN). Values
+           computed once during initialization are parameters here, as in
+           ``data_1``.
        * - ``type``
          - string
          - The declared type, named as Arrow names it (see *Column types*).
-           Default ``"Float64"``.
+           Default ``"Float64"``. Only an entry with a ``value`` carries it;
+           a variable with a ``column`` has the type of that column's field
+           metadata.
        * - ``description``
          - string
          - The variable's description. Default empty.
@@ -280,9 +286,10 @@ Schema metadata
            unit scales it but adds no offset. Default ``false``.
        * - ``enumeration``
          - integer
-         - For an enumeration variable, the index of its type in
-           ``modelica.enumerations``. The literal a ``parameter``'s ``value``
-           names is that table's entry at ``value - 1``.
+         - The index in ``modelica.enumerations`` of the type of an enumeration
+           parameter; the literal its ``value`` names is that table's entry at
+           ``value - 1``. Like ``type``, it is the column's field metadata for
+           a variable that has one.
 
   ``modelica.enumerations``
     A JSON array of the distinct enumeration types, each an array of its


### PR DESCRIPTION
Three keys of `modelica.variables` said what the file already said somewhere else.

`kind` ("time", "variable" or "parameter") was redundant: a parameter is the entry that carries `value` and no `column`, and the reader never told "time" from "variable" — the time column is column 0 whether the entry naming it is the time variable or an alias of it. An entry now either names a `column` or carries a `value`, and that is the whole rule.

`type` and `enumeration` belong to the column rather than to the variable: the schema's field metadata already carries both, and aliases sharing a column share the type. They stay in the variable table only for a parameter, which has no column to carry them.

`value` could not be a JSON boolean, so a Boolean parameter was written as `1.0`. It now takes the JSON type its own type calls for: a boolean for a `Boolean`, a string for a `Utf8`, an integer for an `Int32`.

A file the old writer produced still reads: `kind` only repeated what the structure says, and the field metadata was always written.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
