### PR TITLE
Hash Integers with a builtin, not a 31-bit mask

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/MetaModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/MetaModelicaBuiltin.mo
@@ -616,6 +616,15 @@ function stringHashDjb2Continue
 external "builtin";
 end stringHashDjb2Continue;
 
+function intHashDjb2Continue
+  "Same result as stringHashDjb2Continue(intString(i), hash), without building
+   the string."
+  input Integer i;
+  input Integer hash;
+  output Integer outHash;
+external "builtin";
+end intHashDjb2Continue;
+
 function stringHashDjb2Mod "Does hashing+modulo without intermediate results."
   input String str;
   input Integer mod;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -443,7 +443,7 @@ public
       local
         Absyn.Path path;
 
-      case INTEGER() then Util.hashIntegerDjb2Continue(exp.value, hash);
+      case INTEGER() then intHashDjb2Continue(exp.value, hash);
       case REAL() then stringHashDjb2Continue(realString(exp.value), hash);
       case STRING() then stringHashDjb2Continue(exp.value, hash);
       case BOOLEAN() then stringHashDjb2Continue(boolString(exp.value), hash);

--- a/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
@@ -1375,7 +1375,7 @@ public
     hash := match sub
       local
         Integer i;
-      case INDEX(index = Expression.INTEGER(value = i)) then Util.hashIntegerDjb2Continue(i, hash);
+      case INDEX(index = Expression.INTEGER(value = i)) then intHashDjb2Continue(i, hash);
       else stringHashDjb2Continue(toString(sub), hash);
     end match;
   end hashStringContinue;

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/string/hash.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/string/hash.rs
@@ -48,6 +48,29 @@ pub fn stringHashDjb2Continue(str: ArcStr, hash: i32) -> i32 {
     (djb2(str.as_bytes(), hash as u32) & HASH_MASK) as i32
 }
 
