### PR TITLE
Do not hard-require QtHttpServer or a qt5 qmake

### DIFF
--- a/OMEdit/OMEdit.config.pre.pri
+++ b/OMEdit/OMEdit.config.pre.pri
@@ -33,8 +33,10 @@
 QT += network core gui xml svg opengl printsupport widgets concurrent webenginewidgets
 equals(QT_MAJOR_VERSION, 6) {
   QT += core5compat openglwidgets
-  greaterThan(QT_MINOR_VERSION, 4) {
+  qtHaveModule(httpserver) {
     QT += httpserver
+  } else {
+    message("QtHttpServer not found; building without the MCP server")
   }
 }
 

--- a/common/m4/qmake.m4
+++ b/common/m4/qmake.m4
@@ -29,7 +29,7 @@ else
     AC_MSG_RESULT([$QMAKE])
   else
     AC_MSG_RESULT([no])
-    AC_CHECK_PROGS(QMAKE,qmake qmake-mac qmake-qt4,"")
+    AC_CHECK_PROGS(QMAKE,qmake qmake6 qmake-mac qmake-qt4,"")
   fi
 fi
 
@@ -49,9 +49,12 @@ if test -n "$QMAKE"; then
     QT4BUILD="-DQT4_BUILD:Boolean=OFF"
   elif "$QMAKE" -v 2>&1 | grep "Qt version 4"; then
     QT4BUILD="-DQT4_BUILD:Boolean=ON"
+  elif "$QMAKE" -v 2>&1 | grep "Qt version 6"; then
+    WITH_QT6="yes"
+    QT4BUILD="-DQT4_BUILD:Boolean=OFF"
   else
     QMAKE_VERSION=`"$QMAKE" -v`
-    AC_MSG_ERROR([qmake does not report qt version 4 or 5: $QMAKE_VERSION])
+    AC_MSG_ERROR([qmake does not report qt version 4, 5 or 6: $QMAKE_VERSION])
   fi
 
   if echo $host | grep darwin; then


### PR DESCRIPTION
OMEdit's .pro added `QT += httpserver` for every Qt >= 6.5, failing the whole build on a distro that ships Qt 6.8 without qt6-httpserver-dev (Debian trixie, Ubuntu resolute).  MCPServer.h already falls back to a stub when <QtHttpServer> is missing, so ask qmake whether the module is installed instead of guessing from the Qt version.

qmake.m4 only accepted a qmake reporting Qt 4 or 5.  It picks the qt6 path from an `lsb_release -cs` codename list, so on an image with no lsb_release - the EL and Fedora rpm images - a Qt6-only qmake aborted configure with "qmake does not report qt version 4 or 5".

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
