### PR TITLE
getVar: a fully indexed scalar cref fails fast

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendVariable.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVariable.mo
@@ -3288,6 +3288,10 @@ algorithm
     return;
   end if;
 
+  if isScalarQuery(cr) then
+    fail();
+  end if;
+
   try
     crlst := ComponentReference.expandCref(cr, true);
     (outVarLst as _::_, outIntegerLst) := getVarLst(crlst, inVariables);
@@ -3327,6 +3331,26 @@ algorithm
     else false;
   end match;
 end isExpandableType;
+
+protected function isScalarQuery
+  "Whether expandCref would return cr itself: every identifier fully indexed
+   with constant subscripts and the last one not a record. The hash miss
+   before this check is then final."
+  input DAE.ComponentRef cr;
+  output Boolean b;
+algorithm
+  b := match cr
+    case DAE.CREF_IDENT()
+      then List.all(cr.subscriptLst, isIntSubscript)
+        and listLength(cr.subscriptLst) >= Types.numberOfDimensions(cr.identType)
+        and not Types.isRecord(Types.arrayElementType(cr.identType));
+    case DAE.CREF_QUAL()
+      then List.all(cr.subscriptLst, isIntSubscript)
+        and listLength(cr.subscriptLst) >= Types.numberOfDimensions(cr.identType)
+        and isScalarQuery(cr.componentRef);
+    else false;
+  end match;
+end isScalarQuery;
 
 protected function isElementOf
   "Whether var, which the query (depth qualifiers, last one of element type ty


### PR DESCRIPTION
`BackendVariable.getVar` answered a hash miss by expanding the cref with `ComponentReference.expandCref`, looking every element up again with `getVarLst`, then trying once more through `replaceVarWithWholeDim`. For a cref whose identifiers are all fully indexed with constant subscripts (and whose last type is not a record) `expandCref` returns the cref itself, so all of that repeats the lookup that just failed.

Such misses are the common case: `traversingadjacencyRowExpFinder` looks up `$START.cr` for every cref of every equation, and parameters are looked up in the ordered variables first. On
`ScalableTestSuite ... DistributionSystemModelica_N_20_M_20`, 374,806 of the 873,056 `getVar` calls missed, and the fallback was 12% of the whole translation (callgrind, Rust omc): `expandCref` 2.62 G Ir, `getVarLst` 0.42 G, `replaceVarWithWholeDim` 0.35 G.

With the early `fail()`:

| omc  | measure                          | before  | after   |
| ---- | -------------------------------- | ------- | ------- |
| Rust | translateModel, G Ir             | 26.34   | 22.99   |
| Rust | getSolvedSystem, G Ir            | 14.56   | 11.63   |
| Rust | allocations                      | 87.2 M  | 69.9 M  |
| C    | execstat allocations, GB         | 1.55    | 1.22    |

The generated C for the model is byte-identical apart from the GUID.

Assisted-by: Claude Fable 5.1

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