+/// Same result as `stringHashDjb2Continue(intString(i), hash)`, without
+/// building the string.
+pub fn intHashDjb2Continue(i: i32, hash: i32) -> i32 {
+    let mut buf = [0u8; 11];
+    let mut n = buf.len();
+    let mut v = i.unsigned_abs();
+
+    loop {
+        n -= 1;
+        buf[n] = b'0' + (v % 10) as u8;
+        v /= 10;
+        if v == 0 {
+            break;
+        }
+    }
+    if i < 0 {
+        n -= 1;
+        buf[n] = b'-';
+    }
+
+    (djb2(&buf[n..], hash as u32) & HASH_MASK) as i32
+}
+
 /// Computes a DJB2 hash and applies modulo, giving a result in `[0, mod_val)`.
 pub fn stringHashDjb2Mod(str: ArcStr, mod_val: i32) -> i32 {
     if mod_val == 0 {
@@ -101,6 +124,17 @@ mod tests {
             // A string long enough to overflow the 32-bit accumulator.
             assert_eq!(stringHashDjb2(literal!("$SEED_ODE_JAC_ADJ.$DER.b")), 1541592153);
             assert_eq!(stringHashDjb2Mod(literal!("$RES_SIM_1"), 13), 4);
+        }
+
+        #[test]
+        fn test_int_hash_djb2_continue() {
+            for i in [0, 1, -1, 7, -42, 1234567890, i32::MAX, i32::MIN] {
+                assert_eq!(
+                    intHashDjb2Continue(i, 5381),
+                    stringHashDjb2Continue(ArcStr::from(i.to_string()), 5381),
+                    "i = {i}"
+                );
+            }
         }
 
         #[test]

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/fallibility.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/fallibility.rs
@@ -141,7 +141,7 @@ pub fn builtin_fallibility(name: &str) -> Option<Fallibility> {
         "stringAppend" => Infallible,
         "stringEq" | "stringEqual" | "stringCompare" => Infallible,
         "stringHash" | "stringHashDjb2" | "stringHashDjb2Continue"
-        | "stringHashDjb2Mod" | "stringHashSdbm" => Infallible,
+        | "stringHashDjb2Mod" | "stringHashSdbm" | "intHashDjb2Continue" => Infallible,
         "substring" => Fallible,           // bails on bogus range
         "listStringCharString" | "stringCharListString" => Infallible,
 

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/typedexp.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/typedexp.rs
@@ -1076,6 +1076,7 @@ fn call_ty(func: &str, args: &[TypedExp], top_level: &BTreeMap<String, NameNode<
         | "intMax" | "intMin" | "intNeg" | "intBitAnd" | "intBitOr" | "intBitXor"
         | "intBitNot" | "intBitLShift" | "intBitRShift" | "intFromChar"
         | "stringLength" | "stringCompare" | "stringHash" | "stringHashDjb2"
+        | "stringHashDjb2Continue" | "intHashDjb2Continue"
         | "stringGet" | "stringInt" | "realInt"
         | "stringGetNoBoundsChecking" | "Dangerous.stringGetNoBoundsChecking" | "MetaModelica.Dangerous.stringGetNoBoundsChecking"
         | "arrayLength" | "listLength" => Ty::I32,

--- a/OMCompiler/Compiler/Util/Util.mo
+++ b/OMCompiler/Compiler/Util/Util.mo
@@ -79,31 +79,6 @@ import System;
 public constant Integer HASH_SEED = 5381;
 public constant SourceInfo dummyInfo = SOURCEINFO("",false,0,0,0,0,0.0);
 
-public function hashIntegerDjb2Continue
-  "Bit-identical to stringHashDjb2Continue(intString(i), hash) without building
-   the string. The builtin wraps its accumulator at 32 bits and masks to 31 at
-   the end; masking to 31 every step gives the same 31 bits, and keeps every
-   constant inside a 32-bit Integer."
-  input Integer i;
-  input output Integer hash;
-protected
-  Integer v = i, div = 1;
-algorithm
-  if v < 0 then
-    hash := intBitAnd(hash * 33 + 45 /* '-' */, 2147483647);
-    v := -v;
-  end if;
-
-  while intDiv(v, div) >= 10 loop
-    div := div * 10;
-  end while;
-
-  while div > 0 loop
-    hash := intBitAnd(hash * 33 + 48 /* '0' */ + intMod(intDiv(v, div), 10), 2147483647);
-    div := intDiv(div, 10);
-  end while;
-end hashIntegerDjb2Continue;
-
 public function isIntGreater "Author: BZ"
   input Integer lhs;
   input Integer rhs;

--- a/OMCompiler/SimulationRuntime/c/meta/meta_modelica_builtin.c
+++ b/OMCompiler/SimulationRuntime/c/meta/meta_modelica_builtin.c
@@ -175,6 +175,22 @@ modelica_integer stringHashDjb2Continue(metamodelica_string_const s, modelica_in
   return djb2_hash_continue((const unsigned char*)str, (uint32_t)hash) & MMC_HASH_MASK;
 }
 
+/* Same result as stringHashDjb2Continue(intString(i), hash), without building
+ * the string. Cannot live in MetaModelica: MMC_HASH_MASK is not a legal
+ * Integer literal where modelica_integer holds 31 bits. */
+modelica_integer intHashDjb2Continue(modelica_integer i, modelica_integer hash)
+{
+  unsigned char buf[24];
+  int n = sizeof(buf) - 1;
+  mmc_uint_t v = i < 0 ? -(mmc_uint_t) i : (mmc_uint_t) i;
+
+  buf[n] = '\0';
+  do { buf[--n] = '0' + (unsigned char) (v % 10); v /= 10; } while (v);
+  if (i < 0) buf[--n] = '-';
+
+  return djb2_hash_continue(buf + n, (uint32_t) hash) & MMC_HASH_MASK;
+}
+
 /* adrpo: see the comment above about djb2 hash */
 modelica_integer stringHashDjb2Mod(metamodelica_string_const s, modelica_integer mod)
 {

--- a/OMCompiler/SimulationRuntime/c/meta/meta_modelica_builtin.h
+++ b/OMCompiler/SimulationRuntime/c/meta/meta_modelica_builtin.h
@@ -80,6 +80,7 @@ extern modelica_metatype boxptr_stringUpdateStringChar(threadData_t *,metamodeli
 extern modelica_integer stringHash(metamodelica_string_const);
 extern modelica_integer stringHashDjb2(metamodelica_string_const s);
 extern modelica_integer stringHashDjb2Continue(metamodelica_string_const s, modelica_integer hash);
+extern modelica_integer intHashDjb2Continue(modelica_integer i, modelica_integer hash);
 extern modelica_integer stringHashDjb2Mod(metamodelica_string_const s,modelica_integer mod);
 extern modelica_integer stringHashSdbm(metamodelica_string_const str);
 #define substring(X,Y,Z) boxptr_substring(threadData,X,mmc_mk_icon(Y),mmc_mk_icon(Z))


### PR DESCRIPTION
`Util.hashIntegerDjb2Continue` masked its accumulator with the literal `2147483647`. A 32-bit build tags fixnums down to **31-bit** signed Integers, so its parser truncates that literal and the nightly fails:

    Error: OpenModelica only supports 31-bit signed integers!
    Truncating integer: 2147483647 to 1073741823

The mask cannot be spelled in MetaModelica at all there - it is larger than the language's `Integer` - so the djb2 recurrence moves into an `intHashDjb2Continue` builtin, where C and Rust have `uint32_t`/`u32` just as `stringHashDjb2Continue` already does. The call sites in `NFExpression` and `NFSubscript` call it directly, so the allocation that the MetaModelica version was written to avoid stays avoided.

The hash values are unchanged: the old loop, the C builtin (with `modelica_integer` as both `long` and `int`) and the Rust builtin all agree with `stringHashDjb2Continue(intString(i), hash)` over +-100000 and the edge cases, `INT_MIN` included.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
