### PR TITLE
List: Nil as a null handle, in-place listReverse

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/lib.rs
@@ -151,7 +151,7 @@ pub extern "C" fn omc_cli_run(argc: c_int, argv: *const *const c_char) -> c_int 
             })
             .collect()
     };
-    let arglist = std::sync::Arc::new(args.into_iter().collect());
+    let arglist: metamodelica::List<_> = args.into_iter().collect();
     let status = catch_unwind(AssertUnwindSafe(|| openmodelica_backend_main::Main::main(arglist)));
     // `process::exit` drops no thread-local, so flush the buffered writers here.
     openmodelica_util::File::flush_all_registered();

--- a/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/wasm_plot.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/libopenmodelica_compiler/src/wasm_plot.rs
@@ -242,7 +242,7 @@ fn finish(mut lc: LayeredChart, a: &PlotArgs, xlabel: &str, ylabel: &str) -> Res
 /// Read full trajectories for `vars` (variable-major) from the result file as
 /// plain `f64` columns.
 fn read_columns(filename: &ArcStr, vars: &[&str]) -> Result<Vec<Vec<f64>>, String> {
-    let mut lst: Arc<List<ArcStr>> = metamodelica::nil();
+    let mut lst: List<ArcStr> = metamodelica::nil();
     for v in vars.iter().rev() {
         lst = metamodelica::cons(ArcStr::from(*v), lst);
     }
@@ -276,7 +276,7 @@ fn real_vec(v: &Values::Value) -> Result<Vec<f64>, String> {
     Ok(out)
 }
 
-fn list_to_vec(l: &Arc<List<ArcStr>>) -> Vec<ArcStr> {
+fn list_to_vec(l: &List<ArcStr>) -> Vec<ArcStr> {
     let mut out = Vec::new();
     for x in l.as_ref() {
         out.push(x.clone());

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/Dangerous.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/Dangerous.rs
@@ -104,66 +104,29 @@ pub fn stringGetNoBoundsChecking(str: ArcStr, index: i32) -> i32 {
     // SAFETY: Caller must ensure index is in bounds.
     unsafe { (*str.as_bytes().get_unchecked(idx)) as i32 }
 }
-/// Reverses a list in place, destructively.
-///
-/// Walks the spine and repoints each `Cons` cell's `tail` at the cell that
-/// preceded it, mutating the cells through a raw pointer (the same
-/// dangerous mechanism as `listSetRest`). No new cells are allocated.
-///
-/// SAFETY / semantics: this mirrors the MetaModelica runtime's destructive
-/// `listReverseInPlace`. Every other holder of a clone of these cons cells
-/// observes the reversal, and the input list head no longer denotes the
-/// same sequence. Only call on a freshly built list that is not shared and
-/// not read concurrently.
-pub fn listReverseInPlace<T: Clone>(list: Arc<List<T>>) -> Arc<List<T>> {
-    let mut prev: Arc<List<T>> = nil();
-    let mut curr: Arc<List<T>> = list;
-    while let List::Cons { tail, .. } = &*curr {
-        let next = tail.clone();
-        // SAFETY: see the method doc — the caller guarantees the cells are
-        // uniquely owned (freshly built) and not read concurrently.
-        unsafe {
-            let p = Arc::as_ptr(&curr) as *mut List<T>;
-            if let List::Cons { tail, .. } = &mut *p {
-                *tail = prev;
-            }
-        }
-        prev = curr;
-        curr = next;
-    }
-    prev
+/// `listReverse`: the uniquely owned prefix is already relinked in place.
+pub fn listReverseInPlace<T: Clone>(list: List<T>) -> List<T> {
+    list.reverse()
 }
-/// Destructively appends `second` onto the end of `first`: walks to the last
-/// cons cell of `first` and repoints its `tail` at `second`. Allocates
-/// nothing. Mirrors the MetaModelica runtime's `listAppendDestroy`
-/// (`SimulationRuntime/c/meta/meta_modelica_builtin.c`).
-///
-/// SAFETY: mutates `first`'s last cell through a raw pointer (the same
-/// mechanism as [`listSetRest`]), so every holder of a clone of that cell
-/// observes the splice. The MetaModelica contract is that `first` is
-/// "destroyed" — the caller must not keep using it as its original sequence,
-/// and the cells must not be read concurrently.
-pub fn listAppendDestroy<T: Clone>(first: Arc<List<T>>, second: Arc<List<T>>) -> Arc<List<T>> {
-    // An empty first list has no cell to repoint; the result is `second`.
-    if matches!(&*first, List::Nil) {
-        return second;
-    }
-    // Walk to the last cons cell (the one whose tail is Nil).
-    let mut lst = first.clone();
-    loop {
-        let next = match &*lst {
-            List::Cons { tail, .. } if !matches!(&**tail, List::Nil) => tail.clone(),
-            _ => break,
-        };
-        lst = next;
-    }
-    // SAFETY: see the doc comment — `first`'s cells are destroyed/uniquely
-    // held by the caller and not read concurrently.
-    unsafe {
-        let p = Arc::as_ptr(&lst) as *mut List<T>;
-        if let List::Cons { tail, .. } = &mut *p {
-            *tail = second;
+/// Appends `second` onto the end of `first` by repointing the last cell when
+/// every cell of `first` is uniquely owned; copies `first` otherwise.
+pub fn listAppendDestroy<T: Clone>(mut first: List<T>, second: List<T>) -> List<T> {
+    let mut p = &first;
+    while let Some(cell) = &p.0 {
+        if Arc::strong_count(cell) != 1 || Arc::weak_count(cell) != 0 {
+            return first.append(&second);
         }
+        let ListNode::Cons { tail, .. } = &**cell else { break };
+        p = tail;
+    }
+    let mut cur = &mut first;
+    while cur.0.as_ref().is_some_and(|c| matches!(&**c, ListNode::Cons { tail, .. } if tail.0.is_some())) {
+        let Some(ListNode::Cons { tail, .. }) = cur.0.as_mut().and_then(Arc::get_mut) else { unreachable!() };
+        cur = tail;
+    }
+    match cur.0.as_mut().and_then(Arc::get_mut) {
+        Some(ListNode::Cons { tail, .. }) => *tail = second,
+        _ => return second,
     }
     first
 }
@@ -173,23 +136,25 @@ pub fn listAppendDestroy<T: Clone>(first: Arc<List<T>>, second: Arc<List<T>>) ->
 /// other holders of clones of this `Arc` observe the change. Caller must
 /// ensure no other thread is reading the cell concurrently. Mirrors the
 /// MetaModelica runtime's RML cons-cell mutation.
-pub fn listSetRest<T: Clone>(list: Arc<List<T>>, new_tail: Arc<List<T>>) -> Result<()> {
-    let ptr = Arc::as_ptr(&list) as *mut List<T>;
+pub fn listSetRest<T: Clone>(list: List<T>, new_tail: List<T>) -> Result<()> {
+    let Some(cell) = &list.0 else { return Err("listSetRest: called on Nil") };
+    let ptr = Arc::as_ptr(cell) as *mut ListNode<T>;
     unsafe {
         match &mut *ptr {
-            List::Cons { tail, .. } => { *tail = new_tail; Ok(()) }
-            List::Nil => return Err("listSetRest: called on Nil"),
+            ListNode::Cons { tail, .. } => { *tail = new_tail; Ok(()) }
+            ListNode::Nil => Err("listSetRest: called on Nil"),
         }
     }
 }
 /// Overwrites the `head` field of the given Cons cell. See `listSetRest`
 /// for the safety contract.
-pub fn listSetFirst<T: Clone>(list: Arc<List<T>>, new_head: T) -> Result<()> {
-    let ptr = Arc::as_ptr(&list) as *mut List<T>;
+pub fn listSetFirst<T: Clone>(list: List<T>, new_head: T) -> Result<()> {
+    let Some(cell) = &list.0 else { return Err("listSetFirst: called on Nil") };
+    let ptr = Arc::as_ptr(cell) as *mut ListNode<T>;
     unsafe {
         match &mut *ptr {
-            List::Cons { head, .. } => { *head = new_head; Ok(()) }
-            List::Nil => return Err("listSetFirst: called on Nil"),
+            ListNode::Cons { head, .. } => { *head = new_head; Ok(()) }
+            ListNode::Nil => Err("listSetFirst: called on Nil"),
         }
     }
 }
@@ -268,15 +233,12 @@ mod tests {
             let r = listAppendDestroy(cons(1, nil()), cons(2, cons(3, nil())));
             assert_eq!(collect(&r), vec![1, 2, 3]);
 
-            // Destructive / zero-alloc: the splice mutates the last cell of
-            // `first` in place, so a clone of `first`'s head taken *before* the
-            // call observes the appended tail afterwards (the cells are shared,
-            // not copied).
+            // A shared `first` is copied, not spliced.
             let first = cons(1, cons(2, nil()));
             let alias = first.clone();
             let r = listAppendDestroy(first, cons(3, cons(4, nil())));
             assert_eq!(collect(&r), vec![1, 2, 3, 4]);
-            assert_eq!(collect(&alias), vec![1, 2, 3, 4]);
+            assert_eq!(collect(&alias), vec![1, 2]);
         }
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/array/mod.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/array/mod.rs
@@ -1,7 +1,6 @@
 //! Mutable (aliasing) `Array<T>` builtins. Read-only constant tables
 //! use [`static_array::StaticArray`].
 
-use std::sync::Arc;
 use std::rc::Rc;
 use std::cell::RefCell;
 use crate::Result;
@@ -17,7 +16,7 @@ pub fn arrayFromVec<A>(v: Vec<A>) -> Array<A> {
 }
 
 // All array fns take `Array<A>` by value: cloning an `Rc` is one atomic-free
-// refcount bump, so the by-value convention matches how `Arc<List<A>>` is
+// refcount bump, so the by-value convention matches how `List<A>` is
 // handled elsewhere and lets generated call sites pass `arr.clone()` directly
 // without needing an explicit `&` prefix.
 
@@ -67,8 +66,8 @@ pub fn arrayCreateDefault<A: Clone + Default>(size: i32) -> Array<A> {
 }
 
 /// Converts an array to a list. O(n).
-pub fn arrayList<A: Clone>(arr: Array<A>) -> Arc<List<A>> {
-    let mut result = Arc::new(List::Nil);
+pub fn arrayList<A: Clone>(arr: Array<A>) -> List<A> {
+    let mut result = crate::nil();
     for item in arr.borrow().iter().rev().cloned() {
         result = List::cons(result, item);
     }
@@ -76,9 +75,9 @@ pub fn arrayList<A: Clone>(arr: Array<A>) -> Arc<List<A>> {
 }
 
 /// Converts a list to an array. O(n).
-pub fn listArray<A: Clone>(lst: Arc<List<A>>) -> Array<A> {
+pub fn listArray<A: Clone>(lst: List<A>) -> Array<A> {
     let mut result = Vec::new();
-    for item in &*lst {
+    for item in &lst {
         result.push(item.clone());
     }
     arrayFromVec(result)

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/gc.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/gc.rs
@@ -236,30 +236,26 @@ impl<T: MMTrace + ?Sized> MMTrace for RefCell<T> {
 /// Iterative, not recursive: lists are routinely tens of thousands of
 /// elements long and a recursive traversal would overflow the stack. Every
 /// spine cell is itself a shared allocation (tail sharing is pervasive), so
-/// each tail handle is reported like any other `Arc`.
+/// each cell is reported like any other `Arc`.
 impl<T: MMTrace + Clone> MMTrace for List<T> {
     fn mm_accept(&self, visitor: &mut dyn MMVisitor) -> Result<(), ()> {
         let mut depth = 0usize;
         let mut cur = self;
         let r = loop {
-            match cur {
-                List::Cons { head, tail } => {
-                    if let e @ Err(()) = head.mm_accept(visitor) {
-                        break e;
-                    }
-                    if visitor.visit_shared(
-                        Arc::as_ptr(tail) as *const (),
-                        Arc::strong_count(tail),
-                        std::any::type_name::<List<T>>(),
-                    ) {
-                        depth += 1;
-                        cur = tail;
-                    } else {
-                        break Ok(());
-                    }
-                }
-                List::Nil => break Ok(()),
+            let Some(cell) = &cur.0 else { break Ok(()) };
+            if !visitor.visit_shared(
+                Arc::as_ptr(cell) as *const (),
+                Arc::strong_count(cell),
+                std::any::type_name::<crate::ListNode<T>>(),
+            ) {
+                break Ok(());
             }
+            depth += 1;
+            let crate::ListNode::Cons { head, tail } = &**cell else { break Ok(()) };
+            if let e @ Err(()) = head.mm_accept(visitor) {
+                break e;
+            }
+            cur = tail;
         };
         for _ in 0..depth {
             visitor.leave_shared();
@@ -643,7 +639,7 @@ mod tests {
     #[test]
     fn representative_shapes_are_traceable() {
         assert_mm_trace::<crate::Array<i32>>();
-        assert_mm_trace::<Arc<List<(ArcStr, i32)>>>();
+        assert_mm_trace::<List<(ArcStr, i32)>>();
         assert_mm_trace::<Option<Box<(String, Vec<f64>)>>>();
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/lib.rs
@@ -10,7 +10,7 @@
 //!   Real -> OrderedFloat<f64> (aliased as `metamodelica::Real`)
 //!   Boolean -> bool
 //!   String -> String
-//!   List<T> -> Arc<List<T>>           (persistent singly-linked list)
+//!   list<T> -> List<T>                (persistent singly-linked list; Option<Arc<ListNode<T>>>)
 //!   array<T> -> Array<T> = Rc<RefCell<Vec<T>>>
 //!
 //! Note: MetaModelica uses 1-based indexing; Rust uses 0-based.

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/list/macros.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/list/macros.rs
@@ -4,7 +4,7 @@
 macro_rules! list {
     // Base case: empty list
     () => {
-        std::sync::Arc::new($crate::List::Nil)
+        $crate::nil()
     };
     // Case with a trailing comma
     ( $($x:expr),*, ) => {

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/list/mod.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/list/mod.rs
@@ -2,96 +2,201 @@
 //! Construction/field macros live in [`macros`].
 
 use std::sync::Arc;
+use std::hash::{Hash, Hasher};
+use std::cmp::Ordering;
 use crate::Result;
 
 #[macro_use]
 mod macros;
 
+/// Heap cell of a [`List`]. `Nil` is never allocated: the empty list is
+/// `List(None)`, and `Deref` hands out a static `Nil` for it.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[derive(Default)]
-pub enum List<T: Clone> {
-    Cons{head: T, tail: Arc<List<T>>},
-    #[default]
+pub enum ListNode<T: Clone> {
+    Cons{head: T, tail: List<T>},
     Nil,
 }
 
-// Hand-written instead of `#[derive(Default)]`: the derive emits
-// `impl<T: Clone + Default> Default for List<T>`, but the empty list is a
-// valid default for *any* element type. The spurious `T: Default` bound
-// otherwise blocks defaulting containers like `DoubleEnded.MutableList<T>`
-// (whose fields are `Mutable<Arc<List<T>>>`) at `T: Clone`.
+pub struct List<T: Clone>(pub(crate) Option<Arc<ListNode<T>>>);
 
-// Without this, dropping a list is recursive in its length (each node's
-// `Arc<List>` field drops the next node from inside its own drop call), so
-// releasing a list of a few hundred thousand elements overflows the stack —
-// the C runtime never had this problem because its GC frees cells without
-// walking the list. Iteratively unlink instead: detach each uniquely-owned
-// tail before its node is dropped, so every node drop sees a Nil tail.
-impl<T: Clone> Drop for List<T> {
-    fn drop(&mut self) {
-        // Fast path: Nil, or a node whose tail is already Nil — in
-        // particular every node the unlink loop below has detached, so the
-        // nested drop it triggers neither allocates nor recurses.
-        let List::Cons { tail, .. } = self else { return };
-        if matches!(&**tail, List::Nil) {
-            return;
+// What the auto traits derive, stated explicitly so the solver need not
+// recurse through the cell type (it hit the recursion limit downstream).
+unsafe impl<T: Clone + Send + Sync> Send for List<T> {}
+unsafe impl<T: Clone + Send + Sync> Sync for List<T> {}
+
+use ListNode::{Cons, Nil};
+
+impl<T: Clone> List<T> {
+    #[inline]
+    pub fn iter(&self) -> ListRefIterator<'_, T> {
+        ListRefIterator { curr: self.0.as_deref() }
+    }
+    #[inline]
+    fn node(&self) -> Option<&ListNode<T>> {
+        self.0.as_deref()
+    }
+}
+
+impl<T: Clone + 'static> List<T> {
+    const NIL: &'static ListNode<T> = &Nil;
+}
+
+impl<T: Clone + 'static> std::ops::Deref for List<T> {
+    type Target = ListNode<T>;
+    #[inline]
+    fn deref(&self) -> &ListNode<T> {
+        match &self.0 {
+            Some(a) => a,
+            None => Self::NIL,
         }
-        // A shared tail is not ours to unlink, and dropping our reference to
-        // it only decrements its refcount, so there is nothing to do.
-        if Arc::strong_count(tail) != 1 || Arc::weak_count(tail) != 0 {
-            return;
-        }
-        // The hole left by each detached tail has to be filled with *some*
-        // `Arc<List<T>>`. Take the list's own terminating Nil rather than
-        // allocating one — a list drop is one of the compiler's most frequent
-        // operations, and `Arc::new(List::Nil)` made every one of them
-        // allocate. The scan only walks the uniquely-owned prefix, i.e. the
-        // nodes the unlink loop below is about to touch anyway; a shared
-        // suffix stops it, and then there is no reachable Nil to borrow.
-        let nil: Arc<List<T>> = {
-            let mut p: &Arc<List<T>> = tail;
-            loop {
-                match &**p {
-                    List::Nil => break p.clone(),
-                    List::Cons { tail: next, .. } => {
-                        if Arc::strong_count(next) != 1 || Arc::weak_count(next) != 0 {
-                            break Arc::new(List::Nil);
+    }
+}
+
+impl<T: Clone + 'static> AsRef<ListNode<T>> for List<T> {
+    #[inline]
+    fn as_ref(&self) -> &ListNode<T> { self }
+}
+
+impl<T: Clone> Clone for List<T> {
+    #[inline]
+    fn clone(&self) -> Self { List(self.0.clone()) }
+}
+
+impl<T: Clone> Default for List<T> {
+    #[inline]
+    fn default() -> Self { List(None) }
+}
+
+impl<T: Clone + std::fmt::Debug> std::fmt::Debug for List<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list().entries(self).finish()
+    }
+}
+
+impl<T: Clone + PartialEq> PartialEq for List<T> {
+    fn eq(&self, other: &Self) -> bool {
+        let (mut a, mut b) = (self, other);
+        loop {
+            match (&a.0, &b.0) {
+                (None, None) => return true,
+                (Some(x), Some(y)) => {
+                    if Arc::ptr_eq(x, y) { return true; }
+                    match (&**x, &**y) {
+                        (Cons{head: h1, tail: t1}, Cons{head: h2, tail: t2}) => {
+                            if h1 != h2 { return false; }
+                            a = t1; b = t2;
                         }
-                        p = next;
+                        _ => return false,
+                    }
+                }
+                _ => return false,
+            }
+        }
+    }
+}
+impl<T: Clone + Eq> Eq for List<T> {}
+
+// Nil sorts after Cons, as the derived enum ordering did.
+impl<T: Clone + Ord> Ord for List<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let (mut a, mut b) = (self, other);
+        loop {
+            match (&a.0, &b.0) {
+                (None, None) => return Ordering::Equal,
+                (None, Some(_)) => return Ordering::Greater,
+                (Some(_), None) => return Ordering::Less,
+                (Some(x), Some(y)) => {
+                    if Arc::ptr_eq(x, y) { return Ordering::Equal; }
+                    match (&**x, &**y) {
+                        (Cons{head: h1, tail: t1}, Cons{head: h2, tail: t2}) => {
+                            match h1.cmp(h2) {
+                                Ordering::Equal => { a = t1; b = t2; }
+                                o => return o,
+                            }
+                        }
+                        (Cons{..}, Nil) => return Ordering::Less,
+                        (Nil, Cons{..}) => return Ordering::Greater,
+                        (Nil, Nil) => return Ordering::Equal,
                     }
                 }
             }
-        };
-        let mut cur = std::mem::replace(tail, nil.clone());
+        }
+    }
+}
+impl<T: Clone + PartialOrd> PartialOrd for List<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let (mut a, mut b) = (self, other);
         loop {
-            match Arc::get_mut(&mut cur) {
-                // Sole owner of this node (strong count 1, no weak refs):
-                // nothing else can observe the detached tail. Take it, then
-                // let the node drop through the fast path above.
-                Some(List::Cons { tail, .. }) => {
-                    let next = std::mem::replace(tail, nil.clone());
-                    cur = next;
+            match (&a.0, &b.0) {
+                (None, None) => return Some(Ordering::Equal),
+                (None, Some(_)) => return Some(Ordering::Greater),
+                (Some(_), None) => return Some(Ordering::Less),
+                (Some(x), Some(y)) => {
+                    if Arc::ptr_eq(x, y) { return Some(Ordering::Equal); }
+                    match (&**x, &**y) {
+                        (Cons{head: h1, tail: t1}, Cons{head: h2, tail: t2}) => {
+                            match h1.partial_cmp(h2) {
+                                Some(Ordering::Equal) => { a = t1; b = t2; }
+                                o => return o,
+                            }
+                        }
+                        (Cons{..}, Nil) => return Some(Ordering::Less),
+                        (Nil, Cons{..}) => return Some(Ordering::Greater),
+                        (Nil, Nil) => return Some(Ordering::Equal),
+                    }
                 }
-                // Nil, or a node shared with another live list: dropping our
-                // reference only decrements the refcount and must leave the
-                // suffix intact, so stop here.
+            }
+        }
+    }
+}
+
+impl<T: Clone + Hash> Hash for List<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let mut n = 0usize;
+        for e in self {
+            e.hash(state);
+            n += 1;
+        }
+        state.write_usize(n);
+    }
+}
+
+// Iterative: a recursive drop is one stack frame per element. Only the
+// uniquely owned prefix is unlinked; a shared suffix just loses a reference.
+impl<T: Clone> Drop for List<T> {
+    #[inline]
+    fn drop(&mut self) {
+        if let Some(node) = &self.0 && Arc::strong_count(node) == 1 {
+            self.unlink();
+        }
+    }
+}
+
+impl<T: Clone> List<T> {
+    #[inline(never)]
+    fn unlink(&mut self) {
+        let mut cur = self.0.take();
+        while let Some(mut node) = cur {
+            match Arc::get_mut(&mut node) {
+                Some(Cons { tail, .. }) => cur = tail.0.take(),
                 _ => break,
             }
         }
     }
 }
-use List::{Cons, Nil};
 
-pub fn nil<T: Clone>() -> Arc<List<T>> {
-    Arc::new(Nil)
+#[inline]
+pub fn nil<T: Clone>() -> List<T> {
+    List(None)
 }
 
-pub fn cons<T: Clone>(head: T, tail: Arc<List<T>>) -> Arc<List<T>> {
-    Arc::new(Cons{head, tail})
+#[inline]
+pub fn cons<T: Clone>(head: T, tail: List<T>) -> List<T> {
+    List(Some(Arc::new(Cons{head, tail})))
 }
 
 pub struct ListRefIterator<'a, T: Clone> {
-    curr: &'a List<T>,
+    curr: Option<&'a ListNode<T>>,
 }
 
 impl<T: Clone> FromIterator<T> for List<T> {
@@ -100,7 +205,7 @@ impl<T: Clone> FromIterator<T> for List<T> {
         for item in iter {
             buf = cons(item, buf);
         }
-        (*buf.reverse()).clone()
+        buf.reverse()
     }
 }
 
@@ -108,53 +213,31 @@ impl<'a, T: Clone> IntoIterator for &'a List<T> {
     type Item = &'a T;
     type IntoIter = ListRefIterator<'a, T>;
 
-    // Required method
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
-       ListRefIterator { curr: self }
+       self.iter()
     }
 }
 
-/*
-pub struct ListIterator<T: Clone> {
-    curr: Arc<List<T>>,
-}
+impl<'a, T: Clone> IntoIterator for &'a ListNode<T> {
+    type Item = &'a T;
+    type IntoIter = ListRefIterator<'a, T>;
 
-impl<T: Clone> IntoIterator for List<T> {
-    type Item = T;
-    type IntoIter = ListIterator<T>;
-
-    // Required method
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        ListIterator { curr: Arc::new(self) }
+       ListRefIterator { curr: Some(self) }
     }
 }
-
-impl<T: Clone> Iterator for ListIterator<T> {
-    type Item = T; // No Clone needed here!
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match *self.curr.clone() {
-            // If it's Nil, we are done.
-            List::Nil => return None,
-
-            // If it's Cons:
-            List::Cons { ref head, ref tail } => {
-                self.curr = tail.clone();
-                Some(head.clone())
-            }
-        }
-    }
-}
-*/
 
 impl<'a, T: Clone> Iterator for ListRefIterator<'a, T> {
     type Item = &'a T;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        match self.curr {
+        match self.curr? {
             Nil => None,
             Cons { head, tail } => {
-                self.curr = tail;
+                self.curr = tail.node();
                 Some(head)
             }
         }
@@ -163,46 +246,57 @@ impl<'a, T: Clone> Iterator for ListRefIterator<'a, T> {
 
 impl<T: Clone> List<T> {
     /// Appends lst2 to lst1. O(length(lst1)), O(1) if either list is empty.
-    pub fn append(self: &Arc<List<T>>, lst2: &Arc<List<T>>) -> Arc<List<T>> {
+    pub fn append(&self, lst2: &List<T>) -> List<T> {
         if self.is_empty() {
             return lst2.clone();
         }
         if lst2.is_empty() {
             return self.clone();
         }
-        let mut result = lst2.clone();
-        for item in &*(self.reverse()) {
-            result = cons(item.clone(), result);
-        }
-        result
+        lst2.prepend_reverse(&self.clone().reverse())
     }
     /// Returns the length of a list. O(n).
     pub fn len(&self) -> i32 {
         self.into_iter().count() as i32
     }
-    /// Reverses the elements in a list. O(n).
-    pub fn reverse(self: &Arc<List<T>>) -> Arc<List<T>> {
-        let mut result: Arc<List<T>> = nil();
-        for e in &**self {
-            result = cons(e.clone(), result);
+    /// Reverses a list. O(n). Relinks the uniquely owned prefix in place
+    /// (no allocation) and copies a shared suffix.
+    pub fn reverse(mut self) -> List<T> {
+        let mut acc = List(None);
+        let mut cur = self.0.take();
+        while let Some(mut node) = cur {
+            match Arc::get_mut(&mut node) {
+                Some(Cons { tail, .. }) => {
+                    cur = tail.0.take();
+                    tail.0 = acc.0.take();
+                    acc = List(Some(node));
+                }
+                _ => {
+                    let shared = List(Some(node));
+                    for e in &shared {
+                        acc = cons(e.clone(), acc);
+                    }
+                    break;
+                }
+            }
         }
-        result
+        acc
     }
     /// Gets the element at the given 1-based index. O(index).
-    pub fn get(self: &Arc<List<T>>, index: i32) -> Result<T> {
-        (&**self).into_iter().nth((index - 1) as usize)
+    pub fn get(&self, index: i32) -> Result<T> {
+        self.into_iter().nth((index - 1) as usize)
             .cloned()
             .ok_or_else(|| "Index {} out of bounds for list of length {}")
     }
-    pub fn prepend_reverse(self: &Arc<List<T>>, prefix: &Arc<List<T>>) -> Arc<List<T>> {
+    pub fn prepend_reverse(&self, prefix: &List<T>) -> List<T> {
         let mut result = self.clone();
-        for item in &**prefix {
+        for item in prefix {
             result = cons(item.clone(), result);
         }
         result
     }
     /// Deletes the element at the given 1-based index. O(index).
-    pub fn delete(self: &Arc<List<T>>, index: i32) -> Result<Arc<List<T>>> {
+    pub fn delete(&self, index: i32) -> Result<List<T>> {
         if index < 1 {
             return Err("Index must be positive, got {}");
         }
@@ -214,9 +308,9 @@ impl<T: Clone> List<T> {
         let mut cur_index = index;
         loop {
             cur_index -= 1;
-            let (head,tail) = match &**iter {
-                Nil => return Err("Index {} out of bounds for list"),
-                Cons{head, tail} => (head, tail)
+            let (head,tail) = match iter.node() {
+                Some(Cons{head, tail}) => (head, tail),
+                _ => return Err("Index {} out of bounds for list"),
             };
             iter = tail;
             if cur_index == 0 {
@@ -225,54 +319,47 @@ impl<T: Clone> List<T> {
             result = cons(head.clone(), result);
         }
     }
-}
-
-impl<T: Clone> List<T> {
-    pub fn new(item: T) -> Arc<List<T>> {
-        Arc::new(Cons{head: item, tail: nil()})
+    pub fn new(item: T) -> List<T> {
+        cons(item, nil())
     }
-    pub fn cons(self: Arc<List<T>>, item: T) -> Arc<List<T>> {
-        Arc::new(Cons{head: item, tail: self})
+    pub fn cons(self, item: T) -> List<T> {
+        cons(item, self)
     }
     /// Gets the first element. O(1).
     /// Fails if the list is empty.
-    pub fn head(self: &Arc<List<T>>) -> Result<&T> {
-        match &**self {
-            Nil => return Err("Cannot get head of empty list"),
-            Cons{head, ..} => Ok(head),
+    pub fn head(&self) -> Result<&T> {
+        match self.node() {
+            Some(Cons{head, ..}) => Ok(head),
+            _ => Err("Cannot get head of empty list"),
         }
     }
     /// Returns all elements except the first. O(1).
     /// Fails if the list is empty.
-    pub fn rest(self: &Arc<List<T>>) -> Result<Arc<List<T>>> {
-        match &**self {
-            Nil => return Err("Cannot get rest of empty list"),
-            Cons{tail, ..} => Ok(tail.clone()),
+    pub fn rest(&self) -> Result<List<T>> {
+        match self.node() {
+            Some(Cons{tail, ..}) => Ok(tail.clone()),
+            _ => Err("Cannot get rest of empty list"),
         }
     }
     /// Returns true if the list is empty. O(1).
-    pub fn is_empty(self: &Arc<List<T>>) -> bool {
-        match **self {
-            Nil => true,
-            _ => false
-        }
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_none()
     }
 }
-
-
 
 impl<T: PartialEq + Clone> List<T> {
     /// Checks if an element is a member of the list. O(n).
     /// Uses PartialEq for comparison.
-    pub fn contains(self: &Arc<List<T>>, element: &T) -> bool {
-        for item in &**self {
+    pub fn contains(&self, element: &T) -> bool {
+        for item in self {
             if element.eq(item) { return true; }
         }
         false
     }
 }
 
-pub fn listAppend<T: Clone>(lst1: Arc<List<T>>, lst2: Arc<List<T>>) -> Arc<List<T>> {
+pub fn listAppend<T: Clone>(lst1: List<T>, lst2: List<T>) -> List<T> {
     lst1.append(&lst2)
 }
 
@@ -281,39 +368,35 @@ pub fn listAppend<T: Clone>(lst1: Arc<List<T>>, lst2: Arc<List<T>>) -> Arc<List<
 /// first-class value (e.g. `Array.map(arr, listReverse)`) there must be a real
 /// function path to reference — methods cannot be named as `fn` items. Codegen
 /// emits `fnptr!(metamodelica::listReverse, _)` for that case.
-pub fn listReverse<T: Clone>(lst: Arc<List<T>>) -> Arc<List<T>> {
+pub fn listReverse<T: Clone>(lst: List<T>) -> List<T> {
     lst.reverse()
 }
 
-pub fn listMember<T: Clone+PartialEq>(element: T, lst: Arc<List<T>>) -> bool {
+pub fn listMember<T: Clone+PartialEq>(element: T, lst: List<T>) -> bool {
     lst.contains(&element)
 }
 
-pub fn listHead<T: Clone>(lst: Arc<List<T>>) -> Result<T> {
-    let Cons{head, ..} = &*lst else {return Err("Cannot get head of empty list")};
-    Ok(head.clone())
+pub fn listHead<T: Clone>(lst: List<T>) -> Result<T> {
+    lst.head().cloned()
 }
 
-pub fn listGet<T: Clone>(lst: Arc<List<T>>, i: i32) -> Result<T> {
+pub fn listGet<T: Clone>(lst: List<T>, i: i32) -> Result<T> {
     lst.get(i)
 }
 
-pub fn listEmpty<T: Clone>(lst: Arc<List<T>>) -> bool {
+pub fn listEmpty<T: Clone>(lst: List<T>) -> bool {
     lst.is_empty()
 }
 
-pub fn listDelete<T: Clone>(lst: Arc<List<T>>, index: i32) -> Result<Arc<List<T>>> {
+pub fn listDelete<T: Clone>(lst: List<T>, index: i32) -> Result<List<T>> {
     lst.delete(index)
 }
 
-pub fn listRest<T: Clone>(lst: Arc<List<T>>) -> Result<Arc<List<T>>> {
-    match &*lst {
-        Nil => return Err("Cannot get rest of empty list"),
-        Cons{tail, ..} => Ok(tail.clone()),
-    }
+pub fn listRest<T: Clone>(lst: List<T>) -> Result<List<T>> {
+    lst.rest()
 }
 
-pub fn listLength<T: Clone>(lst: Arc<List<T>>) -> i32 {
+pub fn listLength<T: Clone>(lst: List<T>) -> i32 {
     lst.len()
 }
 
@@ -332,13 +415,13 @@ mod tests {
         /// unlink walk must leave a shared suffix intact.
         #[test]
         fn test_drop_long_list_is_iterative() {
-            let mut l: Arc<List<i32>> = nil();
+            let mut l: List<i32> = nil();
             for i in 0..500_000 {
                 l = cons(i, l);
             }
             drop(l);
 
-            let mut shared: Arc<List<i32>> = nil();
+            let mut shared: List<i32> = nil();
             for i in 0..200_000 {
                 shared = cons(i, shared);
             }
@@ -359,7 +442,7 @@ mod tests {
             assert_eq!(result, list![1, 2, 3, 4, 5]);
 
             // Empty list cases
-            let empty: Arc<List<i32>> = nil();
+            let empty: List<i32> = nil();
             assert_eq!(empty.append(&b), b);
             assert_eq!(a.append(&empty), a);
         }
@@ -367,10 +450,12 @@ mod tests {
         #[test]
         fn test_list_reverse() {
             let lst = list![1, 2, 3, 4, 5];
-            let result = lst.reverse();
+            let result = lst.clone().reverse();
             assert_eq!(result, list![5, 4, 3, 2, 1]);
+            assert_eq!(lst, list![1, 2, 3, 4, 5]);
+            assert_eq!(lst.reverse(), list![5, 4, 3, 2, 1]);
 
-            let empty: Arc<List<i32>> = nil();
+            let empty: List<i32> = nil();
             assert_eq!(empty.reverse(), nil());
         }
 
@@ -378,7 +463,7 @@ mod tests {
         fn test_list_length() {
             let lst = list![1, 2, 3];
             assert_eq!(lst.len(), 3);
-            let empty: Arc<List<i32>> = nil();
+            let empty: List<i32> = nil();
             assert_eq!(empty.len(), 0);
         }
 
@@ -408,7 +493,7 @@ mod tests {
             let single = list![1];
             assert!(single.rest().unwrap().is_empty());
 
-            let empty: Arc<List<i32>> = nil();
+            let empty: List<i32> = nil();
             assert!(empty.rest().is_err());
         }
 
@@ -417,7 +502,7 @@ mod tests {
             let lst = list![1, 2, 3];
             assert_eq!(lst.head().unwrap().clone(), 1);
 
-            let empty: Arc<List<i32>> = nil();
+            let empty: List<i32> = nil();
             assert!(empty.head().is_err());
         }
 
@@ -434,7 +519,7 @@ mod tests {
             let lst = list![1, 2, 3];
             assert!(!lst.is_empty());
 
-            let empty: Arc<List<i32>> = nil();
+            let empty: List<i32> = nil();
             assert!(empty.is_empty());
         }
 
@@ -444,16 +529,30 @@ mod tests {
             let result = cons(1, lst);
             assert_eq!(result, list![1, 2, 3]);
 
-            let empty: Arc<List<i32>> = nil();
+            let empty: List<i32> = nil();
             let result = cons(42, empty);
             assert_eq!(result, List::new(42));
         }
 
         #[test]
+        fn test_list_reverse_shared_suffix() {
+            let suffix = list![3, 4];
+            let lst = cons(1, cons(2, suffix.clone()));
+            assert_eq!(lst.reverse(), list![4, 3, 2, 1]);
+            assert_eq!(suffix, list![3, 4]);
+            let mut long: List<i32> = nil();
+            for i in 0..500_000 {
+                long = cons(i, long);
+            }
+            assert_eq!(long.reverse().head().unwrap(), &0);
+            assert!(nil::<i32>().reference_eq(&nil()));
+        }
+
+        #[test]
         fn test_list_reverse2() -> () {
             let lst1 = list![1,2,3,4];
-            let lst2 = lst1.reverse();
-            let lst3 = lst2.reverse();
+            let lst2 = lst1.clone().reverse();
+            let lst3 = lst2.clone().reverse();
             assert_eq!(lst1, lst3);
             assert!(lst1 != lst2);
         }

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/string/mod.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/string/mod.rs
@@ -1,7 +1,6 @@
 //! String builtins: char conversions, length/get/compare, append, and
 //! `substring`. Hashing lives in [`hash`], URI resolution in [`uri`].
 
-use std::sync::Arc;
 use crate::Result;
 use arcstr::{ArcStr, format};
 use ordered_float::OrderedFloat;
@@ -63,19 +62,19 @@ pub fn stringReal(str: ArcStr) -> Result<Real> {
 }
 
 /// Converts a string to a list of single-character strings.
-pub fn stringListStringChar(str: ArcStr) -> Arc<List<ArcStr>> {
+pub fn stringListStringChar(str: ArcStr) -> List<ArcStr> {
     // TODO: We could have constants for all these short strings to avoid allocations.
-    Arc::new(str.chars().map(|c| format!("{}", c)).collect())
+    str.chars().map(|c| format!("{}", c)).collect()
 }
 
 /// Appends a list of strings into a single string.
-pub fn stringAppendList(strs: Arc<List<ArcStr>>) -> ArcStr {
+pub fn stringAppendList(strs: List<ArcStr>) -> ArcStr {
     let mut len = 0;
-    for s in &*strs {
+    for s in &strs {
         len += s.len();
     }
     let mut result = String::with_capacity(len);
-    for s in &*strs {
+    for s in &strs {
         result.push_str(s);
     }
     result.into()
@@ -83,17 +82,17 @@ pub fn stringAppendList(strs: Arc<List<ArcStr>>) -> ArcStr {
 
 /// Takes a list of strings and a delimiter and joins them with the delimiter inserted between elements.
 /// Example: stringDelimitList({"x","y","z"}, ", ") => "x, y, z"
-pub fn stringDelimitList(strs: Arc<List<ArcStr>>, delimiter: ArcStr) -> ArcStr {
+pub fn stringDelimitList(strs: List<ArcStr>, delimiter: ArcStr) -> ArcStr {
     let mut len = 0;
     let delimiter_len = delimiter.len();
-    for s in &*strs {
+    for s in &strs {
         len += s.len() + delimiter_len;
     }
 
     let mut result = String::with_capacity(len);
     let mut first = true;
 
-    for s in &*strs {
+    for s in &strs {
         if !first {
             result.push_str(&delimiter);
         }
@@ -214,12 +213,12 @@ pub fn substring(str: ArcStr, start: i32, stop: i32) -> Result<ArcStr> {
 }
 
 /// Alias for string_append_list (maps a list of single-char strings to one string).
-pub fn listStringCharString(strs: Arc<List<ArcStr>>) -> ArcStr {
+pub fn listStringCharString(strs: List<ArcStr>) -> ArcStr {
     stringAppendList(strs)
 }
 
 /// Alias for string_append_list (maps a list of single-char strings to one string).
-pub fn stringCharListString(strs: Arc<List<ArcStr>>) -> ArcStr {
+pub fn stringCharListString(strs: List<ArcStr>) -> ArcStr {
     stringAppendList(strs)
 }
 
@@ -274,7 +273,7 @@ mod tests {
         #[test]
         fn test_string_list_string_char() {
             let result = stringListStringChar(literal!("abc "));
-            assert_eq!(&*result, &List::from_iter([literal!("a"), literal!("b"), literal!("c"), literal!(" ")]));
+            assert_eq!(result, List::from_iter([literal!("a"), literal!("b"), literal!("c"), literal!(" ")]));
         }
 
         #[test]
@@ -285,7 +284,7 @@ mod tests {
 
         #[test]
         fn test_string_delimit_list() {
-            let strs: Arc<List<ArcStr>> = list![literal!("x"), literal!("y"), literal!("z")];
+            let strs: List<ArcStr> = list![literal!("x"), literal!("y"), literal!("z")];
             assert_eq!(stringDelimitList(strs, literal!(", ")), "x, y, z");
         }
     }
@@ -399,13 +398,13 @@ mod tests {
 
         #[test]
         fn test_list_string_char_string() {
-            let strs: Arc<List<ArcStr>> = list![literal!("a"), literal!("b"), literal!("c")];
+            let strs: List<ArcStr> = list![literal!("a"), literal!("b"), literal!("c")];
             assert_eq!(&*listStringCharString(strs), "abc");
         }
 
         #[test]
         fn test_string_char_list_string() {
-            let strs: Arc<List<ArcStr>> = list![literal!("a"), literal!("b"), literal!("c")];
+            let strs: List<ArcStr> = list![literal!("a"), literal!("b"), literal!("c")];
             assert_eq!(&*stringCharListString(strs), "abc");
         }
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/value/reference_eq.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/metamodelica/src/value/reference_eq.rs
@@ -98,7 +98,7 @@ impl ReferenceEq for ArcStr {
         std::ptr::eq(self.as_str() as *const str, other.as_str() as *const str)
     }
 }
-/// Shared handles: allocation identity. Covers lists (`Arc<List<T>>`),
+/// Shared handles: allocation identity. Covers
 /// Arc-boxed uniontype values, and `Arc<dyn Fn(...)>` callbacks (`?Sized`).
 impl<T: ?Sized> ReferenceEq for Arc<T> {
     fn reference_eq(&self, other: &Self) -> bool { Arc::ptr_eq(self, other) }
@@ -140,16 +140,12 @@ impl_reference_eq_tuple!(A: 0, B: 1, C: 2, D: 3, E: 4, F: 5, G: 6);
 impl_reference_eq_tuple!(A: 0, B: 1, C: 2, D: 3, E: 4, F: 5, G: 6, H: 7);
 impl_reference_eq_tuple!(A: 0, B: 1, C: 2, D: 3, E: 4, F: 5, G: 6, H: 7, I: 8);
 impl_reference_eq_tuple!(A: 0, B: 1, C: 2, D: 3, E: 4, F: 5, G: 6, H: 7, I: 8, J: 9);
-/// Bare `List<T>` (the usual MM representation is `Arc<List<T>>`, caught by
-/// the `Arc` impl): shallow like the derive would emit — heads compare via
-/// `ReferenceEq`, tails via `Arc` identity, so the comparison is O(1).
-impl<T: Clone + ReferenceEq> ReferenceEq for List<T> {
+/// Lists: cell identity. Two empty lists are identical, like `mmc_nil` in MMC.
+impl<T: Clone> ReferenceEq for List<T> {
     fn reference_eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (List::Nil, List::Nil) => true,
-            (List::Cons { head: lh, tail: lt }, List::Cons { head: rh, tail: rt }) => {
-                lh.reference_eq(rh) && Arc::ptr_eq(lt, rt)
-            }
+        match (&self.0, &other.0) {
+            (None, None) => true,
+            (Some(l), Some(r)) => Arc::ptr_eq(l, r),
             _ => false,
         }
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/MM.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/MM.rs
@@ -372,7 +372,7 @@ fn is_nf_builtin(info: &Info) -> bool {
 }
 
 fn convert_element_items(
-    items: Arc<metamodelica::List<Arc<Absyn::ElementItem>>>,
+    items: metamodelica::List<Arc<Absyn::ElementItem>>,
     visibility: Visibility,
     class_info: &Info,
     members: &mut Vec<ClassMember>,

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
@@ -6455,7 +6455,7 @@ fn function_source_replacement(qname: &str) -> Option<&'static str> {
     }
 }
 
-const LIST_SORT_SRC: &str = r#"pub fn sort<T: Clone + 'static + metamodelica::gc::MMTrace>(inList: Arc<metamodelica::List<T>>, inCompFunc: Arc<dyn ::std::ops::Fn(T, T) -> Result<bool> + 'static>) -> Result<Arc<metamodelica::List<T>>> {
+const LIST_SORT_SRC: &str = r#"pub fn sort<T: Clone + 'static + metamodelica::gc::MMTrace>(inList: metamodelica::List<T>, inCompFunc: Arc<dyn ::std::ops::Fn(T, T) -> Result<bool> + 'static>) -> Result<metamodelica::List<T>> {
     fn sort_slice<T: Clone>(v: &[T], comp: &dyn Fn(T, T) -> Result<bool>) -> Result<Vec<T>> {
         let n = v.len();
         if n < 2 {
@@ -6565,10 +6565,10 @@ fn cref_dotted2(cref: &Absyn::ComponentRef) -> Option<String> {
     match cref {
         C::CREF_FULLYQUALIFIED { componentRef } => cref_dotted2(componentRef),
         C::CREF_QUAL { name, subscripts, componentRef }
-            if matches!(&**subscripts, metamodelica::List::Nil) =>
+            if matches!(&**subscripts, metamodelica::ListNode::Nil) =>
         {
             if let C::CREF_IDENT { name: n2, subscripts: s2 } = &**componentRef
-                && matches!(&**s2, metamodelica::List::Nil)
+                && matches!(&**s2, metamodelica::ListNode::Nil)
             {
                 return Some(format!("{name}.{n2}"));
             }
@@ -6581,19 +6581,19 @@ fn cref_dotted2(cref: &Absyn::ComponentRef) -> Option<String> {
 fn subst_exp_list(
     l: &metamodelica::List<Arc<Absyn::Exp>>,
     map: &HashMap<String, Arc<Absyn::Exp>>,
-) -> Arc<metamodelica::List<Arc<Absyn::Exp>>> {
-    Arc::new(metamodelica::List::from_iter(l.into_iter().map(|e| subst_exp(e, map))))
+) -> metamodelica::List<Arc<Absyn::Exp>> {
+    metamodelica::List::from_iter(l.into_iter().map(|e| subst_exp(e, map)))
 }
 
 fn subst_subscripts(
     l: &metamodelica::List<Arc<Absyn::Subscript>>,
     map: &HashMap<String, Arc<Absyn::Exp>>,
-) -> Arc<metamodelica::List<Arc<Absyn::Subscript>>> {
-    Arc::new(metamodelica::List::from_iter(l.into_iter().map(|s| match &**s {
+) -> metamodelica::List<Arc<Absyn::Subscript>> {
+    metamodelica::List::from_iter(l.into_iter().map(|s| match &**s {
         Absyn::Subscript::SUBSCRIPT { subscript } =>
             Arc::new(Absyn::Subscript::SUBSCRIPT { subscript: subst_exp(subscript, map) }),
         Absyn::Subscript::NOSUB => s.clone(),
-    })))
+    }))
 }
 
 /// Rewrite every `Pkg.const` component reference in an expression.
@@ -6616,9 +6616,9 @@ fn subst_exp(e: &Arc<Absyn::Exp>, map: &HashMap<String, Arc<Absyn::Exp>>) -> Arc
             ifExp: subst_exp(ifExp, map),
             trueBranch: subst_exp(trueBranch, map),
             elseBranch: subst_exp(elseBranch, map),
-            elseIfBranch: Arc::new(metamodelica::List::from_iter(
+            elseIfBranch: metamodelica::List::from_iter(
                 elseIfBranch.into_iter().map(|(c, t)| (subst_exp(c, map), subst_exp(t, map))),
-            )),
+            ),
         }),
         E::CALL { function_, functionArgs, typeVars } => Arc::new(E::CALL {
             function_: function_.clone(), functionArgs: subst_fargs(functionArgs, map), typeVars: typeVars.clone(),
@@ -6628,7 +6628,7 @@ fn subst_exp(e: &Arc<Absyn::Exp>, map: &HashMap<String, Arc<Absyn::Exp>>) -> Arc
         }),
         E::ARRAY { arrayExp } => Arc::new(E::ARRAY { arrayExp: subst_exp_list(arrayExp, map) }),
         E::MATRIX { matrix } => Arc::new(E::MATRIX {
-            matrix: Arc::new(metamodelica::List::from_iter(matrix.into_iter().map(|row| subst_exp_list(row, map)))),
+            matrix: metamodelica::List::from_iter(matrix.into_iter().map(|row| subst_exp_list(row, map))),
         }),
         E::RANGE { start, step, stop } => Arc::new(E::RANGE {
             start: subst_exp(start, map), step: step.as_ref().map(|s| subst_exp(s, map)), stop: subst_exp(stop, map),
@@ -6646,7 +6646,7 @@ fn subst_exp(e: &Arc<Absyn::Exp>, map: &HashMap<String, Arc<Absyn::Exp>>) -> Arc
         }),
         E::MATCHEXP { matchTy, inputExp, localDecls, cases, comment } => Arc::new(E::MATCHEXP {
             matchTy: matchTy.clone(), inputExp: subst_exp(inputExp, map), localDecls: localDecls.clone(),
-            cases: Arc::new(metamodelica::List::from_iter(cases.into_iter().map(|cse| subst_case(cse, map)))),
+            cases: metamodelica::List::from_iter(cases.into_iter().map(|cse| subst_case(cse, map))),
             comment: comment.clone(),
         }),
         // Leaves with no sub-expressions.
@@ -6660,10 +6660,10 @@ fn subst_fargs(fa: &Arc<Absyn::FunctionArgs>, map: &HashMap<String, Arc<Absyn::E
     match &**fa {
         F::FUNCTIONARGS { args, argNames } => Arc::new(F::FUNCTIONARGS {
             args: subst_exp_list(args, map),
-            argNames: Arc::new(metamodelica::List::from_iter(argNames.into_iter().map(|na| {
+            argNames: metamodelica::List::from_iter(argNames.into_iter().map(|na| {
                 let Absyn::NamedArg { argName, argValue } = &**na;
                 Arc::new(Absyn::NamedArg { argName: argName.clone(), argValue: subst_exp(argValue, map) })
-            }))),
+            })),
         }),
         F::FOR_ITER_FARG { exp, iterType, iterators } => Arc::new(F::FOR_ITER_FARG {
             exp: subst_exp(exp, map), iterType: iterType.clone(), iterators: subst_for_iterators(iterators, map),
@@ -6675,30 +6675,30 @@ fn subst_for_iterators(
     l: &Absyn::ForIterators,
     map: &HashMap<String, Arc<Absyn::Exp>>,
 ) -> Absyn::ForIterators {
-    Arc::new(metamodelica::List::from_iter(l.into_iter().map(|it| {
+    metamodelica::List::from_iter(l.into_iter().map(|it| {
         let Absyn::ForIterator { name, guardExp, range } = &**it;
         Arc::new(Absyn::ForIterator {
             name: name.clone(),
             guardExp: guardExp.as_ref().map(|g| subst_exp(g, map)),
             range: range.as_ref().map(|r| subst_exp(r, map)),
         })
-    })))
+    }))
 }
 
 fn subst_alg_item_list(
     l: &metamodelica::List<Arc<Absyn::AlgorithmItem>>,
     map: &HashMap<String, Arc<Absyn::Exp>>,
-) -> Arc<metamodelica::List<Arc<Absyn::AlgorithmItem>>> {
-    Arc::new(metamodelica::List::from_iter(l.into_iter().map(|it| subst_alg_item(it, map))))
+) -> metamodelica::List<Arc<Absyn::AlgorithmItem>> {
+    metamodelica::List::from_iter(l.into_iter().map(|it| subst_alg_item(it, map)))
 }
 
 fn subst_alg_elseif(
-    l: &metamodelica::List<(Arc<Absyn::Exp>, Arc<metamodelica::List<Arc<Absyn::AlgorithmItem>>>)>,
+    l: &metamodelica::List<(Arc<Absyn::Exp>, metamodelica::List<Arc<Absyn::AlgorithmItem>>)>,
     map: &HashMap<String, Arc<Absyn::Exp>>,
-) -> Arc<metamodelica::List<(Arc<Absyn::Exp>, Arc<metamodelica::List<Arc<Absyn::AlgorithmItem>>>)>> {
-    Arc::new(metamodelica::List::from_iter(
+) -> metamodelica::List<(Arc<Absyn::Exp>, metamodelica::List<Arc<Absyn::AlgorithmItem>>)> {
+    metamodelica::List::from_iter(
         l.into_iter().map(|(cond, body)| (subst_exp(cond, map), subst_alg_item_list(body, map))),
-    ))
+    )
 }
 
 fn subst_alg_item(it: &Arc<Absyn::AlgorithmItem>, map: &HashMap<String, Arc<Absyn::Exp>>) -> Arc<Absyn::AlgorithmItem> {
@@ -9838,7 +9838,7 @@ fn emit_exp<'a>(exp: &TypedExp, is_const: bool, ctx: &mut GenCtx, top_level: &'a
             // unconditionally `metamodelica::cons`, and a glob-imported bare
             // `cons` is shadowed when the function has a local binding named
             // `cons` (e.g. a `Constraint` list in BackendDAEUtil), turning the
-            // call into `Arc<List<..>>(..)` — E0618 "expected function".
+            // call into `List<..>(..)` — E0618 "expected function".
             format!("metamodelica::cons({head_s}, {tail_s})")
         }
 
@@ -10602,7 +10602,7 @@ fn emit_reduction<'a>(
             // The reduction body's static type carries type variables from a
             // callee's signature (e.g. `tuple21<T1,T2>`'s `T1` flowing into
             // the accumulator) that aren't in scope at the caller. Emitting
-            // them verbatim would produce `Arc<List<T1>>` against an
+            // them verbatim would produce `List<T1>` against an
             // undeclared name; defer to Rust inference instead. The body
             // assignment to `__x` pins the concrete type from the call site.
             "_".to_owned()
@@ -10625,7 +10625,7 @@ fn emit_reduction<'a>(
             // over the cons-cells and avoids the Vec allocation entirely.
             let elem_ty = match ty { Ty::List(t) => ty_or_underscore(t, ctx), _ => "_".to_owned() };
             (
-                format!("let mut __acc: Arc<metamodelica::List<{elem_ty}>> = metamodelica::nil();"),
+                format!("let mut __acc: metamodelica::List<{elem_ty}> = metamodelica::nil();"),
                 "__acc = cons(__x, __acc);".to_owned(),
                 "__acc.reverse()".to_owned(),
             )
@@ -10634,7 +10634,7 @@ fn emit_reduction<'a>(
             // Reverse-iteration order: cons directly onto the accumulator.
             let elem_ty = match ty { Ty::List(t) => ty_or_underscore(t, ctx), _ => "_".to_owned() };
             (
-                format!("let mut __acc: Arc<metamodelica::List<{elem_ty}>> = metamodelica::nil();"),
+                format!("let mut __acc: metamodelica::List<{elem_ty}> = metamodelica::nil();"),
                 "__acc = cons(__x, __acc);".to_owned(),
                 "__acc".to_owned(),
             )
@@ -10715,7 +10715,7 @@ fn emit_reduction<'a>(
             // matches the existing helper's argument order: prepend __x onto acc.
             let inner_ty = match ty { Ty::List(t) => ty_or_underscore(t, ctx), _ => "_".to_owned() };
             (
-                format!("let mut __acc: Arc<metamodelica::List<{inner_ty}>> = metamodelica::nil();"),
+                format!("let mut __acc: metamodelica::List<{inner_ty}> = metamodelica::nil();"),
                 "__acc = __x.append(&__acc);".to_owned(),
                 "__acc".to_owned(),
             )
@@ -11808,7 +11808,7 @@ fn emit_builtin_call<'a>(func: &str, args: &[TypedExp], is_const: bool, ctx: &mu
             // where the loop binds a `&_` whose `_` Rust can't resolve from the
             // body alone).
             let arg = args.first().map(|a| emit_builtin_call_arg_raw(func, 0, a, is_const, ctx, top_level)).unwrap_or_default();
-            Ok(format!("Arc::new({arg}.borrow().iter().cloned().collect::<metamodelica::List<_>>())"))
+            Ok(format!("{arg}.borrow().iter().cloned().collect::<metamodelica::List<_>>()"))
         },
         // Modelica trigonometric, exponential and square-root builtins.
         // The MetaModelica compiler accepts these bare-name builtins (declared
@@ -12573,7 +12573,7 @@ fn find_record_split<'a>(segments: &[CrefSegment], ctx: &GenCtx, top_level: &'a 
                     .map(|n| n.children.contains_key(&segments[1].name))
                     .unwrap_or(true)
             }
-            // For non-record local types (Arc<List<_>>, enums, primitives, …)
+            // For non-record local types (List<_>, enums, primitives, …)
             // we keep the original shadowing behaviour. A field access on
             // those is either via `var_field!` (enum) or a downstream
             // type-error that points at the real bug.
@@ -14558,7 +14558,7 @@ fn emit_match<'a>(kind: &MatchKind, input: &TypedExp, cases: &[TypedCase], as_bi
     // The macro provides stable-Rust replacements for nightly's `deref_patterns`:
     // a `::match_deref::Deref @ <inner>` token sequence inside an arm pattern
     // desugars to `if let inner = Deref::deref(binding) { … }`. This lets us match
-    // through `Arc<List<T>>`, recursive `Arc<Enum>` variants, and `ArcStr` literal
+    // through `List<T>`, recursive `Arc<Enum>` variants, and `ArcStr` literal
     // patterns — all of which were the previous use cases for the
     // `#![feature(deref_patterns)]` attribute.
     //
@@ -14594,12 +14594,12 @@ fn emit_match<'a>(kind: &MatchKind, input: &TypedExp, cases: &[TypedCase], as_bi
     // own match ergonomics on `&T` then makes the bindings by-reference,
     // which matches the implicit_ref regime in
     // `emit_pat_with_implicit_bind`. We extend this to `Ty::List`
-    // (`Arc<metamodelica::List<T>>`).
+    // (`metamodelica::List<T>`).
     let input_is_arc_recursive = is_arc_wrapped(&input_ty, ctx)
         || matches!(input_ty, Ty::List(_));
     // A `matchcontinue` with a tuple scrutinee whose elements include `Arc<…>`
     // values needs the subject rebuilt as a tuple of references: each
-    // `Arc<List<T>>` / `Arc<Enum>` element gets `.as_ref()` (yielding
+    // `List<T>` / `Arc<Enum>` element gets `.as_ref()` (yielding
     // `&List<T>` / `&Enum`), every other element is passed by value. Rust's
     // match ergonomics then makes all bindings inside the tuple pattern
     // by-reference, which is exactly the regime `emit_pat_with_implicit_bind`
@@ -15397,7 +15397,7 @@ fn emit_match<'a>(kind: &MatchKind, input: &TypedExp, cases: &[TypedCase], as_bi
                 // body in `::match_deref::match_deref!{}` (each arm is a
                 // separate `let pat = … else { bail }`), but we *can* wrap a
                 // single arm's destructure when its pattern crosses an Arc
-                // edge (e.g. `Cons { tail: Nil }` against `Arc<List<T>>`) or
+                // edge (e.g. `Cons { tail: Nil }` against `List<T>`) or
                 // matches a `String` literal against an `ArcStr`. The arm
                 // then becomes `match_deref!{ match &__mc_input { <pat> => …
                 // _ => bail }}` inside the IIFE — the `_` branch falls
@@ -15923,10 +15923,10 @@ fn emit_pat<'a>(pat: &TypedPat, ctx: &mut GenCtx, top_level: &'a BTreeMap<String
 /// Return true if matching `pat` against a scrutinee of `ty` will cross an
 /// Arc edge — i.e. the pattern destructures through an `Arc<T>` wrapper.
 /// Crossing an Arc edge happens for:
-///   - `Ty::List(_)` (lowered to `Arc<metamodelica::List<T>>`).
+///   - `Ty::List(_)` (lowered to `metamodelica::List<T>`).
 ///   - Any type marked recursive in `ctx.recursive_types` (uniontype enums and
 ///     their variant records are stored behind `Arc`).
-///   - The `tail` field of a `Cons` pattern (typed as `Arc<List<T>>` regardless
+///   - The `tail` field of a `Cons` pattern (typed as `List<T>` regardless
 ///     of the outer scrutinee, since the field itself is Arc-wrapped).
 /// Once we cross an Arc edge, the `deref_patterns` feature binds every
 /// nested name by reference; `mut <name>` is therefore rejected as a
@@ -15963,7 +15963,7 @@ fn pat_has_str_lit(pat: &TypedPat) -> bool {
 /// the following holds for the input or its destructured sub-elements:
 ///
 ///   * The scrutinee is `Arc<…>` over a recursive uniontype (`is_arc_wrapped`).
-///   * The scrutinee is `Arc<metamodelica::List<T>>` (every `Ty::List`).
+///   * The scrutinee is `metamodelica::List<T>` (every `Ty::List`).
 ///   * A `(_, _, …)` tuple scrutinee contains at least one Arc-crossing
 ///     element — `type_destructure_needs_borrow` already recurses through
 ///     tuples.
@@ -15983,7 +15983,7 @@ fn match_uses_match_deref(input_ty: &Ty, cases: &[TypedCase], ctx: &GenCtx, top_
 
 /// True when destructuring `pat` against a scrutinee of type `scrut_ty`
 /// would require descending through an `Arc<…>` edge — e.g. a constructor
-/// pattern whose field type is `Arc<List<…>>` and whose sub-pattern is
+/// pattern whose field type is `List<…>` and whose sub-pattern is
 /// anything other than a bare `_` / variable binding (which doesn't
 /// destructure further). When this returns true the match must be wrapped
 /// in `::match_deref::match_deref!{ … }` so the inner pattern can match
@@ -15994,7 +15994,7 @@ fn pat_crosses_arc_edge(pat: &TypedPat, scrut_ty: &Ty, ctx: &GenCtx, top_level: 
         !matches!(p, TypedPat::Wildcard | TypedPat::Var(_))
     }
     // A Constructor / Cons / EmptyList pattern matched against an Arc-wrapped
-    // (or List, which is itself Arc<List<...>>) scrutinee must peel the smart
+    // (or List, which is itself List<...>) scrutinee must peel the smart
     // pointer with `Deref @ ...`. This applies whether the Arc edge is the
     // outer scrutinee or sits behind a Some/Cons.tail; the caller already
     // recurses with the inner type, so checking the *current* scrutinee here
@@ -16222,7 +16222,7 @@ fn pat_deref_bindings(pat: &TypedPat, scrut_ty: &Ty, ctx: &GenCtx, top_level: &B
     // Otherwise, recurse type-aware to find where Arc edges are crossed.
     match pat {
         TypedPat::Cons { head, tail } => {
-            // The Cons.tail field is `Arc<List<T>>` — itself an Arc edge —
+            // The Cons.tail field is `List<T>` — itself an Arc edge —
             // so everything below the tail subtree is in deref. The head
             // is bound by value (type T) without crossing an Arc edge, so
             // recurse type-aware into it.
@@ -16454,14 +16454,14 @@ fn emit_pat_with_implicit_bind_md<'a>(pat: &TypedPat, allow_implicit_bind: bool,
     //    within an implicitly-borrowing pattern"). Emit bare names. Once
     //    set, it propagates to every nested sub-pattern.
     //
-    // 2. `in_deref` (regime 2): subject is `Arc<List<T>>` matched directly
+    // 2. `in_deref` (regime 2): subject is `List<T>` matched directly
     //    via `deref_patterns`, or we're inside the `Cons.tail` of one. A
     //    bare `head: x` would try to move from behind the Arc (E0507), so
     //    we emit explicit `ref x`.
     //
     // `implicit_ref` only enters via the outer `emit_match` call (which
     // tracks whether the match is wrapped in `match_deref!{ ... }`). Don't
-    // re-derive it from inner scrut_ty: a nested `(Arc<List<T>>, Arc<Tree>)`
+    // re-derive it from inner scrut_ty: a nested `(List<T>, Arc<Tree>)`
     // tuple scrutinee is *not* implicit-borrowed even though its second
     // element is a recursive Arc-wrapped uniontype — `emit_match` decides at
     // the outer level whether match_deref is in scope. Just propagate what
@@ -16491,7 +16491,7 @@ fn emit_pat_with_implicit_bind_md<'a>(pat: &TypedPat, allow_implicit_bind: bool,
     // pattern (see `match_uses_match_deref` in `emit_match`).
     // Pattern-shape fallback: when scrut_ty is Unknown (typedexp couldn't
     // pin a generic call's return type, etc.) but the pattern itself proves
-    // the scrutinee is wrapped in an `Arc<List<_>>`, force the Arc-edge
+    // the scrutinee is wrapped in an `List<_>`, force the Arc-edge
     // prefix. Without this, the outermost `Cons` of a Cons/Nil chain over a
     // generic-returning call's result emits without `Deref @` and Rust
     // rejects the pattern with E0308.
@@ -16531,7 +16531,7 @@ fn emit_pat_with_implicit_bind_md<'a>(pat: &TypedPat, allow_implicit_bind: bool,
     // `#[tailcall::tailcall]` bodies where match_deref would hide arms from
     // the tailcall rewriter), the OUTER scrutinee has already been peeled
     // by `.as_ref()` — and inner Arc edges (e.g. `Cons.tail` typed
-    // `Arc<List<T>>`) are not destructured further by the legacy lowering,
+    // `List<T>`) are not destructured further by the legacy lowering,
     // so no Deref prefix is needed there either. Hence we gate the prefix
     // on `in_match_deref` alone, not on `implicit_ref`.
     let arc_prefix: &str = if in_match_deref && at_arc_edge { "Deref @ " } else { "" };
@@ -16543,7 +16543,7 @@ fn emit_pat_with_implicit_bind_md<'a>(pat: &TypedPat, allow_implicit_bind: bool,
             Some(renamed) => bind_var(&renamed.clone()),
             None => bind_var(name),
         },
-        TypedPat::EmptyList   => format!("{arc_prefix}metamodelica::List::Nil"),
+        TypedPat::EmptyList   => format!("{arc_prefix}metamodelica::ListNode::Nil"),
         TypedPat::Some_(inner) => {
             // Propagate the Option's inner type into the sub-pattern so it can
             // decide whether a `Deref @` prefix is required at an Arc edge
@@ -16607,14 +16607,14 @@ fn emit_pat_with_implicit_bind_md<'a>(pat: &TypedPat, allow_implicit_bind: bool,
             // that itself crosses an Arc edge (e.g. an element which is a
             // recursive uniontype) gets `in_deref` set correctly.
             let elem_ty: Ty = match scrut_ty { Some(Ty::List(t)) => (**t).clone(), _ => Ty::Unknown };
-            // The `tail` field of `metamodelica::List::Cons` is `Arc<List<T>>`
+            // The `tail` field of `metamodelica::ListNode::Cons` is `List<T>`
             // (itself an Arc edge), so emit the tail sub-pattern with a
             // synthetic `Ty::List(elem)` scrutinee. Inside `match_deref!`
             // this triggers another `::match_deref::Deref @` prefix on the
             // tail's variant pattern; outside it forces `ref <name>` binding
             // (the legacy Arc<List> behavior).
             let tail_ty = Ty::List(Box::new(elem_ty.clone()));
-            let body = format!("metamodelica::List::Cons {{ head: {}, tail: {} }}",
+            let body = format!("metamodelica::ListNode::Cons {{ head: {}, tail: {} }}",
                 emit_pat_with_implicit_bind_md(head, allow_implicit_bind, mut_bindings, in_deref, implicit_ref, in_match_deref, Some(&elem_ty), ctx, top_level),
                 emit_pat_with_implicit_bind_md(tail, allow_implicit_bind, mut_bindings, true, implicit_ref, in_match_deref, Some(&tail_ty), ctx, top_level));
             format!("{arc_prefix}{body}")
@@ -16996,9 +16996,9 @@ fn emit_pat_with_implicit_bind_md<'a>(pat: &TypedPat, allow_implicit_bind: bool,
             // `var @ inner` matches the same value against both sides, so the
             // inner needs the same `scrut_ty` to decide whether to emit a
             // `Deref @ ` prefix (e.g. an `As` pattern sitting on `Cons.tail`,
-            // which is itself `Arc<List<T>>`, must wrap its inner Cons/Nil
+            // which is itself `List<T>`, must wrap its inner Cons/Nil
             // sub-pattern in `Deref @ …`). Passing `None` here previously
-            // dropped that information, producing `tail: rest @ List::Cons{…}`
+            // dropped that information, producing `tail: rest @ metamodelica::ListNode::Cons{…}`
             // and a `&Arc<…>` vs `List<…>` mismatch.
             format!("{} @ {}", outer, emit_pat_with_implicit_bind_md(pat, false, false, in_deref || force_ref, implicit_ref, in_match_deref, scrut_ty, ctx, top_level))
         }
@@ -17486,7 +17486,7 @@ fn is_static_const_emittable(exp: &TypedExp, ctx: &GenCtx, top_level: &BTreeMap<
 /// True if the lowered Rust type for `ty` implements `Sync` for the purposes of
 /// `pub static` storage. The only non-`Sync` MetaModelica primitive we generate
 /// today is `Array<T> = Rc<RefCell<Vec<T>>>` (see `metamodelica::Array`); every
-/// other built-in maps to a `Sync` Rust type (`Arc<List<T>>`, `ArcStr`,
+/// other built-in maps to a `Sync` Rust type (`List<T>`, `ArcStr`,
 /// `Mutable<T> = Arc<Mutex<T>>`, primitives, function pointers, etc.).
 ///
 /// User-defined struct/enum types are checked against
@@ -17533,7 +17533,7 @@ fn ty_is_sync(ty: &Ty, ctx: &GenCtx) -> bool {
 
 /// Whether a value of this type is represented at the Rust level as a
 /// shared-pointer *handle* (`Arc<Enum>` for recursive uniontypes,
-/// `Arc<List<T>>` for lists, `ArcStr` for strings, `Rc<RefCell<Vec<T>>>` for
+/// `List<T>` for lists, `ArcStr` for strings, `Rc<RefCell<Vec<T>>>` for
 /// arrays) whose clones all designate the same MetaModelica heap object.
 ///
 /// `referenceEq` lowers to a pointer comparison; for handle-represented
@@ -17543,7 +17543,7 @@ fn ty_is_sync(ty: &Ty, ctx: &GenCtx) -> bool {
 /// result always-false. See [`try_emit_reference_eq`].
 fn referenceeq_derefs_to_pointee(ty: &Ty, ctx: &GenCtx) -> bool {
     match ty {
-        // list<T> → Arc<List<T>>; String → ArcStr; array<T> → Rc<RefCell<Vec<T>>>.
+        // list<T> → List<T>; String → ArcStr; array<T> → Rc<RefCell<Vec<T>>>.
         Ty::List(_) | Ty::Str | Ty::Array(_) => true,
         // Recursive uniontypes / variant-narrowed values / recursive generics
         // → Arc<Enum>.
@@ -17624,7 +17624,7 @@ fn try_emit_reference_eq<'a>(
         // and Cons by head identity + tail allocation — O(1), true whenever
         // the MMC pointer compare would be.
         Ty::List(_) => Some(format!(
-            "metamodelica::ReferenceEq::reference_eq(&*({lhs}), &*({rhs}))"
+            "metamodelica::ReferenceEq::reference_eq(&({lhs}), &({rhs}))"
         )),
         _ if referenceeq_derefs_to_pointee(ty, ctx) => {
             Some(format!("referenceEq(&*({lhs}),&*({rhs}))"))
@@ -17794,7 +17794,7 @@ fn type_destructure_needs_borrow(ty: &Ty, ctx: &GenCtx) -> bool {
 }
 
 /// True when the *pattern's shape* already proves the scrutinee is wrapped in
-/// an `Arc<_>` (or `Arc<List<_>>`/`Arc<Option<_>>`/etc.) and must be matched
+/// an `Arc<_>` (or `List<_>`/`Arc<Option<_>>`/etc.) and must be matched
 /// through `match_deref!` rather than a bare `let … = … else { fail };`.
 ///
 /// Used as a fallback when typedexp can't fully resolve the scrutinee's type
@@ -17818,8 +17818,8 @@ fn pat_requires_arc_deref(pat: &TypedPat, ctx: &GenCtx) -> bool {
         //     callback `fun()` whose return type is `Ty::Unknown` — has no such
         //     scrutinee type, so we recover it from the pattern's own `ty`); or
         //   * a nested field is itself an Arc-edge pattern (e.g. a
-        //     `FCore::Cache { …, scope: List::Cons{…}, .. }` destructure) —
-        //     the inner List::Cons is on an `Arc<List<_>>` field even though
+        //     `FCore::Cache { …, scope: metamodelica::ListNode::Cons{…}, .. }` destructure) —
+        //     the inner metamodelica::ListNode::Cons is on an `List<_>` field even though
         //     the outer Constructor's own type is a plain struct.
         TypedPat::Constructor { fields, named_fields, ty, .. } => {
             // `is_arc_wrapped` only recognises the bare recursive-uniontype
@@ -18117,7 +18117,7 @@ fn emit_pat_assign<'a>(
             // Render shallow with deferrals for Arc-edge crossings.
             let mut deferrals: Vec<(String, TypedPat, Ty)> = Vec::new();
             let surface = render_shallow(pat_for_render, scrut_ty, ctx, env, top_level, fresh, &mut deferrals, /*force_ref=*/false, scrut_borrowed);
-            // When the scrutinee is Arc-wrapped (list<T> → Arc<List<T>>; recursive
+            // When the scrutinee is Arc-wrapped (list<T> → List<T>; recursive
             // uniontypes wrapped in Arc), destructuring a variant pattern such as
             // `Cons { head, tail }` only succeeds via the `deref_patterns`
             // feature, which deref's through the Arc. The deref produces a
@@ -18130,7 +18130,7 @@ fn emit_pat_assign<'a>(
             //
             // We must also recurse through Tuple types: a let-let pattern
             // `(STRING{r#str=key}, tokens) := parse_string(..)` has
-            // scrut_ty = (Arc<JSON>, Arc<List<Token>>), where the outer tuple
+            // scrut_ty = (Arc<JSON>, List<Token>), where the outer tuple
             // itself isn't Arc-wrapped but the first element is. Without
             // borrowing the whole tuple, the inner Constructor pattern would
             // still trigger Arc deref_patterns and fail to move non-Copy
@@ -18194,8 +18194,8 @@ fn emit_pat_assign<'a>(
             //
             // The legacy `let PAT = &(expr) else { fail };` form relied on the
             // nightly `deref_patterns` feature to peel the `Arc<…>` around
-            // `&Arc<List<T>>` etc. On stable we have no auto-deref, so the
-            // raw pattern fails to compile (E0308 "expected `Arc<List<T>>`,
+            // `&List<T>` etc. On stable we have no auto-deref, so the
+            // raw pattern fails to compile (E0308 "expected `List<T>`,
             // found `List<_>`"). Replace it with a `::match_deref::match_deref!`
             // wrapped `match` that yields a tuple of the pattern's clones:
             //
@@ -18514,7 +18514,7 @@ fn render_shallow<'a>(
                 escape_ident(name)
             }
         }
-        TypedPat::EmptyList => "metamodelica::List::Nil".to_owned(),
+        TypedPat::EmptyList => "metamodelica::ListNode::Nil".to_owned(),
         TypedPat::None_ => "None".to_owned(),
         TypedPat::Some_(inner) => {
             let inner_ty = match scrut_ty {
@@ -18530,21 +18530,21 @@ fn render_shallow<'a>(
         TypedPat::Cons { head, tail } => {
             let elem_ty = match scrut_ty { Ty::List(t) => (**t).clone(), _ => Ty::Unknown };
             let h = render_shallow(head, &elem_ty, ctx, env, top_level, fresh, deferrals, force_ref, scrut_borrowed);
-            // The `tail` field of `metamodelica::List::Cons` is `Arc<List<T>>`, and
+            // The `tail` field of `metamodelica::ListNode::Cons` is `List<T>`, and
             // the surface MetaModelica type `list<T>` is also lowered to
-            // `Arc<List<T>>`, so binding the tail directly in the pattern yields a
+            // `List<T>`, so binding the tail directly in the pattern yields a
             // value of exactly the right user-visible type. We still route the
             // tail through a fresh `__tN` temporary so that a non-trivial sub-pattern
             // (e.g. another `Cons`, a constructor, or a name that shadows an
             // already-bound variable) can be re-emitted by `emit_pat_assign` against
-            // an owned `Arc<List<T>>` scrutinee. The deferred expression is therefore
+            // an owned `List<T>` scrutinee. The deferred expression is therefore
             // `__tN.clone()` (an Arc bump), NOT `(*__tN).clone()` — the latter would
             // strip the Arc and produce a `List<T>` value, which no longer matches
             // the surface type.
             // Wildcards pass through unchanged — there is nothing to bind.
             // A simple `Var(name)` sub-pattern can also be bound directly in the
-            // pattern: by-value matching on an `Arc<List<T>>` moves the `tail`
-            // field out as an `Arc<List<T>>`, which is exactly the surface type
+            // pattern: by-value matching on an `List<T>` moves the `tail`
+            // field out as an `List<T>`, which is exactly the surface type
             // of the user's variable. No fresh temporary or follow-up clone is
             // needed in that case. Note that `rewrite_pat_for_existing_bindings`
             // has already substituted any name that collides with the current
@@ -18561,7 +18561,7 @@ fn render_shallow<'a>(
                     tmp
                 }
             };
-            format!("metamodelica::List::Cons {{ head: {h}, tail: {t} }}")
+            format!("metamodelica::ListNode::Cons {{ head: {h}, tail: {t} }}")
         }
         TypedPat::Tuple(pats) => {
             let tys: Vec<Ty> = match scrut_ty {
@@ -19533,7 +19533,7 @@ fn record_pattern_variants_inner<'a>(
     record_constructor_pattern_bindings(inner_pat, &scrut_ty, env, top_level, shapes, ctx, md);
     // (5) List-cons patterns: walk through `head :: tail` (= TypedPat::Cons).
     //     `head` is a single element; `tail` is the same list type. When the
-    //     scrutinee is `Arc<List<T>>` and the list crosses Arc (always true
+    //     scrutinee is `List<T>` and the list crosses Arc (always true
     //     for `Ty::List`), every name binding inside the pattern is by-ref
     //     under match_deref!. Record the shape so downstream `var_field!`
     //     and `.field` emission deref correctly, and recurse so nested
@@ -21317,7 +21317,7 @@ fn fmt_param_ty(ty: &Ty, ctx: &mut GenCtx) -> String {
         // Same for `Option<F>` / `List<F>` / `Array<F>`: any container whose
         // element is itself a function type needs the trait-object form.
         Ty::Option(inner) => format!("Option<{}>", fmt_param_ty(inner, ctx)),
-        Ty::List(inner) => format!("Arc<metamodelica::List<{}>>", fmt_param_ty(inner, ctx)),
+        Ty::List(inner) => format!("metamodelica::List<{}>", fmt_param_ty(inner, ctx)),
         Ty::Array(inner) => format!("metamodelica::Array<{}>", fmt_param_ty(inner, ctx)),
         _ => fmt_ty(ty, ctx),
     }
@@ -23734,7 +23734,7 @@ fn fmt_ty(ty: &Ty, ctx: &mut GenCtx) -> String {
             fmt_ty(&Ty::RustEnum(union_qname.clone()), ctx)
         }
         Ty::Option(inner) => format!("Option<{}>", fmt_ty(inner, ctx)),
-        Ty::List(inner) => format!("Arc<metamodelica::List<{}>>", fmt_ty(inner, ctx)),
+        Ty::List(inner) => format!("metamodelica::List<{}>", fmt_ty(inner, ctx)),
         // MetaModelica `array<T>` has reference (aliasing) semantics: arrayUpdate
         // mutates in place and the change is visible through every alias. We model
         // that with `metamodelica::Array<T>` (alias for `Rc<RefCell<Vec<T>>>`).
@@ -23908,7 +23908,7 @@ fn component_fields<'a>(c: &'a MM::Class, children: &'a BTreeMap<String, NameNod
 /// Same as [`component_fields`] but also returns each component's original
 /// AST `TypeSpec`. The TypeSpec lets the emitter recover the type *name as
 /// written* (e.g. `Key`, `Value`) rather than its fully resolved Rust type
-/// (e.g. `ArcStr`, `Arc<metamodelica::List<TplAbsyn::ASTDef>>`). This is what
+/// (e.g. `ArcStr`, `metamodelica::List<TplAbsyn::ASTDef>`). This is what
 /// lets uniontype record fields reference sibling type aliases instead of
 /// inlining the resolved type — keeping the generated code stable across
 /// future redeclarations of the alias.
@@ -24127,10 +24127,10 @@ fn component_ref_simple_name(cref: &Absyn::ComponentRef) -> String {
 /// function input parameter — anything more complex (a literal, a nested
 /// expression) is rejected with a placeholder so the broken case shows
 /// up at compile time instead of silently dropping arguments.
-fn collect_external_arg_names(args: &std::sync::Arc<metamodelica::List<std::sync::Arc<Absyn::Exp>>>) -> Vec<String> {
+fn collect_external_arg_names(args: &metamodelica::List<std::sync::Arc<Absyn::Exp>>) -> Vec<String> {
     let mut out = Vec::new();
     let mut cur = args.clone();
-    while let metamodelica::List::Cons { head, tail } = &*cur {
+    while let metamodelica::ListNode::Cons { head, tail } = &*cur {
         match crate::hierarchy::strip_exp_wrappers(head) {
             // `OpenModelica.threadData()` — drop.
             Absyn::Exp::CALL { function_, .. }

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/const_patterns.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/const_patterns.rs
@@ -90,7 +90,7 @@ fn collect_functions<'a>(
 
 /// Pull the declared component names out of a `localDecls` list.
 fn collect_local_names(
-    decls: &Arc<metamodelica::List<Arc<Absyn::ElementItem>>>,
+    decls: &metamodelica::List<Arc<Absyn::ElementItem>>,
     out: &mut BTreeSet<String>,
 ) {
     for item in (&**decls).into_iter() {
@@ -245,9 +245,9 @@ impl<'a> Scan<'a> {
     fn process_match(
         &mut self,
         match_ty: &Absyn::MatchType,
-        match_locals: &Arc<metamodelica::List<Arc<Absyn::ElementItem>>>,
+        match_locals: &metamodelica::List<Arc<Absyn::ElementItem>>,
         input_exp: &Absyn::Exp,
-        cases: &Arc<metamodelica::List<Arc<Absyn::Case>>>,
+        cases: &metamodelica::List<Arc<Absyn::Case>>,
         env: &BTreeSet<String>,
     ) {
         let kind = match match_ty {

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/fallibility.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/fallibility.rs
@@ -151,7 +151,7 @@ pub fn builtin_fallibility(name: &str) -> Option<Fallibility> {
         // are total over `List<T>`.
         "listAppend" | "listMember" | "listLength" | "listEmpty" => Infallible,
         // `cons(head, tail)` is the function-call form of `head :: tail`. It
-        // wraps in Arc<List<_>> via a single allocation and never fails.
+        // wraps in List<_> via a single allocation and never fails.
         "cons" | "nil" => Infallible,
         "listHead" | "listRest" => Fallible,
         // `listGet` / `listDelete` bounds-check the 1-based index and bail

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/hierarchy.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/hierarchy.rs
@@ -1917,7 +1917,7 @@ pub(crate) fn strip_exp_wrappers(mut e: &Absyn::Exp) -> &Absyn::Exp {
         match e {
             Absyn::Exp::EXPRESSIONCOMMENT { exp, .. } => e = exp,
             Absyn::Exp::TUPLE { expressions } => match &**expressions {
-                metamodelica::List::Cons { head, tail } if tail.is_empty() => e = head,
+                metamodelica::ListNode::Cons { head, tail } if tail.is_empty() => e = head,
                 _ => return e,
             },
             _ => return e,

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/scripting_api_qt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/scripting_api_qt.rs
@@ -231,7 +231,7 @@ fn rust_ty(ty: &Ty) -> String {
         Ty::I32 => "i32".to_string(),
         Ty::F64 => "metamodelica::Real".to_string(),
         Ty::Bool => "bool".to_string(),
-        Ty::List(inner) => format!("std::sync::Arc<metamodelica::List<{}>>", rust_ty(inner)),
+        Ty::List(inner) => format!("metamodelica::List<{}>", rust_ty(inner)),
         other => unreachable!("rust_ty on unsupported {other:?}"),
     }
 }
@@ -449,7 +449,7 @@ fn json_arg(ty: &Ty, idx: usize) -> String {
         Ty::F64 => format!("__jf64(a, {idx})"),
         Ty::Bool => format!("__jbool(a, {idx})"),
         Ty::List(inner) => format!(
-            "std::sync::Arc::new(a.get({idx}).and_then(|__v| __v.as_array()).map(|__arr0| __arr0.iter().map(|__o0| {}).collect::<metamodelica::List<{}>>()).unwrap_or(metamodelica::List::Nil))",
+            "a.get({idx}).and_then(|__v| __v.as_array()).map(|__arr0| __arr0.iter().map(|__o0| {}).collect::<metamodelica::List<{}>>()).unwrap_or_default()",
             json_elem(inner, "__o0", 1),
             rust_ty(inner)
         ),
@@ -468,7 +468,7 @@ fn json_elem(ty: &Ty, o: &str, depth: usize) -> String {
             let arr = format!("__arr{depth}");
             let o2 = format!("__o{depth}");
             format!(
-                "std::sync::Arc::new({o}.as_array().map(|{arr}| {arr}.iter().map(|{o2}| {}).collect::<metamodelica::List<{}>>()).unwrap_or(metamodelica::List::Nil))",
+                "{o}.as_array().map(|{arr}| {arr}.iter().map(|{o2}| {}).collect::<metamodelica::List<{}>>()).unwrap_or_default()",
                 json_elem(inner, &o2, depth + 1),
                 rust_ty(inner)
             )
@@ -591,7 +591,7 @@ fn abi_in(ty: &Ty, c: &str, depth: usize) -> String {
         Ty::List(inner) => {
             let o = format!("__o{depth}");
             format!(
-                "std::sync::Arc::new(unsafe {{ seq_slice({c}) }}.iter().map(|{o}| {}).collect::<metamodelica::List<{}>>())",
+                "unsafe {{ seq_slice({c}) }}.iter().map(|{o}| {}).collect::<metamodelica::List<{}>>()",
                 read_elem(inner, &o, depth + 1),
                 rust_ty(inner)
             )
@@ -614,7 +614,7 @@ fn read_elem(ty: &Ty, o: &str, depth: usize) -> String {
         Ty::List(inner) => {
             let o2 = format!("__o{depth}");
             format!(
-                "match {o} {{ OmcVal::Seq(__sb) => std::sync::Arc::new(__sb.0.iter().map(|{o2}| {}).collect::<metamodelica::List<{}>>()), _ => std::sync::Arc::new(metamodelica::List::Nil) }}",
+                "match {o} {{ OmcVal::Seq(__sb) => __sb.0.iter().map(|{o2}| {}).collect::<metamodelica::List<{}>>(), _ => metamodelica::nil() }}",
                 read_elem(inner, &o2, depth + 1),
                 rust_ty(inner)
             )

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/typedexp.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/typedexp.rs
@@ -1170,7 +1170,7 @@ fn call_ty(func: &str, args: &[TypedExp], top_level: &BTreeMap<String, NameNode<
         }
         // MetaModelica builtin: `stringListStringChar(s)` → `List<String>` of one-char strings.
         // Declared in MetaModelicaBuiltin.mo (`output List<String> chars`); the metamodelica
-        // runtime crate exposes it returning `Arc<List<ArcStr>>` to match the list convention.
+        // runtime crate exposes it returning `List<ArcStr>` to match the list convention.
         "stringListStringChar" => Ty::List(Box::new(Ty::Str)),
         // `listStringCharString` / `stringCharListString` invert that — list of one-char strings → String.
         "listStringCharString" | "stringCharListString" => Ty::Str,
@@ -2297,7 +2297,7 @@ fn infer_case<'a>(
         }
     }
 
-    fn infer_case_locals(local_decls: &std::sync::Arc<metamodelica::List<std::sync::Arc<Absyn::ElementItem>>>, type_vars: &[String], top_level: &BTreeMap<String, NameNode<'_>>, pkg_prefix: &str) -> Vec<(String, Ty, Option<Absyn::Exp>, Option<Absyn::TypeSpec>)> {
+    fn infer_case_locals(local_decls: &metamodelica::List<std::sync::Arc<Absyn::ElementItem>>, type_vars: &[String], top_level: &BTreeMap<String, NameNode<'_>>, pkg_prefix: &str) -> Vec<(String, Ty, Option<Absyn::Exp>, Option<Absyn::TypeSpec>)> {
         let mut out = Vec::new();
         for item in (&**local_decls).into_iter() {
             let Absyn::ElementItem::ELEMENTITEM { element } = item.as_ref() else { continue };
@@ -2414,7 +2414,7 @@ fn infer_case<'a>(
     }
 
     fn infer_eq_items_list<'a>(
-        items: &std::sync::Arc<metamodelica::List<Absyn::EquationItem>>,
+        items: &metamodelica::List<Absyn::EquationItem>,
         env: &mut HashMap<String, Ty>,
         top_level: &'a BTreeMap<String, NameNode<'a>>,
         pkg_prefix: &str,
@@ -2430,7 +2430,7 @@ fn infer_case<'a>(
     }
 
     fn infer_eq_items_list_arc<'a>(
-        items: &std::sync::Arc<metamodelica::List<std::sync::Arc<Absyn::EquationItem>>>,
+        items: &metamodelica::List<std::sync::Arc<Absyn::EquationItem>>,
         env: &mut HashMap<String, Ty>,
         top_level: &'a BTreeMap<String, NameNode<'a>>,
         pkg_prefix: &str,
@@ -2630,7 +2630,7 @@ fn infer_case<'a>(
 ///
 /// `type_vars` must be the function-level type variable names (e.g. `["Key"]`).
 fn infer_case_locals_standalone(
-    local_decls: &std::sync::Arc<metamodelica::List<std::sync::Arc<Absyn::ElementItem>>>,
+    local_decls: &metamodelica::List<std::sync::Arc<Absyn::ElementItem>>,
     type_vars: &[String],
     top_level: &BTreeMap<String, NameNode<'_>>,
     pkg_prefix: &str,
@@ -3576,7 +3576,7 @@ fn infer_stmt<'a>(
 }
 
 fn infer_stmts_list<'a>(
-    items: &std::sync::Arc<metamodelica::List<std::sync::Arc<Absyn::AlgorithmItem>>>,
+    items: &metamodelica::List<std::sync::Arc<Absyn::AlgorithmItem>>,
     env: &mut HashMap<String, Ty>,
     top_level: &'a BTreeMap<String, NameNode<'a>>,
     pkg_prefix: &str,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/src/Absyn.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/src/Absyn.rs
@@ -89,7 +89,7 @@ pub type ITERATOR = ForIterator;
 ///     see 3.3.3.2 Several Iterators from Modelica Specification.
 ///   * in array iterators where the expression should always be SOME(Exp),
 ///     see 3.4.4.2 Array constructor with iterators from Specification
-pub type ForIterators = Arc<metamodelica::List<Arc<ForIterator>>>;
+pub type ForIterators = metamodelica::List<Arc<ForIterator>>;
 
 /// - Programs, the top level construct
 ///   A program is simply a list of class definitions declared at top
@@ -99,7 +99,7 @@ pub type ForIterators = Arc<metamodelica::List<Arc<ForIterator>>>;
 #[derive(Clone, Debug, Eq, Hash, metamodelica::MMCtor, metamodelica::MetaCmp, metamodelica::ReferenceEq)]
 pub struct Program {
     /// List of classes
-    pub classes: Arc<metamodelica::List<Arc<Class>>>,
+    pub classes: metamodelica::List<Arc<Class>>,
     /// Within clause
     pub within_: Within,
 }
@@ -167,11 +167,11 @@ pub struct Class {
     pub restriction: Restriction,
     pub body: Arc<ClassDef>,
     /// when a class is the first one in the file and has a comment before it
-    pub commentsBeforeClass: Arc<metamodelica::List<ArcStr>>,
+    pub commentsBeforeClass: metamodelica::List<ArcStr>,
     /// when a class has comments before its end
-    pub commentsBeforeEnd: Arc<metamodelica::List<ArcStr>>,
+    pub commentsBeforeEnd: metamodelica::List<ArcStr>,
     /// when the class has comments after its end, before the next class or the end of the file
-    pub commentsAfterEnd: Arc<metamodelica::List<ArcStr>>,
+    pub commentsAfterEnd: metamodelica::List<ArcStr>,
     /// Information: FileName is the class is defined in +
     ///               isReadOnly bool + start line no + start column no +
     ///               end line no + end column no
@@ -224,20 +224,20 @@ pub type CLASS = Class;
 pub enum ClassDef {
     PARTS {
         /// class A<B,C> ... has type variables B,C
-        typeVars: Arc<metamodelica::List<ArcStr>>,
+        typeVars: metamodelica::List<ArcStr>,
         /// optimization Op (objective=...) end Op. A list arguments attributing a
         ///    class declaration. Currently used only for Optimica extensions
-        classAttrs: Arc<metamodelica::List<Arc<NamedArg>>>,
-        classParts: Arc<metamodelica::List<Arc<ClassPart>>>,
+        classAttrs: metamodelica::List<Arc<NamedArg>>,
+        classParts: metamodelica::List<Arc<ClassPart>>,
         /// Modelica2 allowed multiple class-annotations
-        ann: Arc<metamodelica::List<Arc<Annotation>>>,
+        ann: metamodelica::List<Arc<Annotation>>,
         comment: Option<ArcStr>,
     },
     DERIVED {
         /// typeSpec specification includes array dimensions
         typeSpec: Arc<TypeSpec>,
         attributes: ElementAttributes,
-        arguments: Arc<metamodelica::List<Arc<ElementArg>>>,
+        arguments: metamodelica::List<Arc<ElementArg>>,
         comment: Option<Arc<Comment>>,
     },
     ENUMERATION {
@@ -245,24 +245,24 @@ pub enum ClassDef {
         comment: Option<Arc<Comment>>,
     },
     OVERLOAD {
-        functionNames: Arc<metamodelica::List<Arc<Path>>>,
+        functionNames: metamodelica::List<Arc<Path>>,
         comment: Option<Arc<Comment>>,
     },
     CLASS_EXTENDS {
         /// name of class to extend
         baseClassName: Ident,
         /// modifications to be applied to the base class
-        modifications: Arc<metamodelica::List<Arc<ElementArg>>>,
+        modifications: metamodelica::List<Arc<ElementArg>>,
         /// comment
         comment: Option<ArcStr>,
         /// class parts
-        parts: Arc<metamodelica::List<Arc<ClassPart>>>,
-        ann: Arc<metamodelica::List<Arc<Annotation>>>,
+        parts: metamodelica::List<Arc<ClassPart>>,
+        ann: metamodelica::List<Arc<Annotation>>,
     },
     PDER {
         functionName: Arc<Path>,
         /// derived variables
-        vars: Arc<metamodelica::List<ArcStr>>,
+        vars: metamodelica::List<ArcStr>,
         /// comment
         comment: Option<Arc<Comment>>,
     },
@@ -330,19 +330,19 @@ pub use self::ClassDef::{PARTS,DERIVED,ENUMERATION,OVERLOAD,CLASS_EXTENDS,PDER};
 ///  dimensions. This type is used to indicate the dimensionality
 ///  of a component or a type definition.
 /// - Array dimensions
-pub type ArrayDim = Arc<metamodelica::List<Arc<Subscript>>>;
+pub type ArrayDim = metamodelica::List<Arc<Subscript>>;
 
 /// ModExtension: new MetaModelica type specification!
 #[derive(Clone, Debug, Eq, Hash, metamodelica::MMCtor, metamodelica::MetaCmp, metamodelica::ReferenceEq)]
 pub enum TypeSpec {
     TPATH {
         path: Arc<Path>,
-        arrayDim: Option<Arc<metamodelica::List<Arc<Subscript>>>>,
+        arrayDim: Option<metamodelica::List<Arc<Subscript>>>,
     },
     TCOMPLEX {
         path: Arc<Path>,
-        typeSpecs: Arc<metamodelica::List<Arc<TypeSpec>>>,
-        arrayDim: Option<Arc<metamodelica::List<Arc<Subscript>>>>,
+        typeSpecs: metamodelica::List<Arc<TypeSpec>>,
+        arrayDim: Option<metamodelica::List<Arc<Subscript>>>,
     },
 }
 impl metamodelica::gc::MMTrace for TypeSpec {
@@ -377,7 +377,7 @@ pub use self::TypeSpec::{TPATH,TCOMPLEX};
 #[derive(Clone, Debug, Eq, Hash, metamodelica::MMCtor, metamodelica::MetaCmp, metamodelica::ReferenceEq)]
 pub enum EnumDef {
     ENUMLITERALS {
-        enumLiterals: Arc<metamodelica::List<Arc<EnumLiteral>>>,
+        enumLiterals: metamodelica::List<Arc<EnumLiteral>>,
     },
     ENUM_COLON,
 }
@@ -430,25 +430,25 @@ pub type ENUMLITERAL = EnumLiteral;
 #[derive(Clone, Debug, Eq, Hash, metamodelica::MMCtor, metamodelica::MetaCmp, metamodelica::ReferenceEq)]
 pub enum ClassPart {
     PUBLIC {
-        contents: Arc<metamodelica::List<Arc<ElementItem>>>,
+        contents: metamodelica::List<Arc<ElementItem>>,
     },
     PROTECTED {
-        contents: Arc<metamodelica::List<Arc<ElementItem>>>,
+        contents: metamodelica::List<Arc<ElementItem>>,
     },
     CONSTRAINTS {
-        contents: Arc<metamodelica::List<Arc<Exp>>>,
+        contents: metamodelica::List<Arc<Exp>>,
     },
     EQUATIONS {
-        contents: Arc<metamodelica::List<Arc<EquationItem>>>,
+        contents: metamodelica::List<Arc<EquationItem>>,
     },
     INITIALEQUATIONS {
-        contents: Arc<metamodelica::List<Arc<EquationItem>>>,
+        contents: metamodelica::List<Arc<EquationItem>>,
     },
     ALGORITHMS {
-        contents: Arc<metamodelica::List<Arc<AlgorithmItem>>>,
+        contents: metamodelica::List<Arc<AlgorithmItem>>,
     },
     INITIALALGORITHMS {
-        contents: Arc<metamodelica::List<Arc<AlgorithmItem>>>,
+        contents: metamodelica::List<Arc<AlgorithmItem>>,
     },
     EXTERNAL {
         /// externalDecl
@@ -557,7 +557,7 @@ pub enum Element {
     },
     DEFINEUNIT {
         name: Ident,
-        args: Arc<metamodelica::List<Arc<NamedArg>>>,
+        args: metamodelica::List<Arc<NamedArg>>,
         info: Info,
     },
     TEXT {
@@ -655,7 +655,7 @@ pub enum ElementSpec {
         /// path
         path: Arc<Path>,
         /// elementArg
-        elementArg: Arc<metamodelica::List<Arc<ElementArg>>>,
+        elementArg: metamodelica::List<Arc<ElementArg>>,
         /// optional annotation
         annotationOpt: Option<Arc<Annotation>>,
     },
@@ -672,7 +672,7 @@ pub enum ElementSpec {
         /// typeSpec
         typeSpec: Arc<TypeSpec>,
         /// components
-        components: Arc<metamodelica::List<Arc<ComponentItem>>>,
+        components: metamodelica::List<Arc<ComponentItem>>,
     },
 }
 impl metamodelica::gc::MMTrace for ElementSpec {
@@ -761,7 +761,7 @@ pub enum Import {
     },
     GROUP_IMPORT {
         prefix: Arc<Path>,
-        groups: Arc<metamodelica::List<GroupImport>>,
+        groups: metamodelica::List<GroupImport>,
     },
 }
 impl metamodelica::gc::MMTrace for Import {
@@ -990,11 +990,11 @@ pub enum Equation {
         /// Conditional expression
         ifExp: Arc<Exp>,
         /// true branch
-        equationTrueItems: Arc<metamodelica::List<Arc<EquationItem>>>,
+        equationTrueItems: metamodelica::List<Arc<EquationItem>>,
         /// elseIfBranches
-        elseIfBranches: Arc<metamodelica::List<(Arc<Exp>, Arc<metamodelica::List<Arc<EquationItem>>>)>>,
+        elseIfBranches: metamodelica::List<(Arc<Exp>, metamodelica::List<Arc<EquationItem>>)>,
         /// equationElseItems Standard 2-side eqn
-        equationElseItems: Arc<metamodelica::List<Arc<EquationItem>>>,
+        equationElseItems: metamodelica::List<Arc<EquationItem>>,
     },
     EQ_EQUALS {
         /// leftSide
@@ -1019,15 +1019,15 @@ pub enum Equation {
     EQ_FOR {
         iterators: ForIterators,
         /// forEquations
-        forEquations: Arc<metamodelica::List<Arc<EquationItem>>>,
+        forEquations: metamodelica::List<Arc<EquationItem>>,
     },
     EQ_WHEN_E {
         /// whenExp
         whenExp: Arc<Exp>,
         /// whenEquations
-        whenEquations: Arc<metamodelica::List<Arc<EquationItem>>>,
+        whenEquations: metamodelica::List<Arc<EquationItem>>,
         /// elseWhenEquations
-        elseWhenEquations: Arc<metamodelica::List<(Arc<Exp>, Arc<metamodelica::List<Arc<EquationItem>>>)>>,
+        elseWhenEquations: metamodelica::List<(Arc<Exp>, metamodelica::List<Arc<EquationItem>>)>,
     },
     EQ_NORETCALL {
         /// functionName
@@ -1113,35 +1113,35 @@ pub enum Algorithm {
         /// ifExp
         ifExp: Arc<Exp>,
         /// trueBranch
-        trueBranch: Arc<metamodelica::List<Arc<AlgorithmItem>>>,
+        trueBranch: metamodelica::List<Arc<AlgorithmItem>>,
         /// elseIfAlgorithmBranch
-        elseIfAlgorithmBranch: Arc<metamodelica::List<(Arc<Exp>, Arc<metamodelica::List<Arc<AlgorithmItem>>>)>>,
+        elseIfAlgorithmBranch: metamodelica::List<(Arc<Exp>, metamodelica::List<Arc<AlgorithmItem>>)>,
         /// elseBranch
-        elseBranch: Arc<metamodelica::List<Arc<AlgorithmItem>>>,
+        elseBranch: metamodelica::List<Arc<AlgorithmItem>>,
     },
     ALG_FOR {
         iterators: ForIterators,
         /// forBody
-        forBody: Arc<metamodelica::List<Arc<AlgorithmItem>>>,
+        forBody: metamodelica::List<Arc<AlgorithmItem>>,
     },
     ALG_PARFOR {
         iterators: ForIterators,
         /// parallel for loop Body
-        parforBody: Arc<metamodelica::List<Arc<AlgorithmItem>>>,
+        parforBody: metamodelica::List<Arc<AlgorithmItem>>,
     },
     ALG_WHILE {
         /// boolExpr
         boolExpr: Arc<Exp>,
         /// whileBody
-        whileBody: Arc<metamodelica::List<Arc<AlgorithmItem>>>,
+        whileBody: metamodelica::List<Arc<AlgorithmItem>>,
     },
     ALG_WHEN_A {
         /// boolExpr
         boolExpr: Arc<Exp>,
         /// whenBody
-        whenBody: Arc<metamodelica::List<Arc<AlgorithmItem>>>,
+        whenBody: metamodelica::List<Arc<AlgorithmItem>>,
         /// elseWhenAlgorithmBranch
-        elseWhenAlgorithmBranch: Arc<metamodelica::List<(Arc<Exp>, Arc<metamodelica::List<Arc<AlgorithmItem>>>)>>,
+        elseWhenAlgorithmBranch: metamodelica::List<(Arc<Exp>, metamodelica::List<Arc<AlgorithmItem>>)>,
     },
     ALG_NORETCALL {
         /// functionCall
@@ -1152,11 +1152,11 @@ pub enum Algorithm {
     ALG_RETURN,
     ALG_BREAK,
     ALG_FAILURE {
-        equ: Arc<metamodelica::List<Arc<AlgorithmItem>>>,
+        equ: metamodelica::List<Arc<AlgorithmItem>>,
     },
     ALG_TRY {
-        body: Arc<metamodelica::List<Arc<AlgorithmItem>>>,
-        elseBody: Arc<metamodelica::List<Arc<AlgorithmItem>>>,
+        body: metamodelica::List<Arc<AlgorithmItem>>,
+        elseBody: metamodelica::List<Arc<AlgorithmItem>>,
     },
     ALG_CONTINUE,
 }
@@ -1246,7 +1246,7 @@ pub static emptyMod: std::sync::LazyLock<Arc<Modification>> = std::sync::LazyLoc
 ///  - Modifications
 #[derive(Clone, Debug, Eq, Hash, metamodelica::MMCtor, metamodelica::MetaCmp, metamodelica::ReferenceEq)]
 pub struct Modification {
-    pub elementArgLst: Arc<metamodelica::List<Arc<ElementArg>>>,
+    pub elementArgLst: metamodelica::List<Arc<ElementArg>>,
     pub eqMod: Arc<EqMod>,
 }
 
@@ -1647,13 +1647,13 @@ pub enum Exp {
         /// elseBranch
         elseBranch: Arc<Exp>,
         /// elseIfBranch Function calls
-        elseIfBranch: Arc<metamodelica::List<(Arc<Exp>, Arc<Exp>)>>,
+        elseIfBranch: metamodelica::List<(Arc<Exp>, Arc<Exp>)>,
     },
     CALL {
         /// function
         function_: Arc<ComponentRef>,
         functionArgs: Arc<FunctionArgs>,
-        typeVars: Arc<metamodelica::List<Arc<Path>>>,
+        typeVars: metamodelica::List<Arc<Path>>,
     },
     /// Partially evaluated function
     PARTEVALFUNCTION {
@@ -1663,11 +1663,11 @@ pub enum Exp {
     },
     /// Array construction using {, }, or array
     ARRAY {
-        arrayExp: Arc<metamodelica::List<Arc<Exp>>>,
+        arrayExp: metamodelica::List<Arc<Exp>>,
     },
     /// Matrix construction using {, }
     MATRIX {
-        matrix: Arc<metamodelica::List<Arc<metamodelica::List<Arc<Exp>>>>>,
+        matrix: metamodelica::List<metamodelica::List<Arc<Exp>>>,
     },
     /// Range expressions, e.g. 1:10 or 1:0.5:10
     RANGE {
@@ -1681,7 +1681,7 @@ pub enum Exp {
     /// Tuples used in function calls returning several values
     TUPLE {
         /// comma-separated expressions
-        expressions: Arc<metamodelica::List<Arc<Exp>>>,
+        expressions: metamodelica::List<Arc<Exp>>,
     },
     /// array access operator for last element, e.g. a{end}:=1;
     END,
@@ -1710,15 +1710,15 @@ pub enum Exp {
         /// match expression of
         inputExp: Arc<Exp>,
         /// local declarations
-        localDecls: Arc<metamodelica::List<Arc<ElementItem>>>,
+        localDecls: metamodelica::List<Arc<ElementItem>>,
         /// case list + else in the end
-        cases: Arc<metamodelica::List<Arc<Case>>>,
+        cases: metamodelica::List<Arc<Case>>,
         /// TODO: Remove this as it was removed from the grammar
         comment: Option<ArcStr>,
     },
     /// Part of MetaModelica extension
     LIST {
-        exps: Arc<metamodelica::List<Arc<Exp>>>,
+        exps: metamodelica::List<Arc<Exp>>,
     },
     /// exp.index
     DOT {
@@ -1726,13 +1726,13 @@ pub enum Exp {
         index: Arc<Exp>,
     },
     EXPRESSIONCOMMENT {
-        commentsBefore: Arc<metamodelica::List<ArcStr>>,
+        commentsBefore: metamodelica::List<ArcStr>,
         exp: Arc<Exp>,
-        commentsAfter: Arc<metamodelica::List<ArcStr>>,
+        commentsAfter: metamodelica::List<ArcStr>,
     },
     SUBSCRIPTED_EXP {
         exp: Arc<Exp>,
-        subscripts: Arc<metamodelica::List<Arc<Subscript>>>,
+        subscripts: metamodelica::List<Arc<Subscript>>,
     },
     BREAK,
 }
@@ -1897,7 +1897,7 @@ pub enum Case {
         /// file information of the pattern
         patternInfo: Info,
         /// TODO: Remove this as it was removed from the grammar
-        localDecls: Arc<metamodelica::List<Arc<ElementItem>>>,
+        localDecls: metamodelica::List<Arc<ElementItem>>,
         /// equation or algorithm section
         classPart: Arc<ClassPart>,
         /// result
@@ -1912,7 +1912,7 @@ pub enum Case {
     /// else in match or matchcontinue
     ELSE {
         /// TODO: Remove this as it was removed from the grammar
-        localDecls: Arc<metamodelica::List<Arc<ElementItem>>>,
+        localDecls: metamodelica::List<Arc<ElementItem>>,
         /// equation or algorithm section
         classPart: Arc<ClassPart>,
         /// result
@@ -1997,15 +1997,15 @@ pub enum CodeNode {
     },
     C_CONSTRAINTSECTION {
         boolean: bool,
-        equationItemLst: Arc<metamodelica::List<Arc<EquationItem>>>,
+        equationItemLst: metamodelica::List<Arc<EquationItem>>,
     },
     C_EQUATIONSECTION {
         boolean: bool,
-        equationItemLst: Arc<metamodelica::List<Arc<EquationItem>>>,
+        equationItemLst: metamodelica::List<Arc<EquationItem>>,
     },
     C_ALGORITHMSECTION {
         boolean: bool,
-        algorithmItemLst: Arc<metamodelica::List<Arc<AlgorithmItem>>>,
+        algorithmItemLst: metamodelica::List<Arc<AlgorithmItem>>,
     },
     C_ELEMENT {
         element: Arc<Element>,
@@ -2073,9 +2073,9 @@ pub use self::CodeNode::{C_TYPENAME,C_VARIABLENAME,C_CONSTRAINTSECTION,C_EQUATIO
 pub enum FunctionArgs {
     FUNCTIONARGS {
         /// args
-        args: Arc<metamodelica::List<Arc<Exp>>>,
+        args: metamodelica::List<Arc<Exp>>,
         /// argNames
-        argNames: Arc<metamodelica::List<Arc<NamedArg>>>,
+        argNames: metamodelica::List<Arc<NamedArg>>,
     },
     FOR_ITER_FARG {
         /// iterator expression
@@ -2296,7 +2296,7 @@ pub enum ComponentRef {
         /// name
         name: Ident,
         /// subscripts
-        subscripts: Arc<metamodelica::List<Arc<Subscript>>>,
+        subscripts: metamodelica::List<Arc<Subscript>>,
         /// componentRef
         componentRef: Arc<ComponentRef>,
     },
@@ -2304,7 +2304,7 @@ pub enum ComponentRef {
         /// name
         name: Ident,
         /// subscripts
-        subscripts: Arc<metamodelica::List<Arc<Subscript>>>,
+        subscripts: metamodelica::List<Arc<Subscript>>,
     },
     WILD,
     ALLWILD,
@@ -2443,7 +2443,7 @@ pub enum Restriction {
         index: i32,
         singleton: bool,
         moved: bool,
-        typeVars: Arc<metamodelica::List<ArcStr>>,
+        typeVars: metamodelica::List<ArcStr>,
     },
     /// Helper restriction
     R_UNKNOWN,
@@ -2546,7 +2546,7 @@ pub use self::FunctionRestriction::{FR_NORMAL_FUNCTION,FR_OPERATOR_FUNCTION,FR_P
 #[derive(Clone, Debug, Eq, Hash, metamodelica::MMCtor, metamodelica::MetaCmp, metamodelica::ReferenceEq)]
 pub struct Annotation {
     /// elementArgs
-    pub elementArgs: Arc<metamodelica::List<Arc<ElementArg>>>,
+    pub elementArgs: metamodelica::List<Arc<ElementArg>>,
 }
 
 impl metamodelica::gc::MMTrace for Annotation {
@@ -2604,7 +2604,7 @@ pub struct ExternalDecl {
     /// output parameter as return value
     pub output_: Option<Arc<ComponentRef>>,
     /// only positional arguments, i.e. expression list
-    pub args: Arc<metamodelica::List<Arc<Exp>>>,
+    pub args: metamodelica::List<Arc<Exp>>,
     pub annotation_: Option<Arc<Annotation>>,
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/src/GlobalScript.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/src/GlobalScript.rs
@@ -87,7 +87,7 @@ pub use self::Statement::{IALG,IEXP};
 #[derive(Clone, Debug, Eq, Hash, metamodelica::MMCtor, metamodelica::MetaCmp, metamodelica::ReferenceEq)]
 pub struct Statements {
     /// interactiveStmtLst
-    pub interactiveStmtLst: Arc<metamodelica::List<Statement>>,
+    pub interactiveStmtLst: metamodelica::List<Statement>,
     /// semicolon; true = statement ending with a semicolon. The result will not be shown in the interactive environment.
     pub semicolon: bool,
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/src/parser/mod.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_ast/src/parser/mod.rs
@@ -697,18 +697,18 @@ pub fn parse_equation(src: &str, filename: &str, grammar: Grammar) -> Result<Abs
 
 #[derive(Debug, Clone)]
 pub enum ClassBodyItem {
-    Section { section: SectionKind, items: Arc<List<ClassBodyItem>> },
+    Section { section: SectionKind, items: List<ClassBodyItem> },
     Element(Absyn::Element),
     Annotation(Absyn::Annotation),
     /// A `//` or `/*` lexer comment captured between elements. Lowered to
     /// `ElementItem::LEXER_COMMENT` inside a class section, preserving the
     /// comment's relative source position next to the surrounding elements.
     LexerComment(ArcStr),
-    Equations(Arc<List<EquationItem>>),
-    InitialEquations(Arc<List<EquationItem>>),
-    Algorithms(Arc<List<AlgorithmItem>>),
-    InitialAlgorithms(Arc<List<AlgorithmItem>>),
-    Constraints(Arc<List<Arc<Absyn::Exp>>>),
+    Equations(List<EquationItem>),
+    InitialEquations(List<EquationItem>),
+    Algorithms(List<AlgorithmItem>),
+    InitialAlgorithms(List<AlgorithmItem>),
+    Constraints(List<Arc<Absyn::Exp>>),
     External {
         /// Language tag from the `external "C"` clause (Modelica allows "C"
         /// and "FORTRAN 77"; OpenModelica only uses "C"). Absent for the bare
@@ -723,7 +723,7 @@ pub enum ClassBodyItem {
         /// through a Modelica `output` declaration position.
         output_: Option<Absyn::ComponentRef>,
         /// Positional argument expressions passed to the C function.
-        args: Arc<List<Arc<Absyn::Exp>>>,
+        args: List<Arc<Absyn::Exp>>,
         annotation_opt: Option<Absyn::Annotation>,
     },
 }
@@ -755,7 +755,7 @@ impl ClassSpecifier {
 #[derive(Debug, Clone)]
 struct ExtendsClause {
     path: Path,
-    modification: Option<Arc<List<Arc<ElementArg>>>>,
+    modification: Option<List<Arc<ElementArg>>>,
     annotation_opt: Option<Annotation>,
 }
 
@@ -763,7 +763,7 @@ struct ExtendsClause {
 struct ComponentClause {
     typePrefix: ElementAttributes,
     typeSpec: TypeSpec,
-    components: Arc<List<Arc<ComponentItem>>>,
+    components: List<Arc<ComponentItem>>,
 }
 
 /// End column for a span, replicating an ANTLR3 line-1 quirk. `PARSER_INFO`
@@ -841,16 +841,16 @@ fn parser_info_from(first: &Token, start: &TokenInput, input: &TokenInput) -> So
 /// public/protected section (when the class has top-level public/protected blocks) are
 /// both promoted to class-level annotations.
 /// Returns `(non_annotation_items, annotations)`.
-fn split_annotations(items: Arc<List<ClassBodyItem>>) -> (Arc<List<ClassBodyItem>>, Arc<List<Arc<Absyn::Annotation>>>) {
-    let mut parts: Arc<List<ClassBodyItem>> = Arc::new(List::Nil);
-    let mut anns:  Arc<List<Arc<Absyn::Annotation>>> = Arc::new(List::Nil);
+fn split_annotations(items: List<ClassBodyItem>) -> (List<ClassBodyItem>, List<Arc<Absyn::Annotation>>) {
+    let mut parts: List<ClassBodyItem> = metamodelica::nil();
+    let mut anns:  List<Arc<Absyn::Annotation>> = metamodelica::nil();
     for item in &*items {
         match item {
             ClassBodyItem::Annotation(ann) => anns = cons(Arc::new(ann.clone()), anns),
             ClassBodyItem::Section { section, items: sec_items } => {
                 // Annotations that appear directly in a section's element list are
                 // class-level annotations (function-level ones are nested inside element bodies).
-                let (inner_parts, inner_anns) = split_annotations(Arc::clone(sec_items));
+                let (inner_parts, inner_anns) = split_annotations(sec_items.clone());
                 // inner_anns is already reversed; re-consing restores the
                 // inner source order relative to this level's accumulator.
                 for ann in &*inner_anns.reverse() { anns = cons(Arc::clone(ann), anns); }
@@ -867,8 +867,8 @@ fn split_annotations(items: Arc<List<ClassBodyItem>>) -> (Arc<List<ClassBodyItem
     (parts.reverse(), anns)
 }
 
-fn body_items_to_classparts(items: Arc<List<ClassBodyItem>>) -> Arc<List<Arc<ClassPart>>> {
-    let mut res: Arc<List<Arc<ClassPart>>> = Arc::new(List::Nil);
+fn body_items_to_classparts(items: List<ClassBodyItem>) -> List<Arc<ClassPart>> {
+    let mut res: List<Arc<ClassPart>> = metamodelica::nil();
     // Consecutive bare elements (and lexer comments between them) form ONE
     // implicit `public` part, exactly like the leading `element_list` of the
     // ANTLR `composition` rule. Emitting one part per element made
@@ -887,15 +887,15 @@ fn body_items_to_classparts(items: Arc<List<ClassBodyItem>>) -> Arc<List<Arc<Cla
     // replacing the leading one at index 0 renders nothing).
     let mut pending: Vec<Arc<ElementItem>> = Vec::new();
     let mut leading_public_emitted = false;
-    fn flush(pending: &mut Vec<Arc<ElementItem>>, res: &mut Arc<List<Arc<ClassPart>>>, force: bool) {
+    fn flush(pending: &mut Vec<Arc<ElementItem>>, res: &mut List<Arc<ClassPart>>, force: bool) {
         if pending.is_empty() && !force {
             return;
         }
-        let mut contents: Arc<List<Arc<ElementItem>>> = Arc::new(List::Nil);
+        let mut contents: List<Arc<ElementItem>> = metamodelica::nil();
         for ei in pending.drain(..).rev() {
             contents = cons(ei, contents);
         }
-        *res = cons(Arc::new(ClassPart::PUBLIC { contents }), Arc::clone(res));
+        *res = cons(Arc::new(ClassPart::PUBLIC { contents }), res.clone());
     }
     for item in &*items {
         match item {
@@ -916,7 +916,7 @@ fn body_items_to_classparts(items: Arc<List<ClassBodyItem>>) -> Arc<List<Arc<Cla
         }
         let converted = match item {
             ClassBodyItem::Section { section, items } => {
-                let content = body_items_to_element_items(Arc::clone(items));
+                let content = body_items_to_element_items(items.clone());
                 match section {
                     SectionKind::Public    => ClassPart::PUBLIC    { contents: content },
                     SectionKind::Protected => ClassPart::PROTECTED { contents: content },
@@ -949,10 +949,10 @@ fn body_items_to_classparts(items: Arc<List<ClassBodyItem>>) -> Arc<List<Arc<Cla
     res.reverse()
 }
 
-fn body_items_to_element_items(items: Arc<List<ClassBodyItem>>) -> Arc<List<Arc<ElementItem>>> {
+fn body_items_to_element_items(items: List<ClassBodyItem>) -> List<Arc<ElementItem>> {
     match &*items {
-        List::Nil => Arc::new(List::Nil),
-        List::Cons { head, tail } => {
+        metamodelica::ListNode::Nil => metamodelica::nil(),
+        metamodelica::ListNode::Cons { head, tail } => {
             let converted = match head {
                 ClassBodyItem::Element(elem)         => ElementItem::ELEMENTITEM { element: Arc::new(elem.clone()) },
                 ClassBodyItem::LexerComment(text)    => ElementItem::LEXER_COMMENT { comment: text.clone() },
@@ -963,10 +963,10 @@ fn body_items_to_element_items(items: Arc<List<ClassBodyItem>>) -> Arc<List<Arc<
     }
 }
 
-fn to_rc_list<T: Clone>(lst: Arc<List<T>>) -> Arc<List<Arc<T>>> {
-    let mut result: Arc<List<Arc<T>>> = Arc::new(List::Nil);
+fn to_rc_list<T: Clone>(lst: List<T>) -> List<Arc<T>> {
+    let mut result: List<Arc<T>> = metamodelica::nil();
     let rev = lst.reverse();
-    for item in &*rev { result = cons(Arc::new(item.clone()), result); }
+    for item in &rev { result = cons(Arc::new(item.clone()), result); }
     result
 }
 
@@ -984,7 +984,7 @@ fn default_element_attrs() -> ElementAttributes {
         // every component of type T into a function input.
         direction: Direction::BIDIR {},
         isField: IsField::NONFIELD {},
-        arrayDim: Arc::new(List::Nil),
+        arrayDim: metamodelica::nil(),
     }
 }
 
@@ -1019,8 +1019,8 @@ fn stored_definition(input: &mut TokenInput) -> ModalResult<Program> {
 }
 
 /// class_definition_list: (FINAL? class_definition SEMICOLON)*
-fn class_definition_list(input: &mut TokenInput) -> ModalResult<Arc<List<Class>>> {
-    let mut defs: Arc<List<Class>> = Arc::new(List::Nil);
+fn class_definition_list(input: &mut TokenInput) -> ModalResult<List<Class>> {
+    let mut defs: List<Class> = metamodelica::nil();
     loop {
         if input.is_empty() { break; }
         // Take everything that lies textually before the next class header
@@ -1060,7 +1060,7 @@ fn attach_comments_before(c: Class, before: Vec<ArcStr>) -> Class {
         name, partialPrefix, finalPrefix, encapsulatedPrefix, restriction,
         body, commentsBeforeClass: _old, commentsBeforeEnd, commentsAfterEnd, info,
     } = c;
-    let mut lst: Arc<List<ArcStr>> = Arc::new(List::Nil);
+    let mut lst: List<ArcStr> = metamodelica::nil();
     for txt in before.into_iter().rev() { lst = cons(txt, lst); }
     Class {
         name, partialPrefix, finalPrefix, encapsulatedPrefix, restriction,
@@ -1071,12 +1071,12 @@ fn attach_comments_before(c: Class, before: Vec<ArcStr>) -> Class {
 /// `defs` is a reverse-order list — its head is the most-recently-parsed
 /// class. Append `tail` to that class's `commentsAfterEnd` list.
 fn attach_comments_after_end_on_head(
-    defs: Arc<List<Class>>,
+    defs: List<Class>,
     tail: Vec<ArcStr>,
-) -> Arc<List<Class>> {
+) -> List<Class> {
     match &*defs {
-        List::Nil => defs, // no class to attach to; drop comments silently
-        List::Cons { head, tail: rest } => {
+        metamodelica::ListNode::Nil => defs, // no class to attach to; drop comments silently
+        metamodelica::ListNode::Cons { head, tail: rest } => {
             let Class {
                 name, partialPrefix, finalPrefix, encapsulatedPrefix, restriction,
                 body, commentsBeforeClass, commentsBeforeEnd, commentsAfterEnd, info,
@@ -1084,7 +1084,7 @@ fn attach_comments_after_end_on_head(
             let lst = commentsAfterEnd;
             // Existing list ordering follows the source; append the new
             // entries to the end.
-            let mut new_tail: Arc<List<ArcStr>> = Arc::new(List::Nil);
+            let mut new_tail: List<ArcStr> = metamodelica::nil();
             for txt in tail.into_iter().rev() { new_tail = cons(txt, new_tail); }
             // Concatenate lst ++ new_tail.
             let mut acc = new_tail;
@@ -1112,8 +1112,8 @@ fn class_definition(input: &mut TokenInput) -> ModalResult<Class> {
     Ok(Class {
         name: specifier.name(), partialPrefix, finalPrefix, encapsulatedPrefix,
         restriction, body: specifier.body(),
-        commentsBeforeClass: Arc::new(List::Nil), commentsBeforeEnd: Arc::new(List::Nil),
-        commentsAfterEnd: Arc::new(List::Nil), info: parser_info(&start, input),
+        commentsBeforeClass: metamodelica::nil(), commentsBeforeEnd: metamodelica::nil(),
+        commentsAfterEnd: metamodelica::nil(), info: parser_info(&start, input),
     })
 }
 
@@ -1173,7 +1173,7 @@ fn class_specifier(input: &mut TokenInput) -> ModalResult<ClassSpecifier> {
         let name = cut_err(t_ident)
             .context(StrContext::Label("class name after 'extends'"))
             .parse_next(input)?;
-        let modifications = opt(class_modification).parse_next(input)?.unwrap_or_else(|| Arc::new(List::Nil));
+        let modifications = opt(class_modification).parse_next(input)?.unwrap_or_else(|| metamodelica::nil());
         let comment   = string_comment(input)?;
         let parts     = cut_err(composition)
             .context(StrContext::Label("class-extends body"))
@@ -1228,7 +1228,7 @@ fn class_specifier2(input: &mut TokenInput, start_name: &ArcStr, start_line: u32
     if opt(t(TK::Subtypeof)).parse_next(input)?.is_some() {
         let ts = type_specifier(input)?;
         return Ok(Arc::new(ClassDef::DERIVED {
-            typeSpec: Arc::new(TypeSpec::TCOMPLEX { path: Arc::new(Path::IDENT{name: "polymorphic".into()}), typeSpecs: List::new(Arc::new(ts)), arrayDim: None }), attributes: default_element_attrs(), arguments: Arc::new(List::Nil), comment: None,
+            typeSpec: Arc::new(TypeSpec::TCOMPLEX { path: Arc::new(Path::IDENT{name: "polymorphic".into()}), typeSpecs: List::new(Arc::new(ts)), arrayDim: None }), attributes: default_element_attrs(), arguments: metamodelica::nil(), comment: None,
         }));
     }
 
@@ -1291,15 +1291,15 @@ fn class_specifier2(input: &mut TokenInput, start_name: &ArcStr, start_line: u32
         let typeSpec = cut_err(type_specifier)
             .context(StrContext::Label("type specifier after '='"))
             .parse_next(input)?;
-        let arguments: Arc<List<Arc<ElementArg>>> = opt(class_modification).parse_next(input)?.unwrap_or_else(|| Arc::new(List::Nil));
+        let arguments: List<Arc<ElementArg>> = opt(class_modification).parse_next(input)?.unwrap_or_else(|| metamodelica::nil());
         let comment = comment.parse_next(input)?;
         return Ok(Arc::new(ClassDef::DERIVED {
             typeSpec: Arc::new(typeSpec), attributes, arguments, comment: comment.map(Arc::new),
         }));
     }
 
-    let mut typeVars: Arc<List<ArcStr>> = Arc::new(List::Nil);
-    let mut classAttrs: Arc<List<Arc<Absyn::NamedArg>>> = Arc::new(List::Nil);
+    let mut typeVars: List<ArcStr> = metamodelica::nil();
+    let mut classAttrs: List<Arc<Absyn::NamedArg>> = metamodelica::nil();
     if opt(t(TK::Less)).parse_next(input)?.is_some() {
         loop {
             let id = t_ident(input)?;
@@ -1368,13 +1368,13 @@ fn class_specifier2(input: &mut TokenInput, start_name: &ArcStr, start_line: u32
     }))
 }
 
-fn composition(input: &mut TokenInput) -> ModalResult<Arc<List<ClassBodyItem>>> {
+fn composition(input: &mut TokenInput) -> ModalResult<List<ClassBodyItem>> {
     let el_items = element_list(input)?;
     let c2_items = composition2(input)?;
     let mut result = el_items.append(&c2_items);
     // Trailing class annotations go at the *end* of the body item list so
     // `split_annotations` sees every annotation in source order.
-    let mut trailing: Arc<List<ClassBodyItem>> = Arc::new(List::Nil);
+    let mut trailing: List<ClassBodyItem> = metamodelica::nil();
     while let Some(ann) = opt(annotation).parse_next(input)? {
         cut_err(t(TK::Semi)).context(StrContext::Label("';' after annotation")).parse_next(input)?;
         trailing = cons(ClassBodyItem::Annotation(ann), trailing);
@@ -1385,8 +1385,8 @@ fn composition(input: &mut TokenInput) -> ModalResult<Arc<List<ClassBodyItem>>> 
     Ok(result)
 }
 
-fn composition2(input: &mut TokenInput) -> ModalResult<Arc<List<ClassBodyItem>>> {
-    let mut parts: Arc<List<ClassBodyItem>> = Arc::new(List::Nil);
+fn composition2(input: &mut TokenInput) -> ModalResult<List<ClassBodyItem>> {
+    let mut parts: List<ClassBodyItem> = metamodelica::nil();
     loop {
         if input.is_empty() { break; }
         if let Some(ext) = opt(external_part).parse_next(input)? {
@@ -1444,7 +1444,7 @@ fn composition2(input: &mut TokenInput) -> ModalResult<Arc<List<ClassBodyItem>>>
             // Algorithm nodes in CONSTRAINTS' list<Exp> — only the expression
             // form is used by real Optimica code, so only that is supported.
             next_tok(input)?;
-            let mut constraints: Arc<List<Arc<Absyn::Exp>>> = Arc::new(List::Nil);
+            let mut constraints: List<Arc<Absyn::Exp>> = metamodelica::nil();
             loop {
                 if matches!(
                     peek_kind(input),
@@ -1490,7 +1490,7 @@ fn opt_constraining_clause(input: &mut TokenInput, replaceable_: bool) -> ModalR
     }
     next_tok(input)?;
     let path       = cut_err(name_path).context(StrContext::Label("path in constraining clause")).parse_next(input)?;
-    let elementArg = opt(class_modification).parse_next(input)?.unwrap_or_else(|| Arc::new(List::Nil));
+    let elementArg = opt(class_modification).parse_next(input)?.unwrap_or_else(|| metamodelica::nil());
     let cmt        = comment(input)?;
     Ok(Some(ConstrainClass {
         elementSpec: Arc::new(ElementSpec::EXTENDS { path: Arc::new(path), elementArg, annotationOpt: None }),
@@ -1498,8 +1498,8 @@ fn opt_constraining_clause(input: &mut TokenInput, replaceable_: bool) -> ModalR
     }))
 }
 
-fn element_list(input: &mut TokenInput) -> ModalResult<Arc<List<ClassBodyItem>>> {
-    let mut items: Arc<List<ClassBodyItem>> = Arc::new(List::Nil);
+fn element_list(input: &mut TokenInput) -> ModalResult<List<ClassBodyItem>> {
+    let mut items: List<ClassBodyItem> = metamodelica::nil();
     loop {
         if input.is_empty() {
             // Flush any comments that follow the last element so they are
@@ -1569,7 +1569,7 @@ fn element_list(input: &mut TokenInput) -> ModalResult<Arc<List<ClassBodyItem>>>
                 innerOuter: InnerOuter::NOT_INNER_OUTER {},
                 specification: Arc::new(ElementSpec::EXTENDS {
                     path: Arc::new(ext.path),
-                    elementArg: ext.modification.unwrap_or_else(|| Arc::new(List::Nil)),
+                    elementArg: ext.modification.unwrap_or_else(|| metamodelica::nil()),
                     annotationOpt: ext.annotation_opt.map(Arc::new),
                 }),
                 info,
@@ -1663,7 +1663,7 @@ fn element(input: &mut TokenInput) -> ModalResult<Absyn::Element> {
             innerOuter: InnerOuter::NOT_INNER_OUTER {},
             specification: Arc::new(ElementSpec::EXTENDS {
                 path: Arc::new(ext.path),
-                elementArg: ext.modification.unwrap_or_else(|| Arc::new(List::Nil)),
+                elementArg: ext.modification.unwrap_or_else(|| metamodelica::nil()),
                 annotationOpt: ext.annotation_opt.map(Arc::new),
             }),
             info,
@@ -1767,7 +1767,7 @@ fn type_prefix(input: &mut TokenInput) -> ModalResult<ElementAttributes> {
 
     Ok(ElementAttributes {
         flowPrefix: flow, streamPrefix: stream, parallelism, variability, direction,
-        isField: is_field, arrayDim: Arc::new(List::Nil),
+        isField: is_field, arrayDim: metamodelica::nil(),
     })
 }
 
@@ -1790,7 +1790,7 @@ fn component_clause(input: &mut TokenInput) -> ModalResult<ComponentClause> {
     Ok(ComponentClause { typePrefix, typeSpec, components })
 }
 
-fn component_list(input: &mut TokenInput) -> ModalResult<Arc<List<Arc<ComponentItem>>>> {
+fn component_list(input: &mut TokenInput) -> ModalResult<List<Arc<ComponentItem>>> {
     let first = component_declaration(input)?;
     let mut items = List::new(Arc::new(first));
     loop {
@@ -1810,7 +1810,7 @@ fn component_declaration(input: &mut TokenInput) -> ModalResult<ComponentItem> {
         _ => return Err(ErrMode::Backtrack(ContextError::default())),
     };
     next_tok(input)?; // consume the validated name token
-    let arrayDim  = opt(array_subscripts).parse_next(input)?.unwrap_or_else(|| Arc::new(List::Nil));
+    let arrayDim  = opt(array_subscripts).parse_next(input)?.unwrap_or_else(|| metamodelica::nil());
     let m         = opt(modification).parse_next(input)?;
     let condition = if opt(t(TK::If)).parse_next(input)?.is_some() {
         Some(expression(input)?)
@@ -1824,7 +1824,7 @@ fn component_declaration(input: &mut TokenInput) -> ModalResult<ComponentItem> {
 }
 
 fn modification(input: &mut TokenInput) -> ModalResult<Modification> {
-    let cm = opt(class_modification).parse_next(input)?.unwrap_or_else(|| Arc::new(List::Nil));
+    let cm = opt(class_modification).parse_next(input)?.unwrap_or_else(|| metamodelica::nil());
     // ANTLR anchors the EQMOD info at the `=`/`:=` token
     // (`PARSER_INFO($eq)`), not at the start of the whole modification.
     let eq_start = *input;
@@ -1849,7 +1849,7 @@ fn modification_expression(input: &mut TokenInput) -> ModalResult<Absyn::Exp> {
     expression(input)
 }
 
-fn class_modification(input: &mut TokenInput) -> ModalResult<Arc<List<Arc<ElementArg>>>> {
+fn class_modification(input: &mut TokenInput) -> ModalResult<List<Arc<ElementArg>>> {
     class_modification_impl(input, false)
 }
 
@@ -1857,20 +1857,20 @@ fn class_modification(input: &mut TokenInput) -> ModalResult<Arc<List<Arc<Elemen
 /// [`class_modification`] but the arguments may also be `break ...`
 /// inheritance modifications (`extends A(break x)`). Only extends clauses
 /// accept these (`argument_list[1]` in the ANTLR grammar).
-fn class_or_inheritance_modification(input: &mut TokenInput) -> ModalResult<Arc<List<Arc<ElementArg>>>> {
+fn class_or_inheritance_modification(input: &mut TokenInput) -> ModalResult<List<Arc<ElementArg>>> {
     class_modification_impl(input, true)
 }
 
-fn class_modification_impl(input: &mut TokenInput, can_have_break: bool) -> ModalResult<Arc<List<Arc<ElementArg>>>> {
+fn class_modification_impl(input: &mut TokenInput, can_have_break: bool) -> ModalResult<List<Arc<ElementArg>>> {
     t(TK::LParen).parse_next(input)?;
     let arguments = opt(|i: &mut TokenInput| argument_list(i, can_have_break))
         .parse_next(input)?
-        .unwrap_or_else(|| Arc::new(List::Nil));
+        .unwrap_or_else(|| metamodelica::nil());
     expect_rparen(input)?;
     Ok(arguments)
 }
 
-fn argument_list(input: &mut TokenInput, can_have_break: bool) -> ModalResult<Arc<List<Arc<ElementArg>>>> {
+fn argument_list(input: &mut TokenInput, can_have_break: bool) -> ModalResult<List<Arc<ElementArg>>> {
     // Mirror the ANTLR3 `argument_list` rule's comment handling: a line/block
     // comment that precedes an argument is preserved as an
     // `Absyn.ELEMENTARGCOMMENT` spliced into the list right before that
@@ -1906,7 +1906,7 @@ fn argument_list(input: &mut TokenInput, can_have_break: bool) -> ModalResult<Ar
     // Comments between the last argument and the closing `)`.
     push_comments_before(&mut out, input);
 
-    let mut res: Arc<List<Arc<ElementArg>>> = Arc::new(List::Nil);
+    let mut res: List<Arc<ElementArg>> = metamodelica::nil();
     for e in out.into_iter().rev() { res = cons(e, res); }
     Ok(res)
 }
@@ -1933,11 +1933,11 @@ fn inheritance_modification(input: &mut TokenInput) -> ModalResult<ElementArg> {
         Equation::EQ_CONNECT {
             connector1: Arc::new(ComponentRef::CREF_IDENT {
                 name: literal!("break"),
-                subscripts: Arc::new(List::Nil),
+                subscripts: metamodelica::nil(),
             }),
             connector2: Arc::new(ComponentRef::CREF_IDENT {
                 name,
-                subscripts: Arc::new(List::Nil),
+                subscripts: metamodelica::nil(),
             }),
         }
     };
@@ -2083,7 +2083,7 @@ fn import_clause(input: &mut TokenInput) -> ModalResult<Import> {
         Some(TK::Dot) => match alt((t(TK::LBrace),t(TK::Star))).parse_next(input)? {
             TK::Star => Ok(Import::UNQUAL_IMPORT { path: Arc::new(path) }), // Modelica 2 where .* is not a separate token
             TK::LBrace => {
-                let mut groups: Arc<List<GroupImport>> = Arc::new(List::Nil);
+                let mut groups: List<GroupImport> = metamodelica::nil();
                 loop {
                     let first = t_any_ident(input)?;
                     let gi = if opt(t(TK::Equal)).parse_next(input)?.is_some() {
@@ -2161,7 +2161,7 @@ fn external_part(input: &mut TokenInput) -> ModalResult<ClassBodyItem> {
     // `=`) or the function name (followed by `(`).
     let mut output_: Option<Absyn::ComponentRef> = None;
     let mut func_name: Option<ArcStr> = None;
-    let mut args: Arc<List<Arc<Absyn::Exp>>> = nil();
+    let mut args: List<Arc<Absyn::Exp>> = nil();
 
     // The function-call body is only present when the next token is an
     // identifier; otherwise we are looking at `annotation` or `;`.
@@ -2224,8 +2224,8 @@ fn external_part(input: &mut TokenInput) -> ModalResult<ClassBodyItem> {
 /// out-parameter — so they are returned separately for the caller to splice
 /// in as [`ClassBodyItem::Annotation`] entries (which `split_annotations`
 /// hoists like any other class annotation).
-fn equation_section_items(input: &mut TokenInput) -> ModalResult<(Arc<List<EquationItem>>, Vec<Annotation>)> {
-    let mut items: Arc<List<EquationItem>> = Arc::new(List::Nil);
+fn equation_section_items(input: &mut TokenInput) -> ModalResult<(List<EquationItem>, Vec<Annotation>)> {
+    let mut items: List<EquationItem> = metamodelica::nil();
     let mut anns: Vec<Annotation> = Vec::new();
     loop {
         let (next_l, next_c) = next_pos(input);
@@ -2254,8 +2254,8 @@ fn equation_section_items(input: &mut TokenInput) -> ModalResult<(Arc<List<Equat
 
 /// Algorithm-section contents; see [`equation_section_items`] for the
 /// interleaved-annotation handling (`algorithm_annotation_list` in ANTLR3).
-fn algorithm_section_items(input: &mut TokenInput) -> ModalResult<(Arc<List<AlgorithmItem>>, Vec<Annotation>)> {
-    let mut items: Arc<List<AlgorithmItem>> = Arc::new(List::Nil);
+fn algorithm_section_items(input: &mut TokenInput) -> ModalResult<(List<AlgorithmItem>, Vec<Annotation>)> {
+    let mut items: List<AlgorithmItem> = metamodelica::nil();
     let mut anns: Vec<Annotation> = Vec::new();
     loop {
         let (next_l, next_c) = next_pos(input);
@@ -2283,8 +2283,8 @@ fn algorithm_section_items(input: &mut TokenInput) -> ModalResult<(Arc<List<Algo
 }
 
 /// Equations stopping at Then / Else / Elseif / Elsewhen / End.
-fn equation_list(input: &mut TokenInput) -> ModalResult<Arc<List<EquationItem>>> {
-    let mut items: Arc<List<EquationItem>> = Arc::new(List::Nil);
+fn equation_list(input: &mut TokenInput) -> ModalResult<List<EquationItem>> {
+    let mut items: List<EquationItem> = metamodelica::nil();
     loop {
         // Flush lexer comments before the next token (or after the last
         // equation if we are about to break). They become EQUATIONITEMCOMMENT
@@ -2306,7 +2306,7 @@ fn equation_list(input: &mut TokenInput) -> ModalResult<Arc<List<EquationItem>>>
     Ok(items.reverse())
 }
 
-fn equation_list_then(input: &mut TokenInput) -> ModalResult<Arc<List<Absyn::EquationItem>>> {
+fn equation_list_then(input: &mut TokenInput) -> ModalResult<List<Absyn::EquationItem>> {
     equation_list(input)
 }
 
@@ -2397,7 +2397,7 @@ fn if_equation_e(input: &mut TokenInput) -> ModalResult<Equation> {
         _        => return Err(ErrMode::Cut(ContextError::default())),
     }
     let true_items = equation_list(input)?;
-    let mut else_if_branches: Vec<(Arc<Absyn::Exp>, Arc<List<Arc<EquationItem>>>)> = Vec::new();
+    let mut else_if_branches: Vec<(Arc<Absyn::Exp>, List<Arc<EquationItem>>)> = Vec::new();
     loop {
         if !matches!(peek_kind(input), Some(TK::Elseif)) { break; }
         next_tok(input)?;
@@ -2413,7 +2413,7 @@ fn if_equation_e(input: &mut TokenInput) -> ModalResult<Equation> {
         has_else = true;
         next_tok(input)?;
         equation_list(input)?
-    } else { Arc::new(List::Nil) };
+    } else { metamodelica::nil() };
     let (end_line, end_col) = next_pos(input);
     match cut_err(next_tok)
         .context(StrContext::Label("'end' closing if-equation"))
@@ -2450,7 +2450,7 @@ fn if_equation_e(input: &mut TokenInput) -> ModalResult<Equation> {
             )));
         }
     }
-    let mut elseif_list: Arc<List<(Arc<Absyn::Exp>, Arc<List<Arc<EquationItem>>>)>> = Arc::new(List::Nil);
+    let mut elseif_list: List<(Arc<Absyn::Exp>, List<Arc<EquationItem>>)> = metamodelica::nil();
     for branch in else_if_branches.into_iter().rev() { elseif_list = cons(branch, elseif_list); }
     Ok(Equation::EQ_IF {
         ifExp: Arc::new(cond),
@@ -2493,7 +2493,7 @@ fn when_equation_e(input: &mut TokenInput) -> ModalResult<Equation> {
         _        => return Err(ErrMode::Cut(ContextError::default())),
     }
     let when_body = equation_list(input)?;
-    let mut else_when: Vec<(Arc<Absyn::Exp>, Arc<List<Arc<EquationItem>>>)> = Vec::new();
+    let mut else_when: Vec<(Arc<Absyn::Exp>, List<Arc<EquationItem>>)> = Vec::new();
     loop {
         if !matches!(peek_kind(input), Some(TK::Elsewhen)) { break; }
         next_tok(input)?;
@@ -2512,7 +2512,7 @@ fn when_equation_e(input: &mut TokenInput) -> ModalResult<Equation> {
         _       => return Err(ErrMode::Cut(ContextError::default())),
     }
     next_tok(input)?; // "when"
-    let mut ew_list: Arc<List<(Arc<Absyn::Exp>, Arc<List<Arc<EquationItem>>>)>> = Arc::new(List::Nil);
+    let mut ew_list: List<(Arc<Absyn::Exp>, List<Arc<EquationItem>>)> = metamodelica::nil();
     for branch in else_when.into_iter().rev() { ew_list = cons(branch, ew_list); }
     Ok(Equation::EQ_WHEN_E {
         whenExp: Arc::new(when_cond),
@@ -2598,8 +2598,8 @@ fn connect_equation(input: &mut TokenInput) -> ModalResult<Equation> {
 }
 
 /// Algorithm statements stopping at Then / Else / Elseif / Elsewhen / End.
-fn algorithm_list(input: &mut TokenInput) -> ModalResult<Arc<List<AlgorithmItem>>> {
-    let mut items: Arc<List<AlgorithmItem>> = Arc::new(List::Nil);
+fn algorithm_list(input: &mut TokenInput) -> ModalResult<List<AlgorithmItem>> {
+    let mut items: List<AlgorithmItem> = metamodelica::nil();
     loop {
         // Mirror equation_list: drain lexer comments interleaved with
         // the algorithm statements so they round-trip through the AST.
@@ -2619,7 +2619,7 @@ fn algorithm_list(input: &mut TokenInput) -> ModalResult<Arc<List<AlgorithmItem>
     Ok(items.reverse())
 }
 
-fn algorithm_list_then(input: &mut TokenInput) -> ModalResult<Arc<List<Absyn::AlgorithmItem>>> {
+fn algorithm_list_then(input: &mut TokenInput) -> ModalResult<List<Absyn::AlgorithmItem>> {
     algorithm_list(input)
 }
 
@@ -2656,7 +2656,7 @@ fn is_der_cref(exp: &Absyn::Exp) -> bool {
         && name.as_str() == "der" && subscripts.is_empty()
         && let Absyn::FunctionArgs::FUNCTIONARGS { args, argNames } = &**functionArgs
         && argNames.is_empty()
-        && let List::Cons { head, tail } = &**args
+        && let metamodelica::ListNode::Cons { head, tail } = &**args
         && tail.is_empty()
     {
         return matches!(&**head, Absyn::Exp::CREF { .. });
@@ -2760,7 +2760,7 @@ fn if_algorithm(input: &mut TokenInput) -> ModalResult<Algorithm> {
         _        => return Err(ErrMode::Cut(ContextError::default())),
     }
     let true_items = algorithm_list(input)?;
-    let mut else_if_branches: Vec<(Arc<Absyn::Exp>, Arc<List<Arc<AlgorithmItem>>>)> = Vec::new();
+    let mut else_if_branches: Vec<(Arc<Absyn::Exp>, List<Arc<AlgorithmItem>>)> = Vec::new();
     loop {
         if !matches!(peek_kind(input), Some(TK::Elseif)) { break; }
         next_tok(input)?;
@@ -2775,7 +2775,7 @@ fn if_algorithm(input: &mut TokenInput) -> ModalResult<Algorithm> {
     let else_items = if matches!(peek_kind(input), Some(TK::Else)) {
         has_else = true;
         next_tok(input)?; algorithm_list(input)?
-    } else { Arc::new(List::Nil) };
+    } else { metamodelica::nil() };
     let (end_line, end_col) = next_pos(input);
     match cut_err(next_tok).context(StrContext::Label("'end' closing if-algorithm")).parse_next(input)? {
         TK::End => {}
@@ -2808,7 +2808,7 @@ fn if_algorithm(input: &mut TokenInput) -> ModalResult<Algorithm> {
             )));
         }
     }
-    let mut elseif_list: Arc<List<(Arc<Absyn::Exp>, Arc<List<Arc<AlgorithmItem>>>)>> = Arc::new(List::Nil);
+    let mut elseif_list: List<(Arc<Absyn::Exp>, List<Arc<AlgorithmItem>>)> = metamodelica::nil();
     for branch in else_if_branches.into_iter().rev() { elseif_list = cons(branch, elseif_list); }
     Ok(Algorithm::ALG_IF {
         ifExp: Arc::new(cond), trueBranch: to_rc_list(true_items),
@@ -2856,7 +2856,7 @@ fn when_algorithm(input: &mut TokenInput) -> ModalResult<Algorithm> {
         _        => return Err(ErrMode::Cut(ContextError::default())),
     }
     let when_body = algorithm_list(input)?;
-    let mut else_when: Vec<(Arc<Absyn::Exp>, Arc<List<Arc<AlgorithmItem>>>)> = Vec::new();
+    let mut else_when: Vec<(Arc<Absyn::Exp>, List<Arc<AlgorithmItem>>)> = Vec::new();
     loop {
         if !matches!(peek_kind(input), Some(TK::Elsewhen)) { break; }
         next_tok(input)?;
@@ -2872,7 +2872,7 @@ fn when_algorithm(input: &mut TokenInput) -> ModalResult<Algorithm> {
         _       => return Err(ErrMode::Cut(ContextError::default())),
     }
     next_tok(input)?; // "when"
-    let mut ew_list: Arc<List<(Arc<Absyn::Exp>, Arc<List<Arc<AlgorithmItem>>>)>> = Arc::new(List::Nil);
+    let mut ew_list: List<(Arc<Absyn::Exp>, List<Arc<AlgorithmItem>>)> = metamodelica::nil();
     for branch in else_when.into_iter().rev() { ew_list = cons(branch, ew_list); }
     Ok(Algorithm::ALG_WHEN_A {
         boolExpr: Arc::new(when_cond), whenBody: to_rc_list(when_body), elseWhenAlgorithmBranch: ew_list,
@@ -2914,7 +2914,7 @@ fn failure_algorithm(input: &mut TokenInput) -> ModalResult<Algorithm> {
 /// print its result in the interactive environment).
 fn interactive_stmt(input: &mut TokenInput) -> ModalResult<crate::GlobalScript::Statements> {
     if matches!(peek_kind(input), Some(TK::BOM)) { next_tok(input)?; }
-    let mut stmts: Arc<List<crate::GlobalScript::Statement>> = Arc::new(List::Nil);
+    let mut stmts: List<crate::GlobalScript::Statement> = metamodelica::nil();
     let mut semicolon = false;
     // The ANTLR rule requires at least one statement; we are slightly more
     // lenient and accept an empty token stream (e.g. a script containing
@@ -3043,15 +3043,15 @@ fn match_case_body(input: &mut TokenInput) -> ModalResult<Absyn::ClassPart> {
                 .parse_next(input)?;
             Ok(Absyn::ClassPart::ALGORITHMS { contents: to_rc_list(contents) })
         }
-        _ => Ok(Absyn::ClassPart::ALGORITHMS { contents: Arc::new(List::Nil) }),
+        _ => Ok(Absyn::ClassPart::ALGORITHMS { contents: metamodelica::nil() }),
     }
 }
 
-fn local_clause(input: &mut TokenInput) -> ModalResult<Arc<List<Arc<Absyn::ElementItem>>>> {
-    if !matches!(peek_kind(input), Some(TK::Local)) { return Ok(Arc::new(List::Nil)); }
+fn local_clause(input: &mut TokenInput) -> ModalResult<List<Arc<Absyn::ElementItem>>> {
+    if !matches!(peek_kind(input), Some(TK::Local)) { return Ok(metamodelica::nil()); }
     next_tok(input)?; // Local
     let items = element_list(input)?;
-    let mut result: Arc<List<Arc<Absyn::ElementItem>>> = Arc::new(List::Nil);
+    let mut result: List<Arc<Absyn::ElementItem>> = metamodelica::nil();
     for item in &*items {
         let ei = match item {
             ClassBodyItem::Element(elem)   => Absyn::ElementItem::ELEMENTITEM { element: Arc::new(elem.clone()) },
@@ -3098,8 +3098,8 @@ fn match_onecase(input: &mut TokenInput) -> ModalResult<Absyn::Case> {
     })
 }
 
-fn match_cases(input: &mut TokenInput) -> ModalResult<Arc<List<Absyn::Case>>> {
-    let mut cases: Arc<List<Absyn::Case>> = Arc::new(List::Nil);
+fn match_cases(input: &mut TokenInput) -> ModalResult<List<Absyn::Case>> {
+    let mut cases: List<Absyn::Case> = metamodelica::nil();
     loop {
         match peek_kind(input) {
             Some(TK::Case) => { cases = cons(match_onecase(input)?, cases); }
@@ -3125,7 +3125,7 @@ fn match_cases(input: &mut TokenInput) -> ModalResult<Arc<List<Absyn::Case>>> {
                             result_start = *input;
                         }
                         opt(t(TK::Then)).parse_next(input)?;
-                        Absyn::ClassPart::ALGORITHMS { contents: Arc::new(List::Nil) }
+                        Absyn::ClassPart::ALGORITHMS { contents: metamodelica::nil() }
                     },
                 };
                 let result = expression(input)?;
@@ -3215,8 +3215,8 @@ fn component_reference2(input: &mut TokenInput) -> ModalResult<Absyn::ComponentR
     } else {
         t_ident(input)?
     };
-    let raw_subs = opt(array_subscripts).parse_next(input)?.unwrap_or_else(|| Arc::new(List::Nil));
-    let mut subscripts: Arc<List<Arc<Absyn::Subscript>>> = Arc::new(List::Nil);
+    let raw_subs = opt(array_subscripts).parse_next(input)?.unwrap_or_else(|| metamodelica::nil());
+    let mut subscripts: List<Arc<Absyn::Subscript>> = metamodelica::nil();
     for s in &*raw_subs.reverse() { subscripts = cons(s.clone(), subscripts); }
     if input.len() >= 2
         && input[0].kind == TK::Dot
@@ -3308,9 +3308,9 @@ fn expression(input: &mut TokenInput) -> ModalResult<Absyn::Exp> {
             if is_interactive_parse() || (before.is_empty() && after.is_empty()) {
                 Ok(exp)
             } else {
-                let mut b: Arc<List<ArcStr>> = Arc::new(List::Nil);
+                let mut b: List<ArcStr> = metamodelica::nil();
                 for t in before.into_iter().rev() { b = cons(t, b); }
-                let mut a: Arc<List<ArcStr>> = Arc::new(List::Nil);
+                let mut a: List<ArcStr> = metamodelica::nil();
                 for t in after.into_iter().rev() { a = cons(t, a); }
                 Ok(Absyn::Exp::EXPRESSIONCOMMENT {
                     commentsBefore: b,
@@ -3334,7 +3334,7 @@ fn if_expression(input: &mut TokenInput) -> ModalResult<Absyn::Exp> {
     let cond    = expression(input)?;
     match next_tok(input)? { TK::Then => {} _ => return Err(ErrMode::Backtrack(ContextError::default())) }
     let true_br = expression(input)?;
-    let mut elseif: Arc<List<(Arc<Absyn::Exp>, Arc<Absyn::Exp>)>> = nil();
+    let mut elseif: List<(Arc<Absyn::Exp>, Arc<Absyn::Exp>)> = nil();
     loop {
         if !matches!(peek_kind(input), Some(TK::Elseif)) { break; }
         next_tok(input)?;
@@ -3503,7 +3503,7 @@ fn code_expression(input: &mut TokenInput) -> ModalResult<Absyn::Exp> {
 }
 
 /// code_equation_clause: equation SEMICOLON code_equation_clause?
-fn code_equation_clause(input: &mut TokenInput) -> ModalResult<Arc<List<Arc<EquationItem>>>> {
+fn code_equation_clause(input: &mut TokenInput) -> ModalResult<List<Arc<EquationItem>>> {
     let eq = Arc::new(equation_item(input)?);
     t(TK::Semi).parse_next(input)?;
     let rest = opt(code_equation_clause).parse_next(input)?.unwrap_or(nil());
@@ -3511,7 +3511,7 @@ fn code_equation_clause(input: &mut TokenInput) -> ModalResult<Arc<List<Arc<Equa
 }
 
 /// code_constraint_clause: equation SEMICOLON code_constraint_clause?
-fn code_constraint_clause(input: &mut TokenInput) -> ModalResult<Arc<List<Arc<EquationItem>>>> {
+fn code_constraint_clause(input: &mut TokenInput) -> ModalResult<List<Arc<EquationItem>>> {
     let eq = Arc::new(equation_item(input)?);
     t(TK::Semi).parse_next(input)?;
     let rest = opt(code_constraint_clause).parse_next(input)?.unwrap_or(nil());
@@ -3519,7 +3519,7 @@ fn code_constraint_clause(input: &mut TokenInput) -> ModalResult<Arc<List<Arc<Eq
 }
 
 /// code_algorithm_clause: algorithm SEMICOLON code_algorithm_clause?
-fn code_algorithm_clause(input: &mut TokenInput) -> ModalResult<Arc<List<Arc<AlgorithmItem>>>> {
+fn code_algorithm_clause(input: &mut TokenInput) -> ModalResult<List<Arc<AlgorithmItem>>> {
     let alg = Arc::new(algorithm_item(input)?);
     t(TK::Semi).parse_next(input)?;
     let rest = opt(code_algorithm_clause).parse_next(input)?.unwrap_or(nil());
@@ -3744,12 +3744,12 @@ fn primary(input: &mut TokenInput) -> ModalResult<Absyn::Exp> {
                     return Err(ErrMode::Cut(ContextError::new()));
                 }
                 let exp = match &*exprs {
-                    List::Cons { head, .. } => head.clone(),
+                    metamodelica::ListNode::Cons { head, .. } => head.clone(),
                     // output_expression_list only reports `()` as a tuple, so
                     // a non-tuple result always has exactly one element.
-                    List::Nil => unreachable!("non-tuple output_expression_list returned no expression"),
+                    metamodelica::ListNode::Nil => unreachable!("non-tuple output_expression_list returned no expression"),
                 };
-                let mut rc_subs: Arc<List<Arc<Subscript>>> = nil();
+                let mut rc_subs: List<Arc<Subscript>> = nil();
                 for s in &*(subs.reverse()) { rc_subs = cons(s.clone(), rc_subs); }
                 return Ok(Absyn::Exp::SUBSCRIPTED_EXP { exp, subscripts: rc_subs });
             }
@@ -3861,9 +3861,9 @@ fn component_reference__function_call(input: &mut TokenInput) -> ModalResult<Abs
     // Polymorphic call: cr <T1,T2,...> ( args )
     if matches!(peek_kind(input), Some(TK::Less)) {
         let saved = *input;
-        if let Ok(type_vars) = (|| -> ModalResult<Arc<List<Path>>> {
+        if let Ok(type_vars) = (|| -> ModalResult<List<Path>> {
             next_tok(input)?; // '<'
-            let mut vars: Arc<List<Path>> = nil();
+            let mut vars: List<Path> = nil();
             loop {
                 if matches!(peek_kind(input), Some(TK::Greater)) { break; }
                 vars = cons(name_path(input)?, vars);
@@ -3916,7 +3916,7 @@ fn function_arguments(input: &mut TokenInput) -> ModalResult<Absyn::FunctionArgs
     match fa {
         Absyn::FunctionArgs::FOR_ITER_FARG { .. } => Ok(fa),
         Absyn::FunctionArgs::FUNCTIONARGS { args, argNames } => {
-            if !matches!(argNames, List::Nil) {
+            if !matches!(argNames, metamodelica::ListNode::Nil) {
                 return Ok(Absyn::FunctionArgs::FUNCTIONARGS { args, argNames });
             }
             let argNames = opt(named_arguments).parse_next(input)?.unwrap_or(nil());
@@ -3962,8 +3962,8 @@ fn for_or_expression_list(input: &mut TokenInput) -> ModalResult<Absyn::Function
     }
 
     // Expression list, possibly ending with named arguments.
-    let mut args: Arc<List<Arc<Absyn::Exp>>> = nil();
-    let mut arg_names: Arc<List<Arc<Absyn::NamedArg>>> = nil();
+    let mut args: List<Arc<Absyn::Exp>> = nil();
+    let mut arg_names: List<Arc<Absyn::NamedArg>> = nil();
     loop {
         let is_plain_ident = matches!(
             &exp,
@@ -3997,9 +3997,9 @@ fn named_argument(input: &mut TokenInput) -> ModalResult<Absyn::NamedArg> {
     Ok(Absyn::NamedArg { argName, argValue })
 }
 
-fn named_arguments(input: &mut TokenInput) -> ModalResult<Arc<List<Arc<Absyn::NamedArg>>>> {
+fn named_arguments(input: &mut TokenInput) -> ModalResult<List<Arc<Absyn::NamedArg>>> {
     let first = named_argument(input)?;
-    let mut args: Arc<List<Arc<Absyn::NamedArg>>> = cons(Arc::new(first), nil());
+    let mut args: List<Arc<Absyn::NamedArg>> = cons(Arc::new(first), nil());
     loop {
         if opt(t(TK::Comma)).parse_next(input)?.is_none() { break; }
         match named_argument(input) {
@@ -4012,7 +4012,7 @@ fn named_arguments(input: &mut TokenInput) -> ModalResult<Arc<List<Arc<Absyn::Na
 
 fn for_indices(input: &mut TokenInput) -> ModalResult<Absyn::ForIterators> {
     let first = for_index(input)?;
-    let mut result: Arc<List<Absyn::ForIterator>> = List::new(first);
+    let mut result: List<Absyn::ForIterator> = List::new(first);
     loop {
         if opt(t(TK::Comma)).parse_next(input)?.is_none() { break; }
         match for_index(input) {
@@ -4039,9 +4039,9 @@ fn for_index(input: &mut TokenInput) -> ModalResult<Absyn::ForIterator> {
     Ok(Absyn::ForIterator { name, guardExp, range })
 }
 
-fn expression_list(input: &mut TokenInput) -> ModalResult<Arc<List<Arc<Absyn::Exp>>>> {
+fn expression_list(input: &mut TokenInput) -> ModalResult<List<Arc<Absyn::Exp>>> {
     let e = expression(input)?;
-    let mut result: Arc<List<Arc<Absyn::Exp>>> = cons(Arc::new(e), nil());
+    let mut result: List<Arc<Absyn::Exp>> = cons(Arc::new(e), nil());
     loop {
         if opt(t(TK::Comma)).parse_next(input)?.is_none() { break; }
         match expression(input) {
@@ -4053,7 +4053,7 @@ fn expression_list(input: &mut TokenInput) -> ModalResult<Arc<List<Arc<Absyn::Ex
 }
 
 /// Consumes up to and including ')'; returns (expressions, isTuple).
-fn output_expression_list(input: &mut TokenInput) -> ModalResult<(Arc<List<Arc<Absyn::Exp>>>, bool)> {
+fn output_expression_list(input: &mut TokenInput) -> ModalResult<(List<Arc<Absyn::Exp>>, bool)> {
     // ()
     if opt(t(TK::RParen)).parse_next(input)?.is_some() {
         return Ok((nil(), true));
@@ -4077,7 +4077,7 @@ fn output_expression_list(input: &mut TokenInput) -> ModalResult<(Arc<List<Arc<A
     Ok((cons(Arc::new(e1), nil()), false))
 }
 
-fn matrix_expression_list(input: &mut TokenInput) -> ModalResult<Arc<List<Arc<List<Arc<Absyn::Exp>>>>>> {
+fn matrix_expression_list(input: &mut TokenInput) -> ModalResult<List<List<Arc<Absyn::Exp>>>> {
     let row = expression_list(input)?;
     let mut rows = cons(row, nil());
     loop {
@@ -4136,7 +4136,7 @@ fn type_specifier_no_dims(input: &mut TokenInput) -> ModalResult<TypeSpec> {
 
 fn type_specifier_impl(input: &mut TokenInput, allow_dims: bool) -> ModalResult<TypeSpec> {
     let path = name_path(input)?;
-    let mut ts: Arc<List<Arc<TypeSpec>>> = nil();
+    let mut ts: List<Arc<TypeSpec>> = nil();
     if opt(t(TK::Less)).parse_next(input)?.is_some() {
         loop {
             if matches!(peek_kind(input), Some(TK::Greater)) || input.is_empty() { break; }
@@ -4166,7 +4166,7 @@ fn subscript(input: &mut TokenInput) -> ModalResult<Subscript> {
 
 fn array_subscripts(input: &mut TokenInput) -> ModalResult<ArrayDim> {
     t(TK::LBracket).parse_next(input)?;
-    let mut subs: Arc<List<Subscript>> = nil();
+    let mut subs: List<Subscript> = nil();
     loop {
         if matches!(peek_kind(input), Some(TK::RBracket)) || input.is_empty() { break; }
         subs = cons(subscript(input)?, subs);
@@ -4176,8 +4176,8 @@ fn array_subscripts(input: &mut TokenInput) -> ModalResult<ArrayDim> {
     Ok(to_rc_list(subs.reverse()))
 }
 
-fn enum_list(input: &mut TokenInput) -> ModalResult<Arc<List<EnumLiteral>>> {
-    let mut literals: Arc<List<EnumLiteral>> = nil();
+fn enum_list(input: &mut TokenInput) -> ModalResult<List<EnumLiteral>> {
+    let mut literals: List<EnumLiteral> = nil();
     loop {
         match peek_kind(input) {
             None | Some(TK::Pipe) | Some(TK::Comma) | Some(TK::Semi)
@@ -4245,7 +4245,7 @@ mod tests {
         match parse(code, "", "", Grammar::MetaModelica, false, 0.0).unwrap() {
             Program { classes, .. } => {
                 assert!(!classes.is_empty());
-                if let List::Cons { head, .. } = &*classes {
+                if let metamodelica::ListNode::Cons { head, .. } = &*classes {
                     let Class { name, .. } = &**head;
                     assert_eq!(&**name, "SimpleSystem");
                 }
@@ -4287,17 +4287,17 @@ end c;\n\
 ";
         let prog = parse(code, "t.mo", "t.mo", Grammar::Modelica3, false, 0.0).expect("parse");
         let Program { classes, .. } = prog;
-        let first = match &*classes { List::Cons { head, .. } => head.clone(), _ => panic!("no classes") };
+        let first = match &*classes { metamodelica::ListNode::Cons { head, .. } => head.clone(), _ => panic!("no classes") };
         let Class { body, .. } = &*first;
         let ClassDef::PARTS { ann, .. } = &**body else { panic!("expected PARTS") };
         let keys: Vec<String> = (&**ann).into_iter().map(|a| {
             let Annotation { elementArgs } = &**a;
             match &**elementArgs {
-                List::Cons { head, .. } => match &**head {
+                metamodelica::ListNode::Cons { head, .. } => match &**head {
                     ElementArg::MODIFICATION { path, .. } => format!("{path:?}"),
                     other => format!("{other:?}"),
                 },
-                List::Nil => "<empty>".to_owned(),
+                metamodelica::ListNode::Nil => "<empty>".to_owned(),
             }
         }).collect();
         assert!(keys.len() == 2 && keys[0].contains("key2") && keys[1].contains("key\""),
@@ -4323,7 +4323,7 @@ end A;\n\
 ";
         let prog = parse(code, "t.mo", "t.mo", Grammar::MetaModelica, false, 0.0).expect("parse");
         let Program { classes, .. } = prog;
-        let first = match &*classes { List::Cons { head, .. } => head.clone(), _ => panic!("no classes") };
+        let first = match &*classes { metamodelica::ListNode::Cons { head, .. } => head.clone(), _ => panic!("no classes") };
         let Class { commentsBeforeClass, commentsAfterEnd, body, .. } = &*first;
         assert!((&*commentsBeforeClass).into_iter().any(|c| c.contains("before A")),
                 "commentsBeforeClass = {:?}", commentsBeforeClass);
@@ -4371,7 +4371,7 @@ end P;\n\
 ";
         let prog = parse(code, "t.mo", "t.mo", Grammar::MetaModelica, false, 0.0).expect("parse");
         let Program { classes, .. } = prog;
-        let first = match &*classes { List::Cons { head, .. } => head.clone(), _ => panic!("no classes") };
+        let first = match &*classes { metamodelica::ListNode::Cons { head, .. } => head.clone(), _ => panic!("no classes") };
         let Class { body, .. } = &*first;
         let ClassDef::PARTS { classParts, .. } = &**body else { panic!("expected PARTS"); };
         let mut saw_wrapper = false;
@@ -4431,7 +4431,7 @@ end P;\n\
 ";
         let prog = parse(code, "t.mo", "t.mo", Grammar::MetaModelica, false, 0.0).expect("parse");
         let Program { classes, .. } = prog;
-        let first = match &*classes { List::Cons { head, .. } => head.clone(), _ => panic!("no classes") };
+        let first = match &*classes { metamodelica::ListNode::Cons { head, .. } => head.clone(), _ => panic!("no classes") };
         let Class { body, .. } = &*first;
         let ClassDef::PARTS { classParts, .. } = &**body else { panic!("expected PARTS"); };
         let mut assigns: Vec<(Arc<Exp>, Arc<Exp>)> = Vec::new();
@@ -4451,7 +4451,7 @@ end P;\n\
         // a*(b + c): the right operand is a parenthesized BINARY.
         let Exp::BINARY { exp2, .. } = &*assigns[0].1 else { panic!("expected BINARY, got {:?}", assigns[0].1) };
         let Exp::TUPLE { expressions } = &**exp2 else { panic!("expected TUPLE wrapper, got {exp2:?}") };
-        let List::Cons { head, tail } = &**expressions else { panic!("expected one element") };
+        let metamodelica::ListNode::Cons { head, tail } = &**expressions else { panic!("expected one element") };
         assert!(tail.is_empty(), "expected exactly one element, got {expressions:?}");
         assert!(matches!(&**head, Exp::BINARY { .. }), "expected inner BINARY, got {head:?}");
 
@@ -4481,7 +4481,7 @@ end P;\n\
 ";
         let prog = parse(code, "t.mo", "t.mo", Grammar::MetaModelica, false, 0.0).expect("parse");
         let Program { classes, .. } = prog;
-        let first = match &*classes { List::Cons { head, .. } => head.clone(), _ => panic!("no classes") };
+        let first = match &*classes { metamodelica::ListNode::Cons { head, .. } => head.clone(), _ => panic!("no classes") };
         let Class { body, .. } = &*first;
         let ClassDef::PARTS { classParts, .. } = &**body else { panic!("expected PARTS"); };
         let mut saw = false;
@@ -4600,7 +4600,7 @@ end P;\n\
         // More lenient than ANTLR (which requires at least one statement):
         // a script of only comments yields an empty statement list.
         let stmts = parse_statements("// nothing here\n", "t.mos", "t.mos", Grammar::Modelica3, false, 0.0).expect("parse");
-        assert!(matches!(&*stmts.interactiveStmtLst, List::Nil));
+        assert!(matches!(&*stmts.interactiveStmtLst, metamodelica::ListNode::Nil));
         assert!(!stmts.semicolon);
     }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend/src/Globals.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend/src/Globals.rs
@@ -32,7 +32,7 @@ thread_local! {
     // Optional list of active rewrite rules. Set to Some(rules) when a
     // rewrite-rule file is loaded; None otherwise.
     // Source: RewriteRules.mo.
-    pub static rewriteRulesIndex: RefCell<Option<Arc<metamodelica::List<crate::RewriteRules::Rule>>>> =
+    pub static rewriteRulesIndex: RefCell<Option<metamodelica::List<crate::RewriteRules::Rule>>> =
         const { RefCell::new(None) };
 
     // Index 25 — optionSimCode
@@ -48,7 +48,7 @@ thread_local! {
     // with that value reference. Live only while one modelDescription.xml is
     // being written; source: SimCodeUtil.cacheFMI3VariableAliases.
     pub static fmi3VariableAliasCache: RefCell<
-        Option<metamodelica::Array<Arc<metamodelica::List<openmodelica_simcode_types::SimCodeVar::SimVar>>>>,
+        Option<metamodelica::Array<metamodelica::List<openmodelica_simcode_types::SimCodeVar::SimVar>>>,
     > = const { RefCell::new(None) };
 
     // Index 26 — interactiveCache

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend/src/HpcOmBenchmarkExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend/src/HpcOmBenchmarkExt.rs
@@ -43,7 +43,6 @@
  */
 #![allow(non_snake_case)]
 
-use std::sync::Arc;
 
 use metamodelica::Result;
 use arcstr::ArcStr;
@@ -55,13 +54,13 @@ use metamodelica::{list, List, OrderedFloat, Real};
 /// Upstream `HpcOmBenchmarkExtImpl__requiredTimeForOp` returns the hardcoded
 /// pair (1, 24) — the original RDTSC micro-benchmark is commented out there
 /// ("the values are bad for equation systems", see `HpcOmBenchmark.benchSystem`).
-pub fn requiredTimeForOp() -> Result<Arc<List<i32>>> {
+pub fn requiredTimeForOp() -> Result<List<i32>> {
     Ok(list![1, 24])
 }
 
 /// Cost coefficients (m, n) for communicating x doubles to another CPU:
 /// `y = m*x + n`. Upstream returns the hardcoded pair (4, 70).
-pub fn requiredTimeForComm() -> Result<Arc<List<i32>>> {
+pub fn requiredTimeForComm() -> Result<List<i32>> {
     Ok(list![4, 70])
 }
 
@@ -69,7 +68,7 @@ pub fn requiredTimeForComm() -> Result<Arc<List<i32>>> {
 /// mirroring the three `mmc_mk_cons` pushes per block in the C++ readers
 /// (the resulting head order count, time, id is what
 /// `HpcOmBenchmark.expandCalcTimes` destructures).
-fn push_block(acc: Arc<List<Real>>, id: f64, time: f64, count: f64) -> Arc<List<Real>> {
+fn push_block(acc: List<Real>, id: f64, time: f64, count: f64) -> List<Real> {
     let acc = metamodelica::cons(OrderedFloat(id), acc);
     let acc = metamodelica::cons(OrderedFloat(time), acc);
     metamodelica::cons(OrderedFloat(count), acc)
@@ -104,13 +103,13 @@ fn push_block(acc: Arc<List<Real>>, id: f64, time: f64, count: f64) -> Arc<List<
 /// malformed document expat returns the blocks parsed before the error, while
 /// roxmltree parses the whole document up front, so we return an empty list.
 /// Neither case occurs with runtime-written files.
-pub fn readCalcTimesFromXml(fileName: ArcStr) -> Result<Arc<List<Real>>> {
+pub fn readCalcTimesFromXml(fileName: ArcStr) -> Result<List<Real>> {
     let Ok(content) = std::fs::read_to_string(fileName.as_str()) else {
         // Mirrors the printf in HpcOmBenchmarkExtImpl__readCalcTimesFromXml.
         println!("File '{}' does not exist", fileName);
         return Err("File '{}' does not exist");
     };
-    let mut res: Arc<List<Real>> = metamodelica::nil();
+    let mut res: List<Real> = metamodelica::nil();
     let doc = match roxmltree::Document::parse(&content) {
         Ok(doc) => doc,
         Err(_) => return Ok(res), // C++: stop parsing, keep what was read so far
@@ -148,13 +147,13 @@ pub fn readCalcTimesFromXml(fileName: ArcStr) -> Result<Arc<List<Real>>> {
 /// an error *string* (ill-typed as `list<Real>`) — here the print is kept and
 /// the function fails directly. Malformed JSON / missing `profileBlocks` keep
 /// the upstream behaviour: a message on stderr and an empty result.
-pub fn readCalcTimesFromJson(fileName: ArcStr) -> Result<Arc<List<Real>>> {
+pub fn readCalcTimesFromJson(fileName: ArcStr) -> Result<List<Real>> {
     let Ok(content) = std::fs::read(fileName.as_str()) else {
         // Mirrors the printf in HpcOmBenchmarkExtImpl__readCalcTimesFromJson.
         println!("File '{}' does not exist", fileName);
         return Err("File '{}' does not exist");
     };
-    let mut res: Arc<List<Real>> = metamodelica::nil();
+    let mut res: List<Real> = metamodelica::nil();
     let Ok(root) = serde_json::from_slice::<serde_json::Value>(&content) else {
         eprintln!("no root object defined in json-file - maybe the json file is corrupt");
         return Ok(res);
@@ -182,7 +181,7 @@ pub fn readCalcTimesFromJson(fileName: ArcStr) -> Result<Arc<List<Real>>> {
 mod tests {
     use super::*;
 
-    fn to_vec(lst: Arc<List<Real>>) -> Vec<f64> {
+    fn to_vec(lst: List<Real>) -> Vec<f64> {
         (&*lst).into_iter().map(|r| r.0).collect()
     }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_main/src/Globals.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_main/src/Globals.rs
@@ -26,11 +26,11 @@ thread_local! {
     // third element, `Interactive.GraphicEnvCache`, is defined in this crate
     // (Script/Interactive.mo); `openmodelica_backend` does not depend on
     // `openmodelica_backend_main`.
-    pub static interactiveCache: RefCell<Option<Arc<metamodelica::List<(
+    pub static interactiveCache: RefCell<Option<metamodelica::List<(
         openmodelica_ast::Absyn::Program,
         Arc<openmodelica_ast::Absyn::Path>,
         crate::Interactive::GraphicEnvCache,
-    )>>>> = const { RefCell::new(None) };
+    )>>> = const { RefCell::new(None) };
 
     // Index 35 — fmuTranslation
     //
@@ -49,24 +49,24 @@ thread_local! {
     // of these three NF caches is `Script/NFApi.mo` (this crate); their value
     // type uses `NFInstNode.InstNode` from `openmodelica_nf_frontend`, on which
     // this crate already depends.
-    pub static instNFInstCacheIndex: RefCell<Arc<metamodelica::List<(
+    pub static instNFInstCacheIndex: RefCell<metamodelica::List<(
         (openmodelica_ast::Absyn::Program, Arc<openmodelica_ast::Absyn::Path>),
-        (Arc<metamodelica::List<Arc<openmodelica_frontend_types::SCode::Element>>>, ArcStr, Arc<openmodelica_nf_frontend::NFInstNode::InstNode::InstNode>),
-    )>>> = RefCell::new(metamodelica::nil());
+        (metamodelica::List<Arc<openmodelica_frontend_types::SCode::Element>>, ArcStr, Arc<openmodelica_nf_frontend::NFInstNode::InstNode::InstNode>),
+    )>> = RefCell::new(metamodelica::nil());
 
     // Index 11 — instNFNodeCacheIndex
     //
     // NF node cache (program → SCode elements, InstNode).
-    pub static instNFNodeCacheIndex: RefCell<Arc<metamodelica::List<(
+    pub static instNFNodeCacheIndex: RefCell<metamodelica::List<(
         openmodelica_ast::Absyn::Program,
-        (Arc<metamodelica::List<Arc<openmodelica_frontend_types::SCode::Element>>>, Arc<openmodelica_nf_frontend::NFInstNode::InstNode::InstNode>),
-    )>>> = RefCell::new(metamodelica::nil());
+        (metamodelica::List<Arc<openmodelica_frontend_types::SCode::Element>>, Arc<openmodelica_nf_frontend::NFInstNode::InstNode::InstNode>),
+    )>> = RefCell::new(metamodelica::nil());
 
     // Index 12 — instNFLookupCacheIndex
     //
     // NF lookup cache. Same type as instNFInstCacheIndex (index 10).
-    pub static instNFLookupCacheIndex: RefCell<Arc<metamodelica::List<(
+    pub static instNFLookupCacheIndex: RefCell<metamodelica::List<(
         (openmodelica_ast::Absyn::Program, Arc<openmodelica_ast::Absyn::Path>),
-        (Arc<metamodelica::List<Arc<openmodelica_frontend_types::SCode::Element>>>, ArcStr, Arc<openmodelica_nf_frontend::NFInstNode::InstNode::InstNode>),
-    )>>> = RefCell::new(metamodelica::nil());
+        (metamodelica::List<Arc<openmodelica_frontend_types::SCode::Element>>, ArcStr, Arc<openmodelica_nf_frontend::NFInstNode::InstNode::InstNode>),
+    )>> = RefCell::new(metamodelica::nil());
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_main/src/capi.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_main/src/capi.rs
@@ -36,7 +36,7 @@ use crate::Main;
 /// default configuration (the installation directory is then taken from the
 /// `OPENMODELICAHOME` environment variable).
 pub fn init(args: &[ArcStr]) -> Result<()> {
-    let arglist: Arc<metamodelica::List<ArcStr>> = Arc::new(args.iter().cloned().collect());
+    let arglist: metamodelica::List<ArcStr> = args.iter().cloned().collect();
     let arglist = Main::init(arglist)?;
     Main::readSettings(arglist)?;
     Ok(())

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_tools/src/CevalScriptOMSimulator_wasm.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_tools/src/CevalScriptOMSimulator_wasm.rs
@@ -12,7 +12,7 @@ use openmodelica_frontend_types::Values;
 
 pub fn ceval(
     inFunctionName: ArcStr,
-    _inVals: Arc<metamodelica::List<Arc<Values::Value>>>,
+    _inVals: metamodelica::List<Arc<Values::Value>>,
 ) -> Result<Arc<Values::Value>> {
     return Err("CevalScriptOMSimulator: the OMSimulator scripting API (libOMSimulator) is unavailable on wasm (called `{inFunctionName}`)")
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_tools/src/SerializeSparsityPattern.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_tools/src/SerializeSparsityPattern.rs
@@ -49,7 +49,7 @@ use std::io::Write;
 
 use metamodelica::Result;
 use arcstr::{literal, ArcStr};
-use metamodelica::{list, List};
+use metamodelica::list;
 
 use openmodelica_simcode_types::SimCode;
 use openmodelica_util::Error;
@@ -63,7 +63,7 @@ pub fn serialize(code: SimCode::SimCode) -> Result<ArcStr> {
         // Pick sparsity and coloring depending on the isAdjoint flag.
         let (pattern, colorList) = if jac.isAdjoint {
             // For the adjoint Jacobian a row coloring must exist.
-            if matches!(&*jac.coloredRows, List::Nil) {
+            if jac.coloredRows.is_empty() {
                 Error::addMessage(
                     Error::INTERNAL_ERROR.clone(),
                     list![literal!(
@@ -77,7 +77,7 @@ pub fn serialize(code: SimCode::SimCode) -> Result<ArcStr> {
             (&jac.sparsity, &jac.coloredCols)
         };
 
-        if matches!(&**pattern, List::Nil) {
+        if pattern.is_empty() {
             continue;
         }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_util/src/BackendDAEEXT.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_backend_util/src/BackendDAEEXT.rs
@@ -47,7 +47,6 @@
 
 use std::cell::RefCell;
 use std::collections::BTreeSet;
-use std::sync::Arc;
 use metamodelica::Result;
 use metamodelica::Array;
 
@@ -88,7 +87,7 @@ fn with_state<R>(f: impl FnOnce(&mut State) -> R) -> R {
 // Build a `list<Integer>` from a set, mirroring the C
 // `for it in set: res = cons(*it, res)` (ascending iteration, prepend → the
 // returned list is in descending order).
-fn set_to_list(set: &BTreeSet<i32>) -> Arc<metamodelica::List<i32>> {
+fn set_to_list(set: &BTreeSet<i32>) -> metamodelica::List<i32> {
     let mut res = metamodelica::nil();
     for &x in set.iter() {
         res = metamodelica::cons(x, res);
@@ -118,11 +117,11 @@ pub fn getVMark(inInteger: i32) -> bool {
     with_state(|s| s.v_mark.contains(&inInteger))
 }
 
-pub fn getMarkedEqns() -> Arc<metamodelica::List<i32>> {
+pub fn getMarkedEqns() -> metamodelica::List<i32> {
     with_state(|s| set_to_list(&s.e_mark))
 }
 
-pub fn getDifferentiatedEqns() -> Arc<metamodelica::List<i32>> {
+pub fn getDifferentiatedEqns() -> metamodelica::List<i32> {
     with_state(|s| set_to_list(&s.differentiated_mark))
 }
 
@@ -134,7 +133,7 @@ pub fn markDifferentiated(inInteger: i32) {
     with_state(|s| { s.differentiated_mark.insert(inInteger); });
 }
 
-pub fn getMarkedVariables() -> Arc<metamodelica::List<i32>> {
+pub fn getMarkedVariables() -> metamodelica::List<i32> {
     with_state(|s| set_to_list(&s.v_mark))
 }
 
@@ -180,7 +179,7 @@ pub fn getNumber(inInteger: i32) -> i32 {
 
 // ── Matching: adjacency + assignment plumbing ──────────────────────────────────
 
-pub fn setAdjacencyMatrix(_nv: i32, ne: i32, nz: i32, m: Array<Arc<metamodelica::List<i32>>>) {
+pub fn setAdjacencyMatrix(_nv: i32, ne: i32, nz: i32, m: Array<metamodelica::List<i32>>) {
     with_state(|s| {
         s.col_ptrs = vec![0i32; (ne + 1) as usize];
         s.col_ptrs[ne as usize] = nz;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -122,8 +122,8 @@ pub(crate) mod dylink_fmi;
 
 /// Iterate a MetaModelica `List` (which is `IntoIterator` by reference, not via
 /// an `.iter()` method).
-pub(crate) fn lst<T: Clone>(l: &Arc<List<T>>) -> impl Iterator<Item = &T> {
-    (&**l).into_iter()
+pub(crate) fn lst<T: Clone>(l: &List<T>) -> impl Iterator<Item = &T> {
+    l.iter()
 }
 
 // ===========================================================================
@@ -881,8 +881,8 @@ pub fn fmu_cs_solvers() -> Vec<&'static str> {
 
 /// `CodegenWasmJit.fmuCsSolvers`: [`fmu_cs_solvers`] for the MetaModelica side,
 /// which folds an accepted `method=` into the FMU's `_flags.json`.
-pub fn fmuCsSolvers() -> Arc<List<ArcStr>> {
-    Arc::new(fmu_cs_solvers().into_iter().map(ArcStr::from).collect())
+pub fn fmuCsSolvers() -> List<ArcStr> {
+    fmu_cs_solvers().into_iter().map(ArcStr::from).collect()
 }
 
 /// The `platforms=` values `buildModelFMU` can serve besides `"wasm"`: those this
@@ -4100,7 +4100,7 @@ fn scalarize_sim_vars(vars: &SimCodeVar::SimVars) -> Result<SimCodeVar::SimVars>
     Ok(out)
 }
 
-fn scalarize_var_list(list: &Arc<List<SimCodeVar::SimVar>>) -> Result<Arc<List<SimCodeVar::SimVar>>> {
+fn scalarize_var_list(list: &List<SimCodeVar::SimVar>) -> Result<List<SimCodeVar::SimVar>> {
     let mut out: Vec<SimCodeVar::SimVar> = Vec::new();
     for sv in &**list {
         let dims = array_dims_of(&sv.numArrayElement)?;
@@ -4121,11 +4121,11 @@ fn scalarize_var_list(list: &Arc<List<SimCodeVar::SimVar>>) -> Result<Arc<List<S
             out.push(e);
         }
     }
-    Ok(Arc::new(out.into_iter().collect::<List<SimCodeVar::SimVar>>()))
+    Ok(out.into_iter().collect::<List<SimCodeVar::SimVar>>())
 }
 
 /// Parse `numArrayElement` (dimension sizes) to integers; empty for a scalar.
-fn array_dims_of(nae: &Arc<List<ArcStr>>) -> Result<Vec<u32>> {
+fn array_dims_of(nae: &List<ArcStr>) -> Result<Vec<u32>> {
     let mut dims = Vec::new();
     for s in &**nae {
         match s.trim().parse::<u32>() {
@@ -4165,7 +4165,7 @@ fn cref_with_indices(cr: &Arc<DAE::ComponentRef>, idx: &[i32]) -> Arc<DAE::Compo
                 .iter()
                 .map(|&i| Arc::new(DAE::Subscript::INDEX { exp: Arc::new(DAE::Exp::ICONST { integer: i }) }))
                 .collect();
-            Arc::new(C::CREF_IDENT { ident: ident.clone(), identType: identType.clone(), subscriptLst: Arc::new(subs) })
+            Arc::new(C::CREF_IDENT { ident: ident.clone(), identType: identType.clone(), subscriptLst: subs })
         }
         C::CREF_QUAL { ident, identType, subscriptLst, componentRef } => Arc::new(C::CREF_QUAL {
             ident: ident.clone(),
@@ -4209,7 +4209,7 @@ fn index_exp(exp: &Arc<DAE::Exp>, idx: &[i32]) -> Arc<DAE::Exp> {
         .iter()
         .map(|&i| Arc::new(DAE::Subscript::INDEX { exp: Arc::new(E::ICONST { integer: i }) }))
         .collect();
-    let asub = Arc::new(E::ASUB { exp: exp.clone(), sub: Arc::new(sub) });
+    let asub = Arc::new(E::ASUB { exp: exp.clone(), sub: sub });
     openmodelica_frontend_base::ExpressionSimplify::simplify1(asub.clone())
         .map(|(e, _)| e)
         .unwrap_or(asub)
@@ -4795,7 +4795,7 @@ fn flat_array_element_of(cr: &Arc<DAE::ComponentRef>) -> Result<Option<GroupEntr
 
 /// Parse a subscript list to constant 1-based integer indices, or `None` if any
 /// subscript is not a constant integer / enum literal (a slice, `:`, expression).
-fn const_int_subscripts(subs: &Arc<List<Arc<DAE::Subscript>>>) -> Result<Option<Vec<i32>>> {
+fn const_int_subscripts(subs: &List<Arc<DAE::Subscript>>) -> Result<Option<Vec<i32>>> {
     let mut out = Vec::new();
     for sub in &**subs {
         match &**sub {
@@ -5012,7 +5012,7 @@ fn path_ident_name(path: &openmodelica_ast::Absyn::Path) -> Option<&str> {
 /// For-loop (`iter`) crossings still error — they need iterator expansion, not
 /// yet ported.
 fn collect_zero_crossings(
-    zcs: &Arc<List<openmodelica_backend_types::BackendDAE::ZeroCrossing>>,
+    zcs: &List<openmodelica_backend_types::BackendDAE::ZeroCrossing>,
 ) -> Result<Vec<ZcInfo>> {
     let mut out = Vec::new();
     for zc in lst(zcs) {
@@ -5047,7 +5047,7 @@ fn collect_zero_crossings(
 /// constant, so the same slots come from substituting each iterator value in.
 fn expand_iter_crossing(
     relation: &Arc<DAE::Exp>,
-    iters: &Option<Arc<List<openmodelica_backend_types::BackendDAE::SimIterator>>>,
+    iters: &Option<List<openmodelica_backend_types::BackendDAE::SimIterator>>,
 ) -> Result<Vec<Arc<DAE::Exp>>> {
     let Some(iters) = iters else { return Ok(vec![relation.clone()]) };
     let mut out = vec![relation.clone()];
@@ -5127,7 +5127,7 @@ fn subst_iterator(exp: &Arc<DAE::Exp>, name: &str, value: &Arc<DAE::Exp>) -> Res
 /// `Some` for a bare relation, `None` for a form C's `relationTpl` also leaves
 /// untouched while still consuming its index.
 fn collect_relations(
-    rels: &Arc<List<openmodelica_backend_types::BackendDAE::ZeroCrossing>>,
+    rels: &List<openmodelica_backend_types::BackendDAE::ZeroCrossing>,
 ) -> Result<Vec<Option<Arc<DAE::Exp>>>> {
     let mut out = Vec::new();
     for zc in lst(rels) {
@@ -5145,7 +5145,7 @@ fn collect_relations(
 /// `iter`) expand to multiple runtime samples and are not handled yet, so bail
 /// loudly rather than mis-simulate.
 fn collect_samples(
-    time_events: &Arc<List<openmodelica_backend_types::BackendDAE::TimeEvent>>,
+    time_events: &List<openmodelica_backend_types::BackendDAE::TimeEvent>,
 ) -> Result<Vec<SampleInfo>> {
     use openmodelica_backend_types::BackendDAE::TimeEvent as TE;
     let mut out = Vec::new();
@@ -5173,7 +5173,7 @@ struct ClockInfo {
 
 /// Split a `ClockedPartition` list into per-base-clock info, assigning the flat
 /// sub-clock indices the `SimData` sub-clock region is addressed by.
-fn collect_clocks(partitions: &Arc<List<SimCode::ClockedPartition>>) -> Result<Vec<ClockInfo>> {
+fn collect_clocks(partitions: &List<SimCode::ClockedPartition>) -> Result<Vec<ClockInfo>> {
     let mut out = Vec::new();
     let mut sub_base = 0u32;
     for part in lst(partitions) {
@@ -5435,7 +5435,7 @@ fn build_sim_model(
     // (or mixed / if-) system, so index every list recursively. `eqFunction_<n>`
     // is emitted once in the C target and shared; here the target is inlined.
     let mut eq_index: HashMap<i32, Arc<SimCode::SimEqSystem>> = HashMap::new();
-    let index_list = |eqs: &Arc<List<Arc<SimCode::SimEqSystem>>>, idx: &mut HashMap<i32, Arc<SimCode::SimEqSystem>>| {
+    let index_list = |eqs: &List<Arc<SimCode::SimEqSystem>>, idx: &mut HashMap<i32, Arc<SimCode::SimEqSystem>>| {
         for e in lst(eqs) {
             index_eq_recursive(e, idx);
         }
@@ -7748,7 +7748,7 @@ fn const_str(e: &Option<Arc<DAE::Exp>>) -> Option<String> {
 /// `spatialDistributionZeroCrossing` are stored as the bare call, which no target
 /// assigns to `relations[]`, but C's `relationDescription` still names them.
 fn rel_descriptions(
-    rels: &Arc<List<openmodelica_backend_types::BackendDAE::ZeroCrossing>>,
+    rels: &List<openmodelica_backend_types::BackendDAE::ZeroCrossing>,
 ) -> Vec<String> {
     lst(rels).map(|zc| dump_exp(&zc.relation_)).collect()
 }
@@ -7775,7 +7775,7 @@ pub(crate) fn t_real() -> Arc<DAE::Type> {
     Arc::new(DAE::Type::T_REAL { varLst: metamodelica::nil() })
 }
 
-pub(crate) fn count<T: Clone>(list: &Arc<List<T>>) -> usize {
+pub(crate) fn count<T: Clone>(list: &List<T>) -> usize {
     lst(list).count()
 }
 
@@ -7795,13 +7795,13 @@ fn extobj_destructor_key(sv: &SimCodeVar::SimVar) -> Result<String> {
 }
 
 /// Flatten a `list<SimEqSystem>` to a Vec of references.
-fn flatten_eqs(eqs: &Arc<List<Arc<SimCode::SimEqSystem>>>) -> Vec<Arc<SimCode::SimEqSystem>> {
+fn flatten_eqs(eqs: &List<Arc<SimCode::SimEqSystem>>) -> Vec<Arc<SimCode::SimEqSystem>> {
     lst(eqs).cloned().collect()
 }
 
 /// Flatten a `list<list<SimEqSystem>>` (partitioned equations) to a flat Vec.
 fn flatten_eqs_ll(
-    eqs: &Arc<List<Arc<List<Arc<SimCode::SimEqSystem>>>>>,
+    eqs: &List<List<Arc<SimCode::SimEqSystem>>>,
 ) -> Vec<Arc<SimCode::SimEqSystem>> {
     let mut out = Vec::new();
     for part in lst(eqs) {
@@ -7966,7 +7966,7 @@ fn prof_plan(
 fn visit_nested_eqs(e: &Arc<SimCode::SimEqSystem>, f: &mut dyn FnMut(&Arc<SimCode::SimEqSystem>)) {
     use SimCode::SimEqSystem as E;
     fn visit_list(
-        eqs: &Arc<List<Arc<SimCode::SimEqSystem>>>,
+        eqs: &List<Arc<SimCode::SimEqSystem>>,
         f: &mut dyn FnMut(&Arc<SimCode::SimEqSystem>),
     ) {
         for e in lst(eqs) {
@@ -9153,7 +9153,7 @@ enum DtSystem<'a> {
 }
 
 /// Every `CONSTRAINT_DT` of an equation's constraint list, as `(condition, local)`.
-pub(crate) fn dt_constraints(cons: &Arc<List<Arc<DAE::Constraint>>>) -> Vec<(Arc<DAE::Exp>, bool)> {
+pub(crate) fn dt_constraints(cons: &List<Arc<DAE::Constraint>>) -> Vec<(Arc<DAE::Exp>, bool)> {
     lst(cons)
         .filter_map(|c| match &**c {
             DAE::Constraint::CONSTRAINT_DT { constraint, localCon } => {
@@ -9362,7 +9362,7 @@ fn lin_torn_use_sparse(lsystem: &SimCode::LinearSystem, n: usize) -> bool {
 
 /// Total f64 count of the state-set Jacobian scratch region: the seeds plus every
 /// variable the column equations write.
-fn stateset_scratch_f64(state_sets: &Arc<List<SimCode::StateSet>>) -> Result<u32> {
+fn stateset_scratch_f64(state_sets: &List<SimCode::StateSet>) -> Result<u32> {
     let mut n = 0u32;
     for set in lst(state_sets) {
         n += count(&set.jacobianMatrix.seedVars) as u32 + jac_column_vars(&set.jacobianMatrix).len() as u32;
@@ -9374,7 +9374,7 @@ fn stateset_scratch_f64(state_sets: &Arc<List<SimCode::StateSet>>) -> Result<u32
 /// collect the driver-side [`StateSetInfo`], so the emitted
 /// `functionStateSetJacobians` works on the Jacobian's own storage.
 fn build_state_set_infos(
-    state_sets: &Arc<List<SimCode::StateSet>>,
+    state_sets: &List<SimCode::StateSet>,
     layout: &SimLayout,
     var_map: &mut SimVarMap,
 ) -> Result<Vec<StateSetInfo>> {
@@ -9467,7 +9467,7 @@ fn build_state_set_infos(
 /// candidate at a time and reads back one Jacobian column
 /// (`getAnalyticalJacobianSet` in C's `stateset.c`).
 fn build_stateset_jac_fn(
-    state_sets: &Arc<List<SimCode::StateSet>>,
+    state_sets: &List<SimCode::StateSet>,
     var_map: &SimVarMap,
     eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
     by_name: &HashMap<String, FnInfo>,
@@ -9509,7 +9509,7 @@ fn stateset_a_slot<'a>(
 /// independent (true for the models in scope; a candidate going singular
 /// mid-run would need the runtime `pivot`/`stateSelection` port).
 fn stateset_diag_offsets(
-    state_sets: &Arc<List<SimCode::StateSet>>,
+    state_sets: &List<SimCode::StateSet>,
     var_map: &SimVarMap,
 ) -> Result<Vec<u32>> {
     let mut offs = Vec::new();
@@ -10457,7 +10457,7 @@ fn build_lin_info(
     // A compile-time-constant input/output has no slot to perturb or read, so the
     // model cannot be linearized (nor can C's); `-l` reports it rather than
     // translation failing.
-    let slots = |list: &Arc<List<SimCodeVar::SimVar>>| -> Result<Option<Vec<LinVar>>> {
+    let slots = |list: &List<SimCodeVar::SimVar>| -> Result<Option<Vec<LinVar>>> {
         let mut out = Vec::new();
         for sv in lst(list) {
             let Some(slot) = var_map.vars.get(&sim_cref_key(&sv.name)?) else { return Ok(None) };
@@ -11241,7 +11241,7 @@ fn parmod_info(ode_eqs: &[Arc<SimCode::SimEqSystem>]) -> Result<openmodelica_sim
         }
         Ok(())
     }
-    let sorted = |eqs: &Arc<List<Arc<E>>>| -> Vec<Arc<E>> {
+    let sorted = |eqs: &List<Arc<E>>| -> Vec<Arc<E>> {
         let mut v: Vec<Arc<E>> = lst(eqs).cloned().collect();
         v.sort_by_key(|e| eq_index_of(e));
         v

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/datarecon.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/datarecon.rs
@@ -234,7 +234,7 @@ pub(crate) fn build_recon_info(
     if !plan.present {
         return Ok(None);
     }
-    let list = |l: &Arc<List<SimCodeVar::SimVar>>| -> Result<Vec<ReconVar>> {
+    let list = |l: &List<SimCodeVar::SimVar>| -> Result<Vec<ReconVar>> {
         let mut out = Vec::new();
         for sv in lst(l) {
             let key = sim_cref_key(&sv.name)?;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/linearize.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/linearize.rs
@@ -59,7 +59,7 @@ fn cref_str_safe(cr: &Arc<DAE::ComponentRef>) -> String {
     }
 }
 
-fn subscripts(subs: &Arc<List<Arc<DAE::Subscript>>>, matlab_safe: bool) -> String {
+fn subscripts(subs: &List<Arc<DAE::Subscript>>, matlab_safe: bool) -> String {
     let items: Vec<String> = lst(subs).map(|s| subscript_str(s)).collect();
     if items.is_empty() {
         return String::new();

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -1132,7 +1132,7 @@ fn main_sig_types(f: &SimCodeFunction::Function::Function) -> Result<(Vec<SigTy>
     }
 }
 
-fn var_sigtys(vars: &Arc<List<Arc<SimCodeFunction::Variable::Variable>>>) -> Result<Vec<SigTy>> {
+fn var_sigtys(vars: &List<Arc<SimCodeFunction::Variable::Variable>>) -> Result<Vec<SigTy>> {
     let mut out = Vec::new();
     for v in &**vars {
         out.push(match &**v {
@@ -1151,7 +1151,7 @@ fn var_sigtys(vars: &Arc<List<Arc<SimCodeFunction::Variable::Variable>>>) -> Res
 /// is the scalar element type with the dimensions in `instDims`. So a `T_ARRAY`
 /// `ty` is authoritative (its `dims` are complete); otherwise a non-empty
 /// `instDims` makes the scalar `ty` the element type of a rank-`|instDims|` array.
-fn variable_sigty(ty: &DAE::Type, inst_dims: &Arc<List<Arc<DAE::Dimension>>>) -> Result<SigTy> {
+fn variable_sigty(ty: &DAE::Type, inst_dims: &List<Arc<DAE::Dimension>>) -> Result<SigTy> {
     // Quiet: `external_known`/`external_general` map a function's variables only to
     // decide whether they can lower the call at all.
     let base = sig_ty_quiet(ty)?;
@@ -1914,7 +1914,7 @@ impl<'a> FnCtx<'a> {
     }
 
     /// Lower a list of algorithm statements into this context.
-    pub(crate) fn sim_stmts(&mut self, stmts: &Arc<List<Arc<DAE::Statement>>>) -> Result<()> {
+    pub(crate) fn sim_stmts(&mut self, stmts: &List<Arc<DAE::Statement>>) -> Result<()> {
         compile_stmts(self, stmts)
     }
 
@@ -2377,8 +2377,8 @@ impl<'a> FnCtx<'a> {
     /// must be saved after each step.
     pub(crate) fn sim_when(
         &mut self,
-        conditions: &Arc<List<Arc<DAE::ComponentRef>>>,
-        stmts: &Arc<List<openmodelica_backend_types::BackendDAE::WhenOperator>>,
+        conditions: &List<Arc<DAE::ComponentRef>>,
+        stmts: &List<openmodelica_backend_types::BackendDAE::WhenOperator>,
         else_when: &Option<Arc<openmodelica_simcode_types::SimCode::SimEqSystem>>,
     ) -> Result<()> {
         use we::Instruction as I;
@@ -2755,7 +2755,7 @@ fn compile_external_function(
 fn emit_shared_external_call(
     ctx: &mut FnCtx,
     sig: &ExtCallSig,
-    extArgs: &Arc<List<Arc<SimCodeFunction::SimExtArg::SimExtArg>>>,
+    extArgs: &List<Arc<SimCodeFunction::SimExtArg::SimExtArg>>,
     extReturn: &Arc<SimCodeFunction::SimExtArg::SimExtArg>,
     fn_path: &dyn Fn() -> ArcStr,
 ) -> Result<()> {
@@ -3093,7 +3093,7 @@ fn emit_known_external_call(
     // not C symbols. Their Integer and Real overloads share one `extName`, so a host
     // import would bind both to the same signature and hand libc's `abs(int)` a double.
     if matches!(ext_name, "abs" | "div" | "mod") {
-        let args = Arc::new(args.iter().cloned().collect::<List<Arc<DAE::Exp>>>());
+        let args = args.iter().cloned().collect::<List<Arc<DAE::Exp>>>();
         let attr = match out {
             SigTy::Int => DAE::callAttrBuiltinInteger(),
             _ => DAE::callAttrBuiltinReal(),
@@ -3537,7 +3537,7 @@ fn cref_ident(cr: &DAE::ComponentRef) -> Result<String> {
     }
 }
 
-fn compile_stmts(ctx: &mut FnCtx, stmts: &Arc<List<Arc<DAE::Statement>>>) -> Result<()> {
+fn compile_stmts(ctx: &mut FnCtx, stmts: &List<Arc<DAE::Statement>>) -> Result<()> {
     for s in &**stmts {
         compile_stmt(ctx, s)?;
     }
@@ -3738,7 +3738,7 @@ fn store_fresh_into_cref(ctx: &mut FnCtx, cref: &DAE::ComponentRef, wty: WTy, vt
 /// generated function (which leaves its results on the stack, first result
 /// deepest), then move each owned result into its target local. A `_` (wildcard)
 /// target discards its value (releasing it if heap).
-fn compile_tuple_assign(ctx: &mut FnCtx, lhs: &Arc<List<Arc<DAE::Exp>>>, call: &DAE::Exp) -> Result<()> {
+fn compile_tuple_assign(ctx: &mut FnCtx, lhs: &List<Arc<DAE::Exp>>, call: &DAE::Exp) -> Result<()> {
     let DAE::Exp::CALL { path, expLst, attr } = call else {
         return Err("CodegenWasmJit: tuple assignment rhs is not a function call");
     };
@@ -4189,7 +4189,7 @@ fn emit_array_record_defaults(ctx: &mut FnCtx, slot: u32, elem: &DAE::Type) -> R
 
 /// A record literal `R(field=…, …)` (`E::RECORD`): the field values are matched
 /// to the type's declaration order by component name.
-fn compile_record(ctx: &mut FnCtx, ty: &DAE::Type, exps: &Arc<List<Arc<DAE::Exp>>>, comp: &Arc<List<ArcStr>>) -> Result<()> {
+fn compile_record(ctx: &mut FnCtx, ty: &DAE::Type, exps: &List<Arc<DAE::Exp>>, comp: &List<ArcStr>) -> Result<()> {
     let SigTy::Record { fields, .. } = sig_ty(ty)? else {
         return Err("CodegenWasmJit: record constructor with non-record type");
     };
@@ -4232,8 +4232,8 @@ fn metarecord_sigty(path: &Arc<Absyn::Path>) -> Result<SigTy> {
 fn compile_metarecord(
     ctx: &mut FnCtx,
     path: &Arc<Absyn::Path>,
-    args: &Arc<List<Arc<DAE::Exp>>>,
-    fieldNames: &Arc<List<ArcStr>>,
+    args: &List<Arc<DAE::Exp>>,
+    fieldNames: &List<ArcStr>,
 ) -> Result<()> {
     let SigTy::Record { fields, .. } = metarecord_sigty(path)? else {
         return Err("CodegenWasmJit: boxed record constructor with non-record type");
@@ -4257,7 +4257,7 @@ fn compile_metarecord(
 /// A record-constructor *call* `R(v1, v2, …)` (a `CALL` whose result is a record
 /// and which is not a generated function): the positional arguments are the
 /// fields in declaration order.
-fn compile_record_call(ctx: &mut FnCtx, ty: &DAE::Type, args: &Arc<List<Arc<DAE::Exp>>>) -> Result<()> {
+fn compile_record_call(ctx: &mut FnCtx, ty: &DAE::Type, args: &List<Arc<DAE::Exp>>) -> Result<()> {
     let SigTy::Record { fields, .. } = sig_ty(ty)? else {
         return Err("CodegenWasmJit: record constructor call with non-record type");
     };
@@ -4340,7 +4340,7 @@ fn compile_record_field_assign(ctx: &mut FnCtx, rec_idx: u32, fields: &[(ArcStr,
 fn push_record_base(
     ctx: &mut FnCtx,
     ident: &str,
-    subs: &Arc<List<Arc<DAE::Subscript>>>,
+    subs: &List<Arc<DAE::Subscript>>,
 ) -> Result<(u32, Arc<Vec<(ArcStr, SigTy)>>)> {
     let (idx, sty) = ctx
         .locals
@@ -4410,7 +4410,7 @@ fn step_into_record(
     rec: u32,
     fields: &[(ArcStr, SigTy)],
     field: &str,
-    fsubs: &Arc<List<Arc<DAE::Subscript>>>,
+    fsubs: &List<Arc<DAE::Subscript>>,
 ) -> Result<(u32, Arc<Vec<(ArcStr, SigTy)>>)> {
     let (vt, fty) = load_field(ctx, rec, fields, field)?;
     if fsubs.is_empty() {
@@ -4491,7 +4491,7 @@ fn compile_cref_read_qual(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<W
 fn navigate_qual<'c>(
     ctx: &mut FnCtx,
     cref: &'c DAE::ComponentRef,
-) -> Result<(u32, Arc<Vec<(ArcStr, SigTy)>>, &'c str, &'c Arc<List<Arc<DAE::Subscript>>>)> {
+) -> Result<(u32, Arc<Vec<(ArcStr, SigTy)>>, &'c str, &'c List<Arc<DAE::Subscript>>)> {
     let DAE::ComponentRef::CREF_QUAL { ident, subscriptLst, componentRef: rest, .. } = cref else {
         return Err("CodegenWasmJit: navigate_qual on non-qualified cref");
     };
@@ -5094,8 +5094,8 @@ fn compile_stmt(ctx: &mut FnCtx, stmt: &DAE::Statement) -> Result<()> {
 /// for when-equations ([`FnCtx::sim_when`]).
 fn compile_stmt_when(
     ctx: &mut FnCtx,
-    conditions: &Arc<List<Arc<DAE::ComponentRef>>>,
-    stmts: &Arc<List<Arc<DAE::Statement>>>,
+    conditions: &List<Arc<DAE::ComponentRef>>,
+    stmts: &List<Arc<DAE::Statement>>,
     else_when: &Option<Arc<DAE::Statement>>,
 ) -> Result<()> {
     use we::Instruction as I;
@@ -5182,7 +5182,7 @@ fn compile_else(ctx: &mut FnCtx, e: &DAE::Else) -> Result<()> {
 fn compile_loop_body(
     ctx: &mut FnCtx,
     break_level: u32,
-    body: &Arc<List<Arc<DAE::Statement>>>,
+    body: &List<Arc<DAE::Statement>>,
 ) -> Result<()> {
     ctx.emit(we::Instruction::Block(we::BlockType::Empty));
     let continue_level = ctx.ctrl_depth;
@@ -5216,7 +5216,7 @@ fn compile_for(
     ctx: &mut FnCtx,
     iter: &ArcStr,
     range: &DAE::Exp,
-    body: &Arc<List<Arc<DAE::Statement>>>,
+    body: &List<Arc<DAE::Statement>>,
     ty: &DAE::Type,
 ) -> Result<()> {
     if let DAE::Exp::RANGE { .. } = range {
@@ -5232,7 +5232,7 @@ fn compile_for_int_range(
     ctx: &mut FnCtx,
     iter: &ArcStr,
     range: &DAE::Exp,
-    body: &Arc<List<Arc<DAE::Statement>>>,
+    body: &List<Arc<DAE::Statement>>,
 ) -> Result<()> {
     let DAE::Exp::RANGE { start, step, stop, .. } = range else {
         return Err("CodegenWasmJit: for-loop over non-range expression not supported");
@@ -5291,7 +5291,7 @@ fn compile_for_array(
     ctx: &mut FnCtx,
     iter: &ArcStr,
     range: &DAE::Exp,
-    body: &Arc<List<Arc<DAE::Statement>>>,
+    body: &List<Arc<DAE::Statement>>,
 ) -> Result<()> {
     let SigTy::Array { elem, rank } = exp_sigty(range)? else {
         return Err("CodegenWasmJit: for-loop over non-array, non-range expression not supported");
@@ -6267,7 +6267,7 @@ fn sim_cref_key_fatal(cr: &DAE::ComponentRef) -> Result<String> {
     })
 }
 
-fn sim_subs_into(subs: &Arc<List<Arc<DAE::Subscript>>>, s: &mut String) -> Result<()> {
+fn sim_subs_into(subs: &List<Arc<DAE::Subscript>>, s: &mut String) -> Result<()> {
     for sub in &**subs {
         match &**sub {
             DAE::Subscript::INDEX { exp } => match &**exp {
@@ -6292,7 +6292,7 @@ fn sim_subs_into(subs: &Arc<List<Arc<DAE::Subscript>>>, s: &mut String) -> Resul
 /// Append an intermediate component's subscripts to an array base key, spelled as
 /// [`sim_cref_key`] spells them (`bodybox[1].body.R_start.T`). `false` when a
 /// subscript is not a constant index, so there is no static base key.
-pub(crate) fn push_qual_subs(subs: &Arc<List<Arc<DAE::Subscript>>>, s: &mut String) -> bool {
+pub(crate) fn push_qual_subs(subs: &List<Arc<DAE::Subscript>>, s: &mut String) -> bool {
     for sub in &**subs {
         match &**sub {
             DAE::Subscript::INDEX { exp } => match const_index_value(exp) {
@@ -6455,7 +6455,7 @@ fn flat_sim_slice_of(cr: &DAE::ComponentRef) -> Result<Option<(String, Vec<Arc<D
 
 /// `base[subs]` (subscripts on the final component) -> `(base key, raw subscript
 /// list)`. Unlike [`sim_slice_of`], any `INDEX`/`SLICE`/whole mix.
-fn sim_array_base_subs(cr: &DAE::ComponentRef) -> Result<Option<(String, Arc<List<Arc<DAE::Subscript>>>)>> {
+fn sim_array_base_subs(cr: &DAE::ComponentRef) -> Result<Option<(String, List<Arc<DAE::Subscript>>)>> {
     use DAE::ComponentRef as C;
     let mut base = String::new();
     let mut node = cr;
@@ -6483,7 +6483,7 @@ fn sim_array_base_subs(cr: &DAE::ComponentRef) -> Result<Option<(String, Arc<Lis
 
 /// [`sim_array_base_subs`] over a flattened group: `module[$i].x[2:3]` selects from
 /// `module.x`. `None` unless an outer component is subscripted.
-fn flat_sim_array_base_subs(cr: &DAE::ComponentRef) -> Result<Option<(String, Arc<List<Arc<DAE::Subscript>>>)>> {
+fn flat_sim_array_base_subs(cr: &DAE::ComponentRef) -> Result<Option<(String, List<Arc<DAE::Subscript>>)>> {
     use DAE::ComponentRef as C;
     let mut base = String::new();
     let mut subs: Vec<Arc<DAE::Subscript>> = Vec::new();
@@ -6506,13 +6506,13 @@ fn flat_sim_array_base_subs(cr: &DAE::ComponentRef) -> Result<Option<(String, Ar
                 node = n;
             }
             None => {
-                return Ok(qualified_subs.then(|| (base, Arc::new(subs.into_iter().collect()))));
+                return Ok(qualified_subs.then(|| (base, subs.into_iter().collect())));
             }
         }
     }
 }
 
-fn subs_select_array(subs: &Arc<List<Arc<DAE::Subscript>>>, group: &ArrayGroup) -> bool {
+fn subs_select_array(subs: &List<Arc<DAE::Subscript>>, group: &ArrayGroup) -> bool {
     let rank = group.dims.len() as u32;
     (&**subs).into_iter().count() as u32 <= rank && !is_scalar_index(subs, rank)
 }
@@ -7344,7 +7344,7 @@ fn box_then_select(
     cref: &DAE::ComponentRef,
     dims: &[u32],
     elem: &SigTy,
-    subs: &Arc<List<Arc<DAE::Subscript>>>,
+    subs: &List<Arc<DAE::Subscript>>,
 ) -> Result<Option<WTy>> {
     let axes: Vec<(Vec<i32>, bool)> = dims.iter().map(|&d| ((1..=d as i32).collect(), true)).collect();
     emit_sim_array_box(ctx, cref, &axes, elem)?;
@@ -7429,7 +7429,7 @@ fn emit_sim_array_box(
     Ok(())
 }
 
-fn cref_leaf(cr: &DAE::ComponentRef) -> Option<(&DAE::Type, &Arc<List<Arc<DAE::Subscript>>>)> {
+fn cref_leaf(cr: &DAE::ComponentRef) -> Option<(&DAE::Type, &List<Arc<DAE::Subscript>>)> {
     use DAE::ComponentRef as C;
     match cr {
         C::CREF_QUAL { componentRef, .. } => cref_leaf(componentRef),
@@ -7452,12 +7452,10 @@ fn cref_with_leaf_subs(cr: &DAE::ComponentRef, index: &[i32]) -> Arc<DAE::Compon
         C::CREF_IDENT { ident, identType, .. } => Arc::new(C::CREF_IDENT {
             ident: ident.clone(),
             identType: identType.clone(),
-            subscriptLst: Arc::new(
-                index
-                    .iter()
-                    .map(|i| Arc::new(DAE::Subscript::INDEX { exp: Arc::new(DAE::Exp::ICONST { integer: *i }) }))
-                    .collect(),
-            ),
+            subscriptLst: index
+                .iter()
+                .map(|i| Arc::new(DAE::Subscript::INDEX { exp: Arc::new(DAE::Exp::ICONST { integer: *i }) }))
+                .collect(),
         }),
         C::CREF_QUAL { ident, identType, subscriptLst, componentRef } => Arc::new(C::CREF_QUAL {
             ident: ident.clone(),
@@ -8843,7 +8841,7 @@ fn relation_operand_sigty(op: &DAE::Operator) -> Result<SigTy> {
 fn compile_call(
     ctx: &mut FnCtx,
     path: &Absyn::Path,
-    args: &Arc<List<Arc<DAE::Exp>>>,
+    args: &List<Arc<DAE::Exp>>,
     attr: &DAE::CallAttributes,
 ) -> Result<Vec<SigTy>> {
     // A call through a function-reference variable: `call_indirect` on the
@@ -8936,7 +8934,7 @@ pub(crate) fn emit_prof(ctx: &mut FnCtx, clock: Option<u32>, hook: &str) -> Resu
 /// prepended — leaving both outputs on the stack, first result deepest.
 /// `initialPoints`/`initialValues` are only used during initialization
 /// (`functionInitSpatialDistribution`), as in C.
-fn compile_spatial_distribution(ctx: &mut FnCtx, args: &Arc<List<Arc<DAE::Exp>>>) -> Result<()> {
+fn compile_spatial_distribution(ctx: &mut FnCtx, args: &List<Arc<DAE::Exp>>) -> Result<()> {
     use we::Instruction as I;
     let argv: Vec<&Arc<DAE::Exp>> = (&**args).into_iter().collect();
     if argv.len() != 7 {
@@ -9148,7 +9146,7 @@ fn compile_math_event(
 fn compile_math_builtin(
     ctx: &mut FnCtx,
     name: &str,
-    args: &Arc<List<Arc<DAE::Exp>>>,
+    args: &List<Arc<DAE::Exp>>,
     attr: &DAE::CallAttributes,
 ) -> Result<SigTy> {
     let argv: Vec<&Arc<DAE::Exp>> = (&**args).into_iter().collect();
@@ -10928,7 +10926,7 @@ fn compile_array_scalar(ctx: &mut FnCtx, e1: &DAE::Exp, e2: &DAE::Exp, op_code: 
 /// Lower `a[i, j, ...]`: one `INDEX` per dimension reads a scalar element,
 /// anything else slices to a lower-rank sub-array. `base` produces the owned
 /// array handle. Returns the result's wasm type.
-fn compile_index(ctx: &mut FnCtx, base: &DAE::Exp, subs: &Arc<List<Arc<DAE::Subscript>>>) -> Result<WTy> {
+fn compile_index(ctx: &mut FnCtx, base: &DAE::Exp, subs: &List<Arc<DAE::Subscript>>) -> Result<WTy> {
     let SigTy::Array { elem, rank } = exp_sigty(base)? else {
         return Err("CodegenWasmJit: subscripting a non-array expression");
     };
@@ -10945,7 +10943,7 @@ fn compile_index(ctx: &mut FnCtx, base: &DAE::Exp, subs: &Arc<List<Arc<DAE::Subs
 /// dimension — and so yields a scalar element. Anything else (a `WHOLEDIM` /
 /// `SLICE`, or fewer subscripts than the rank, i.e. trailing whole dimensions)
 /// slices the array to a lower-rank sub-array and goes through [`slice_loaded`].
-fn is_scalar_index(subs: &Arc<List<Arc<DAE::Subscript>>>, rank: u32) -> bool {
+fn is_scalar_index(subs: &List<Arc<DAE::Subscript>>, rank: u32) -> bool {
     let mut n = 0u32;
     let mut all_index = true;
     for s in &**subs {
@@ -10959,7 +10957,7 @@ fn is_scalar_index(subs: &Arc<List<Arc<DAE::Subscript>>>, rank: u32) -> bool {
 
 /// Extract one `INDEX` expression per dimension from a subscript list. Callers
 /// gate on [`is_scalar_index`] first, so anything else is a codegen bug.
-fn index_subscripts(subs: &Arc<List<Arc<DAE::Subscript>>>, rank: u32) -> Result<Vec<Arc<DAE::Exp>>> {
+fn index_subscripts(subs: &List<Arc<DAE::Subscript>>, rank: u32) -> Result<Vec<Arc<DAE::Exp>>> {
     let subs: Vec<&Arc<DAE::Subscript>> = (&**subs).into_iter().collect();
     if subs.len() as u32 != rank {
         return Err("CodegenWasmJit: partial indexing on the scalar-index path");
@@ -11089,7 +11087,7 @@ fn emit_slice_spec(ctx: &mut FnCtx, subs: &[&Arc<DAE::Subscript>]) -> Result<(u3
 /// subscripts than the rank), build the per-axis spec and call `rt_array_slice`,
 /// leaving a fresh (owned) lower-rank sub-array handle. The source array and any
 /// `SLICE` index arrays are released. Returns `WTy::I32` (an array handle).
-fn slice_loaded(ctx: &mut FnCtx, subs: &Arc<List<Arc<DAE::Subscript>>>) -> Result<WTy> {
+fn slice_loaded(ctx: &mut FnCtx, subs: &List<Arc<DAE::Subscript>>) -> Result<WTy> {
     let subs: Vec<&Arc<DAE::Subscript>> = (&**subs).into_iter().collect();
     let nspec = subs.len() as u32;
 
@@ -11123,7 +11121,7 @@ fn slice_loaded(ctx: &mut FnCtx, subs: &Arc<List<Arc<DAE::Subscript>>>) -> Resul
 fn compile_slice_assign(
     ctx: &mut FnCtx,
     arr_idx: u32,
-    subs: &Arc<List<Arc<DAE::Subscript>>>,
+    subs: &List<Arc<DAE::Subscript>>,
     rhs: RhsSource,
 ) -> Result<()> {
     let subs: Vec<&Arc<DAE::Subscript>> = (&**subs).into_iter().collect();
@@ -11777,7 +11775,7 @@ fn native_fallbacks(
 /// call the exported `main`, marshalling `args` in and the result out. Returns
 /// `Values.META_FAIL` on any failure (missing/invalid module, a wasm trap from
 /// a failed assertion or division by zero, …), mirroring `DynLoad.executeFunction`.
-pub fn loadAndExecute(fileName: ArcStr, name: ArcStr, args: Arc<List<Arc<Values::Value>>>) -> Arc<Values::Value> {
+pub fn loadAndExecute(fileName: ArcStr, name: ArcStr, args: List<Arc<Values::Value>>) -> Arc<Values::Value> {
     match runtime::load_and_execute(&fileName, &name, &args) {
         Ok(v) => v,
         // Failure is a normal MetaModelica value the caller handles; no stderr.

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/closures.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/closures.rs
@@ -113,8 +113,8 @@ fn intern_type(params: &[SigTy], results: &[SigTy]) -> u32 {
 
 /// The `SigTy` of a `FUNCTION_PTR` function argument — what its holder may call.
 pub(crate) fn function_ptr_sigty(
-    tys: &Arc<List<Arc<DAE::Type>>>,
-    args: &Arc<List<Arc<SimCodeFunction::Variable::Variable>>>,
+    tys: &List<Arc<DAE::Type>>,
+    args: &List<Arc<SimCodeFunction::Variable::Variable>>,
 ) -> Result<SigTy> {
     let results: Result<Vec<SigTy>> = (&**tys).into_iter().map(|t| sig_ty(t)).collect();
     Ok(SigTy::Func { params: Arc::new(var_sigtys(args)?), results: Arc::new(results?) })
@@ -303,7 +303,7 @@ fn intern_thunk(
 pub(crate) fn compile_fnptr_call(
     ctx: &mut FnCtx,
     name: &str,
-    args: &Arc<List<Arc<DAE::Exp>>>,
+    args: &List<Arc<DAE::Exp>>,
 ) -> Result<Vec<SigTy>> {
     let Some((local, SigTy::Func { params, results })) = ctx.locals.get(name).cloned() else {
         return Err("CodegenWasmJit: function-pointer calls are only supported through a local variable");

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/generic_calls.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/generic_calls.rs
@@ -18,7 +18,7 @@ use super::*;
 pub(crate) fn emit_resizable_assign(
     ctx: &mut FnCtx,
     call_index: i32,
-    iters: &Arc<List<BackendDAE::SimIterator>>,
+    iters: &List<BackendDAE::SimIterator>,
 ) -> Result<()> {
     let call = lookup_call(ctx, call_index)?;
     let iters: Vec<&BackendDAE::SimIterator> = (&**iters).into_iter().collect();
@@ -29,7 +29,7 @@ pub(crate) fn emit_resizable_assign(
 pub(crate) fn emit_generic_assign(
     ctx: &mut FnCtx,
     call_index: i32,
-    scal_indices: &Arc<List<i32>>,
+    scal_indices: &List<i32>,
 ) -> Result<()> {
     let call = lookup_call(ctx, call_index)?;
     let indices: Vec<i32> = (&**scal_indices).into_iter().copied().collect();
@@ -41,8 +41,8 @@ pub(crate) fn emit_generic_assign(
 /// own index list in turn. The order is constant, so C's switch unrolls.
 pub(crate) fn emit_entwined_assign(
     ctx: &mut FnCtx,
-    call_order: &Arc<List<i32>>,
-    single_calls: &Arc<List<Arc<SimCode::SimEqSystem>>>,
+    call_order: &List<i32>,
+    single_calls: &List<Arc<SimCode::SimEqSystem>>,
     eq_index: &HashMap<i32, Arc<SimCode::SimEqSystem>>,
 ) -> Result<()> {
     use SimCode::SimEqSystem as E;
@@ -198,7 +198,7 @@ fn emit_const_int_table(ctx: &mut FnCtx, values: &[i32]) -> Result<u32> {
             integer: values.len() as i32
         })],
     });
-    let exp = DAE::Exp::ARRAY { ty, scalar: true, array: Arc::new(array) };
+    let exp = DAE::Exp::ARRAY { ty, scalar: true, array };
     let g = shared_lits::intern_const(&exp);
     let ptr = ctx.alloc_temp(WTy::I32);
     ctx.emit(we::Instruction::GlobalGet(g));
@@ -207,11 +207,11 @@ fn emit_const_int_table(ctx: &mut FnCtx, values: &[i32]) -> Result<u32> {
     Ok(ptr)
 }
 
-fn int_list(values: &Arc<List<i32>>) -> Vec<i32> {
+fn int_list(values: &List<i32>) -> Vec<i32> {
     (&**values).into_iter().copied().collect()
 }
 
-fn call_iters(call: &SimCode::SimGenericCall) -> &Arc<List<BackendDAE::SimIterator>> {
+fn call_iters(call: &SimCode::SimGenericCall) -> &List<BackendDAE::SimIterator> {
     use SimCode::SimGenericCall as G;
     match call {
         G::SINGLE_GENERIC_CALL { iters, .. }
@@ -220,7 +220,7 @@ fn call_iters(call: &SimCode::SimGenericCall) -> &Arc<List<BackendDAE::SimIterat
     }
 }
 
-type SubIters = Arc<List<(Arc<DAE::ComponentRef>, metamodelica::Array<Arc<DAE::Exp>>)>>;
+type SubIters = List<(Arc<DAE::ComponentRef>, metamodelica::Array<Arc<DAE::Exp>>)>;
 
 fn iter_sub_iter(iter: &BackendDAE::SimIterator) -> &SubIters {
     use BackendDAE::SimIterator as S;
@@ -351,7 +351,7 @@ fn emit_in_range(ctx: &mut FnCtx, it: u32, start_l: u32, stop_l: u32) {
 /// C's `subIterator`: `name = name_arr[parent - 1]`.
 fn emit_sub_iters(
     ctx: &mut FnCtx,
-    sub_iter: &Arc<List<(Arc<DAE::ComponentRef>, metamodelica::Array<Arc<DAE::Exp>>)>>,
+    sub_iter: &List<(Arc<DAE::ComponentRef>, metamodelica::Array<Arc<DAE::Exp>>)>,
     parent: u32,
 ) -> Result<Vec<IterBinding>> {
     use we::Instruction as I;
@@ -422,7 +422,7 @@ fn emit_call_body(ctx: &mut FnCtx, call: &SimCode::SimGenericCall) -> Result<()>
 }
 
 /// C's `genericBranch` chain; a branch with no condition is the trailing `else`.
-fn emit_branches(ctx: &mut FnCtx, branches: &Arc<List<SimCode::SimBranch>>) -> Result<()> {
+fn emit_branches(ctx: &mut FnCtx, branches: &List<SimCode::SimBranch>) -> Result<()> {
     use SimCode::SimBranch as B;
     let mut depth = 0;
     for branch in &**branches {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_stub.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_stub.rs
@@ -14,7 +14,7 @@ use openmodelica_frontend_types::Values;
 pub(super) fn load_and_execute(
     _file_name: &str,
     _name: &str,
-    _args: &Arc<List<Arc<Values::Value>>>,
+    _args: &List<Arc<Values::Value>>,
 ) -> Result<Arc<Values::Value>> {
     return Err("CodegenWasmJit: the wasm JIT engine is not built in (enable the `jit` feature)")
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmer.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmer.rs
@@ -126,7 +126,7 @@ fn value_as_i32(v: &Values::Value) -> Result<i32> {
 pub(super) fn load_and_execute(
     file_name: &str,
     _name: &str,
-    args: &Arc<List<Arc<Values::Value>>>,
+    args: &List<Arc<Values::Value>>,
 ) -> Result<Arc<Values::Value>> {
     let wasm_path = format!("{file_name}.wasm");
     let sig = read_sig(&format!("{file_name}.wasm.sig"))?;
@@ -228,7 +228,7 @@ pub(super) fn load_and_execute(
     Ok(match out.len() {
         0 => Arc::new(Values::Value::NORETCALL),
         1 => out.pop().unwrap(),
-        _ => Arc::new(Values::Value::TUPLE { valueLst: Arc::new(List::from_iter(out)) }),
+        _ => Arc::new(Values::Value::TUPLE { valueLst: List::from_iter(out) }),
     })
 }
 
@@ -457,8 +457,8 @@ fn record_to_value(store: &mut Store, rt: &RtFns, path: &ArcStr, fields: &[(ArcS
     }
     Ok(Values::Value::RECORD {
         record_: path_from_dotted(path),
-        orderd: Arc::new(List::from_iter(orderd)),
-        comp: Arc::new(List::from_iter(comp)),
+        orderd: List::from_iter(orderd),
+        comp: List::from_iter(comp),
         index: -1,
     })
 }
@@ -551,8 +551,8 @@ fn nest_values(dims: &[i32], flat: &[Values::Value]) -> Values::Value {
             .collect()
     };
     Values::Value::ARRAY {
-        valueLst: Arc::new(List::from_iter(values)),
-        dimLst: Arc::new(List::from_iter(dims.iter().copied())),
+        valueLst: List::from_iter(values),
+        dimLst: List::from_iter(dims.iter().copied()),
     }
 }
 
@@ -853,10 +853,10 @@ mod tests {
             "II\nI\n",
             &[we::Instruction::LocalGet(0), we::Instruction::LocalGet(1), we::Instruction::I32Add, we::Instruction::End],
         );
-        let args = Arc::new(List::from_iter([
+        let args = List::from_iter([
             Arc::new(Values::Value::INTEGER { integer: 3 }),
             Arc::new(Values::Value::INTEGER { integer: 4 }),
-        ]));
+        ]);
         let r = load_and_execute(&base, "main", &args).unwrap();
         assert_eq!(ival(&r), 7);
     }
@@ -876,7 +876,7 @@ mod tests {
                 we::Instruction::End,
             ],
         );
-        let args = Arc::new(List::from_iter([Arc::new(Values::Value::REAL { real: metamodelica::Real::from(21.0) })]));
+        let args = List::from_iter([Arc::new(Values::Value::REAL { real: metamodelica::Real::from(21.0) })]);
         let r = load_and_execute(&base, "main", &args).unwrap();
         assert_eq!(rval(&r), 42.0);
     }
@@ -897,7 +897,7 @@ mod tests {
                 we::Instruction::End,
             ],
         );
-        let args = Arc::new(List::from_iter([Arc::new(Values::Value::INTEGER { integer: 41 })]));
+        let args = List::from_iter([Arc::new(Values::Value::INTEGER { integer: 41 })]);
         let r = load_and_execute(&base, "main", &args).unwrap();
         match &*r {
             Values::Value::TUPLE { valueLst } => {
@@ -921,10 +921,10 @@ mod tests {
             "II\nI\n",
             &[we::Instruction::LocalGet(0), we::Instruction::LocalGet(1), we::Instruction::I32Add, we::Instruction::End],
         );
-        let args = Arc::new(List::from_iter([
+        let args = List::from_iter([
             Arc::new(Values::Value::INTEGER { integer: 5 }),
             Arc::new(Values::Value::INTEGER { integer: 7 }),
-        ]));
+        ]);
         assert_eq!(ival(&load_and_execute(&base, "main", &args).unwrap()), 12);
         assert_eq!(ival(&load_and_execute(&base, "main", &args).unwrap()), 12);
 
@@ -971,9 +971,9 @@ mod tests {
         std::fs::write(format!("{path}.wasm"), m.finish()).unwrap();
         std::fs::write(format!("{path}.wasm.sig"), "R\nR\n").unwrap();
 
-        let args = Arc::new(List::from_iter([Arc::new(Values::Value::REAL {
+        let args = List::from_iter([Arc::new(Values::Value::REAL {
             real: metamodelica::Real::from(std::f64::consts::FRAC_PI_2),
-        })]));
+        })]);
         let r = load_and_execute(&path, "main", &args).unwrap();
         assert!((rval(&r) - 1.0).abs() < 1e-12);
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/runtime_wasmtime.rs
@@ -274,7 +274,7 @@ fn value_as_i32(v: &Values::Value) -> Result<i32> {
 pub(super) fn load_and_execute(
     file_name: &str,
     _name: &str,
-    args: &Arc<List<Arc<Values::Value>>>,
+    args: &List<Arc<Values::Value>>,
 ) -> Result<Arc<Values::Value>> {
     let wasm_path = format!("{file_name}.wasm");
     let sig = read_sig(&format!("{file_name}.wasm.sig"))?;
@@ -377,7 +377,7 @@ pub(super) fn load_and_execute(
     Ok(match out.len() {
         0 => Arc::new(Values::Value::NORETCALL),
         1 => out.pop().unwrap(),
-        _ => Arc::new(Values::Value::TUPLE { valueLst: Arc::new(List::from_iter(out)) }),
+        _ => Arc::new(Values::Value::TUPLE { valueLst: List::from_iter(out) }),
     })
 }
 
@@ -607,8 +607,8 @@ fn record_to_value(store: &mut Store, rt: &RtFns, path: &ArcStr, fields: &[(ArcS
     }
     Ok(Values::Value::RECORD {
         record_: path_from_dotted(path),
-        orderd: Arc::new(List::from_iter(orderd)),
-        comp: Arc::new(List::from_iter(comp)),
+        orderd: List::from_iter(orderd),
+        comp: List::from_iter(comp),
         index: -1,
     })
 }
@@ -701,8 +701,8 @@ fn nest_values(dims: &[i32], flat: &[Values::Value]) -> Values::Value {
             .collect()
     };
     Values::Value::ARRAY {
-        valueLst: Arc::new(List::from_iter(values)),
-        dimLst: Arc::new(List::from_iter(dims.iter().copied())),
+        valueLst: List::from_iter(values),
+        dimLst: List::from_iter(dims.iter().copied()),
     }
 }
 
@@ -1003,10 +1003,10 @@ mod tests {
             "II\nI\n",
             &[we::Instruction::LocalGet(0), we::Instruction::LocalGet(1), we::Instruction::I32Add, we::Instruction::End],
         );
-        let args = Arc::new(List::from_iter([
+        let args = List::from_iter([
             Arc::new(Values::Value::INTEGER { integer: 3 }),
             Arc::new(Values::Value::INTEGER { integer: 4 }),
-        ]));
+        ]);
         let r = load_and_execute(&base, "main", &args).unwrap();
         assert_eq!(ival(&r), 7);
     }
@@ -1026,7 +1026,7 @@ mod tests {
                 we::Instruction::End,
             ],
         );
-        let args = Arc::new(List::from_iter([Arc::new(Values::Value::REAL { real: metamodelica::Real::from(21.0) })]));
+        let args = List::from_iter([Arc::new(Values::Value::REAL { real: metamodelica::Real::from(21.0) })]);
         let r = load_and_execute(&base, "main", &args).unwrap();
         assert_eq!(rval(&r), 42.0);
     }
@@ -1047,7 +1047,7 @@ mod tests {
                 we::Instruction::End,
             ],
         );
-        let args = Arc::new(List::from_iter([Arc::new(Values::Value::INTEGER { integer: 41 })]));
+        let args = List::from_iter([Arc::new(Values::Value::INTEGER { integer: 41 })]);
         let r = load_and_execute(&base, "main", &args).unwrap();
         match &*r {
             Values::Value::TUPLE { valueLst } => {
@@ -1071,10 +1071,10 @@ mod tests {
             "II\nI\n",
             &[we::Instruction::LocalGet(0), we::Instruction::LocalGet(1), we::Instruction::I32Add, we::Instruction::End],
         );
-        let args = Arc::new(List::from_iter([
+        let args = List::from_iter([
             Arc::new(Values::Value::INTEGER { integer: 5 }),
             Arc::new(Values::Value::INTEGER { integer: 7 }),
-        ]));
+        ]);
         assert_eq!(ival(&load_and_execute(&base, "main", &args).unwrap()), 12);
         assert_eq!(ival(&load_and_execute(&base, "main", &args).unwrap()), 12);
 
@@ -1122,9 +1122,9 @@ mod tests {
         std::fs::write(format!("{path}.wasm"), m.finish()).unwrap();
         std::fs::write(format!("{path}.wasm.sig"), "R\nR\n").unwrap();
 
-        let args = Arc::new(List::from_iter([Arc::new(Values::Value::REAL {
+        let args = List::from_iter([Arc::new(Values::Value::REAL {
             real: metamodelica::Real::from(std::f64::consts::FRAC_PI_2),
-        })]));
+        })]);
         let r = load_and_execute(&path, "main", &args).unwrap();
         assert!((rval(&r) - 1.0).abs() < 1e-12);
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_error/src/ErrorExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_error/src/ErrorExt.rs
@@ -35,7 +35,7 @@
 #![allow(non_snake_case)]
 
 use std::cell::RefCell;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use std::thread::ThreadId;
 
 use arcstr::ArcStr;
@@ -52,7 +52,7 @@ use crate::ErrorTypes::{Message, Severity, MessageType, TotalMessage};
 #[derive(Clone, Debug)]
 struct QueuedMessage {
     msg: Message,
-    tokens: Arc<List<ArcStr>>,
+    tokens: List<ArcStr>,
     info: SourceInfo,
 }
 
@@ -129,11 +129,11 @@ impl QueuedMessage {
 /// in one template. On a missing token the C++ side prints an internal
 /// error to stderr and renders the message as the empty string — we
 /// preserve that so test output matches.
-fn substitute_tokens(template: &str, tokens: &Arc<List<ArcStr>>) -> String {
+fn substitute_tokens(template: &str, tokens: &List<ArcStr>) -> String {
     let toks: Vec<&ArcStr> = {
         let mut v = Vec::new();
         let mut cur = tokens;
-        while let List::Cons { head, tail } = &**cur {
+        while let metamodelica::ListNode::Cons { head, tail } = &**cur {
             v.push(head);
             cur = tail;
         }
@@ -303,7 +303,7 @@ pub fn addSourceMessage(
     read_only: bool,
     filename: ArcStr,
     msg: ArcStr,
-    tokens: Arc<List<ArcStr>>,
+    tokens: List<ArcStr>,
 ) {
     let entry = QueuedMessage {
         msg: Message {
@@ -382,7 +382,7 @@ pub fn deleteNumCheckpoints(n: i32) {
 /// that must be `delete`d. In Rust the `QueuedMessage` lives by value, so
 /// there is nothing to free — the handle list is purely an opaque
 /// MetaModelica value we no longer reference once it is dropped.
-pub fn freeMessages(_handles: Arc<List<i32>>) {
+pub fn freeMessages(_handles: List<i32>) {
     // Intentionally empty — see doc comment.
 }
 
@@ -390,7 +390,7 @@ pub fn freeMessages(_handles: Arc<List<i32>>) {
 /// oldest first. Like `ErrorImpl__getCheckpointMessages` this *consumes*
 /// the messages (popping consecutive duplicates as it goes); callers that
 /// want to keep them re-add via `Error.addTotalMessages`.
-pub fn getCheckpointMessages() -> Arc<List<TotalMessage>> {
+pub fn getCheckpointMessages() -> List<TotalMessage> {
     with_state(|s| {
         let mut out = nil::<TotalMessage>();
         let Some(&(boundary, _)) = s.check_points.last() else {
@@ -408,7 +408,7 @@ pub fn getCheckpointMessages() -> Arc<List<TotalMessage>> {
 }
 
 /// `Error_getMessages`: `listReverse(ErrorImpl__getMessages())`, so newest first.
-pub fn getMessages() -> Arc<List<TotalMessage>> {
+pub fn getMessages() -> List<TotalMessage> {
     with_state(|s| {
         let mut newest_first = Vec::with_capacity(s.queue.len());
         while !s.queue.is_empty() {
@@ -675,7 +675,7 @@ pub fn moveMessagesToParentThread() {
 /// The returned list of "handles" mirrors the C++ runtime's `void*` queue
 /// of detached `ErrorMessage*`s; on the Rust side it is stored in a
 /// thread-local side table keyed by an opaque integer.
-pub fn popCheckPoint(id: ArcStr) -> Arc<List<i32>> {
+pub fn popCheckPoint(id: ArcStr) -> List<i32> {
     with_state(|s| {
         let start = s.check_points.last().map(|(p, _)| *p).unwrap_or(0);
         if !s.check_points.last().map(|(_, cid)| cid == &id).unwrap_or(false) {
@@ -756,10 +756,10 @@ pub fn printMessagesStr(warningsAsErrors: bool) -> ArcStr {
 }
 
 /// Push previously [`popCheckPoint`]-detached handles back onto the queue.
-pub fn pushMessages(handles: Arc<List<i32>>) {
+pub fn pushMessages(handles: List<i32>) {
     let mut cur = handles;
     let mut batch = Vec::new();
-    while let List::Cons { head, tail } = &*cur {
+    while let metamodelica::ListNode::Cons { head, tail } = &*cur {
         if let Some(d) = take_detached(*head) {
             batch.push(d);
         }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_error/src/ErrorTypes.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_error/src/ErrorTypes.rs
@@ -161,5 +161,5 @@ pub type TOTALMESSAGE = TotalMessage;
 ///            positions identified by
 ///            - %s for string
 ///            - %n for string number n
-pub type MessageTokens = Arc<metamodelica::List<ArcStr>>;
+pub type MessageTokens = metamodelica::List<ArcStr>;
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend/src/Globals.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend/src/Globals.rs
@@ -57,16 +57,16 @@ thread_local! {
     //
     // Builtin function index: list of (flag × parse functions).
     // Initialised by FBuiltin.mo; reset to nil() between runs.
-    pub static builtinIndex: RefCell<Arc<metamodelica::List<(
+    pub static builtinIndex: RefCell<metamodelica::List<(
         (i32, bool),
-        (openmodelica_ast::Absyn::Program, Arc<metamodelica::List<Arc<openmodelica_frontend_types::SCode::Element>>>),
-    )>>> = RefCell::new(metamodelica::nil());
+        (openmodelica_ast::Absyn::Program, metamodelica::List<Arc<openmodelica_frontend_types::SCode::Element>>),
+    )>> = RefCell::new(metamodelica::nil());
 
     // Index 18 — builtinGraphIndex
     //
     // Builtin environment graph index: list of (flag × FCore.Graph).
     // Initialised by Builtin.mo; reset to nil() between runs.
-    pub static builtinGraphIndex: RefCell<Arc<metamodelica::List<(i32, openmodelica_frontend_dump::FCore::Graph)>>> =
+    pub static builtinGraphIndex: RefCell<metamodelica::List<(i32, openmodelica_frontend_dump::FCore::Graph)>> =
         RefCell::new(metamodelica::nil());
 
     // Index 22 — inlineHashTable: moved to openmodelica_frontend_base::Globals

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_dump/src/unittests/component_reference_basics_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_dump/src/unittests/component_reference_basics_tests.rs
@@ -36,7 +36,7 @@ fn make_ident(name: &str) -> Arc<DAE::ComponentRef> {
 
 fn make_ident_with_subs(
     name: &str,
-    subs: Arc<metamodelica::List<Arc<DAE::Subscript>>>,
+    subs: metamodelica::List<Arc<DAE::Subscript>>,
 ) -> Arc<DAE::ComponentRef> {
     CRB::makeCrefIdent(arcstr::format!("{}", name), DAE::T_REAL_DEFAULT().clone(), subs)
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_dump/src/unittests/expression_basics_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend_dump/src/unittests/expression_basics_tests.rs
@@ -274,7 +274,7 @@ fn subscript_int_from_index() -> Result<()> {
 
 #[test]
 fn subscripts_int_list() -> Result<()> {
-    let subs: Arc<metamodelica::List<Arc<DAE::Subscript>>> =
+    let subs: metamodelica::List<Arc<DAE::Subscript>> =
         list![index_sub(iconst(2)), index_sub(iconst(7))];
     let result = ExpressionBasics::subscriptsInt(subs)?;
     let v: Vec<i32> = result.into_iter().cloned().collect();
@@ -359,7 +359,7 @@ fn print_list_str_empty() -> Result<()> {
 #[test]
 fn print_list_str_multiple() -> Result<()> {
     init_flags();
-    let subs: Arc<metamodelica::List<Arc<DAE::Subscript>>> =
+    let subs: metamodelica::List<Arc<DAE::Subscript>> =
         list![index_sub(iconst(3)), index_sub(iconst(5))];
     let result = ExpressionBasics::printListStr(
         subs,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_nbackend/src/NBASSCExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_nbackend/src/NBASSCExt.rs
@@ -7,7 +7,6 @@
 // `crate::NBASSCExt::ASSC_setMatrix`, etc.), so the generated `NBASSC.rs`
 // calls into this hand-written module rather than emitting `todo!()`.
 
-use std::sync::Arc;
 
 use metamodelica::{Result, Array, List};
 
@@ -49,8 +48,8 @@ pub fn ASSC_setMatrix(
     nv: i32,
     ne: i32,
     nz: i32,
-    adj: Array<Arc<List<i32>>>,
-    val: Array<Arc<List<i32>>>,
+    adj: Array<List<i32>>,
+    val: Array<List<i32>>,
 ) {
     let mut m = AsscMatrix {
         nv,
@@ -80,7 +79,7 @@ pub fn ASSC_setMatrix(
 
 /// `ASSC_getMatrix(adj, val)`: fill pre-allocated adj/val arrays from the stored
 /// rows, respecting the row permutation established by the last Bareiss call.
-pub fn ASSC_getMatrix(adj: Array<Arc<List<i32>>>, val: Array<Arc<List<i32>>>) {
+pub fn ASSC_getMatrix(adj: Array<List<i32>>, val: Array<List<i32>>) {
     ASSC_MATRIX.with(|s| {
         let borrow = s.borrow();
         let Some(m) = borrow.as_ref() else { return };
@@ -90,12 +89,12 @@ pub fn ASSC_getMatrix(adj: Array<Arc<List<i32>>>, val: Array<Arc<List<i32>>>) {
             if !m.rows[row_idx].is_empty() {
                 // Build immutable cons lists in forward order by folding in reverse.
                 let adj_list = m.rows[row_idx].iter().rev().fold(
-                    Arc::new(List::Nil),
-                    |tail, &(idx, _)| Arc::new(List::Cons { head: idx, tail }),
+                    metamodelica::nil(),
+                    |tail, &(idx, _)| metamodelica::cons(idx, tail),
                 );
                 let val_list = m.rows[row_idx].iter().rev().fold(
-                    Arc::new(List::Nil),
-                    |tail, &(_, v)| Arc::new(List::Cons { head: v, tail }),
+                    metamodelica::nil(),
+                    |tail, &(_, v)| metamodelica::cons(v, tail),
                 );
                 adj.borrow_mut()[i] = adj_list;
                 val.borrow_mut()[i] = val_list;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_nf_frontend/src/FFI.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_nf_frontend/src/FFI.rs
@@ -136,14 +136,8 @@ fn round_up(n: usize, align: usize) -> usize {
     n.div_ceil(align) * align
 }
 
-fn list_len<T: Clone>(list: &Arc<metamodelica::List<T>>) -> usize {
-    let mut n = 0;
-    let mut cur = list;
-    while let metamodelica::List::Cons { tail, .. } = &**cur {
-        n += 1;
-        cur = tail;
-    }
-    n
+fn list_len<T: Clone>(list: &metamodelica::List<T>) -> usize {
+    list.iter().count()
 }
 
 /// `array_dim_size`: the number of values a dimension spans.
@@ -164,8 +158,8 @@ fn dim_size(dim: &Dimension::NFDimension) -> usize {
 fn array_length(ty: &Type::NFType) -> usize {
     match ty {
         Type::NFType::ARRAY { dimensions, .. } => match &**dimensions {
-            metamodelica::List::Cons { head, .. } => dim_size(head),
-            metamodelica::List::Nil => 0,
+            metamodelica::ListNode::Cons { head, .. } => dim_size(head),
+            metamodelica::ListNode::Nil => 0,
         },
         _ => 0,
     }
@@ -178,7 +172,7 @@ fn array_scalar_count(ty: &Type::NFType) -> usize {
         Type::NFType::ARRAY { dimensions, .. } => {
             let mut count = 1usize;
             let mut cur = dimensions;
-            while let metamodelica::List::Cons { head, tail } = &**cur {
+            while let metamodelica::ListNode::Cons { head, tail } = &**cur {
                 count *= dim_size(head);
                 cur = tail;
             }
@@ -193,8 +187,8 @@ fn unlift_array_type(ty: &Arc<Type::NFType>) -> Arc<Type::NFType> {
     match &**ty {
         Type::NFType::ARRAY { elementType, dimensions } => {
             let rest = match &**dimensions {
-                metamodelica::List::Cons { tail, .. } => tail.clone(),
-                metamodelica::List::Nil => metamodelica::nil(),
+                metamodelica::ListNode::Cons { tail, .. } => tail.clone(),
+                metamodelica::ListNode::Nil => metamodelica::nil(),
             };
             Arc::new(Type::NFType::ARRAY { elementType: elementType.clone(), dimensions: rest })
         }
@@ -272,7 +266,7 @@ fn exp_alignment(exp: &Expression::NFExpression) -> Result<(CType, Alignment)> {
             let mut off = 0usize;
             let mut max_align = 1usize;
             let mut cur = elements;
-            while let metamodelica::List::Cons { head, tail } = &**cur {
+            while let metamodelica::ListNode::Cons { head, tail } = &**cur {
                 let (_, field) = exp_alignment(head)?;
                 off = round_up(off, field.align);
                 offsets.push(off);
@@ -352,7 +346,7 @@ unsafe fn write_exp_value(
             Expression::NFExpression::RECORD { elements, .. } => {
                 let mut cur = elements;
                 let mut i = 0usize;
-                while let metamodelica::List::Cons { head, tail } = &**cur {
+                while let metamodelica::ListNode::Cons { head, tail } = &**cur {
                     if i >= align.offsets.len() {
                         break;
                     }
@@ -412,7 +406,7 @@ unsafe fn mk_enum_exp(
     }
     let mut cur = literals;
     let mut i = 1;
-    while let metamodelica::List::Cons { head, tail } = &**cur {
+    while let metamodelica::ListNode::Cons { head, tail } = &**cur {
         if i == index {
             return Ok(Arc::new(Expression::NFExpression::ENUM_LITERAL {
                 ty: enum_ty.clone(),
@@ -484,7 +478,7 @@ unsafe fn mk_record_exp(
     let mut out: Vec<Arc<Expression::NFExpression>> = Vec::with_capacity(align.fields.len());
     let mut cur = elements;
     let mut i = 0usize;
-    while let metamodelica::List::Cons { head, tail } = &**cur {
+    while let metamodelica::ListNode::Cons { head, tail } = &**cur {
         if i >= align.fields.len() {
             break;
         }
@@ -568,7 +562,7 @@ pub fn callFunction(
     args: metamodelica::Array<Arc<Expression::NFExpression>>,
     specs: metamodelica::Array<ArgSpec>,
     returnType: Arc<Type::NFType>,
-) -> Result<(Arc<Expression::NFExpression>, Arc<metamodelica::List<Arc<Expression::NFExpression>>>)> {
+) -> Result<(Arc<Expression::NFExpression>, metamodelica::List<Arc<Expression::NFExpression>>)> {
     let fn_addr = openmodelica_util::dynload::function_addr(fnHandle)?;
 
     let args_vec: Vec<Arc<Expression::NFExpression>> = args.borrow().clone();

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_nf_frontend/src/FFI_wasm.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_nf_frontend/src/FFI_wasm.rs
@@ -37,6 +37,6 @@ pub fn callFunction(
     _args: metamodelica::Array<Arc<Expression::NFExpression>>,
     _specs: metamodelica::Array<ArgSpec>,
     _returnType: Arc<Type::NFType>,
-) -> Result<(Arc<Expression::NFExpression>, Arc<metamodelica::List<Arc<Expression::NFExpression>>>)> {
+) -> Result<(Arc<Expression::NFExpression>, metamodelica::List<Arc<Expression::NFExpression>>)> {
     return Err("FFI.callFunction: external \"C\" evaluation (dlopen+libffi) is unavailable on this target")
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/Curl.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/Curl.rs
@@ -30,7 +30,6 @@
 use std::collections::VecDeque;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
-use std::sync::Arc;
 use std::time::Duration;
 
 use metamodelica::Result;
@@ -67,7 +66,7 @@ impl Shared {
 /// `c_add_message(NULL, -1, ErrorType_runtime, ErrorLevel_error, ...)`
 /// equivalent: an ad-hoc runtime error with no source location.
 fn add_error(template: &str, tokens: Vec<ArcStr>) -> Result<()> {
-    let mut toks: Arc<List<ArcStr>> = Arc::new(List::Nil);
+    let mut toks: List<ArcStr> = metamodelica::nil();
     for t in tokens.into_iter().rev() {
         toks = metamodelica::cons(t, toks);
     }
@@ -178,15 +177,15 @@ fn worker(shared: &Shared) {
 }
 
 pub fn multiDownload(
-    urlFileList: Arc<List<(Arc<List<ArcStr>>, ArcStr)>>,
+    urlFileList: List<(List<ArcStr>, ArcStr)>,
     maxParallel: i32,
 ) -> Result<bool> {
     let mut queue: VecDeque<WorkItem> = VecDeque::new();
     let mut cur = urlFileList;
-    while let List::Cons { head: (urls, filename), tail } = &*cur {
+    while let metamodelica::ListNode::Cons { head: (urls, filename), tail } = &*cur {
         let mut mirror_urls = VecDeque::new();
         let mut u = urls.clone();
-        while let List::Cons { head, tail } = &*u {
+        while let metamodelica::ListNode::Cons { head, tail } = &*u {
             mirror_urls.push_back(head.clone());
             let tail = tail.clone();
             u = tail;
@@ -223,7 +222,7 @@ mod tests {
     use super::*;
     use metamodelica::{cons, nil};
 
-    fn item(urls: &[&str], file: &str) -> (Arc<List<ArcStr>>, ArcStr) {
+    fn item(urls: &[&str], file: &str) -> (List<ArcStr>, ArcStr) {
         let mut l = nil::<ArcStr>();
         for u in urls.iter().rev() {
             l = cons(ArcStr::from(*u), l);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/Curl_wasm.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/Curl_wasm.rs
@@ -43,13 +43,13 @@ pub fn take_pending_downloads() -> Vec<(Vec<String>, String)> {
 /// the VFS; otherwise record it as pending and fail. `maxParallel` is unused — the
 /// host fetches the pending list. Returns whether every file was already present.
 pub fn multiDownload(
-    urlFileList: Arc<List<(Arc<List<ArcStr>>, ArcStr)>>,
+    urlFileList: List<(List<ArcStr>, ArcStr)>,
     _maxParallel: i32,
 ) -> Result<bool> {
     let mut all_present = true;
 
     let mut cur = urlFileList;
-    while let List::Cons { head: (urls, filename), tail } = &*cur {
+    while let metamodelica::ListNode::Cons { head: (urls, filename), tail } = &*cur {
         if openmodelica_wasi::read(filename.as_str()).is_none() {
             // Flatten this item's mirror URLs and record it for the host to fetch.
             // A single command can ask for the same file repeatedly before it is
@@ -61,7 +61,7 @@ pub fn multiDownload(
             if !dup {
                 let mut mirrors: Vec<String> = Vec::new();
                 let mut u = urls.clone();
-                while let List::Cons { head, tail } = &*u {
+                while let metamodelica::ListNode::Cons { head, tail } = &*u {
                     mirrors.push(head.to_string());
                     let tail = tail.clone();
                     u = tail;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/DynLoadExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/DynLoadExt.rs
@@ -492,7 +492,7 @@ fn desc_to_value(d: &TypeDesc) -> Result<Arc<Values::Value>> {
                 let e = unsafe { &*elems.add(i) };
                 vals.push(desc_to_value(e)?);
             }
-            Ok(Arc::new(Values::Value::TUPLE { valueLst: Arc::new(List::from_iter(vals)) }))
+            Ok(Arc::new(Values::Value::TUPLE { valueLst: List::from_iter(vals) }))
         }
         TD_RECORD => {
             // union: d0 = record name, d1 = count, d2 = names, d3 = elements.
@@ -512,8 +512,8 @@ fn desc_to_value(d: &TypeDesc) -> Result<Arc<Values::Value>> {
             }
             Ok(Arc::new(Values::Value::RECORD {
                 record_: underscore_name_to_path(&read_c_str(d.d0 as *const c_char)?),
-                orderd: Arc::new(List::from_iter(vals)),
-                comp: Arc::new(List::from_iter(comps)),
+                orderd: List::from_iter(vals),
+                comp: List::from_iter(comps),
                 index: -1,
             }))
         }
@@ -568,8 +568,8 @@ fn decode_array_level(tag: i32, dims: &[i64], cursor: &mut *const u8) -> Result<
         }
     }
     Ok(Arc::new(Values::Value::ARRAY {
-        valueLst: Arc::new(List::from_iter(items)),
-        dimLst: Arc::new(List::from_iter(dims.iter().map(|d| *d as i32))),
+        valueLst: List::from_iter(items),
+        dimLst: List::from_iter(dims.iter().map(|d| *d as i32)),
     }))
 }
 
@@ -623,7 +623,7 @@ fn decode_metatype(m: usize) -> Result<Arc<Values::Value>> {
                 items.push(decode_metatype(unsafe { slot(b, 1) })?);
                 cur = unsafe { slot(b, 2) };
             }
-            Ok(Arc::new(Values::Value::LIST { valueLst: Arc::new(List::from_iter(items)) }))
+            Ok(Arc::new(Values::Value::LIST { valueLst: List::from_iter(items) }))
         }
         _ if hdr == MMC_NONEHDR => Ok(Arc::new(Values::Value::OPTION { some: None })),
         _ if hdr == MMC_SOMEHDR => {
@@ -635,7 +635,7 @@ fn decode_metatype(m: usize) -> Result<Arc<Values::Value>> {
             for i in 1..=n {
                 items.push(decode_metatype(unsafe { slot(base, i) })?);
             }
-            Ok(Arc::new(Values::Value::META_ARRAY { valueLst: Arc::new(List::from_iter(items)) }))
+            Ok(Arc::new(Values::Value::META_ARRAY { valueLst: List::from_iter(items) }))
         }
         // Constructor 0 with at least one field is a MetaModelica tuple.
         (0, n) if n >= 1 => {
@@ -643,7 +643,7 @@ fn decode_metatype(m: usize) -> Result<Arc<Values::Value>> {
             for i in 1..=n {
                 items.push(decode_metatype(unsafe { slot(base, i) })?);
             }
-            Ok(Arc::new(Values::Value::META_TUPLE { valueLst: Arc::new(List::from_iter(items)) }))
+            Ok(Arc::new(Values::Value::META_TUPLE { valueLst: List::from_iter(items) }))
         }
         // Constructor >= 2 is a record/uniontype instance: slot 1 points
         // (untagged) at the generated `record_description`, the fields follow.
@@ -660,8 +660,8 @@ fn decode_metatype(m: usize) -> Result<Arc<Values::Value>> {
             }
             Ok(Arc::new(Values::Value::RECORD {
                 record_: underscore_name_to_path(&read_c_str(desc.path)?),
-                orderd: Arc::new(List::from_iter(vals)),
-                comp: Arc::new(List::from_iter(comps)),
+                orderd: List::from_iter(vals),
+                comp: List::from_iter(comps),
                 index: c as i32 - 3,
             }))
         }
@@ -817,7 +817,7 @@ pub extern "C" fn omc_Error_getCurrentComponent(
     str_box as *mut c_void
 }
 
-pub fn executeFunction(handle: i32, values: Arc<List<Arc<Values::Value>>>, _debug: bool) -> Result<Arc<Values::Value>> {
+pub fn executeFunction(handle: i32, values: List<Arc<Values::Value>>, _debug: bool) -> Result<Arc<Values::Value>> {
     let addr = dynload::function_addr(handle)?;
     let thread_data = dynload::thread_data()? as *mut c_void;
 
@@ -841,7 +841,7 @@ pub fn executeFunction(handle: i32, values: Arc<List<Arc<Values::Value>>>, _debu
     result
 }
 
-fn executeFunctionGuarded(addr: usize, thread_data: *mut c_void, values: &Arc<List<Arc<Values::Value>>>) -> Result<Arc<Values::Value>> {
+fn executeFunctionGuarded(addr: usize, thread_data: *mut c_void, values: &List<Arc<Values::Value>>) -> Result<Arc<Values::Value>> {
     let rt = MmcAlloc::resolve()?;
     // Generated functions read the compiler flags through the dlopened
     // runtime's global roots; keep them in sync with the host's (see

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/SimulationResults.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/SimulationResults.rs
@@ -242,7 +242,7 @@ struct CachedReader {
 static READER_CACHE: Mutex<Option<CachedReader>> = Mutex::new(None);
 
 fn err(msg: &ErrorTypes::Message, tokens: impl IntoIterator<Item = ArcStr>) -> Result<()> {
-    Error::addMessage(msg.clone(), Arc::new(List::from_iter(tokens)))
+    Error::addMessage(msg.clone(), List::from_iter(tokens))
 }
 
 /// Lock the cache and ensure it holds an open reader for `filename`, reopening
@@ -276,12 +276,12 @@ fn mk_real(x: f64) -> Arc<Values::Value> {
 /// the new outer dimension is prepended to the inner array's `dimLst`.
 fn make_array(vals: Vec<Arc<Values::Value>>) -> Arc<Values::Value> {
     let n = vals.len() as i32;
-    let inner_dims: Arc<List<i32>> = match vals.first().map(|v| &**v) {
+    let inner_dims: List<i32> = match vals.first().map(|v| &**v) {
         Some(Values::ARRAY { dimLst, .. }) => dimLst.clone(),
-        _ => Arc::new(List::Nil),
+        _ => metamodelica::nil(),
     };
     Arc::new(Values::ARRAY {
-        valueLst: Arc::new(List::from_iter(vals)),
+        valueLst: List::from_iter(vals),
         dimLst: metamodelica::cons(n, inner_dims),
     })
 }
@@ -351,13 +351,13 @@ pub fn val(mut filename: ArcStr, mut varname: ArcStr, mut timeStamp: metamodelic
     }
 }
 
-pub fn readVariables(mut filename: ArcStr, mut readParameters: bool, mut openmodelicaStyle: bool) -> Result<Arc<metamodelica::List<ArcStr>>> {
+pub fn readVariables(mut filename: ArcStr, mut readParameters: bool, mut openmodelicaStyle: bool) -> Result<metamodelica::List<ArcStr>> {
     // C: SimulationResults_readVariables — list the variable names stored in
     // a result file (sorted), optionally including parameters and converting
     // der()-style names to OpenModelica style.
     let mut guard = match lock_reader(&filename)? {
         Some(g) => g,
-        None => return Ok(Arc::new(List::Nil)),
+        None => return Ok(metamodelica::nil()),
     };
     // C `makeOMCStyle`.
     let omc_style = |name: &str| -> ArcStr {
@@ -390,10 +390,10 @@ pub fn readVariables(mut filename: ArcStr, mut readParameters: bool, mut openmod
             names = reader.variables.iter().filter(|v| !v.is_empty()).map(|v| omc_style(v)).collect();
         }
     }
-    Ok(Arc::new(List::from_iter(names)))
+    Ok(List::from_iter(names))
 }
 
-pub fn readDataset(mut filename: ArcStr, mut vars: Arc<metamodelica::List<ArcStr>>, mut dimsize: i32) -> Result<Arc<Values::Value>> {
+pub fn readDataset(mut filename: ArcStr, mut vars: metamodelica::List<ArcStr>, mut dimsize: i32) -> Result<Arc<Values::Value>> {
     // C: SimulationResults_readDataset — read the full trajectories of the
     // given variables, returning a Values.ARRAY matrix (variable-major rows,
     // time-major columns). This combines the external `readDataset_work`
@@ -862,7 +862,7 @@ fn write_log_file(
     openmodelica_wasi::fs::write(filename, s.as_bytes())
 }
 
-pub fn cmpSimulationResults(mut runningTestsuite: bool, mut filename: ArcStr, mut reffilename: ArcStr, mut logfilename: ArcStr, mut refTol: metamodelica::Real, mut absTol: metamodelica::Real, mut vars: Arc<metamodelica::List<ArcStr>>) -> Result<Arc<metamodelica::List<ArcStr>>> {
+pub fn cmpSimulationResults(mut runningTestsuite: bool, mut filename: ArcStr, mut reffilename: ArcStr, mut logfilename: ArcStr, mut refTol: metamodelica::Real, mut absTol: metamodelica::Real, mut vars: metamodelica::List<ArcStr>) -> Result<metamodelica::List<ArcStr>> {
     // C: SimulationResults_cmpSimulationResults ->
     //    SimulationResultsCmp_compareResults(isResultCmp=1, isHtml=0).
     let reltol = refTol.into_inner();
@@ -872,14 +872,14 @@ pub fn cmpSimulationResults(mut runningTestsuite: bool, mut filename: ArcStr, mu
         Some(r) => r,
         None => {
             err(&ERROR_OPEN_FILE, [filename.clone()])?;
-            return Ok(Arc::new(List::Nil));
+            return Ok(metamodelica::nil());
         }
     };
     let mut reader_ref = match open_reporting(&reffilename)? {
         Some(r) => r,
         None => {
             err(&ERROR_OPEN_REFFILE, [reffilename.clone()])?;
-            return Ok(Arc::new(List::Nil));
+            return Ok(metamodelica::nil());
         }
     };
 
@@ -892,7 +892,7 @@ pub fn cmpSimulationResults(mut runningTestsuite: bool, mut filename: ArcStr, mu
         cmpvars = allvarsref.clone();
         if cmpvars.is_empty() {
             err(&ERROR_GET_VARS, [])?;
-            return Ok(Arc::new(List::Nil));
+            return Ok(metamodelica::nil());
         }
     }
 
@@ -908,14 +908,14 @@ pub fn cmpSimulationResults(mut runningTestsuite: bool, mut filename: ArcStr, mu
         Some(t) if !t.is_empty() => t,
         _ => {
             err(&ERROR_GET_TIME, [])?;
-            return Ok(Arc::new(List::Nil));
+            return Ok(metamodelica::nil());
         }
     };
     let timeref = match get_data(&mut reader_ref, timeref_name, &ref_file)? {
         Some(t) if !t.is_empty() => t,
         _ => {
             err(&ERROR_GET_TIME_REF, [])?;
-            return Ok(Arc::new(List::Nil));
+            return Ok(metamodelica::nil());
         }
     };
 
@@ -937,7 +937,7 @@ pub fn cmpSimulationResults(mut runningTestsuite: bool, mut filename: ArcStr, mu
                 severity: ErrorTypes::Severity::WARNING,
                 message: ArcStr::from(buf),
             },
-            Arc::new(List::Nil),
+            metamodelica::nil(),
         )?;
     }
 
@@ -981,7 +981,7 @@ pub fn cmpSimulationResults(mut runningTestsuite: bool, mut filename: ArcStr, mu
                 severity: ErrorTypes::Severity::WARNING,
                 message: literal!("Cannot write to the difference (.csv) file!\n"),
             },
-            Arc::new(List::Nil),
+            metamodelica::nil(),
         )?;
     }
 
@@ -993,13 +993,13 @@ pub fn cmpSimulationResults(mut runningTestsuite: bool, mut filename: ArcStr, mu
                 severity: ErrorTypes::Severity::WARNING,
                 message: literal!("Files not Equal\n"),
             },
-            Arc::new(List::Nil),
+            metamodelica::nil(),
         )?;
         let mut items = vec![literal!("Files not Equal!")];
         items.extend(diff_vars.into_iter().rev());
-        Ok(Arc::new(List::from_iter(items)))
+        Ok(List::from_iter(items))
     } else {
-        Ok(Arc::new(List::from_iter([literal!("Files Equal!")])))
+        Ok(List::from_iter([literal!("Files Equal!")]))
     }
 }
 
@@ -1046,7 +1046,7 @@ fn delta_data(method: &ErrorMethod, time: &[f64], reftime: &[f64], data: &[f64],
     }
 }
 
-pub fn deltaSimulationResults(mut filename: ArcStr, mut reffilename: ArcStr, mut method: ArcStr, mut vars: Arc<metamodelica::List<ArcStr>>) -> Result<metamodelica::Real> {
+pub fn deltaSimulationResults(mut filename: ArcStr, mut reffilename: ArcStr, mut method: ArcStr, mut vars: metamodelica::List<ArcStr>) -> Result<metamodelica::Real> {
     // C: SimulationResults_deltaSimulationResults -> SimulationResultsCmp_deltaResults.
     let errmethod = match method.as_str() {
         "1norm" => ErrorMethod::Norm1,
@@ -1060,7 +1060,7 @@ pub fn deltaSimulationResults(mut filename: ArcStr, mut reffilename: ArcStr, mut
                     severity: ErrorTypes::Severity::WARNING,
                     message: literal!("Unknown method string: %s. 1-Norm is chosen."),
                 },
-                Arc::new(List::from_iter([method.clone()])),
+                List::from_iter([method.clone()]),
             )?;
             ErrorMethod::Norm1
         }
@@ -1141,7 +1141,7 @@ pub fn deltaSimulationResults(mut filename: ArcStr, mut reffilename: ArcStr, mut
     Ok(OrderedFloat(res))
 }
 
-pub fn diffSimulationResults(mut runningTestsuite: bool, mut filename: ArcStr, mut reffilename: ArcStr, mut prefix: ArcStr, mut refTol: metamodelica::Real, mut relTolDiffMaxMin: metamodelica::Real, mut rangeDelta: metamodelica::Real, mut vars: Arc<metamodelica::List<ArcStr>>, mut keepEqualResults: bool) -> Result<(bool, Arc<metamodelica::List<ArcStr>>)> {
+pub fn diffSimulationResults(mut runningTestsuite: bool, mut filename: ArcStr, mut reffilename: ArcStr, mut prefix: ArcStr, mut refTol: metamodelica::Real, mut relTolDiffMaxMin: metamodelica::Real, mut rangeDelta: metamodelica::Real, mut vars: metamodelica::List<ArcStr>, mut keepEqualResults: bool) -> Result<(bool, metamodelica::List<ArcStr>)> {
     // C: SimulationResults_diffSimulationResults ->
     //    SimulationResultsCmp_compareResults(isResultCmp=0, isHtml=0).
     let reltol = refTol.into_inner();
@@ -1152,14 +1152,14 @@ pub fn diffSimulationResults(mut runningTestsuite: bool, mut filename: ArcStr, m
         Some(r) => r,
         None => {
             err(&ERROR_OPEN_FILE, [filename.clone()])?;
-            return Ok((false, Arc::new(List::Nil)));
+            return Ok((false, metamodelica::nil()));
         }
     };
     let mut reader_ref = match open_reporting(&reffilename)? {
         Some(r) => r,
         None => {
             err(&ERROR_OPEN_REFFILE, [reffilename.clone()])?;
-            return Ok((false, Arc::new(List::Nil)));
+            return Ok((false, metamodelica::nil()));
         }
     };
 
@@ -1170,7 +1170,7 @@ pub fn diffSimulationResults(mut runningTestsuite: bool, mut filename: ArcStr, m
         cmpvars = allvarsref.clone();
         if cmpvars.is_empty() {
             err(&ERROR_GET_VARS, [])?;
-            return Ok((false, Arc::new(List::Nil)));
+            return Ok((false, metamodelica::nil()));
         }
     }
 
@@ -1186,14 +1186,14 @@ pub fn diffSimulationResults(mut runningTestsuite: bool, mut filename: ArcStr, m
         Some(t) if !t.is_empty() => t,
         _ => {
             err(&ERROR_GET_TIME, [])?;
-            return Ok((false, Arc::new(List::Nil)));
+            return Ok((false, metamodelica::nil()));
         }
     };
     let timeref = match get_data(&mut reader_ref, timeref_name, &ref_file)? {
         Some(t) if !t.is_empty() => t,
         _ => {
             err(&ERROR_GET_TIME_REF, [])?;
-            return Ok((false, Arc::new(List::Nil)));
+            return Ok((false, metamodelica::nil()));
         }
     };
 
@@ -1215,7 +1215,7 @@ pub fn diffSimulationResults(mut runningTestsuite: bool, mut filename: ArcStr, m
                 severity: ErrorTypes::Severity::WARNING,
                 message: ArcStr::from(buf),
             },
-            Arc::new(List::Nil),
+            metamodelica::nil(),
         )?;
     }
 
@@ -1251,7 +1251,7 @@ pub fn diffSimulationResults(mut runningTestsuite: bool, mut filename: ArcStr, m
     }
 
     let success = diff_vars.is_empty();
-    Ok((success, Arc::new(List::from_iter(diff_vars))))
+    Ok((success, List::from_iter(diff_vars)))
 }
 
 pub fn diffSimulationResultsHtml(mut runningTestsuite: bool, mut filename: ArcStr, mut reffilename: ArcStr, mut refTol: metamodelica::Real, mut relTolDiffMaxMin: metamodelica::Real, mut rangeDelta: metamodelica::Real, mut var: ArcStr) -> Result<ArcStr> {
@@ -1499,7 +1499,7 @@ fn filter_csv_input(
     Ok(true)
 }
 
-pub fn filterSimulationResults(mut inFile: ArcStr, mut outFile: ArcStr, mut vars: Arc<metamodelica::List<ArcStr>>, mut numberOfIntervals: i32, mut removeDescription: bool, mut hintReadAllVars: bool) -> Result<bool> {
+pub fn filterSimulationResults(mut inFile: ArcStr, mut outFile: ArcStr, mut vars: metamodelica::List<ArcStr>, mut numberOfIntervals: i32, mut removeDescription: bool, mut hintReadAllVars: bool) -> Result<bool> {
     // C: SimulationResults_filterSimulationResults — copy a result file keeping
     // only the requested variables (optionally resampled to `numberOfIntervals`
     // intervals). MATLAB v4 and Arrow input (the C switch has only the former);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/UnitParserExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/UnitParserExt.rs
@@ -27,7 +27,6 @@
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;
-use std::sync::Arc;
 
 use metamodelica::Result;
 use arcstr::{ArcStr, literal};
@@ -563,7 +562,7 @@ impl UnitParser {
     /// All unit symbols, in reverse key order (the C++ prepends while iterating
     /// the sorted map). `getDerivedUnits` relies on this to ultimately produce
     /// an ascending list.
-    fn all_unit_symbols(&self) -> Arc<List<ArcStr>> {
+    fn all_unit_symbols(&self) -> List<ArcStr> {
         let mut res = nil();
         for u in self.units.values() {
             res = cons(ArcStr::from(u.unit_symbol.as_str()), res);
@@ -1043,11 +1042,11 @@ pub fn initSIUnits() {
 }
 
 pub fn unit2str(
-    noms: Arc<List<i32>>,
-    denoms: Arc<List<i32>>,
-    tpnoms: Arc<List<i32>>,
-    tpdenoms: Arc<List<i32>>,
-    tpstrs: Arc<List<ArcStr>>,
+    noms: List<i32>,
+    denoms: List<i32>,
+    tpnoms: List<i32>,
+    tpdenoms: List<i32>,
+    tpstrs: List<ArcStr>,
     _scaleFactor: Real,
     _offset: Real,
 ) -> ArcStr {
@@ -1071,11 +1070,11 @@ pub fn unit2str(
 pub fn str2unit(
     res: ArcStr,
 ) -> Result<(
-    Arc<List<i32>>,
-    Arc<List<i32>>,
-    Arc<List<i32>>,
-    Arc<List<i32>>,
-    Arc<List<ArcStr>>,
+    List<i32>,
+    List<i32>,
+    List<i32>,
+    List<i32>,
+    List<ArcStr>,
     Real,
     Real,
 )> {
@@ -1086,7 +1085,7 @@ pub fn str2unit(
         // Matches the C++ `Error parsing unit <str>: <reason>` message.
         Error::addMessage(
             ERROR_PARSING_UNIT.clone(),
-            Arc::new(List::from_iter([ArcStr::from(input), ArcStr::from(e.message())])),
+            List::from_iter([ArcStr::from(input), ArcStr::from(e.message())]),
         )?;
         return Err("Error parsing unit {}: {}");
     }
@@ -1094,18 +1093,18 @@ pub fn str2unit(
     let scale_factor = unit.scale_factor.to_real() * 10f64.powf(unit.prefix_expo.to_real());
     let offset = unit.offset.to_real();
 
-    let noms = Arc::new(List::from_iter(unit.unit_vec.iter().map(|r| r.num as i32)));
-    let denoms = Arc::new(List::from_iter(unit.unit_vec.iter().map(|r| r.denom as i32)));
-    let tpnoms = Arc::new(List::from_iter(unit.type_param_vec.values().map(|r| r.num as i32)));
-    let tpdenoms = Arc::new(List::from_iter(unit.type_param_vec.values().map(|r| r.denom as i32)));
-    let tpstrs = Arc::new(List::from_iter(
+    let noms = List::from_iter(unit.unit_vec.iter().map(|r| r.num as i32));
+    let denoms = List::from_iter(unit.unit_vec.iter().map(|r| r.denom as i32));
+    let tpnoms = List::from_iter(unit.type_param_vec.values().map(|r| r.num as i32));
+    let tpdenoms = List::from_iter(unit.type_param_vec.values().map(|r| r.denom as i32));
+    let tpstrs = List::from_iter(
         unit.type_param_vec.keys().map(|k| ArcStr::from(k.as_str())),
-    ));
+    );
 
     Ok((noms, denoms, tpnoms, tpdenoms, tpstrs, OrderedFloat(scale_factor), OrderedFloat(offset)))
 }
 
-pub fn allUnitSymbols() -> Arc<List<ArcStr>> {
+pub fn allUnitSymbols() -> List<ArcStr> {
     with_state(|s| s.parser.all_unit_symbols())
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/Unzip.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_script_util/src/Unzip.rs
@@ -22,7 +22,6 @@
 #![allow(non_snake_case)]
 
 use std::io::Read;
-use std::sync::Arc;
 
 use arcstr::ArcStr;
 use metamodelica::List;
@@ -34,7 +33,7 @@ use openmodelica_error::ErrorTypes;
 /// to push the message are ignored — this function is itself only used on
 /// error paths that already return `false`.
 fn add_error(template: &str, tokens: &[&str]) {
-    let mut toks: Arc<List<ArcStr>> = Arc::new(List::Nil);
+    let mut toks: List<ArcStr> = metamodelica::nil();
     for t in tokens.iter().rev() {
         toks = metamodelica::cons(ArcStr::from(*t), toks);
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Autoconf.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Autoconf.rs
@@ -44,7 +44,6 @@
  */
 #![allow(non_upper_case_globals, non_snake_case, dead_code)]
 
-use std::sync::Arc;
 
 use arcstr::{literal, ArcStr};
 use metamodelica::list;
@@ -232,7 +231,7 @@ pub const corbaLibs: &str = "";
 /// requested at configure time; mirror the default.
 pub const hwloc: &str = "";
 
-pub static systemLibs: std::sync::LazyLock<Arc<metamodelica::List<ArcStr>>> =
+pub static systemLibs: std::sync::LazyLock<metamodelica::List<ArcStr>> =
     std::sync::LazyLock::new(|| {
         if isWindows {
             // Autoconf.mo.omdev.mingw: constant list<String> systemLibs = {};

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/FMIExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/FMIExt.rs
@@ -39,7 +39,6 @@
 #![allow(non_snake_case)]
 
 use std::io::Read;
-use std::sync::Arc;
 
 use metamodelica::Result;
 use arcstr::ArcStr;
@@ -59,7 +58,7 @@ const CS_UNSUPPORTED_ERR: &str =
 /// `c_add_message(NULL, -1, ErrorType_scripting, ErrorLevel_error, ...)`
 /// equivalent: an ad-hoc scripting error with no source location.
 fn add_scripting_error(template: &str, tokens: &[&str]) {
-    let mut toks: Arc<List<ArcStr>> = Arc::new(List::Nil);
+    let mut toks: List<ArcStr> = metamodelica::nil();
     for t in tokens.iter().rev() {
         toks = metamodelica::cons(ArcStr::from(*t), toks);
     }
@@ -113,10 +112,10 @@ type InitializeFMIImportResult = (
     Option<i32>,                            // outFMIContext
     Option<i32>,                            // outFMIInstance
     FMI::Info,                              // outFMIInfo
-    Arc<List<FMI::TypeDefinitions>>,        // outTypeDefinitionsList
+    List<FMI::TypeDefinitions>,        // outTypeDefinitionsList
     FMI::ExperimentAnnotation,              // outExperimentAnnotation
     Option<i32>,                            // outModelVariablesInstance
-    Arc<List<FMI::ModelVariables>>,         // outModelVariablesList
+    List<FMI::ModelVariables>,         // outModelVariablesList
 );
 
 /// The all-defaults failure tuple: `result = false`, everything else empty.
@@ -300,8 +299,8 @@ fn attr_or_empty(node: &roxmltree::Node, name: &str) -> ArcStr {
 
 /// `[n, n-1, .., 1]` — the C builds these by consing 1..n and never
 /// reverses them.
-fn descending_int_list(n: u32) -> Arc<List<i32>> {
-    let mut list: Arc<List<i32>> = metamodelica::nil();
+fn descending_int_list(n: u32) -> List<i32> {
+    let mut list: List<i32> = metamodelica::nil();
     for i in 1..=n as i64 {
         list = metamodelica::cons(i as i32, list);
     }
@@ -480,8 +479,8 @@ fn parse_default_experiment(root: &roxmltree::Node<'_, '_>, version: u32) -> Opt
 
 /// Prepend `items` (already in fmilib order) onto a list, so the result is
 /// reversed exactly like the C `mmc_mk_cons` loops produce.
-fn prepended_list<T: Clone>(items: impl IntoIterator<Item = T>) -> Arc<List<T>> {
-    let mut list: Arc<List<T>> = metamodelica::nil();
+fn prepended_list<T: Clone>(items: impl IntoIterator<Item = T>) -> List<T> {
+    let mut list: List<T> = metamodelica::nil();
     for item in items {
         list = metamodelica::cons(item, list);
     }
@@ -520,9 +519,9 @@ fn enumeration_items(
 
 type ParsedModelDescription = (
     FMI::Info,
-    Arc<List<FMI::TypeDefinitions>>,
+    List<FMI::TypeDefinitions>,
     FMI::ExperimentAnnotation,
-    Arc<List<FMI::ModelVariables>>,
+    List<FMI::ModelVariables>,
 );
 
 fn parse_fmi2(
@@ -722,7 +721,7 @@ fn parse_type_definitions(
     root: &roxmltree::Node<'_, '_>,
     type_tag: &'static str,
     explicit_values: bool,
-) -> Option<Arc<List<FMI::TypeDefinitions>>> {
+) -> Option<List<FMI::TypeDefinitions>> {
     let mut enums: Vec<FMI::TypeDefinitions> = Vec::new();
     if let Some(td) = child_element(root, "TypeDefinitions") {
         for ty in element_children(&td, type_tag) {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Globals.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Globals.rs
@@ -67,7 +67,7 @@ thread_local! {
     ///
     /// Stores the list of active try/throw levels during code generation.
     /// Source: `SimCodeFunctionUtil.mo`.
-    pub static codegenTryThrowIndex: RefCell<Arc<metamodelica::List<i32>>> =
+    pub static codegenTryThrowIndex: RefCell<metamodelica::List<i32>> =
         RefCell::new(metamodelica::nil());
 
     /// Index 2 — Codegen function list.
@@ -99,20 +99,20 @@ thread_local! {
 
     // Index 10 — instNFInstCacheIndex
     // Declared in openmodelica_frontend::Globals.
-    // Type: Arc<List<((Absyn::Program, Arc<Absyn::Path>),
-    //               (Arc<List<Arc<SCode::Element>>>, ArcStr, Arc<InstNode::InstNode>))>>
+    // Type: List<((Absyn::Program, Arc<Absyn::Path>),
+    //               (List<Arc<SCode::Element>>, ArcStr, Arc<InstNode::InstNode>))>
 
     // Index 11 — instNFNodeCacheIndex
     // Declared in openmodelica_frontend::Globals.
-    // Type: Arc<List<(Absyn::Program,
-    //               (Arc<List<Arc<SCode::Element>>>, Arc<InstNode::InstNode>))>>
+    // Type: List<(Absyn::Program,
+    //               (List<Arc<SCode::Element>>, Arc<InstNode::InstNode>))>
 
     // Index 12 — instNFLookupCacheIndex
     // Declared in openmodelica_frontend::Globals. Same type as index 10.
 
     // Index 13 — builtinIndex
     // Declared in openmodelica_frontend::Globals.
-    // Type: Arc<List<((i32, bool), (Absyn::Program, Arc<List<Arc<SCode::Element>>>))>>
+    // Type: List<((i32, bool), (Absyn::Program, List<Arc<SCode::Element>>))>
 
     // Index 14 — builtinEnvIndex
     // Type: unknown; not used in generated code seen so far.
@@ -150,11 +150,11 @@ thread_local! {
 
     // Index 18 — builtinGraphIndex
     // Declared in openmodelica_frontend::Globals.
-    // Type: Arc<List<(i32, FCore::Graph)>> — from openmodelica_frontend::Builtin.
+    // Type: List<(i32, FCore::Graph)> — from openmodelica_frontend::Builtin.
 
     // Index 19 — rewriteRulesIndex
     // Declared in openmodelica_backend::Globals.
-    // Type: Option<Arc<List<RewriteRules::Rule>>> — from openmodelica_backend::RewriteRules.
+    // Type: Option<List<RewriteRules::Rule>> — from openmodelica_backend::RewriteRules.
 
     /// Index 20 — Stack-overflow sentinel.
     ///
@@ -216,7 +216,7 @@ thread_local! {
 
     // Index 26 — interactiveCache
     // Declared in openmodelica_backend::Globals.
-    // Type: Option<Arc<List<(Absyn::Program, Arc<Absyn::Path>, Interactive::GraphicEnvCache)>>>
+    // Type: Option<List<(Absyn::Program, Arc<Absyn::Path>, Interactive::GraphicEnvCache)>>
 
     /// Index 27 — Whether currently processing stream connectors.
     ///
@@ -245,7 +245,7 @@ thread_local! {
     /// Stores a list of `(library_path, handle)` pairs for already-opened
     /// shared libraries.  Initialised to `nil()` by `Global.initialize`.
     /// Source: `NFEvalFunction.mo`.
-    pub static sharedLibraryCacheIndex: RefCell<Arc<metamodelica::List<(ArcStr, i32)>>> =
+    pub static sharedLibraryCacheIndex: RefCell<metamodelica::List<(ArcStr, i32)>> =
         RefCell::new(metamodelica::nil());
 
     // Index 31 — backendInterface
@@ -261,6 +261,6 @@ thread_local! {
     /// Index 36 — Build projects already run this session, keyed
     /// `<resources>\n<library>\n<forWasm>`; a failed build installs nothing.
     /// Source: `SimCodeFunctionUtil.extLibraryBuildAttempted`.
-    pub static extLibraryBuildIndex: RefCell<Arc<metamodelica::List<ArcStr>>> =
+    pub static extLibraryBuildIndex: RefCell<metamodelica::List<ArcStr>> =
         RefCell::new(metamodelica::nil());
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/IOStreamExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/IOStreamExt.rs
@@ -12,7 +12,6 @@
 
 #![allow(non_snake_case)]
 
-use std::sync::Arc;
 
 use metamodelica::Result;
 use arcstr::ArcStr;
@@ -83,7 +82,7 @@ pub fn printBuffer(_bufferID: i32, _whereToPrint: i32) -> Result<()> {
 /// Concatenate a *reversed* list of strings: the IOStream LIST() backend
 /// conses new chunks onto the head, so the last list element is the first
 /// chunk of the output.
-pub fn appendReversedList(inStringLst: Arc<List<ArcStr>>) -> ArcStr {
+pub fn appendReversedList(inStringLst: List<ArcStr>) -> ArcStr {
     let chunks: Vec<&ArcStr> = (&*inStringLst).into_iter().collect();
     let total: usize = chunks.iter().map(|s| s.len()).sum();
     let mut out = String::with_capacity(total);
@@ -95,7 +94,7 @@ pub fn appendReversedList(inStringLst: Arc<List<ArcStr>>) -> ArcStr {
 
 /// Print a *reversed* list of strings to stdout (`whereToPrint` = 1) or
 /// stderr (= 2); any other destination fails like the C version.
-pub fn printReversedList(inStringLst: Arc<List<ArcStr>>, whereToPrint: i32) -> Result<()> {
+pub fn printReversedList(inStringLst: List<ArcStr>, whereToPrint: i32) -> Result<()> {
     use std::io::Write;
     let chunks: Vec<&ArcStr> = (&*inStringLst).into_iter().collect();
     match whereToPrint {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Lapack.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Lapack.rs
@@ -28,15 +28,14 @@
 
 extern crate openmodelica_lapack;
 
-use std::sync::Arc;
 
 use arcstr::ArcStr;
 use core::ffi::c_char;
 use metamodelica::{List, OrderedFloat, Real, nil};
 
-type Mat = Arc<List<Arc<List<Real>>>>;
-type Vec64 = Arc<List<Real>>;
-type IVec = Arc<List<i32>>;
+type Mat = List<List<Real>>;
+type Vec64 = List<Real>;
+type IVec = List<i32>;
 
 unsafe extern "C" {
     fn dgeev_(
@@ -135,9 +134,9 @@ fn mat_in(rows: i32, cols: i32, data: &Mat) -> Vec<f64> {
 /// Build a `list<list<Real>>` of `rows`×`cols` from a column-major buffer.
 fn mat_out(rows: i32, cols: i32, m: &[f64]) -> Mat {
     let (r, c) = (rows.max(0) as usize, cols.max(0) as usize);
-    Arc::new(List::from_iter((0..r).map(|i| {
-        Arc::new(List::from_iter((0..c).map(|j| OrderedFloat(m[j * r + i]))))
-    })))
+    List::from_iter((0..r).map(|i| {
+        List::from_iter((0..c).map(|j| OrderedFloat(m[j * r + i])))
+    }))
 }
 
 fn vec_in(n: i32, data: &Vec64) -> Vec<f64> {
@@ -154,7 +153,7 @@ fn vec_in(n: i32, data: &Vec64) -> Vec<f64> {
 
 fn vec_out(n: i32, v: &[f64]) -> Vec64 {
     let len = n.max(0) as usize;
-    Arc::new(List::from_iter((0..len).map(|i| OrderedFloat(v[i]))))
+    List::from_iter((0..len).map(|i| OrderedFloat(v[i])))
 }
 
 fn ivec_in(n: i32, data: &IVec) -> Vec<i32> {
@@ -171,7 +170,7 @@ fn ivec_in(n: i32, data: &IVec) -> Vec<i32> {
 
 fn ivec_out(n: i32, v: &[i32]) -> IVec {
     let len = n.max(0) as usize;
-    Arc::new(List::from_iter((0..len).map(|i| v[i])))
+    List::from_iter((0..len).map(|i| v[i]))
 }
 
 /// First byte of a LAPACK single-character option (`"N"`, `"T"`, `"V"`, …).

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/ModelInstanceReference.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/ModelInstanceReference.rs
@@ -226,8 +226,8 @@ pub struct OmcJsonIter {
 pub extern "C" fn omc_json_iter_new(node: *const JSON) -> *mut OmcJsonIter {
     // SAFETY: `node` points into a live, immutable JSON tree.
     let cur = match unsafe { &*node } {
-        JSON::LIST { values } => Cursor::List(Arc::as_ptr(values)),
-        JSON::LIST_OBJECT { values } => Cursor::Object(Arc::as_ptr(values)),
+        JSON::LIST { values } => Cursor::List(values as *const _),
+        JSON::LIST_OBJECT { values } => Cursor::Object(values as *const _),
         _ => return ptr::null_mut(),
     };
     Box::into_raw(Box::new(OmcJsonIter { cur }))
@@ -238,8 +238,8 @@ pub extern "C" fn omc_json_iter_new(node: *const JSON) -> *mut OmcJsonIter {
 pub extern "C" fn omc_json_iter_at_end(it: *const OmcJsonIter) -> c_int {
     let it = unsafe { &*it };
     let at_end = match it.cur {
-        Cursor::List(p) => matches!(unsafe { &*p }, List::Nil),
-        Cursor::Object(p) => matches!(unsafe { &*p }, List::Nil),
+        Cursor::List(p) => unsafe { &*p }.is_empty(),
+        Cursor::Object(p) => unsafe { &*p }.is_empty(),
     };
     if at_end { 1 } else { 0 }
 }
@@ -250,13 +250,13 @@ pub extern "C" fn omc_json_iter_at_end(it: *const OmcJsonIter) -> c_int {
 pub extern "C" fn omc_json_iter_value(it: *const OmcJsonIter) -> *const JSON {
     let it = unsafe { &*it };
     match it.cur {
-        Cursor::List(p) => match unsafe { &*p } {
-            List::Cons { head, .. } => Arc::as_ptr(head),
-            List::Nil => ptr::null(),
+        Cursor::List(p) => match &**unsafe { &*p } {
+            metamodelica::ListNode::Cons { head, .. } => Arc::as_ptr(head),
+            metamodelica::ListNode::Nil => ptr::null(),
         },
-        Cursor::Object(p) => match unsafe { &*p } {
-            List::Cons { head, .. } => Arc::as_ptr(&head.1),
-            List::Nil => ptr::null(),
+        Cursor::Object(p) => match &**unsafe { &*p } {
+            metamodelica::ListNode::Cons { head, .. } => Arc::as_ptr(&head.1),
+            metamodelica::ListNode::Nil => ptr::null(),
         },
     }
 }
@@ -268,12 +268,12 @@ pub extern "C" fn omc_json_iter_value(it: *const OmcJsonIter) -> *const JSON {
 pub extern "C" fn omc_json_iter_key(it: *const OmcJsonIter, len: *mut usize) -> *const c_char {
     let it = unsafe { &*it };
     match it.cur {
-        Cursor::Object(p) => match unsafe { &*p } {
-            List::Cons { head, .. } => {
+        Cursor::Object(p) => match &**unsafe { &*p } {
+            metamodelica::ListNode::Cons { head, .. } => {
                 unsafe { *len = head.0.len() };
                 head.0.as_ptr() as *const c_char
             }
-            List::Nil => {
+            metamodelica::ListNode::Nil => {
                 unsafe { *len = 0 };
                 ptr::null()
             }
@@ -291,13 +291,13 @@ pub extern "C" fn omc_json_iter_advance(it: *mut OmcJsonIter) {
     let it = unsafe { &mut *it };
     match &mut it.cur {
         Cursor::List(p) => {
-            if let List::Cons { tail, .. } = unsafe { &**p } {
-                *p = Arc::as_ptr(tail);
+            if let metamodelica::ListNode::Cons { tail, .. } = unsafe { &***p } {
+                *p = tail as *const _;
             }
         }
         Cursor::Object(p) => {
-            if let List::Cons { tail, .. } = unsafe { &**p } {
-                *p = Arc::as_ptr(tail);
+            if let metamodelica::ListNode::Cons { tail, .. } = unsafe { &***p } {
+                *p = tail as *const _;
             }
         }
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/StackOverflow.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/StackOverflow.rs
@@ -62,13 +62,13 @@ fn unmangle(mut inSymbol: ArcStr) -> Result<ArcStr> {
 fn stripAddresses(mut inSymbol: ArcStr) -> Result<ArcStr> {
     let mut outSymbol: ArcStr = arcstr::literal!("");
     let mut n: i32 = 0;
-    let mut strs: Arc<metamodelica::List<ArcStr>> = metamodelica::nil();
+    let mut strs: metamodelica::List<ArcStr> = metamodelica::nil();
     let mut so: ArcStr = arcstr::literal!("");
     let mut fun: ArcStr = arcstr::literal!("");
     (n, strs) = System::regex((inSymbol.clone()).clone(), (literal!("^([^(]*)[(]([^+]*[^+]*)[+][^)]*[)] *[[]0x[0-9a-fA-F]*[]]$")).clone(), 3, true, false);
     if n.clone() == 3 {
         let (__pa0, __pa1) = ::match_deref::match_deref! { match &(strs.clone()) {
-            Deref @ metamodelica::List::Cons { head: _, tail: Deref @ metamodelica::List::Cons { head: __pa0, tail: Deref @ metamodelica::List::Cons { head: __pa1, tail: Deref @ metamodelica::List::Nil } } } => (__pa0.clone(), __pa1.clone()),
+            Deref @ metamodelica::ListNode::Cons { head: _, tail: Deref @ metamodelica::ListNode::Cons { head: __pa0, tail: Deref @ metamodelica::ListNode::Cons { head: __pa1, tail: Deref @ metamodelica::ListNode::Nil } } } => (__pa0.clone(), __pa1.clone()),
             _ => return Err("pattern mismatch"),
         } };
         so = __pa0.clone();
@@ -78,7 +78,7 @@ fn stripAddresses(mut inSymbol: ArcStr) -> Result<ArcStr> {
         (n, strs) = System::regex((inSymbol.clone()).clone(), (literal!("^[0-9 ]*([A-Za-z0-9.]*) *0x[0-9a-fA-F]* ([A-Za-z0-9_]*) *[+] *[0-9]*$")).clone(), 3, true, false);
         if n.clone() == 3 {
             let (__pa3, __pa4) = ::match_deref::match_deref! { match &(strs.clone()) {
-                Deref @ metamodelica::List::Cons { head: _, tail: Deref @ metamodelica::List::Cons { head: __pa3, tail: Deref @ metamodelica::List::Cons { head: __pa4, tail: Deref @ metamodelica::List::Nil } } } => (__pa3.clone(), __pa4.clone()),
+                Deref @ metamodelica::ListNode::Cons { head: _, tail: Deref @ metamodelica::ListNode::Cons { head: __pa3, tail: Deref @ metamodelica::ListNode::Cons { head: __pa4, tail: Deref @ metamodelica::ListNode::Nil } } } => (__pa3.clone(), __pa4.clone()),
                 _ => return Err("pattern mismatch"),
             } };
             so = __pa3.clone();
@@ -109,8 +109,8 @@ pub fn getReadableMessage(mut delimiter: ArcStr) -> Result<ArcStr> {
     Ok(r#str)
 }
 
-pub fn readableStacktraceMessages() -> Result<Arc<metamodelica::List<ArcStr>>> {
-    let mut symbols: Arc<metamodelica::List<ArcStr>> = metamodelica::nil();
+pub fn readableStacktraceMessages() -> Result<metamodelica::List<ArcStr>> {
+    let mut symbols: metamodelica::List<ArcStr> = metamodelica::nil();
     let mut prev: ArcStr = literal!("");
     let mut n: i32 = 1;
     let mut prevN: i32 = 1;
@@ -119,7 +119,7 @@ pub fn readableStacktraceMessages() -> Result<Arc<metamodelica::List<ArcStr>>> {
         return Ok(symbols.clone());
     }
     for mut symbol in &*({
-        let mut __acc: Arc<metamodelica::List<ArcStr>> = metamodelica::nil();
+        let mut __acc: metamodelica::List<ArcStr> = metamodelica::nil();
         for mut s in (getStacktraceMessages()).into_iter().cloned() {
             let __x = stripAddresses((s.clone()).clone())?;
             __acc = cons(__x, __acc);
@@ -142,8 +142,8 @@ pub fn readableStacktraceMessages() -> Result<Arc<metamodelica::List<ArcStr>>> {
     Ok(symbols)
 }
 
-pub fn getStacktraceMessages() -> Arc<metamodelica::List<ArcStr>> {
-    let mut symbols: Arc<metamodelica::List<ArcStr>> = metamodelica::nil();
+pub fn getStacktraceMessages() -> metamodelica::List<ArcStr> {
+    let mut symbols: metamodelica::List<ArcStr> = metamodelica::nil();
     symbols
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
@@ -111,7 +111,7 @@ fn with<R>(f: impl FnOnce(&mut SysState) -> R) -> R {
 /// Build a `List` (MetaModelica cons-list) from a `Vec`, preserving order
 /// — the rightmost element ends up at the tail. Mirrors `list![..]` for
 /// the dynamic case.
-fn list_from_vec<T: Clone>(xs: Vec<T>) -> Arc<List<T>> {
+fn list_from_vec<T: Clone>(xs: Vec<T>) -> List<T> {
     let mut acc = metamodelica::nil::<T>();
     for x in xs.into_iter().rev() {
         acc = metamodelica::cons(x, acc);
@@ -192,8 +192,8 @@ pub fn regex(
     maxMatches: i32,
     extended: bool,
     ignoreCase: bool,
-) -> (i32, Arc<List<ArcStr>>) {
-    fn list_forward(items: Vec<ArcStr>) -> Arc<List<ArcStr>> {
+) -> (i32, List<ArcStr>) {
+    fn list_forward(items: Vec<ArcStr>) -> List<ArcStr> {
         let mut res = metamodelica::nil();
         for it in items.into_iter().rev() {
             res = metamodelica::cons(it, res);
@@ -297,7 +297,7 @@ pub fn tolower(inString: ArcStr) -> ArcStr {
     ArcStr::from(inString.to_lowercase())
 }
 
-pub fn strtok(string: ArcStr, token: ArcStr) -> Arc<List<ArcStr>> {
+pub fn strtok(string: ArcStr, token: ArcStr) -> List<ArcStr> {
     // C strtok semantics: each char of `token` is a delimiter; empty
     // segments are dropped. Returned as a MetaModelica list.
     let delims: Vec<char> = token.chars().collect();
@@ -309,7 +309,7 @@ pub fn strtok(string: ArcStr, token: ArcStr) -> Arc<List<ArcStr>> {
     list_from_vec(parts)
 }
 
-pub fn strtokIncludingDelimiters(string: ArcStr, token: ArcStr) -> Arc<List<ArcStr>> {
+pub fn strtokIncludingDelimiters(string: ArcStr, token: ArcStr) -> List<ArcStr> {
     // Splits on the *substring* `token` and re-emits the delimiter between
     // the surrounding segments (mirrors `SystemImpl__strtokIncludingDelimiters`).
     if token.is_empty() {
@@ -330,7 +330,7 @@ pub fn strtokIncludingDelimiters(string: ArcStr, token: ArcStr) -> Arc<List<ArcS
     list_from_vec(out)
 }
 
-pub fn splitOnNewline(r#str: ArcStr, includeDelimiter: bool) -> Result<Arc<List<ArcStr>>> {
+pub fn splitOnNewline(r#str: ArcStr, includeDelimiter: bool) -> Result<List<ArcStr>> {
     // Split on '\n' and '\r\n', mirroring `System_splitOnNewline` in
     // `runtime/System_omc.c`. When `includeDelimiter` is true the newline
     // delimiters are emitted as their OWN tokens, not re-attached to the
@@ -562,7 +562,7 @@ pub fn popen(command: ArcStr) -> (ArcStr, i32) {
     }
 }
 
-pub fn systemCallParallel(_inStrings: Arc<List<ArcStr>>, _numThreads: i32) -> Arc<List<i32>> {
+pub fn systemCallParallel(_inStrings: List<ArcStr>, _numThreads: i32) -> List<i32> {
     // Fan-out N shell commands across a thread pool and collect the exit
     // codes. Not used by code paths exercised today; defer until needed.
     todo!("System.systemCallParallel: parallel shell-out not yet ported")
@@ -785,7 +785,7 @@ pub fn setEnv(varName: ArcStr, value: ArcStr, overwrite: bool) -> i32 {
     }
 }
 
-pub fn subDirectories(inString: ArcStr) -> Arc<List<ArcStr>> {
+pub fn subDirectories(inString: ArcStr) -> List<ArcStr> {
     let out: Vec<ArcStr> = openmodelica_wasi::fs::read_dir(inString.as_str())
         .unwrap_or_default()
         .into_iter()
@@ -812,10 +812,10 @@ fn files_with_ext(dir: &str, ext: &str) -> Vec<ArcStr> {
         .collect()
 }
 
-pub fn moFiles(inString: ArcStr) -> Arc<List<ArcStr>> {
+pub fn moFiles(inString: ArcStr) -> List<ArcStr> {
     list_from_vec(files_with_ext(&inString, "mo"))
 }
-pub fn mocFiles(inString: ArcStr) -> Arc<List<ArcStr>> {
+pub fn mocFiles(inString: ArcStr) -> List<ArcStr> {
     list_from_vec(files_with_ext(&inString, "moc"))
 }
 
@@ -877,7 +877,7 @@ fn split_version(version: &str) -> ([i64; MODELICAPATH_LEVELS], String, bool) {
 /// entries whose name is `name`, `name.<ext>` or `name <version>[.<ext>]`,
 /// either as a library directory (containing `package.mo`/`package.moc`)
 /// or as a plain `.mo`/`.moc` file.
-fn get_all_modelica_paths(name: &str, mps: &Arc<List<ArcStr>>) -> Vec<ModelicaPathEntry> {
+fn get_all_modelica_paths(name: &str, mps: &List<ArcStr>) -> Vec<ModelicaPathEntry> {
     let mut res = Vec::new();
     for mp in &**mps {
         for (file, _) in dir_entries(mp.as_str()) {
@@ -1033,8 +1033,8 @@ fn load_model_path_default_target(entries: &[ModelicaPathEntry]) -> Option<&Mode
 /// best available version); fails (MMC_THROW in C) when nothing matches.
 pub fn getLoadModelPath(
     className: ArcStr,
-    prios: Arc<List<ArcStr>>,
-    mps: Arc<List<ArcStr>>,
+    prios: List<ArcStr>,
+    mps: List<ArcStr>,
     requireExactVersion: bool,
 ) -> Result<(ArcStr, ArcStr, bool)> {
     let entries = get_all_modelica_paths(&className, &mps);
@@ -1198,8 +1198,8 @@ pub fn setClassnamesForSimulation(inString: ArcStr) {
 
 pub fn getVariableValue(
     _timeStamp: metamodelica::Real,
-    _timeValues: Arc<List<metamodelica::Real>>,
-    _varValues: Arc<List<metamodelica::Real>>,
+    _timeValues: List<metamodelica::Real>,
+    _varValues: List<metamodelica::Real>,
 ) -> Result<metamodelica::Real> {
     // Linear interpolation of a varValues sample at timeStamp; the C
     // runtime walks the parallel `timeValues` list looking for the
@@ -1747,9 +1747,9 @@ pub fn gccVersion() -> ArcStr {
 // ───────────────────────────────── LAPACK / iconv / printf ───────────────────
 
 pub fn dgesv(
-    A: Arc<List<Arc<List<metamodelica::Real>>>>,
-    B: Arc<List<metamodelica::Real>>,
-) -> Result<(Arc<List<metamodelica::Real>>, i32)> {
+    A: List<List<metamodelica::Real>>,
+    B: List<metamodelica::Real>,
+) -> Result<(List<metamodelica::Real>, i32)> {
     // Port of SystemImpl__dgesv (systemimpl.c), which calls LAPACK `dgesv` to
     // solve the dense linear system A*X = B for a single right-hand side.
     // LAPACK's dgesv is an LU factorization with partial pivoting (dgetrf)
@@ -1772,7 +1772,7 @@ pub fn dgesv(
         return Ok((B.clone(), -1));
     }
     if n == 0 {
-        return Ok((Arc::new(List::Nil), 0));
+        return Ok((metamodelica::nil(), 0));
     }
 
     // Working copy of the matrix: a[i][j] = row i, column j (as in the C code,
@@ -1826,7 +1826,7 @@ pub fn dgesv(
     }
 
     let out = List::from_iter(x.into_iter().map(metamodelica::OrderedFloat));
-    Ok((Arc::new(out), 0))
+    Ok((out, 0))
 }
 
 pub fn reopenStandardStream(_stream: i32, _filename: ArcStr) -> bool {
@@ -2190,9 +2190,9 @@ pub fn numProcessors() -> i32 {
 
 pub fn launchParallelTasks<AnyInput: Clone + 'static, AnyOutput: Clone + 'static>(
     _numThreads: i32,
-    inData: Arc<List<AnyInput>>,
+    inData: List<AnyInput>,
     func: Arc<dyn Fn(AnyInput) -> Result<AnyOutput> + 'static>,
-) -> Result<Arc<List<AnyOutput>>> {
+) -> Result<List<AnyOutput>> {
     // The C runtime (System_omc.c) spawns `numThreads` worker pthreads pulling
     // tasks off a shared queue, but collects the results back in INPUT ORDER
     // (`commands[i] = fn(task[i])`) and itself falls back to a plain serial map
@@ -2210,7 +2210,7 @@ pub fn launchParallelTasks<AnyInput: Clone + 'static, AnyOutput: Clone + 'static
     // `collect`).
     let results: Result<Vec<AnyOutput>> =
         (&*inData).into_iter().map(|x| func(x.clone())).collect();
-    Ok(Arc::new(results?.into_iter().collect::<List<AnyOutput>>()))
+    Ok(results?.into_iter().collect::<List<AnyOutput>>())
 }
 
 // A process-wide pool, sized on first use to the requested thread count and
@@ -2229,15 +2229,15 @@ fn parallel_pool(n: usize) -> Option<&'static rayon::ThreadPool> {
 #[cfg(not(target_arch = "wasm32"))]
 pub fn launchParallelTasksThreaded<AnyInput: Clone + Send + 'static, AnyOutput: Clone + Send + 'static>(
     numThreads: i32,
-    inData: Arc<List<AnyInput>>,
+    inData: List<AnyInput>,
     func: Arc<dyn Fn(AnyInput) -> Result<AnyOutput> + 'static>,
-) -> Result<Arc<List<AnyOutput>>> {
+) -> Result<List<AnyOutput>> {
     use rayon::prelude::*;
 
     let items: Vec<AnyInput> = (&*inData).into_iter().cloned().collect();
     if numThreads <= 1 || items.len() < 2 {
         let results: Result<Vec<AnyOutput>> = items.into_iter().map(|x| func(x)).collect();
-        return Ok(Arc::new(results?.into_iter().collect::<List<AnyOutput>>()));
+        return Ok(results?.into_iter().collect::<List<AnyOutput>>());
     }
 
     struct SendSync<T>(T);
@@ -2270,19 +2270,19 @@ pub fn launchParallelTasksThreaded<AnyInput: Clone + Send + 'static, AnyOutput: 
     for r in results {
         out.push(r?);
     }
-    Ok(Arc::new(out.into_iter().collect::<List<AnyOutput>>()))
+    Ok(out.into_iter().collect::<List<AnyOutput>>())
 }
 
 #[cfg(target_arch = "wasm32")]
 pub fn launchParallelTasksThreaded<AnyInput: Clone + Send + 'static, AnyOutput: Clone + Send + 'static>(
     _numThreads: i32,
-    inData: Arc<List<AnyInput>>,
+    inData: List<AnyInput>,
     func: Arc<dyn Fn(AnyInput) -> Result<AnyOutput> + 'static>,
-) -> Result<Arc<List<AnyOutput>>> {
+) -> Result<List<AnyOutput>> {
     // wasm32-unknown-unknown has no OS threads; run serially.
     let results: Result<Vec<AnyOutput>> =
         (&*inData).into_iter().map(|x| func(x.clone())).collect();
-    Ok(Arc::new(results?.into_iter().collect::<List<AnyOutput>>()))
+    Ok(results?.into_iter().collect::<List<AnyOutput>>())
 }
 
 pub fn exit(status: i32) -> Result<()> {
@@ -2638,7 +2638,7 @@ pub fn stringAllocatorResult<T: Clone + 'static>(sa: StringAllocator, _dummy: T)
     }
 }
 
-pub fn relocateFunctions(_fileName: ArcStr, _names: Arc<List<(ArcStr, ArcStr)>>) -> bool {
+pub fn relocateFunctions(_fileName: ArcStr, _names: List<(ArcStr, ArcStr)>) -> bool {
     // Hot-swap runtime symbols from a fresh .so — needs dlopen + relocation
     // walking. Not used by the Rust-side compile path.
     todo!("System.relocateFunctions: symbol relocation not yet ported")

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/TaskGraphResults.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/TaskGraphResults.rs
@@ -37,7 +37,6 @@
 #![allow(non_snake_case)]
 
 use std::fmt::Write as _;
-use std::sync::Arc;
 
 use metamodelica::Result;
 use arcstr::ArcStr;
@@ -474,7 +473,7 @@ fn fill_edges_with_node_names(graph: &mut Graph) -> bool {
 /// Build the result list `{[errorMsg,] verdict}` the way the C++ entry
 /// points do: the verdict string first (cons last), the accumulated
 /// diagnostics prepended when non-empty.
-fn result_list(error_msg: String, verdict: &'static str) -> Arc<List<ArcStr>> {
+fn result_list(error_msg: String, verdict: &'static str) -> List<ArcStr> {
     let mut res = metamodelica::cons(ArcStr::from(verdict), metamodelica::nil());
     if !error_msg.is_empty() {
         res = metamodelica::cons(ArcStr::from(error_msg), res);
@@ -485,7 +484,7 @@ fn result_list(error_msg: String, verdict: &'static str) -> Arc<List<ArcStr>> {
 /// `TaskGraphResults_checkTaskGraph(filename, reffilename)`: compare the
 /// dumped task graph against a reference GraphML file by node names, with
 /// calc/comm-time presence checks.
-pub fn checkTaskGraph(filename: ArcStr, reffilename: ArcStr) -> Result<Arc<List<ArcStr>>> {
+pub fn checkTaskGraph(filename: ArcStr, reffilename: ArcStr) -> Result<List<ArcStr>> {
     for f in [&filename, &reffilename] {
         if !std::path::Path::new(f.as_str()).exists() {
             return Ok(metamodelica::cons(
@@ -504,7 +503,7 @@ pub fn checkTaskGraph(filename: ArcStr, reffilename: ArcStr) -> Result<Arc<List<
 /// `TaskGraphResults_checkCodeGraph(graphfile, codefile)`: compare the dumped
 /// task graph against the TG_NODE/TG_DEPENDENCY comments in generated code,
 /// by node ids and without time checks.
-pub fn checkCodeGraph(graphfile: ArcStr, codefile: ArcStr) -> Result<Arc<List<ArcStr>>> {
+pub fn checkCodeGraph(graphfile: ArcStr, codefile: ArcStr) -> Result<List<ArcStr>> {
     for f in [&graphfile, &codefile] {
         if !std::path::Path::new(f.as_str()).exists() {
             return Ok(metamodelica::cons(
@@ -555,7 +554,7 @@ mod tests {
         path.to_str().unwrap().to_string()
     }
 
-    fn to_vec(lst: Arc<List<ArcStr>>) -> Vec<String> {
+    fn to_vec(lst: List<ArcStr>) -> Vec<String> {
         (&*lst).into_iter().map(|s| s.to_string()).collect()
     }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Vector.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Vector.rs
@@ -75,13 +75,13 @@ pub fn rawArray<T: Clone + 'static>(v: Arc<Vector<T>>) -> Array<T> {
     (*v).clone()
 }
 
-pub fn fromList<T: Clone + 'static>(l: Arc<List<T>>) -> Arc<Vector<T>> {
+pub fn fromList<T: Clone + 'static>(l: List<T>) -> Arc<Vector<T>> {
     Arc::new(metamodelica::arrayFromVec(l.into_iter().cloned().collect()))
 }
 
-pub fn toList<T: Clone + 'static>(v: Arc<Vector<T>>) -> Arc<List<T>> {
+pub fn toList<T: Clone + 'static>(v: Arc<Vector<T>>) -> List<T> {
     let data = v.borrow();
-    let mut acc: Arc<List<T>> = nil();
+    let mut acc: List<T> = nil();
     for e in data.iter().rev() {
         acc = cons(e.clone(), acc);
     }
@@ -113,7 +113,7 @@ pub fn append<T: Clone + 'static>(v1: Arc<Vector<T>>, v2: Arc<Vector<T>>) {
     v1.borrow_mut().extend(extension);
 }
 
-pub fn appendList<T: Clone + 'static>(v: Arc<Vector<T>>, l: Arc<List<T>>) -> Result<()> {
+pub fn appendList<T: Clone + 'static>(v: Arc<Vector<T>>, l: List<T>) -> Result<()> {
     let mut data = v.borrow_mut();
     let mut rest = l;
     while !rest.is_empty() {
@@ -281,8 +281,8 @@ pub fn map<OT: Clone + 'static, T: Clone + 'static>(
 pub fn mapToList<OT: Clone + 'static, T: Clone + 'static>(
     v: Arc<Vector<T>>,
     r#fn: Arc<dyn ::std::ops::Fn(T) -> Result<OT> + 'static>,
-) -> Result<Arc<List<OT>>> {
-    let mut l: Arc<List<OT>> = nil();
+) -> Result<List<OT>> {
+    let mut l: List<OT> = nil();
     let len = v.borrow().len();
     for i in (0..len).rev() {
         let Some(e) = elem_at(&v, i) else { continue };
@@ -441,7 +441,7 @@ pub fn toString<T: Clone + 'static>(
     delim: ArcStr,
     strEnd: ArcStr,
 ) -> Result<ArcStr> {
-    let mut acc: Arc<List<ArcStr>> = nil();
+    let mut acc: List<ArcStr> = nil();
     let len = v.borrow().len();
     for i in (0..len).rev() {
         let Some(e) = elem_at(&v, i) else { continue };

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/avl_set_string_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/avl_set_string_tests.rs
@@ -126,7 +126,7 @@ fn test_addlist_basic() -> Result<()> {
 
 #[test]
 fn test_addlist_empty_list() -> Result<()> {
-    let lst: Arc<List<ArcStr>> = metamodelica::nil();
+    let lst: List<ArcStr> = metamodelica::nil();
     let t = S::addList(S::new(), lst)?;
     assert!(S::isEmpty(t));
     Ok(())

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/diff_algorithm_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/diff_algorithm_tests.rs
@@ -41,27 +41,27 @@ fn to_str(s: ArcStr) -> Result<ArcStr> {
 // ---------------------------------------------------------------------------
 
 fn collect_diff(
-    result: Arc<metamodelica::List<(Diff, Arc<metamodelica::List<ArcStr>>)>>,
+    result: metamodelica::List<(Diff, metamodelica::List<ArcStr>)>,
 ) -> Vec<(Diff, Vec<String>)> {
     let mut out = Vec::new();
     let mut node = result;
     loop {
         match node.as_ref() {
-            metamodelica::List::Nil => break,
-            metamodelica::List::Cons { head: (d, ts), tail } => {
+            metamodelica::ListNode::Nil => break,
+            metamodelica::ListNode::Cons { head: (d, ts), tail } => {
                 let mut tokens = Vec::new();
-                let mut t = Arc::clone(ts);
+                let mut t = ts.clone();
                 loop {
                     match t.as_ref() {
-                        metamodelica::List::Nil => break,
-                        metamodelica::List::Cons { head, tail: t2 } => {
+                        metamodelica::ListNode::Nil => break,
+                        metamodelica::ListNode::Cons { head, tail: t2 } => {
                             tokens.push(head.to_string());
-                            t = Arc::clone(t2);
+                            t = t2.clone();
                         }
                     }
                 }
                 out.push((*d, tokens));
-                node = Arc::clone(tail);
+                node = tail.clone();
             }
         }
     }
@@ -69,11 +69,11 @@ fn collect_diff(
 }
 
 fn run_diff(seq1: &[&str], seq2: &[&str]) -> Result<Vec<(Diff, Vec<String>)>> {
-    let list1: Arc<metamodelica::List<ArcStr>> = seq1
+    let list1: metamodelica::List<ArcStr> = seq1
         .iter()
         .rev()
         .fold(metamodelica::nil(), |acc, &s| cons(arcstr::format!("{}", s), acc));
-    let list2: Arc<metamodelica::List<ArcStr>> = seq2
+    let list2: metamodelica::List<ArcStr> = seq2
         .iter()
         .rev()
         .fold(metamodelica::nil(), |acc, &s| cons(arcstr::format!("{}", s), acc));
@@ -282,7 +282,7 @@ fn diff_enum_ordinals_match_metamodelica_source() {
 // ---------------------------------------------------------------------------
 
 /// One diff chunk `(tag, [tokens...])`.
-fn chunk(tag: Diff, tokens: &[&str]) -> (Diff, Arc<metamodelica::List<ArcStr>>) {
+fn chunk(tag: Diff, tokens: &[&str]) -> (Diff, metamodelica::List<ArcStr>) {
     let toks = tokens
         .iter()
         .rev()
@@ -291,7 +291,7 @@ fn chunk(tag: Diff, tokens: &[&str]) -> (Diff, Arc<metamodelica::List<ArcStr>>) 
 }
 
 /// A sequence with one equal, one added and one deleted chunk.
-fn sample_seq() -> Arc<metamodelica::List<(Diff, Arc<metamodelica::List<ArcStr>>)>> {
+fn sample_seq() -> metamodelica::List<(Diff, metamodelica::List<ArcStr>)> {
     [
         chunk(Diff::Equal, &["a"]),
         chunk(Diff::Add, &["b"]),

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/unordered_map_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/unordered_map_tests.rs
@@ -47,8 +47,8 @@ fn to_sorted_pairs(m: Arc<UM::UnorderedMap<ArcStr, i32>>) -> Vec<(String, i32)> 
     let mut vi = vals.as_ref();
     loop {
         match (ki, vi) {
-            (metamodelica::List::Cons { head: k, tail: kt },
-             metamodelica::List::Cons { head: v, tail: vt }) => {
+            (metamodelica::ListNode::Cons { head: k, tail: kt },
+             metamodelica::ListNode::Cons { head: v, tail: vt }) => {
                 pairs.push((k.to_string(), *v));
                 ki = kt.as_ref();
                 vi = vt.as_ref();
@@ -336,8 +336,8 @@ fn test_from_lists_basic() -> Result<()> {
 
 #[test]
 fn test_from_lists_empty() -> Result<()> {
-    let keys: Arc<metamodelica::List<ArcStr>> = metamodelica::nil();
-    let vals: Arc<metamodelica::List<i32>>    = metamodelica::nil();
+    let keys: metamodelica::List<ArcStr> = metamodelica::nil();
+    let vals: metamodelica::List<i32>    = metamodelica::nil();
     let m = UM::fromLists(keys, vals, Arc::new(hash_str), Arc::new(eq_str))?;
     assert!(UM::isEmpty(m));
     Ok(())

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/unordered_set_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/unordered_set_tests.rs
@@ -264,7 +264,7 @@ fn test_from_list_deduplicates() -> Result<()> {
 
 #[test]
 fn test_from_list_empty() -> Result<()> {
-    let lst: Arc<metamodelica::List<ArcStr>> = metamodelica::nil();
+    let lst: metamodelica::List<ArcStr> = metamodelica::nil();
     let s = US::fromList(lst, Arc::new(hash_str), Arc::new(eq_str))?;
     assert!(US::isEmpty(s));
     Ok(())

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/util_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/unittests/util_tests.rs
@@ -678,7 +678,7 @@ fn test_mul_list_integer_opt_with_none() -> Result<()> {
 
 #[test]
 fn test_mul_list_integer_opt_empty() -> Result<()> {
-    let lst: Arc<metamodelica::List<Option<i32>>> = nil();
+    let lst: metamodelica::List<Option<i32>> = nil();
     assert_eq!(U::mulListIntegerOpt(lst, 1)?, 1);
     Ok(())
 }
@@ -762,7 +762,7 @@ fn test_int_lst_string_single() {
 
 #[test]
 fn test_int_lst_string_empty() {
-    let lst: Arc<metamodelica::List<i32>> = nil();
+    let lst: metamodelica::List<i32> = nil();
     assert_eq!(U::intLstString(lst).unwrap(), literal!(""));
 }
 
@@ -803,7 +803,7 @@ fn test_string_contains_char_dot() -> Result<()> {
 
 // ── stringSplitAtChar ─────────────────────────────────────────────────────────
 
-fn list_to_vec(lst: Arc<metamodelica::List<ArcStr>>) -> Vec<String> {
+fn list_to_vec(lst: metamodelica::List<ArcStr>) -> Vec<String> {
     let mut v = vec![];
     for s in &*lst { v.push(s.to_string()); }
     v

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/unittests/array_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/unittests/array_tests.rs
@@ -90,7 +90,7 @@ fn test_any_empty() {
 fn test_append_list() -> Result<()> {
     let a = arr(vec![1, 2]);
     let lst = list![3i32, 4];
-    let result = Array::appendList(a, Arc::clone(&lst))?;
+    let result = Array::appendList(a, lst.clone())?;
     assert_eq!(*result.borrow(), vec![1, 2, 3, 4]);
     Ok(())
 }
@@ -99,7 +99,7 @@ fn test_append_list() -> Result<()> {
 fn test_append_list_empty_arr() -> Result<()> {
     let a: metamodelica::Array<i32> = arrayFromVec(vec![]);
     let lst = list![1i32, 2];
-    let result = Array::appendList(a, Arc::clone(&lst))?;
+    let result = Array::appendList(a, lst.clone())?;
     assert_eq!(*result.borrow(), vec![1, 2]);
     Ok(())
 }
@@ -107,7 +107,7 @@ fn test_append_list_empty_arr() -> Result<()> {
 #[test]
 fn test_append_list_empty_lst() -> Result<()> {
     let a = arr(vec![1, 2]);
-    let lst: Arc<List<i32>> = nil();
+    let lst: List<i32> = nil();
     let result = Array::appendList(a, lst)?;
     assert_eq!(*result.borrow(), vec![1, 2]);
     Ok(())
@@ -357,7 +357,7 @@ fn test_heap_sort_empty() -> Result<()> {
 fn test_insert_list() -> Result<()> {
     let a = arr(vec![0, 0, 0, 0, 0]);
     let lst = list![1i32, 2, 3];
-    let result = Array::insertList(a, Arc::clone(&lst), 2)?;
+    let result = Array::insertList(a, lst.clone(), 2)?;
     assert_eq!(*result.borrow(), vec![0, 1, 2, 3, 0]);
     Ok(())
 }
@@ -476,7 +476,7 @@ fn test_map_fold() {
 #[test]
 fn test_map_list() -> Result<()> {
     let lst = list![1i32, 2, 3];
-    let result = Array::mapList(Arc::clone(&lst), Arc::new(double))?;
+    let result = Array::mapList(lst.clone(), Arc::new(double))?;
     assert_eq!(*result.borrow(), vec![2, 4, 6]);
     Ok(())
 }
@@ -564,7 +564,7 @@ fn test_reverse() -> Result<()> {
 fn test_select() -> Result<()> {
     let a = arr(vec![10, 20, 30, 40]);
     let indices = list![3i32, 1];
-    let result = Array::select(a, Arc::clone(&indices))?;
+    let result = Array::select(a, indices.clone())?;
     assert_eq!(*result.borrow(), vec![30, 10]);
     Ok(())
 }
@@ -696,20 +696,20 @@ fn test_update_index_first() -> Result<()> {
 fn test_append_to_element() -> Result<()> {
     let lst1 = list![1i32, 2];
     let lst2 = list![3i32];
-    let a = arrayFromVec(vec![Arc::clone(&lst1), Arc::clone(&lst2)]);
+    let a = arrayFromVec(vec![lst1.clone(), lst2.clone()]);
     let elements = list![4i32, 5];
-    let result = Array::appendToElement(1, Arc::clone(&elements), a)?;
-    assert_eq!(Arc::clone(&result.borrow()[0]), list![1i32, 2, 4, 5]);
-    assert_eq!(Arc::clone(&result.borrow()[1]), list![3i32]);
+    let result = Array::appendToElement(1, elements.clone(), a)?;
+    assert_eq!(result.borrow()[0].clone(), list![1i32, 2, 4, 5]);
+    assert_eq!(result.borrow()[1].clone(), list![3i32]);
     Ok(())
 }
 
 #[test]
 fn test_cons_to_element() -> Result<()> {
     let lst = list![2i32, 3];
-    let a = arrayFromVec(vec![Arc::clone(&lst)]);
+    let a = arrayFromVec(vec![lst.clone()]);
     let result = Array::consToElement(1, 1i32, a)?;
-    assert_eq!(Arc::clone(&result.borrow()[0]), list![1i32, 2, 3]);
+    assert_eq!(result.borrow()[0].clone(), list![1i32, 2, 3]);
     Ok(())
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/unittests/double_ended_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/unittests/double_ended_tests.rs
@@ -85,7 +85,7 @@ fn test_pop_front_empty_fails() {
 #[test]
 fn test_from_list() -> Result<()> {
     let lst = list![1i32, 2, 3];
-    let de = DoubleEnded::fromList(Arc::clone(&lst))?;
+    let de = DoubleEnded::fromList(lst.clone())?;
     assert_eq!(DoubleEnded::length(de.clone()), 3);
     assert_eq!(DoubleEnded::pop_front(de.clone())?, 1);
     assert_eq!(DoubleEnded::pop_front(de.clone())?, 2);
@@ -95,7 +95,7 @@ fn test_from_list() -> Result<()> {
 
 #[test]
 fn test_from_list_empty() -> Result<()> {
-    let lst: Arc<List<i32>> = nil();
+    let lst: List<i32> = nil();
     let de = DoubleEnded::fromList(lst)?;
     assert_eq!(DoubleEnded::length(de), 0);
     Ok(())
@@ -128,8 +128,8 @@ fn test_to_list_and_clear() -> Result<()> {
     let de = DoubleEnded::new(1);
     DoubleEnded::push_back(de.clone(), 2)?;
     DoubleEnded::push_back(de.clone(), 3)?;
-    let prepend: Arc<List<i32>> = list![0i32];
-    let result = DoubleEnded::toListAndClear(de.clone(), Arc::clone(&prepend))?;
+    let prepend: List<i32> = list![0i32];
+    let result = DoubleEnded::toListAndClear(de.clone(), prepend.clone())?;
     assert_eq!(result.get(1)?, 1);
     assert_eq!(result.get(2)?, 2);
     assert_eq!(result.get(3)?, 3);
@@ -142,7 +142,7 @@ fn test_to_list_and_clear() -> Result<()> {
 fn test_to_list_and_clear_empty() {
     let de = DoubleEnded::empty(0i32);
     let prepend = list![1i32, 2];
-    let result = DoubleEnded::toListAndClear(de, Arc::clone(&prepend)).unwrap();
+    let result = DoubleEnded::toListAndClear(de, prepend.clone()).unwrap();
     assert_eq!(result, prepend);
 }
 
@@ -170,7 +170,7 @@ fn test_current_back_cell() -> Result<()> {
 fn test_push_list_back() -> Result<()> {
     let de = DoubleEnded::new(1);
     let lst = list![2i32, 3, 4];
-    DoubleEnded::push_list_back(de.clone(), Arc::clone(&lst))?;
+    DoubleEnded::push_list_back(de.clone(), lst.clone())?;
     assert_eq!(DoubleEnded::length(de.clone()), 4);
     assert_eq!(DoubleEnded::pop_front(de.clone())?, 1);
     assert_eq!(DoubleEnded::pop_front(de.clone())?, 2);
@@ -183,14 +183,14 @@ fn test_push_list_back() -> Result<()> {
 fn test_push_list_back_empty_de() {
     let de = DoubleEnded::empty(0i32);
     let lst = list![1i32, 2];
-    DoubleEnded::push_list_back(de.clone(), Arc::clone(&lst)).unwrap();
+    DoubleEnded::push_list_back(de.clone(), lst.clone()).unwrap();
     assert_eq!(DoubleEnded::length(de), 2);
 }
 
 #[test]
 fn test_push_list_back_empty_list() {
     let de = DoubleEnded::new(1);
-    let lst: Arc<List<i32>> = nil();
+    let lst: List<i32> = nil();
     DoubleEnded::push_list_back(de.clone(), lst).unwrap();
     assert_eq!(DoubleEnded::length(de), 1);
 }
@@ -199,7 +199,7 @@ fn test_push_list_back_empty_list() {
 fn test_push_list_front() -> Result<()> {
     let de = DoubleEnded::new(4);
     let lst = list![1i32, 2, 3];
-    DoubleEnded::push_list_front(de.clone(), Arc::clone(&lst))?;
+    DoubleEnded::push_list_front(de.clone(), lst.clone())?;
     assert_eq!(DoubleEnded::length(de.clone()), 4);
     assert_eq!(DoubleEnded::pop_front(de.clone())?, 1);
     assert_eq!(DoubleEnded::pop_front(de.clone())?, 2);
@@ -212,7 +212,7 @@ fn test_push_list_front() -> Result<()> {
 fn test_push_list_front_empty_de() -> Result<()> {
     let de = DoubleEnded::empty(0i32);
     let lst = list![1i32, 2];
-    DoubleEnded::push_list_front(de.clone(), Arc::clone(&lst))?;
+    DoubleEnded::push_list_front(de.clone(), lst.clone())?;
     assert_eq!(DoubleEnded::length(de), 2);
     Ok(())
 }
@@ -220,7 +220,7 @@ fn test_push_list_front_empty_de() -> Result<()> {
 #[test]
 fn test_push_list_front_empty_list() -> Result<()> {
     let de = DoubleEnded::new(1);
-    let lst: Arc<List<i32>> = nil();
+    let lst: List<i32> = nil();
     DoubleEnded::push_list_front(de.clone(), lst)?;
     assert_eq!(DoubleEnded::length(de), 1);
     Ok(())
@@ -312,7 +312,7 @@ fn test_pop_to_one_then_push_back() -> Result<()> {
 fn test_to_list_and_clear_nil_prepend() -> Result<()> {
     let de = DoubleEnded::new(1);
     DoubleEnded::push_back(de.clone(), 2)?;
-    let result = DoubleEnded::toListAndClear(de.clone(), Arc::clone(&nil()))?;
+    let result = DoubleEnded::toListAndClear(de.clone(), nil())?;
     assert_eq!(result.get(1)?, 1);
     assert_eq!(result.get(2)?, 2);
     assert_eq!(result.len(), 2);
@@ -327,8 +327,8 @@ fn test_to_list_and_clear_after_push_front_push_back() -> Result<()> {
     let de = DoubleEnded::new(2);
     DoubleEnded::push_front(de.clone(), 1); // front=[1,2], back=cons(2,nil)
     DoubleEnded::push_back(de.clone(), 3);  // back becomes cons(3,nil)
-    let tail: Arc<List<i32>> = list![99i32];
-    let result = DoubleEnded::toListAndClear(de.clone(), Arc::clone(&tail))?;
+    let tail: List<i32> = list![99i32];
+    let result = DoubleEnded::toListAndClear(de.clone(), tail.clone())?;
     assert_eq!(result.len(), 4);
     assert_eq!(result.get(1)?, 1);
     assert_eq!(result.get(2)?, 2);
@@ -358,7 +358,7 @@ fn test_clear_then_push_back() -> Result<()> {
 fn test_push_list_back_to_empty_then_pop_all() -> Result<()> {
     let de = DoubleEnded::empty(0i32);
     let lst = list![10i32, 20, 30];
-    DoubleEnded::push_list_back(de.clone(), Arc::clone(&lst))?;
+    DoubleEnded::push_list_back(de.clone(), lst.clone())?;
     assert_eq!(DoubleEnded::length(de.clone()), 3);
     assert_eq!(DoubleEnded::pop_front(de.clone())?, 10);
     assert_eq!(DoubleEnded::pop_front(de.clone())?, 20);
@@ -373,7 +373,7 @@ fn test_push_list_back_to_empty_then_pop_all() -> Result<()> {
 fn test_push_list_front_order() -> Result<()> {
     let de = DoubleEnded::new(4);
     let lst = list![1i32, 2, 3];
-    DoubleEnded::push_list_front(de.clone(), Arc::clone(&lst))?;
+    DoubleEnded::push_list_front(de.clone(), lst.clone())?;
     assert_eq!(DoubleEnded::length(de.clone()), 4);
     assert_eq!(DoubleEnded::pop_front(de.clone())?, 1);
     assert_eq!(DoubleEnded::pop_front(de.clone())?, 2);
@@ -388,7 +388,7 @@ fn test_push_list_front_order() -> Result<()> {
 fn test_push_list_front_does_not_change_back() -> Result<()> {
     let de = DoubleEnded::new(3);     // back = cons(3,nil)
     let lst = list![1i32, 2];
-    DoubleEnded::push_list_front(de.clone(), Arc::clone(&lst))?; // back unchanged
+    DoubleEnded::push_list_front(de.clone(), lst.clone())?; // back unchanged
     DoubleEnded::push_back(de.clone(), 4); // must link through back=cons(3,nil)
     assert_eq!(DoubleEnded::length(de.clone()), 4);
     assert_eq!(DoubleEnded::pop_front(de.clone())?, 1);
@@ -417,7 +417,7 @@ fn test_map_fold_no_copy_empty() -> Result<()> {
 #[test]
 fn test_from_list_pop_all() -> Result<()> {
     let lst = list![5i32, 6, 7];
-    let de = DoubleEnded::fromList(Arc::clone(&lst))?;
+    let de = DoubleEnded::fromList(lst.clone())?;
     assert_eq!(DoubleEnded::pop_front(de.clone())?, 5);
     assert_eq!(DoubleEnded::pop_front(de.clone())?, 6);
     assert_eq!(DoubleEnded::pop_front(de.clone())?, 7);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/unittests/list_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/unittests/list_tests.rs
@@ -19,7 +19,7 @@ fn cmp_i(a: i32, b: i32) -> Result<i32> { Ok(if a < b { -1 } else if a > b { 1 }
 fn test_accumulate_map_accum() {
     let lst = list![1i32, 2, 3];
     // accumulates: each call gets (element, accumulated_so_far), must return new accumulator
-    let result = L::accumulateMapAccum(Arc::clone(&lst), Arc::new(|x, acc| Ok(cons(x, acc)))).unwrap();
+    let result = L::accumulateMapAccum(lst.clone(), Arc::new(|x, acc| Ok(cons(x, acc)))).unwrap();
     assert_eq!(result.len(), 3);
 }
 
@@ -27,36 +27,36 @@ fn test_accumulate_map_accum() {
 #[test]
 fn test_all_true() {
     let lst = list![1i32, 2, 3];
-    assert!(L::all(Arc::clone(&lst), Arc::new(is_positive)).unwrap());
+    assert!(L::all(lst.clone(), Arc::new(is_positive)).unwrap());
 }
 #[test]
 fn test_all_false() {
     let lst = list![1i32, -2, 3];
-    assert!(!L::all(Arc::clone(&lst), Arc::new(is_positive)).unwrap());
+    assert!(!L::all(lst.clone(), Arc::new(is_positive)).unwrap());
 }
 #[test]
 fn test_all_empty() {
-    let lst: Arc<List<i32>> = nil();
-    assert!(L::all(Arc::clone(&lst), Arc::new(is_positive)).unwrap());
+    let lst: List<i32> = nil();
+    assert!(L::all(lst.clone(), Arc::new(is_positive)).unwrap());
 }
 
 // ── AllEqual ──
 #[test]
 fn test_all_equal_true() -> Result<()> {
     let lst = list![5i32, 5, 5];
-    assert!(L::allEqual(Arc::clone(&lst), Arc::new(eq_i))?);
+    assert!(L::allEqual(lst.clone(), Arc::new(eq_i))?);
     Ok(())
 }
 #[test]
 fn test_all_equal_false() -> Result<()> {
     let lst = list![5i32, 3, 5];
-    assert!(!L::allEqual(Arc::clone(&lst), Arc::new(eq_i))?);
+    assert!(!L::allEqual(lst.clone(), Arc::new(eq_i))?);
     Ok(())
 }
 #[test]
 fn test_all_equal_empty() -> Result<()> {
-    let lst: Arc<List<i32>> = nil();
-    assert!(L::allEqual(Arc::clone(&lst), Arc::new(eq_i))?);
+    let lst: List<i32> = nil();
+    assert!(L::allEqual(lst.clone(), Arc::new(eq_i))?);
     Ok(())
 }
 
@@ -65,16 +65,16 @@ fn test_all_equal_empty() -> Result<()> {
 fn test_all_reference_eq_true() -> Result<()> {
     // referenceEq uses ptr::eq, so cloned values are never ptr-eq
     // Empty lists are trivially equal
-    let lst: Arc<List<Arc<List<i32>>>> = nil();
-    let lst2: Arc<List<Arc<List<i32>>>> = nil();
-    assert!(L::allReferenceEq(Arc::clone(&lst), Arc::clone(&lst2))?);
+    let lst: List<List<i32>> = nil();
+    let lst2: List<List<i32>> = nil();
+    assert!(L::allReferenceEq(lst.clone(), lst2.clone())?);
     Ok(())
 }
 #[test]
 fn test_all_reference_eq_false() -> Result<()> {
     let lst = list![list![1i32], list![1i32]];
     let lst2 = list![list![1i32, 2], list![1i32]];
-    assert!(!L::allReferenceEq(Arc::clone(&lst), Arc::clone(&lst2))?);
+    assert!(!L::allReferenceEq(lst.clone(), lst2.clone())?);
     Ok(())
 }
 
@@ -82,24 +82,24 @@ fn test_all_reference_eq_false() -> Result<()> {
 #[test]
 fn test_any_found() {
     let lst = list![-1i32, 2, -3];
-    assert!(L::any(Arc::clone(&lst), Arc::new(is_positive)).unwrap());
+    assert!(L::any(lst.clone(), Arc::new(is_positive)).unwrap());
 }
 #[test]
 fn test_any_none() {
     let lst = list![-1i32, -2];
-    assert!(!L::any(Arc::clone(&lst), Arc::new(is_positive)).unwrap());
+    assert!(!L::any(lst.clone(), Arc::new(is_positive)).unwrap());
 }
 #[test]
 fn test_any_empty() {
-    let lst: Arc<List<i32>> = nil();
-    assert!(!L::any(Arc::clone(&lst), Arc::new(is_positive)).unwrap());
+    let lst: List<i32> = nil();
+    assert!(!L::any(lst.clone(), Arc::new(is_positive)).unwrap());
 }
 
 // ── AppendElt ──
 #[test]
 fn test_append_elt() {
     let lst = list![1i32, 2];
-    let result = L::appendElt(3, Arc::clone(&lst));
+    let result = L::appendElt(3, lst.clone());
     assert_eq!(result, list![1i32, 2, 3]);
 }
 
@@ -108,7 +108,7 @@ fn test_append_elt() {
 fn test_append_last_list() -> Result<()> {
     let lst1 = list![1i32, 2];
     let lst2 = list![3i32, 4];
-    let list_of_lists = list![Arc::clone(&lst1), Arc::clone(&lst2)];
+    let list_of_lists = list![lst1.clone(), lst2.clone()];
     let result = L::appendLastList(list_of_lists, list![5i32, 6])?;
     assert_eq!(result.len(), 2);
     Ok(())
@@ -118,7 +118,7 @@ fn test_append_last_list() -> Result<()> {
 #[test]
 fn test_append_reverse() {
     let lst = list![1i32, 2, 3];
-    let result = L::append_reverse(Arc::clone(&lst), nil());
+    let result = L::append_reverse(lst.clone(), nil());
     assert_eq!(result, list![3i32, 2, 1]);
 }
 
@@ -126,7 +126,7 @@ fn test_append_reverse() {
 #[test]
 fn test_apply_and_fold() {
     let lst = list![1i32, 2, 3];
-    let result = L::applyAndFold(Arc::clone(&lst), Arc::new(|acc, x| Ok(acc + x)), Arc::new(|x| Ok(x)), 0i32).unwrap();
+    let result = L::applyAndFold(lst.clone(), Arc::new(|acc, x| Ok(acc + x)), Arc::new(|x| Ok(x)), 0i32).unwrap();
     assert_eq!(result, 6);
 }
 
@@ -134,7 +134,7 @@ fn test_apply_and_fold() {
 #[test]
 fn test_apply_and_fold1() {
     let lst = list![1i32];
-    let result = L::applyAndFold1(Arc::clone(&lst), Arc::new(|acc, x| Ok(acc + x)), Arc::new(|x, _arg: i32| Ok(x)), 10i32, 0i32).unwrap();
+    let result = L::applyAndFold1(lst.clone(), Arc::new(|acc, x| Ok(acc + x)), Arc::new(|x, _arg: i32| Ok(x)), 10i32, 0i32).unwrap();
     assert_eq!(result, 1);
 }
 
@@ -142,7 +142,7 @@ fn test_apply_and_fold1() {
 #[test]
 fn test_balanced_partition() -> Result<()> {
     let lst = list![1i32, 2, 3, 4, 5];
-    let result = L::balancedPartition(Arc::clone(&lst), 2)?;
+    let result = L::balancedPartition(lst.clone(), 2)?;
     assert!(result.len() >= 2);
     Ok(())
 }
@@ -151,17 +151,17 @@ fn test_balanced_partition() -> Result<()> {
 #[test]
 fn test_combination() -> Result<()> {
     let lst = list![list![1i32, 2], list![3i32, 4]];
-    let result = L::combination(Arc::clone(&lst));
+    let result = L::combination(lst.clone());
     assert!(result.len() >= 0);
     Ok(())
 }
 
 // ── CombinationMap ──
-fn combination_map_fn(pair: Arc<metamodelica::List<i32>>) -> Result<i32> { Ok(pair.len()) }
+fn combination_map_fn(pair: metamodelica::List<i32>) -> Result<i32> { Ok(pair.len()) }
 #[test]
 fn test_combination_map() -> Result<()> {
     let lst = list![list![1i32, 2], list![3i32, 4]];
-    let result = L::combinationMap(Arc::clone(&lst), Arc::new(combination_map_fn)).unwrap();
+    let result = L::combinationMap(lst.clone(), Arc::new(combination_map_fn)).unwrap();
     assert!(result.len() >= 0);
     Ok(())
 }
@@ -171,21 +171,21 @@ fn test_combination_map() -> Result<()> {
 fn test_compare_equal() -> Result<()> {
     let a = list![1i32, 2, 3];
     let b = list![1i32, 2, 3];
-    assert_eq!(L::compare(Arc::clone(&a), Arc::clone(&b), Arc::new(cmp_i))?, 0);
+    assert_eq!(L::compare(a.clone(), b.clone(), Arc::new(cmp_i))?, 0);
     Ok(())
 }
 #[test]
 fn test_compare_less() -> Result<()> {
     let a = list![1i32, 2];
     let b = list![1i32, 3];
-    assert_eq!(L::compare(Arc::clone(&a), Arc::clone(&b), Arc::new(cmp_i))?, -1);
+    assert_eq!(L::compare(a.clone(), b.clone(), Arc::new(cmp_i))?, -1);
     Ok(())
 }
 #[test]
 fn test_compare_greater() -> Result<()> {
     let a = list![1i32, 4];
     let b = list![1i32, 3];
-    assert_eq!(L::compare(Arc::clone(&a), Arc::clone(&b), Arc::new(cmp_i))?, 1);
+    assert_eq!(L::compare(a.clone(), b.clone(), Arc::new(cmp_i))?, 1);
     Ok(())
 }
 
@@ -194,9 +194,9 @@ fn test_compare_greater() -> Result<()> {
 fn test_compare_length() -> Result<()> {
     let a = list![1i32, 2];
     let b = list![1i32, 2, 3];
-    assert!(L::compareLength(Arc::clone(&a), Arc::clone(&b))? < 0);
-    assert_eq!(L::compareLength(Arc::clone(&b), Arc::clone(&b))?, 0);
-    assert!(L::compareLength(Arc::clone(&b), Arc::clone(&a))? > 0);
+    assert!(L::compareLength(a.clone(), b.clone())? < 0);
+    assert_eq!(L::compareLength(b.clone(), b.clone())?, 0);
+    assert!(L::compareLength(b.clone(), a.clone())? > 0);
     Ok(())
 }
 
@@ -242,7 +242,7 @@ fn test_cons_option_none() -> Result<()> {
 #[test]
 fn test_consr() {
     let lst = list![2i32, 3];
-    let result = L::consr(Arc::clone(&lst), 1i32);
+    let result = L::consr(lst.clone(), 1i32);
     assert_eq!(result, list![1i32, 2, 3]);
 }
 
@@ -250,26 +250,26 @@ fn test_consr() {
 #[test]
 fn test_contains_true() {
     let lst = list![1i32, 2, 3];
-    assert!(L::contains(Arc::clone(&lst), 2, Arc::new(eq_i)).unwrap());
+    assert!(L::contains(lst.clone(), 2, Arc::new(eq_i)).unwrap());
 }
 #[test]
 fn test_contains_false() {
     let lst = list![1i32, 2, 3];
-    assert!(!L::contains(Arc::clone(&lst), 4, Arc::new(eq_i)).unwrap());
+    assert!(!L::contains(lst.clone(), 4, Arc::new(eq_i)).unwrap());
 }
 
 // ── Count ──
 #[test]
 fn test_count() {
     let lst = list![1i32, 2, 3, 4, 5, 6];
-    assert_eq!(L::count(Arc::clone(&lst), Arc::new(is_even)).unwrap(), 3);
+    assert_eq!(L::count(lst.clone(), Arc::new(is_even)).unwrap(), 3);
 }
 
 // ── CountingSort ──
 #[test]
 fn test_counting_sort() -> Result<()> {
     let lst = list![3i32, 1, 4, 1, 5, 9, 2, 6];
-    let result = L::countingSort(Arc::clone(&lst), 9)?;
+    let result = L::countingSort(lst.clone(), 9)?;
     assert_eq!(result, list![1i32, 1, 2, 3, 4, 5, 6, 9]);
     Ok(())
 }
@@ -285,7 +285,7 @@ fn test_create() {
 #[test]
 fn test_delete_member_on_true() -> Result<()> {
     let lst = list![1i32, 2, 3, 4];
-    let (result, deleted) = L::deleteMemberOnTrue(2i32, Arc::clone(&lst), Arc::new(eq_i))?;
+    let (result, deleted) = L::deleteMemberOnTrue(2i32, lst.clone(), Arc::new(eq_i))?;
     assert_eq!(deleted, Some(2));
     assert_eq!(result, list![1i32, 3, 4]);
     Ok(())
@@ -296,7 +296,7 @@ fn test_delete_member_on_true() -> Result<()> {
 fn test_delete_positions() -> Result<()> {
     let lst = list![1i32, 2, 3, 4, 5];
     let positions = list![2i32, 4];
-    let result = L::deletePositions(Arc::clone(&lst), Arc::clone(&positions), false)?;
+    let result = L::deletePositions(lst.clone(), positions.clone(), false)?;
     assert_eq!(result, list![1i32, 3, 5]);
     Ok(())
 }
@@ -306,7 +306,7 @@ fn test_delete_positions() -> Result<()> {
 fn test_delete_positions_sorted() -> Result<()> {
     let lst = list![1i32, 2, 3, 4, 5];
     let positions = list![1i32, 3, 5];
-    let result = L::deletePositionsSorted(Arc::clone(&lst), Arc::clone(&positions), false)?;
+    let result = L::deletePositionsSorted(lst.clone(), positions.clone(), false)?;
     assert_eq!(result, list![2i32, 4]);
     Ok(())
 }
@@ -325,7 +325,7 @@ fn test_exist1_false() {
 #[test]
 fn test_extract_on_true() {
     let lst = list![1i32, 2, 3, 4, 5];
-    let (matched, _unmatched) = L::extractOnTrue(Arc::clone(&lst), Arc::new(|x| Ok(x % 2 == 0))).unwrap();
+    let (matched, _unmatched) = L::extractOnTrue(lst.clone(), Arc::new(|x| Ok(x % 2 == 0))).unwrap();
     assert_eq!(matched, list![2i32, 4]);
 }
 
@@ -333,7 +333,7 @@ fn test_extract_on_true() {
 #[test]
 fn test_extract1_on_true() {
     let lst = list![1i32, 2, 3];
-    let (matched, _unmatched) = L::extract1OnTrue(Arc::clone(&lst), Arc::new(|x, _arg: i32| Ok(x % 2 == 0)), 0i32).unwrap();
+    let (matched, _unmatched) = L::extract1OnTrue(lst.clone(), Arc::new(|x, _arg: i32| Ok(x % 2 == 0)), 0i32).unwrap();
     assert_eq!(matched, list![2i32]);
 }
 
@@ -348,7 +348,7 @@ fn test_fill() {
 #[test]
 fn test_filter() {
     let lst = list![1i32, 2, 3, 4, 5, 6];
-    let result = L::filter(Arc::clone(&lst), Arc::new(|x| { if x % 2 == 0 { Ok(()) } else { return Err("skip") } }));
+    let result = L::filter(lst.clone(), Arc::new(|x| { if x % 2 == 0 { Ok(()) } else { return Err("skip") } }));
     assert_eq!(result, list![2i32, 4, 6]);
 }
 
@@ -356,7 +356,7 @@ fn test_filter() {
 #[test]
 fn test_filter1() {
     let lst = list![1i32];
-    let result = L::filter1(Arc::clone(&lst), Arc::new(|x, _arg: i32| { if x > 0 { Ok(()) } else { return Err("skip") } }), 0i32);
+    let result = L::filter1(lst.clone(), Arc::new(|x, _arg: i32| { if x > 0 { Ok(()) } else { return Err("skip") } }), 0i32);
     assert_eq!(result, list![1i32]);
 }
 
@@ -364,7 +364,7 @@ fn test_filter1() {
 #[test]
 fn test_filter1_on_true() {
     let lst = list![1i32, 2, 3];
-    let result = L::filter1OnTrue(Arc::clone(&lst), Arc::new(|x, _arg: i32| Ok(x % 2 == 0)), 0i32).unwrap();
+    let result = L::filter1OnTrue(lst.clone(), Arc::new(|x, _arg: i32| Ok(x % 2 == 0)), 0i32).unwrap();
     assert_eq!(result, list![2i32]);
 }
 
@@ -372,7 +372,7 @@ fn test_filter1_on_true() {
 #[test]
 fn test_filter1_on_true_and_update() {
     let lst = list![1i32, 2, 3];
-    let result = L::filter1OnTrueAndUpdate(Arc::clone(&lst), Arc::new(|x, _arg: i32| Ok(x > 1)), Arc::new(|x, _arg: i32| Ok(x * 10)), 0i32).unwrap();
+    let result = L::filter1OnTrueAndUpdate(lst.clone(), Arc::new(|x, _arg: i32| Ok(x > 1)), Arc::new(|x, _arg: i32| Ok(x * 10)), 0i32).unwrap();
     assert_eq!(result, list![20i32, 30i32]);
 }
 
@@ -381,7 +381,7 @@ fn test_filter1_on_true_and_update() {
 fn test_filter1_on_true_sync() -> Result<()> {
     let lst = list![1i32, 2, 3];
     let sync = list![10i32, 20, 30];
-    let (kept, _removed) = L::filter1OnTrueSync(Arc::clone(&lst), Arc::new(|x, _arg: i32| Ok(x % 2 == 0)), 0i32, Arc::clone(&sync))?;
+    let (kept, _removed) = L::filter1OnTrueSync(lst.clone(), Arc::new(|x, _arg: i32| Ok(x % 2 == 0)), 0i32, sync.clone())?;
     assert_eq!(kept, list![2i32]);
     Ok(())
 }
@@ -390,7 +390,7 @@ fn test_filter1_on_true_sync() -> Result<()> {
 #[test]
 fn test_filter1r_on_true() {
     let lst = list![2i32, 4, 6];
-    let result = L::filter1rOnTrue(Arc::clone(&lst), Arc::new(|_arg: i32, x| Ok(x % 2 == 0)), 0i32).unwrap();
+    let result = L::filter1rOnTrue(lst.clone(), Arc::new(|_arg: i32, x| Ok(x % 2 == 0)), 0i32).unwrap();
     assert_eq!(result, list![2i32, 4, 6]);
 }
 
@@ -398,7 +398,7 @@ fn test_filter1r_on_true() {
 #[test]
 fn test_filter2_on_true() {
     let lst = list![1i32, 2, 3, 4];
-    let result = L::filter2OnTrue(Arc::clone(&lst), Arc::new(|x, _a: i32, _b: i32| Ok(x % 2 == 0)), 0i32, 0i32).unwrap();
+    let result = L::filter2OnTrue(lst.clone(), Arc::new(|x, _a: i32, _b: i32| Ok(x % 2 == 0)), 0i32, 0i32).unwrap();
     assert_eq!(result, list![2i32, 4]);
 }
 
@@ -406,7 +406,7 @@ fn test_filter2_on_true() {
 #[test]
 fn test_filter_cons() {
     let lst = list![1i32, 2, 3];
-    let result = L::filterCons(Arc::clone(&lst), Arc::new(|x| Ok(x % 2 == 0)), nil()).unwrap();
+    let result = L::filterCons(lst.clone(), Arc::new(|x| Ok(x % 2 == 0)), nil()).unwrap();
     assert_eq!(result, list![2i32]);
 }
 
@@ -414,7 +414,7 @@ fn test_filter_cons() {
 #[test]
 fn test_filter_map() {
     let lst = list![1i32, 2, 3, 4];
-    let result = L::filterMap(Arc::clone(&lst), Arc::new(|x| if x % 2 == 0 { Ok(x * 10) } else { return Err("skip") }));
+    let result = L::filterMap(lst.clone(), Arc::new(|x| if x % 2 == 0 { Ok(x * 10) } else { return Err("skip") }));
     assert_eq!(result, list![20i32, 40]);
 }
 
@@ -422,7 +422,7 @@ fn test_filter_map() {
 #[test]
 fn test_filter_map1() {
     let lst = list![2i32];
-    let result = L::filterMap1(Arc::clone(&lst), Arc::new(|x, _arg: i32| if x > 0 { Ok(x * 2) } else { return Err("skip") }), 0i32);
+    let result = L::filterMap1(lst.clone(), Arc::new(|x, _arg: i32| if x > 0 { Ok(x * 2) } else { return Err("skip") }), 0i32);
     assert_eq!(result, list![4i32]);
 }
 
@@ -430,7 +430,7 @@ fn test_filter_map1() {
 #[test]
 fn test_filter_on_false() {
     let lst = list![1i32, 2, 3, 4];
-    let result = L::filterOnFalse(Arc::clone(&lst), Arc::new(|x| Ok(x % 2 == 0))).unwrap();
+    let result = L::filterOnFalse(lst.clone(), Arc::new(|x| Ok(x % 2 == 0))).unwrap();
     assert_eq!(result, list![1i32, 3]);
 }
 
@@ -438,7 +438,7 @@ fn test_filter_on_false() {
 #[test]
 fn test_filter_on_true() {
     let lst = list![1i32, 2, 3, 4];
-    let result = L::filterOnTrue(Arc::clone(&lst), Arc::new(is_even)).unwrap();
+    let result = L::filterOnTrue(lst.clone(), Arc::new(is_even)).unwrap();
     assert_eq!(result, list![2i32, 4]);
 }
 
@@ -447,7 +447,7 @@ fn test_filter_on_true() {
 fn test_filter_on_true_sync() -> Result<()> {
     let lst = list![1i32, 2, 3, 4];
     let sync = list![10i32, 20, 30, 40];
-    let (matched, _unmatched) = L::filterOnTrueSync(Arc::clone(&lst), Arc::new(is_even), Arc::clone(&sync))?;
+    let (matched, _unmatched) = L::filterOnTrueSync(lst.clone(), Arc::new(is_even), sync.clone())?;
     assert_eq!(matched, list![2i32, 4]);
     Ok(())
 }
@@ -456,21 +456,21 @@ fn test_filter_on_true_sync() -> Result<()> {
 #[test]
 fn test_find_found() -> Result<()> {
     let lst = list![1i32, 2, 3];
-    let result = L::find(Arc::clone(&lst), Arc::new(|x| Ok(x == 2)))?;
+    let result = L::find(lst.clone(), Arc::new(|x| Ok(x == 2)))?;
     assert_eq!(result, 2);
     Ok(())
 }
 #[test]
 fn test_find_not_found() {
     let lst = list![1i32, 2, 3];
-    assert!(L::find(Arc::clone(&lst), Arc::new(|x| Ok(x == 4))).is_err());
+    assert!(L::find(lst.clone(), Arc::new(|x| Ok(x == 4))).is_err());
 }
 
 // ── Find1 ──
 #[test]
 fn test_find1_found() -> Result<()> {
     let lst = list![1i32];
-    let result = L::find1(Arc::clone(&lst), Arc::new(|x, _arg: i32| Ok(x > 0)), 0i32)?;
+    let result = L::find1(lst.clone(), Arc::new(|x, _arg: i32| Ok(x > 0)), 0i32)?;
     assert_eq!(result, 1);
     Ok(())
 }
@@ -479,7 +479,7 @@ fn test_find1_found() -> Result<()> {
 #[test]
 fn test_find_and_map() -> Result<()> {
     let lst = list![1i32, 2, 3];
-    let (result, found) = L::findAndMap(Arc::clone(&lst), Arc::new(|x| Ok(x > 1)), Arc::new(|x| Ok(x * 10)))?;
+    let (result, found) = L::findAndMap(lst.clone(), Arc::new(|x| Ok(x > 1)), Arc::new(|x| Ok(x * 10)))?;
     assert!(found);
     Ok(())
 }
@@ -488,7 +488,7 @@ fn test_find_and_map() -> Result<()> {
 #[test]
 fn test_find_and_remove() -> Result<()> {
     let lst = list![1i32, 2, 3];
-    let (found, rest) = L::findAndRemove(Arc::clone(&lst), Arc::new(|x| Ok(x == 2)))?;
+    let (found, rest) = L::findAndRemove(lst.clone(), Arc::new(|x| Ok(x == 2)))?;
     assert_eq!(found, 2);
     assert_eq!(rest, list![1i32, 3]);
     Ok(())
@@ -498,7 +498,7 @@ fn test_find_and_remove() -> Result<()> {
 #[test]
 fn test_find_and_remove1() -> Result<()> {
     let lst = list![1i32, 2];
-    let (found, rest) = L::findAndRemove1(Arc::clone(&lst), Arc::new(|x, _arg: i32| Ok(x == 2)), 0i32)?;
+    let (found, rest) = L::findAndRemove1(lst.clone(), Arc::new(|x, _arg: i32| Ok(x == 2)), 0i32)?;
     assert_eq!(found, 2);
     assert_eq!(rest, list![1i32]);
     Ok(())
@@ -509,7 +509,7 @@ fn test_find_and_remove1() -> Result<()> {
 fn test_find_bool_list() -> Result<()> {
     let bools = list![true, false, false];
     let lst = list![10i32, 20, 30];
-    let result = L::findBoolList(Arc::clone(&bools), Arc::clone(&lst), 99i32)?;
+    let result = L::findBoolList(bools.clone(), lst.clone(), 99i32)?;
     assert_eq!(result, 10);
     Ok(())
 }
@@ -521,7 +521,7 @@ fn test_find_map() -> Result<()> {
     // findMap applies fn to elements until predicate returns true; fn also transforms each element
     // x=1: fn returns (10, false) -> keep going; x=2: fn returns (20, true) -> stop
     // result via cons-accumulation: [10, 20, 3] (pre-found elements also transformed)
-    let (result, found) = L::findMap(Arc::clone(&lst), Arc::new(|x| Ok((x * 10, x == 2))))?;
+    let (result, found) = L::findMap(lst.clone(), Arc::new(|x| Ok((x * 10, x == 2))))?;
     assert!(found);
     assert_eq!(result, list![10i32, 20, 3]);
     Ok(())
@@ -531,13 +531,13 @@ fn test_find_map() -> Result<()> {
 #[test]
 fn test_find_option_some() {
     let lst = list![Some(1i32), None, Some(3)];
-    let result = L::findOption(Arc::clone(&lst), Arc::new(|x| Ok(x.unwrap_or(0) > 0))).unwrap();
+    let result = L::findOption(lst.clone(), Arc::new(|x| Ok(x.unwrap_or(0) > 0))).unwrap();
     assert!(result.is_some());
 }
 #[test]
 fn test_find_option_none() {
-    let lst: Arc<List<Option<i32>>> = nil();
-    let result = L::findOption(Arc::clone(&lst), Arc::new(|x| Ok(x.is_some()))).unwrap();
+    let lst: List<Option<i32>> = nil();
+    let result = L::findOption(lst.clone(), Arc::new(|x| Ok(x.is_some()))).unwrap();
     assert_eq!(result, None);
 }
 
@@ -545,7 +545,7 @@ fn test_find_option_none() {
 #[test]
 fn test_find_some() {
     let lst = list![None::<i32>, Some(3)];
-    let result = L::findSome(Arc::clone(&lst), Arc::new(|x| Ok(x))).unwrap();
+    let result = L::findSome(lst.clone(), Arc::new(|x| Ok(x))).unwrap();
     assert_eq!(result, Some(3));
 }
 
@@ -553,7 +553,7 @@ fn test_find_some() {
 #[test]
 fn test_first_n() -> Result<()> {
     let lst = list![1i32, 2, 3, 4, 5];
-    let result = L::firstN(Arc::clone(&lst), 3)?;
+    let result = L::firstN(lst.clone(), 3)?;
     assert_eq!(result, list![1i32, 2, 3]);
     Ok(())
 }
@@ -562,14 +562,14 @@ fn test_first_n() -> Result<()> {
 #[test]
 fn test_first_or_empty_some() -> Result<()> {
     let lst = list![1i32, 2];
-    let result = L::firstOrEmpty(Arc::clone(&lst));
+    let result = L::firstOrEmpty(lst.clone());
     assert_eq!(result.len(), 1);
     Ok(())
 }
 #[test]
 fn test_first_or_empty_none() -> Result<()> {
-    let lst: Arc<List<i32>> = nil();
-    let result = L::firstOrEmpty(Arc::clone(&lst));
+    let lst: List<i32> = nil();
+    let result = L::firstOrEmpty(lst.clone());
     assert_eq!(result.len(), 0);
     Ok(())
 }
@@ -578,7 +578,7 @@ fn test_first_or_empty_none() -> Result<()> {
 #[test]
 fn test_flatten() {
     let lst = list![list![1i32, 2], list![3i32, 4], list![5i32]];
-    let result = L::flatten(Arc::clone(&lst)).unwrap();
+    let result = L::flatten(lst.clone()).unwrap();
     assert_eq!(result, list![1i32, 2, 3, 4, 5]);
 }
 
@@ -586,7 +586,7 @@ fn test_flatten() {
 #[test]
 fn test_flatten_reverse() {
     let lst = list![list![1i32, 2], list![3i32]];
-    let result = L::flattenReverse(Arc::clone(&lst)).unwrap();
+    let result = L::flattenReverse(lst.clone()).unwrap();
     assert_eq!(result.len(), 3);
 }
 
@@ -594,7 +594,7 @@ fn test_flatten_reverse() {
 #[test]
 fn test_fold() {
     let lst = list![1i32, 2, 3, 4, 5];
-    let result = L::fold(Arc::clone(&lst), Arc::new(|x, acc| Ok(acc + x)), 0i32).unwrap();
+    let result = L::fold(lst.clone(), Arc::new(|x, acc| Ok(acc + x)), 0i32).unwrap();
     assert_eq!(result, 15);
 }
 
@@ -602,7 +602,7 @@ fn test_fold() {
 #[test]
 fn test_fold1() {
     let lst = list![1i32, 2, 3];
-    let result = L::fold1(Arc::clone(&lst), Arc::new(|x, _arg: i32, acc| Ok(acc + x)), 0i32, 0i32).unwrap();
+    let result = L::fold1(lst.clone(), Arc::new(|x, _arg: i32, acc| Ok(acc + x)), 0i32, 0i32).unwrap();
     assert_eq!(result, 6);
 }
 
@@ -610,7 +610,7 @@ fn test_fold1() {
 #[test]
 fn test_fold1r() {
     let lst = list![1i32, 2, 3];
-    let result = L::fold1r(Arc::clone(&lst), Arc::new(|acc, x, _arg: i32| Ok(acc + x)), 0i32, 0i32).unwrap();
+    let result = L::fold1r(lst.clone(), Arc::new(|acc, x, _arg: i32| Ok(acc + x)), 0i32, 0i32).unwrap();
     assert_eq!(result, 6);
 }
 
@@ -618,7 +618,7 @@ fn test_fold1r() {
 #[test]
 fn test_fold2() {
     let lst = list![1i32, 2];
-    let result = L::fold2(Arc::clone(&lst), Arc::new(|x, _a: i32, _b: i32, acc| Ok(acc + x)), 0i32, 0i32, 0i32).unwrap();
+    let result = L::fold2(lst.clone(), Arc::new(|x, _a: i32, _b: i32, acc| Ok(acc + x)), 0i32, 0i32, 0i32).unwrap();
     assert_eq!(result, 3);
 }
 
@@ -626,7 +626,7 @@ fn test_fold2() {
 #[test]
 fn test_fold2r() {
     let lst = list![1i32, 2];
-    let result = L::fold2r(Arc::clone(&lst), Arc::new(|acc, x, _a: i32, _b: i32| Ok(acc + x)), 0i32, 0i32, 0i32).unwrap();
+    let result = L::fold2r(lst.clone(), Arc::new(|acc, x, _a: i32, _b: i32| Ok(acc + x)), 0i32, 0i32, 0i32).unwrap();
     assert_eq!(result, 3);
 }
 
@@ -634,7 +634,7 @@ fn test_fold2r() {
 #[test]
 fn test_fold3() {
     let lst = list![1i32];
-    let result = L::fold3(Arc::clone(&lst), Arc::new(|x, _a: i32, _b: i32, _c: i32, acc| Ok(acc + x)), 0i32, 0i32, 0i32, 0i32).unwrap();
+    let result = L::fold3(lst.clone(), Arc::new(|x, _a: i32, _b: i32, _c: i32, acc| Ok(acc + x)), 0i32, 0i32, 0i32, 0i32).unwrap();
     assert_eq!(result, 1);
 }
 
@@ -642,14 +642,14 @@ fn test_fold3() {
 #[test]
 fn test_fold31() {
     let lst = list![1i32, 2];
-    let (_r1, _r2, _r3) = L::fold31(Arc::clone(&lst), Arc::new(|x, _a: i32, s1: i32, s2: i32, s3: i32| Ok((s1 + x, s2 + x, s3 + x))), 0i32, 0i32, 0i32, 0i32).unwrap();
+    let (_r1, _r2, _r3) = L::fold31(lst.clone(), Arc::new(|x, _a: i32, s1: i32, s2: i32, s3: i32| Ok((s1 + x, s2 + x, s3 + x))), 0i32, 0i32, 0i32, 0i32).unwrap();
 }
 
 // ── Fold4 ──
 #[test]
 fn test_fold4() {
     let lst = list![1i32];
-    let result = L::fold4(Arc::clone(&lst), Arc::new(|x, _a: i32, _b: i32, _c: i32, _d: i32, acc| Ok(acc + x)), 0i32, 0i32, 0i32, 0i32, 0i32).unwrap();
+    let result = L::fold4(lst.clone(), Arc::new(|x, _a: i32, _b: i32, _c: i32, _d: i32, acc| Ok(acc + x)), 0i32, 0i32, 0i32, 0i32, 0i32).unwrap();
     assert_eq!(result, 1);
 }
 
@@ -658,7 +658,7 @@ fn test_fold4() {
 fn test_fold_all_value() -> Result<()> {
     let lst = list![1i32, 2, 3];
     // foldAllValue requires fn output == inValue for each element
-    L::foldAllValue(Arc::clone(&lst), Arc::new(|_x, acc: i32| Ok((true, acc))), true, 0i32)?;
+    L::foldAllValue(lst.clone(), Arc::new(|_x, acc: i32| Ok((true, acc))), true, 0i32)?;
     Ok(())
 }
 
@@ -666,7 +666,7 @@ fn test_fold_all_value() -> Result<()> {
 #[test]
 fn test_fold_list() {
     let outer = list![list![1i32, 2], list![3i32, 4]];
-    let result = L::foldList(Arc::clone(&outer), Arc::new(|x, acc| Ok(acc + x)), 0i32).unwrap();
+    let result = L::foldList(outer.clone(), Arc::new(|x, acc| Ok(acc + x)), 0i32).unwrap();
     assert_eq!(result, 10);
 }
 
@@ -674,7 +674,7 @@ fn test_fold_list() {
 #[test]
 fn test_foldr() {
     let lst = list![1i32, 2, 3];
-    let result = L::foldr(Arc::clone(&lst), Arc::new(|acc, x| Ok(acc + x)), 0i32).unwrap();
+    let result = L::foldr(lst.clone(), Arc::new(|acc, x| Ok(acc + x)), 0i32).unwrap();
     assert_eq!(result, 6);
 }
 
@@ -682,7 +682,7 @@ fn test_foldr() {
 #[test]
 fn test_fold20() {
     let lst = list![1i32, 2];
-    let (s1, s2) = L::fold20(Arc::clone(&lst), Arc::new(|x, acc1: i32, acc2: i32| Ok((acc1 + x, acc2 + x))), 0i32, 0i32).unwrap();
+    let (s1, s2) = L::fold20(lst.clone(), Arc::new(|x, acc1: i32, acc2: i32| Ok((acc1 + x, acc2 + x))), 0i32, 0i32).unwrap();
     assert_eq!(s1, 3);
     assert_eq!(s2, 3);
 }
@@ -691,7 +691,7 @@ fn test_fold20() {
 #[test]
 fn test_fold21() {
     let lst = list![1i32, 2];
-    let (s1, s2) = L::fold21(Arc::clone(&lst), Arc::new(|x, _arg: i32, acc1: i32, acc2: i32| Ok((acc1 + x, acc2 + x))), 0i32, 0i32, 0i32).unwrap();
+    let (s1, s2) = L::fold21(lst.clone(), Arc::new(|x, _arg: i32, acc1: i32, acc2: i32| Ok((acc1 + x, acc2 + x))), 0i32, 0i32, 0i32).unwrap();
     assert_eq!(s1, 3);
     assert_eq!(s2, 3);
 }
@@ -700,7 +700,7 @@ fn test_fold21() {
 #[test]
 fn test_fold22() {
     let lst = list![1i32, 2];
-    let (s1, s2) = L::fold22(Arc::clone(&lst), Arc::new(|x, _a: i32, _b: i32, acc1: i32, acc2: i32| Ok((acc1 + x, acc2 + x))), 0i32, 0i32, 0i32, 0i32).unwrap();
+    let (s1, s2) = L::fold22(lst.clone(), Arc::new(|x, _a: i32, _b: i32, acc1: i32, acc2: i32| Ok((acc1 + x, acc2 + x))), 0i32, 0i32, 0i32, 0i32).unwrap();
     assert_eq!(s1, 3);
     assert_eq!(s2, 3);
 }
@@ -724,7 +724,7 @@ fn test_from_option_none() -> Result<()> {
 fn test_get_at_index_lst() -> Result<()> {
     let lst = list![10i32, 20, 30];
     let positions = list![1i32, 2, 3];
-    let result = L::getAtIndexLst(Arc::clone(&lst), Arc::clone(&positions), false)?;
+    let result = L::getAtIndexLst(lst.clone(), positions.clone(), false)?;
     assert_eq!(result, list![10i32, 20, 30]);
     Ok(())
 }
@@ -734,8 +734,8 @@ fn test_get_at_index_lst() -> Result<()> {
 fn test_get_index_first() -> Result<()> {
     // getIndexFirst forwards to listGet, which bounds-checks (fallible).
     let lst = list![10i32, 20, 30];
-    assert_eq!(L::getIndexFirst(1, Arc::clone(&lst))?, 10);
-    assert!(L::getIndexFirst(4, Arc::clone(&lst)).is_err());
+    assert_eq!(L::getIndexFirst(1, lst.clone())?, 10);
+    assert!(L::getIndexFirst(4, lst.clone()).is_err());
     Ok(())
 }
 
@@ -743,7 +743,7 @@ fn test_get_index_first() -> Result<()> {
 #[test]
 fn test_get_member() -> Result<()> {
     let lst = list![1i32, 2, 3];
-    assert_eq!(L::getMember(2, Arc::clone(&lst))?, 2);
+    assert_eq!(L::getMember(2, lst.clone())?, 2);
     Ok(())
 }
 
@@ -751,7 +751,7 @@ fn test_get_member() -> Result<()> {
 #[test]
 fn test_get_member_on_true() -> Result<()> {
     let lst = list![1i32, 2, 3];
-    assert_eq!(L::getMemberOnTrue(2i32, Arc::clone(&lst), Arc::new(eq_i))?, 2);
+    assert_eq!(L::getMemberOnTrue(2i32, lst.clone(), Arc::new(eq_i))?, 2);
     Ok(())
 }
 
@@ -785,7 +785,7 @@ fn test_has_several_elements_false() -> Result<()> {
 #[test]
 fn test_heap_sort_int_list() -> Result<()> {
     let lst = list![3i32, 1, 4, 1, 5, 9, 2, 6];
-    let result = L::heapSortIntList(Arc::clone(&lst))?;
+    let result = L::heapSortIntList(lst.clone())?;
     assert_eq!(result, list![1i32, 1, 2, 3, 4, 5, 6, 9]);
     Ok(())
 }
@@ -794,7 +794,7 @@ fn test_heap_sort_int_list() -> Result<()> {
 #[test]
 fn test_insert() -> Result<()> {
     let lst = list![1i32, 4, 5];
-    let result = L::insert(Arc::clone(&lst), 2, 2i32)?;
+    let result = L::insert(lst.clone(), 2, 2i32)?;
     assert_eq!(result, list![1i32, 2, 4, 5]);
     Ok(())
 }
@@ -804,7 +804,7 @@ fn test_insert() -> Result<()> {
 fn test_insert_list_sorted() -> Result<()> {
     let lst = list![1i32, 3, 5];
     let to_insert = list![2i32, 4];
-    let result = L::insertListSorted(Arc::clone(&lst), Arc::clone(&to_insert), Arc::new(less_i))?;
+    let result = L::insertListSorted(lst.clone(), to_insert.clone(), Arc::new(less_i))?;
     assert_eq!(result, list![1i32, 2, 3, 4, 5]);
     Ok(())
 }
@@ -847,7 +847,7 @@ fn test_int_range3_step() -> Result<()> {
 fn test_intersection1_on_true() -> Result<()> {
     let a = list![1i32, 2, 3];
     let b = list![2i32, 3, 4];
-    let result = L::intersection1OnTrue(Arc::clone(&a), Arc::clone(&b), Arc::new(eq_i))?;
+    let result = L::intersection1OnTrue(a.clone(), b.clone(), Arc::new(eq_i))?;
     assert!(result.0.len() > 0);
     Ok(())
 }
@@ -857,7 +857,7 @@ fn test_intersection1_on_true() -> Result<()> {
 fn test_intersection_on_true() {
     let a = list![1i32, 2, 3];
     let b = list![2i32, 3, 4];
-    let result = L::intersectionOnTrue(Arc::clone(&a), Arc::clone(&b), Arc::new(eq_i)).unwrap();
+    let result = L::intersectionOnTrue(a.clone(), b.clone(), Arc::new(eq_i)).unwrap();
     assert_eq!(result, list![2i32, 3]);
 }
 
@@ -885,8 +885,8 @@ fn test_is_equal_on_true() -> Result<()> {
 #[test]
 fn test_is_member_on_true() {
     let lst = list![1i32, 2, 3];
-    assert!(L::isMemberOnTrue(2i32, Arc::clone(&lst), Arc::new(eq_i)).unwrap());
-    assert!(!L::isMemberOnTrue(4i32, Arc::clone(&lst), Arc::new(eq_i)).unwrap());
+    assert!(L::isMemberOnTrue(2i32, lst.clone(), Arc::new(eq_i)).unwrap());
+    assert!(!L::isMemberOnTrue(4i32, lst.clone(), Arc::new(eq_i)).unwrap());
 }
 
 // ── IsPrefixOnTrue ──
@@ -894,7 +894,7 @@ fn test_is_member_on_true() {
 fn test_is_prefix_on_true() -> Result<()> {
     let prefix = list![1i32, 2];
     let full = list![1i32, 2, 3, 4];
-    assert!(L::isPrefixOnTrue(Arc::clone(&prefix), Arc::clone(&full), Arc::new(eq_i)).unwrap());
+    assert!(L::isPrefixOnTrue(prefix.clone(), full.clone(), Arc::new(eq_i)).unwrap());
     assert!(!L::isPrefixOnTrue(list![1i32, 3], full, Arc::new(eq_i)).unwrap());
     Ok(())
 }
@@ -904,7 +904,7 @@ fn test_is_prefix_on_true() -> Result<()> {
 fn test_keep_positions() -> Result<()> {
     let lst = list![1i32, 2, 3, 4, 5];
     let positions = list![1i32, 3, 5];
-    let result = L::keepPositions(Arc::clone(&lst), Arc::clone(&positions), false)?;
+    let result = L::keepPositions(lst.clone(), positions.clone(), false)?;
     assert_eq!(result, list![1i32, 3, 5]);
     Ok(())
 }
@@ -914,7 +914,7 @@ fn test_keep_positions() -> Result<()> {
 fn test_keep_positions_sorted() -> Result<()> {
     let lst = list![1i32, 2, 3, 4, 5];
     let positions = list![1i32, 3, 5];
-    let result = L::keepPositionsSorted(Arc::clone(&lst), Arc::clone(&positions), false)?;
+    let result = L::keepPositionsSorted(lst.clone(), positions.clone(), false)?;
     assert_eq!(result, list![1i32, 3, 5]);
     Ok(())
 }
@@ -923,7 +923,7 @@ fn test_keep_positions_sorted() -> Result<()> {
 #[test]
 fn test_last() -> Result<()> {
     let lst = list![1i32, 2, 3];
-    assert_eq!(L::last(Arc::clone(&lst))?, 3);
+    assert_eq!(L::last(lst.clone())?, 3);
     Ok(())
 }
 
@@ -931,7 +931,7 @@ fn test_last() -> Result<()> {
 #[test]
 fn test_last_list_or_empty() {
     let lst = list![list![1i32], list![2i32, 3]];
-    let result = L::lastListOrEmpty(Arc::clone(&lst));
+    let result = L::lastListOrEmpty(lst.clone());
     assert_eq!(result, list![2i32, 3]);
 }
 
@@ -939,7 +939,7 @@ fn test_last_list_or_empty() {
 #[test]
 fn test_last_n() -> Result<()> {
     let lst = list![1i32, 2, 3, 4, 5];
-    let result = L::lastN(Arc::clone(&lst), 3)?;
+    let result = L::lastN(lst.clone(), 3)?;
     assert_eq!(result, list![3i32, 4, 5]);
     Ok(())
 }
@@ -948,14 +948,14 @@ fn test_last_n() -> Result<()> {
 #[test]
 fn test_length_list_elements() {
     let lst = list![list![1i32, 2], list![3i32, 4, 5], list![6i32]];
-    assert_eq!(L::lengthListElements(Arc::clone(&lst)), 6);
+    assert_eq!(L::lengthListElements(lst.clone()), 6);
 }
 
 // ── ListArrayReverse ──
 #[test]
 fn test_list_array_reverse() -> Result<()> {
     let lst = list![1i32, 2, 3];
-    let result = L::listArrayReverse(Arc::clone(&lst))?;
+    let result = L::listArrayReverse(lst.clone())?;
     // Result is metamodelica::Array<i32> (Rc<RefCell<Vec<i32>>>)
     assert_eq!(result.borrow().len(), 3);
     Ok(())
@@ -966,15 +966,15 @@ fn test_list_array_reverse() -> Result<()> {
 fn test_list_is_longer() {
     let a = list![1i32, 2, 3];
     let b = list![1i32, 2];
-    assert!(L::listIsLonger(Arc::clone(&a), Arc::clone(&b)).unwrap());
-    assert!(!L::listIsLonger(Arc::clone(&b), Arc::clone(&a)).unwrap());
+    assert!(L::listIsLonger(a.clone(), b.clone()).unwrap());
+    assert!(!L::listIsLonger(b.clone(), a.clone()).unwrap());
 }
 
 // ── Map ──
 #[test]
 fn test_map() {
     let lst = list![1i32, 2, 3];
-    let result = L::map(Arc::clone(&lst), Arc::new(double)).unwrap();
+    let result = L::map(lst.clone(), Arc::new(double)).unwrap();
     assert_eq!(result, list![2i32, 4, 6]);
 }
 
@@ -983,7 +983,7 @@ fn test_map() {
 #[test]
 fn test_map1() {
     let lst = list![1i32, 2, 3];
-    let result = L::map1(Arc::clone(&lst), Arc::new(|x, factor: i32| Ok(x * factor)), 2i32).unwrap();
+    let result = L::map1(lst.clone(), Arc::new(|x, factor: i32| Ok(x * factor)), 2i32).unwrap();
     assert_eq!(result, list![2i32, 4, 6]);
 }
 
@@ -992,7 +992,7 @@ fn test_map1() {
 #[test]
 fn test_map1_fold() {
     let lst = list![1i32, 2, 3];
-    let (result, acc) = L::map1Fold(Arc::clone(&lst), Arc::new(|x, _const: i32, fold: i32| Ok((x + fold, fold + 1))), 0i32, 0i32).unwrap();
+    let (result, acc) = L::map1Fold(lst.clone(), Arc::new(|x, _const: i32, fold: i32| Ok((x + fold, fold + 1))), 0i32, 0i32).unwrap();
     assert_eq!(result, list![1i32, 3, 5]);
     assert_eq!(acc, 3);
 }
@@ -1001,7 +1001,7 @@ fn test_map1_fold() {
 #[test]
 fn test_map1_list() {
     let lst = list![list![1i32, 2]];
-    let result = L::map1List(Arc::clone(&lst), Arc::new(|x: i32, _arg: i32| Ok(x * 2)), 0i32).unwrap();
+    let result = L::map1List(lst.clone(), Arc::new(|x: i32, _arg: i32| Ok(x * 2)), 0i32).unwrap();
     // map1List reverses inner list due to cons-accumulation
     assert_eq!(result.len(), 1);
 }
@@ -1011,7 +1011,7 @@ fn test_map1_list() {
 #[test]
 fn test_map1_option() -> Result<()> {
     let lst = list![Some(1i32), Some(2)];
-    let result = L::map1Option(Arc::clone(&lst), Arc::new(|x, factor: i32| Ok(x * factor)), 2i32)?;
+    let result = L::map1Option(lst.clone(), Arc::new(|x, factor: i32| Ok(x * factor)), 2i32)?;
     assert_eq!(result, list![2i32, 4]);
     Ok(())
 }
@@ -1021,7 +1021,7 @@ fn test_map1_option() -> Result<()> {
 #[test]
 fn test_map1_0() {
     let lst = list![1i32, 2, 3];
-    L::map1_0(Arc::clone(&lst), Arc::new(|_x, _arg: i32| Ok(())), 0i32).unwrap();
+    L::map1_0(lst.clone(), Arc::new(|_x, _arg: i32| Ok(())), 0i32).unwrap();
 }
 
 // ── Map1_2 ──
@@ -1029,7 +1029,7 @@ fn test_map1_0() {
 #[test]
 fn test_map1_2() {
     let lst = list![1i32, 2];
-    let (r1, r2) = L::map1_2(Arc::clone(&lst), Arc::new(|x, _: i32| Ok((x * 2, x * 3))), 0i32).unwrap();
+    let (r1, r2) = L::map1_2(lst.clone(), Arc::new(|x, _: i32| Ok((x * 2, x * 3))), 0i32).unwrap();
     assert_eq!(r1, list![2i32, 4]);
     assert_eq!(r2, list![3i32, 6]);
 }
@@ -1039,7 +1039,7 @@ fn test_map1_2() {
 #[test]
 fn test_map1r() {
     let lst = list![1i32, 2, 3];
-    let result = L::map1r(Arc::clone(&lst), Arc::new(|factor: i32, x| Ok(x * factor)), 2i32).unwrap();
+    let result = L::map1r(lst.clone(), Arc::new(|factor: i32, x| Ok(x * factor)), 2i32).unwrap();
     assert_eq!(result, list![2i32, 4, 6]);
 }
 
@@ -1048,7 +1048,7 @@ fn test_map1r() {
 #[test]
 fn test_map2() {
     let lst = list![1i32, 2, 3];
-    let result = L::map2(Arc::clone(&lst), Arc::new(|x, a: i32, b: i32| Ok(x + a + b)), 10i32, 100i32).unwrap();
+    let result = L::map2(lst.clone(), Arc::new(|x, a: i32, b: i32| Ok(x + a + b)), 10i32, 100i32).unwrap();
     assert_eq!(result, list![111i32, 112, 113]);
 }
 
@@ -1057,7 +1057,7 @@ fn test_map2() {
 #[test]
 fn test_map2_fold() {
     let lst = list![1i32, 2];
-    let (result, acc) = L::map2Fold(Arc::clone(&lst), Arc::new(|x, _a: i32, _b: i32, fold: i32| Ok((x * 2, fold + 1))), 0i32, 0i32, 0i32, nil()).unwrap();
+    let (result, acc) = L::map2Fold(lst.clone(), Arc::new(|x, _a: i32, _b: i32, fold: i32| Ok((x * 2, fold + 1))), 0i32, 0i32, 0i32, nil()).unwrap();
     assert_eq!(result, list![2i32, 4]);
     assert_eq!(acc, 2);
 }
@@ -1066,7 +1066,7 @@ fn test_map2_fold() {
 #[test]
 fn test_map2_fold_check_reference_eq() {
     let lst = list![1i32, 2];
-    let (result, _acc) = L::map2FoldCheckReferenceEq(Arc::clone(&lst), Arc::new(|x, _a: i32, _b: i32, fold: i32| Ok((x * 2, fold + 1))), 0i32, 0i32, 0i32).unwrap();
+    let (result, _acc) = L::map2FoldCheckReferenceEq(lst.clone(), Arc::new(|x, _a: i32, _b: i32, fold: i32| Ok((x * 2, fold + 1))), 0i32, 0i32, 0i32).unwrap();
     assert_eq!(result, list![2i32, 4]);
 }
 
@@ -1075,7 +1075,7 @@ fn test_map2_fold_check_reference_eq() {
 #[test]
 fn test_map2_list() {
     let lst = list![list![1i32, 2]];
-    let result = L::map2List(Arc::clone(&lst), Arc::new(|x, a: i32, b: i32| Ok(x + a + b)), 10i32, 100i32).unwrap();
+    let result = L::map2List(lst.clone(), Arc::new(|x, a: i32, b: i32| Ok(x + a + b)), 10i32, 100i32).unwrap();
     assert_eq!(result, list![list![111i32, 112]]);
 }
 
@@ -1084,7 +1084,7 @@ fn test_map2_list() {
 #[test]
 fn test_map2_option() -> Result<()> {
     let lst = list![Some(1i32), Some(2)];
-    let result = L::map2Option(Arc::clone(&lst), Arc::new(|x, a: i32, b: i32| Ok(x + a + b)), 10i32, 100i32)?;
+    let result = L::map2Option(lst.clone(), Arc::new(|x, a: i32, b: i32| Ok(x + a + b)), 10i32, 100i32)?;
     assert_eq!(result, list![111i32, 112]);
     Ok(())
 }
@@ -1093,7 +1093,7 @@ fn test_map2_option() -> Result<()> {
 #[test]
 fn test_map2_reverse() {
     let lst = list![1i32, 2, 3];
-    let result = L::map2Reverse(Arc::clone(&lst), Arc::new(|x, a: i32, b: i32| Ok(x + a + b)), 10i32, 100i32).unwrap();
+    let result = L::map2Reverse(lst.clone(), Arc::new(|x, a: i32, b: i32| Ok(x + a + b)), 10i32, 100i32).unwrap();
     assert_eq!(result, list![113i32, 112, 111]);
 }
 
@@ -1101,14 +1101,14 @@ fn test_map2_reverse() {
 #[test]
 fn test_map2_0() {
     let lst = list![1i32, 2, 3];
-    L::map2_0(Arc::clone(&lst), Arc::new(|_x, _a: i32, _b: i32| Ok(())), 0i32, 0i32).unwrap();
+    L::map2_0(lst.clone(), Arc::new(|_x, _a: i32, _b: i32| Ok(())), 0i32, 0i32).unwrap();
 }
 
 // ── Map2_2 ──
 #[test]
 fn test_map2_2() {
     let lst = list![1i32, 2];
-    let (r1, r2) = L::map2_2(Arc::clone(&lst), Arc::new(|x, a: i32, _b: i32| Ok((x + a, x * 2))), 10i32, 0i32).unwrap();
+    let (r1, r2) = L::map2_2(lst.clone(), Arc::new(|x, a: i32, _b: i32| Ok((x + a, x * 2))), 10i32, 0i32).unwrap();
     assert_eq!(r1, list![11i32, 12]);
     assert_eq!(r2, list![2i32, 4]);
 }
@@ -1117,7 +1117,7 @@ fn test_map2_2() {
 #[test]
 fn test_map3() {
     let lst = list![1i32];
-    let result = L::map3(Arc::clone(&lst), Arc::new(|x, a: i32, b: i32, c: i32| Ok(x + a + b + c)), 10i32, 100i32, 1000i32).unwrap();
+    let result = L::map3(lst.clone(), Arc::new(|x, a: i32, b: i32, c: i32| Ok(x + a + b + c)), 10i32, 100i32, 1000i32).unwrap();
     assert_eq!(result, list![1111i32]);
 }
 
@@ -1125,7 +1125,7 @@ fn test_map3() {
 #[test]
 fn test_map3_fold() {
     let lst = list![1i32];
-    let (result, acc) = L::map3Fold(Arc::clone(&lst), Arc::new(|x, _a: i32, _b: i32, _c: i32, fold: i32| Ok((x * 2, fold + 1))), 0i32, 0i32, 0i32, 0i32).unwrap();
+    let (result, acc) = L::map3Fold(lst.clone(), Arc::new(|x, _a: i32, _b: i32, _c: i32, fold: i32| Ok((x * 2, fold + 1))), 0i32, 0i32, 0i32, 0i32).unwrap();
     assert_eq!(result, list![2i32]);
     assert_eq!(acc, 1);
 }
@@ -1134,7 +1134,7 @@ fn test_map3_fold() {
 #[test]
 fn test_map4() {
     let lst = list![1i32];
-    let result = L::map4(Arc::clone(&lst), Arc::new(|x, a: i32, b: i32, c: i32, d: i32| Ok(x + a + b + c + d)), 1i32, 2i32, 3i32, 4i32).unwrap();
+    let result = L::map4(lst.clone(), Arc::new(|x, a: i32, b: i32, c: i32, d: i32| Ok(x + a + b + c + d)), 1i32, 2i32, 3i32, 4i32).unwrap();
     assert_eq!(result, list![11i32]);
 }
 
@@ -1142,14 +1142,14 @@ fn test_map4() {
 #[test]
 fn test_map4_0() {
     let lst = list![1i32];
-    L::map4_0(Arc::clone(&lst), Arc::new(|_x, _a: i32, _b: i32, _c: i32, _d: i32| Ok(())), 0i32, 0i32, 0i32, 0i32).unwrap();
+    L::map4_0(lst.clone(), Arc::new(|_x, _a: i32, _b: i32, _c: i32, _d: i32| Ok(())), 0i32, 0i32, 0i32, 0i32).unwrap();
 }
 
 // ── Map5 ──
 #[test]
 fn test_map5() {
     let lst = list![1i32];
-    let result = L::map5(Arc::clone(&lst), Arc::new(|x, a: i32, b: i32, c: i32, d: i32, e: i32| Ok(x + a + b + c + d + e)), 1i32, 2i32, 3i32, 4i32, 5i32).unwrap();
+    let result = L::map5(lst.clone(), Arc::new(|x, a: i32, b: i32, c: i32, d: i32, e: i32| Ok(x + a + b + c + d + e)), 1i32, 2i32, 3i32, 4i32, 5i32).unwrap();
     assert_eq!(result, list![16i32]);
 }
 
@@ -1157,7 +1157,7 @@ fn test_map5() {
 #[test]
 fn test_map6() {
     let lst = list![1i32];
-    let result = L::map6(Arc::clone(&lst), Arc::new(|x, a: i32, b: i32, c: i32, d: i32, e: i32, f: i32| Ok(x + a + b + c + d + e + f)), 1i32, 2i32, 3i32, 4i32, 5i32, 6i32).unwrap();
+    let result = L::map6(lst.clone(), Arc::new(|x, a: i32, b: i32, c: i32, d: i32, e: i32, f: i32| Ok(x + a + b + c + d + e + f)), 1i32, 2i32, 3i32, 4i32, 5i32, 6i32).unwrap();
     assert_eq!(result, list![22i32]);
 }
 
@@ -1174,7 +1174,7 @@ fn test_map_array() {
 #[test]
 fn test_map_check_reference_eq() {
     let lst = list![1i32, 2, 3];
-    let result = L::mapCheckReferenceEq(Arc::clone(&lst), Arc::new(|x| Ok(x))).unwrap();
+    let result = L::mapCheckReferenceEq(lst.clone(), Arc::new(|x| Ok(x))).unwrap();
     assert_eq!(result, list![1i32, 2, 3]);
 }
 
@@ -1182,7 +1182,7 @@ fn test_map_check_reference_eq() {
 #[test]
 fn test_map_flat() {
     let lst = list![list![1i32, 2], list![3i32, 4]];
-    let result = L::mapFlat(Arc::clone(&lst), Arc::new(|inner| Ok(inner))).unwrap();
+    let result = L::mapFlat(lst.clone(), Arc::new(|inner| Ok(inner))).unwrap();
     // mapFlat reverses inner lists due to cons-accumulation
     assert_eq!(result.len(), 4);
 }
@@ -1191,7 +1191,7 @@ fn test_map_flat() {
 #[test]
 fn test_map_flat_reverse() {
     let lst = list![list![1i32, 2], list![3i32]];
-    let result = L::mapFlatReverse(Arc::clone(&lst), Arc::new(|inner| Ok(inner))).unwrap();
+    let result = L::mapFlatReverse(lst.clone(), Arc::new(|inner| Ok(inner))).unwrap();
     assert_eq!(result.len(), 3);
 }
 
@@ -1199,7 +1199,7 @@ fn test_map_flat_reverse() {
 #[test]
 fn test_map_fold() {
     let lst = list![1i32, 2, 3];
-    let (result, acc) = L::mapFold(Arc::clone(&lst), Arc::new(|x, a| Ok((x * 2, a + x))), 0i32).unwrap();
+    let (result, acc) = L::mapFold(lst.clone(), Arc::new(|x, a| Ok((x * 2, a + x))), 0i32).unwrap();
     assert_eq!(result, list![2i32, 4, 6]);
     assert_eq!(acc, 6);
 }
@@ -1208,7 +1208,7 @@ fn test_map_fold() {
 #[test]
 fn test_map_fold2() {
     let lst = list![1i32, 2];
-    let (result, a, b) = L::mapFold2(Arc::clone(&lst), Arc::new(|x, acc1: i32, acc2: i32| Ok((x * 2, acc1 + x, acc2 + x))), 0i32, 0i32).unwrap();
+    let (result, a, b) = L::mapFold2(lst.clone(), Arc::new(|x, acc1: i32, acc2: i32| Ok((x * 2, acc1 + x, acc2 + x))), 0i32, 0i32).unwrap();
     assert_eq!(result, list![2i32, 4]);
     assert_eq!(a, 3);
     assert_eq!(b, 3);
@@ -1218,7 +1218,7 @@ fn test_map_fold2() {
 #[test]
 fn test_map_fold3() {
     let lst = list![1i32];
-    let (result, a, b, c) = L::mapFold3(Arc::clone(&lst), Arc::new(|x, f1: i32, f2: i32, f3: i32| Ok((x * 2, f1 + x, f2 + x, f3 + x))), 0i32, 0i32, 0i32).unwrap();
+    let (result, a, b, c) = L::mapFold3(lst.clone(), Arc::new(|x, f1: i32, f2: i32, f3: i32| Ok((x * 2, f1 + x, f2 + x, f3 + x))), 0i32, 0i32, 0i32).unwrap();
     assert_eq!(result, list![2i32]);
     assert_eq!(a, 1);
     assert_eq!(b, 1);
@@ -1229,7 +1229,7 @@ fn test_map_fold3() {
 #[test]
 fn test_map_fold5() {
     let lst = list![1i32];
-    let (result, a, b, c, d, e) = L::mapFold5(Arc::clone(&lst), Arc::new(|x, f1: i32, f2: i32, f3: i32, f4: i32, f5: i32| Ok((x, f1+1, f2+1, f3+1, f4+1, f5+1))), 0i32, 0i32, 0i32, 0i32, 0i32).unwrap();
+    let (result, a, b, c, d, e) = L::mapFold5(lst.clone(), Arc::new(|x, f1: i32, f2: i32, f3: i32, f4: i32, f5: i32| Ok((x, f1+1, f2+1, f3+1, f4+1, f5+1))), 0i32, 0i32, 0i32, 0i32, 0i32).unwrap();
     assert_eq!(result, list![1i32]);
     assert_eq!(a, 1);
     assert_eq!(e, 1);
@@ -1239,7 +1239,7 @@ fn test_map_fold5() {
 #[test]
 fn test_map_fold_list() {
     let lst = list![list![1i32, 2], list![3i32]];
-    let (_result, acc) = L::mapFoldList(Arc::clone(&lst), Arc::new(|x, fold: i32| Ok((x * 2, fold + x))), 0i32).unwrap();
+    let (_result, acc) = L::mapFoldList(lst.clone(), Arc::new(|x, fold: i32| Ok((x * 2, fold + x))), 0i32).unwrap();
     assert_eq!(acc, 6);
 }
 
@@ -1248,7 +1248,7 @@ fn test_map_fold_list() {
 fn test_map_indices() -> Result<()> {
     let lst = list![1i32, 2, 3];
     let indices = list![1i32, 3];
-    let result = L::mapIndices(Arc::clone(&lst), Arc::clone(&indices), Arc::new(double))?;
+    let result = L::mapIndices(lst.clone(), indices.clone(), Arc::new(double))?;
     assert_eq!(result.len(), 3);
     Ok(())
 }
@@ -1257,7 +1257,7 @@ fn test_map_indices() -> Result<()> {
 #[test]
 fn test_map_list() {
     let lst = list![list![1i32, 2], list![3i32, 4]];
-    let result = L::mapList(Arc::clone(&lst), Arc::new(double)).unwrap();
+    let result = L::mapList(lst.clone(), Arc::new(double)).unwrap();
     assert_eq!(result, list![list![2i32, 4], list![6i32, 8]]);
 }
 
@@ -1265,7 +1265,7 @@ fn test_map_list() {
 #[test]
 fn test_map_list_reverse() {
     let lst = list![list![1i32, 2], list![3i32]];
-    let result = L::mapListReverse(Arc::clone(&lst), Arc::new(double)).unwrap();
+    let result = L::mapListReverse(lst.clone(), Arc::new(double)).unwrap();
     assert_eq!(result.len(), 2);
 }
 
@@ -1273,7 +1273,7 @@ fn test_map_list_reverse() {
 #[test]
 fn test_map_map() {
     let lst = list![1i32, 2, 3];
-    let result = L::mapMap(Arc::clone(&lst), Arc::new(double), Arc::new(|x| Ok(x + 1))).unwrap();
+    let result = L::mapMap(lst.clone(), Arc::new(double), Arc::new(|x| Ok(x + 1))).unwrap();
     assert_eq!(result, list![3i32, 5, 7]);
 }
 
@@ -1281,13 +1281,13 @@ fn test_map_map() {
 #[test]
 fn test_map_map_bool_and() {
     let lst = list![2i32, 4, 6];
-    let result = L::mapMapBoolAnd(Arc::clone(&lst), Arc::new(|x| Ok(x)), Arc::new(is_even)).unwrap();
+    let result = L::mapMapBoolAnd(lst.clone(), Arc::new(|x| Ok(x)), Arc::new(is_even)).unwrap();
     assert!(result);
 }
 #[test]
 fn test_map_map_bool_and_false() {
     let lst = list![1i32, 2, 3];
-    let result = L::mapMapBoolAnd(Arc::clone(&lst), Arc::new(|x| Ok(x)), Arc::new(is_even)).unwrap();
+    let result = L::mapMapBoolAnd(lst.clone(), Arc::new(|x| Ok(x)), Arc::new(is_even)).unwrap();
     assert!(!result);
 }
 
@@ -1295,7 +1295,7 @@ fn test_map_map_bool_and_false() {
 #[test]
 fn test_map_option() -> Result<()> {
     let lst = list![Some(1i32), Some(2)];
-    let result = L::mapOption(Arc::clone(&lst), Arc::new(|x| Ok(x * 2)))?;
+    let result = L::mapOption(lst.clone(), Arc::new(|x| Ok(x * 2)))?;
     assert_eq!(result, list![2i32, 4]);
     Ok(())
 }
@@ -1304,7 +1304,7 @@ fn test_map_option() -> Result<()> {
 #[test]
 fn test_map_reverse() {
     let lst = list![1i32, 2, 3];
-    let result = L::mapReverse(Arc::clone(&lst), Arc::new(double)).unwrap();
+    let result = L::mapReverse(lst.clone(), Arc::new(double)).unwrap();
     assert_eq!(result, list![6i32, 4, 2]);
 }
 
@@ -1312,14 +1312,14 @@ fn test_map_reverse() {
 #[test]
 fn test_map_0() {
     let lst = list![1i32, 2, 3];
-    L::map_0(Arc::clone(&lst), Arc::new(|_x| Ok(()))).unwrap();
+    L::map_0(lst.clone(), Arc::new(|_x| Ok(()))).unwrap();
 }
 
 // ── Map_2 ──
 #[test]
 fn test_map_2() {
     let lst = list![1i32, 2];
-    let (r1, r2) = L::map_2(Arc::clone(&lst), Arc::new(|x| Ok((x * 2, x * 3)))).unwrap();
+    let (r1, r2) = L::map_2(lst.clone(), Arc::new(|x| Ok((x * 2, x * 3)))).unwrap();
     assert_eq!(r1, list![2i32, 4]);
     assert_eq!(r2, list![3i32, 6]);
 }
@@ -1328,7 +1328,7 @@ fn test_map_2() {
 #[test]
 fn test_map_3() {
     let lst = list![1i32, 2];
-    let (r1, r2, r3) = L::map_3(Arc::clone(&lst), Arc::new(|x| Ok((x, x * 2, x * 3)))).unwrap();
+    let (r1, r2, r3) = L::map_3(lst.clone(), Arc::new(|x| Ok((x, x * 2, x * 3)))).unwrap();
     assert_eq!(r1, list![1i32, 2]);
     assert_eq!(r2, list![2i32, 4]);
     assert_eq!(r3, list![3i32, 6]);
@@ -1338,7 +1338,7 @@ fn test_map_3() {
 #[test]
 fn test_max_element() -> Result<()> {
     let lst = list![3i32, 1, 4, 1, 5, 9, 2, 6];
-    assert_eq!(L::maxElement(Arc::clone(&lst), Arc::new(less_i))?, 9);
+    assert_eq!(L::maxElement(lst.clone(), Arc::new(less_i))?, 9);
     Ok(())
 }
 
@@ -1347,7 +1347,7 @@ fn test_max_element() -> Result<()> {
 fn test_merge_sorted() -> Result<()> {
     let a = list![1i32, 3, 5];
     let b = list![2i32, 4, 6];
-    let result = L::mergeSorted(Arc::clone(&a), Arc::clone(&b), Arc::new(less_i))?;
+    let result = L::mergeSorted(a.clone(), b.clone(), Arc::new(less_i))?;
     assert_eq!(result, list![1i32, 2, 3, 4, 5, 6]);
     Ok(())
 }
@@ -1356,7 +1356,7 @@ fn test_merge_sorted() -> Result<()> {
 #[test]
 fn test_min_element() -> Result<()> {
     let lst = list![3i32, 1, 4, 1, 5];
-    assert_eq!(L::minElement(Arc::clone(&lst), Arc::new(less_i))?, 1);
+    assert_eq!(L::minElement(lst.clone(), Arc::new(less_i))?, 1);
     Ok(())
 }
 
@@ -1364,41 +1364,41 @@ fn test_min_element() -> Result<()> {
 #[test]
 fn test_mk_option_some() {
     let lst = list![1i32, 2];
-    let result = L::mkOption(Arc::clone(&lst));
+    let result = L::mkOption(lst.clone());
     assert!(result.is_some());
 }
 #[test]
 fn test_mk_option_none() {
-    let lst: Arc<List<i32>> = nil();
-    let result = L::mkOption(Arc::clone(&lst));
+    let lst: List<i32> = nil();
+    let result = L::mkOption(lst.clone());
     assert!(result.is_none());
 }
 
 // ── None ──
 #[test]
 fn test_none() {
-    let lst: Arc<List<i32>> = nil();
-    assert!(L::none(Arc::clone(&lst), Arc::new(is_positive)).unwrap());
+    let lst: List<i32> = nil();
+    assert!(L::none(lst.clone(), Arc::new(is_positive)).unwrap());
 }
 #[test]
 fn test_none_false() {
     let lst = list![1i32, -2];
-    assert!(!L::none(Arc::clone(&lst), Arc::new(is_positive)).unwrap());
+    assert!(!L::none(lst.clone(), Arc::new(is_positive)).unwrap());
 }
 
 // ── NotMember ──
 #[test]
 fn test_not_member() {
     let lst = list![1i32, 2, 3];
-    assert!(L::notMember(4, Arc::clone(&lst)));
-    assert!(!L::notMember(2, Arc::clone(&lst)));
+    assert!(L::notMember(4, lst.clone()));
+    assert!(!L::notMember(2, lst.clone()));
 }
 
 // ── Partition ──
 #[test]
 fn test_partition() -> Result<()> {
     let lst = list![1i32, 2, 3, 4, 5, 6];
-    let result = L::partition(Arc::clone(&lst), 2)?;
+    let result = L::partition(lst.clone(), 2)?;
     assert!(result.len() > 0);
     Ok(())
 }
@@ -1407,35 +1407,35 @@ fn test_partition() -> Result<()> {
 #[test]
 fn test_position() -> Result<()> {
     let lst = list![1i32, 2, 3, 4, 5];
-    assert_eq!(L::position(3, Arc::clone(&lst))?, 3);
+    assert_eq!(L::position(3, lst.clone())?, 3);
     Ok(())
 }
 #[test]
 fn test_position_not_found() {
     let lst = list![1i32, 2, 3];
     // position returns Err when element not found
-    assert!(L::position(9, Arc::clone(&lst)).is_err());
+    assert!(L::position(9, lst.clone()).is_err());
 }
 
 // ── Position1OnTrue ──
 #[test]
 fn test_position1_on_true() {
     let lst = list![1i32, 2, 3];
-    assert_eq!(L::position1OnTrue(Arc::clone(&lst), Arc::new(|x, _: i32| Ok(x == 2)), 0i32).unwrap(), 2);
+    assert_eq!(L::position1OnTrue(lst.clone(), Arc::new(|x, _: i32| Ok(x == 2)), 0i32).unwrap(), 2);
 }
 
 // ── PositionOnTrue ──
 #[test]
 fn test_position_on_true() {
     let lst = list![1i32, 2, 3];
-    assert_eq!(L::positionOnTrue(Arc::clone(&lst), Arc::new(is_even)).unwrap(), 2);
+    assert_eq!(L::positionOnTrue(lst.clone(), Arc::new(is_even)).unwrap(), 2);
 }
 
 // ── Reduce ──
 #[test]
 fn test_reduce() -> Result<()> {
     let lst = list![1i32, 2, 3, 4];
-    let result = L::reduce(Arc::clone(&lst), Arc::new(add_i))?;
+    let result = L::reduce(lst.clone(), Arc::new(add_i))?;
     assert_eq!(result, 10);
     Ok(())
 }
@@ -1444,7 +1444,7 @@ fn test_reduce() -> Result<()> {
 #[test]
 fn test_remove_on_true() {
     let lst = list![1i32, 2, 3, 4];
-    let result = L::removeOnTrue(2i32, Arc::new(eq_i), Arc::clone(&lst)).unwrap();
+    let result = L::removeOnTrue(2i32, Arc::new(eq_i), lst.clone()).unwrap();
     assert_eq!(result, list![1i32, 3, 4]);
 }
 
@@ -1452,7 +1452,7 @@ fn test_remove_on_true() {
 #[test]
 fn test_repeat() {
     let elt = list![42i32];
-    let result = L::repeat(Arc::clone(&elt), 3);
+    let result = L::repeat(elt.clone(), 3);
     assert_eq!(result.len(), 3);
 }
 
@@ -1460,7 +1460,7 @@ fn test_repeat() {
 #[test]
 fn test_replace_at() -> Result<()> {
     let lst = list![1i32, 2, 3];
-    let result = L::replaceAt(99i32, 2, Arc::clone(&lst))?;
+    let result = L::replaceAt(99i32, 2, lst.clone())?;
     assert_eq!(result, list![1i32, 99, 3]);
     Ok(())
 }
@@ -1469,7 +1469,7 @@ fn test_replace_at() -> Result<()> {
 #[test]
 fn test_replace_at_index_first() -> Result<()> {
     let lst = list![1i32, 2, 3];
-    let result = L::replaceAtIndexFirst(1, 99i32, Arc::clone(&lst))?;
+    let result = L::replaceAtIndexFirst(1, 99i32, lst.clone())?;
     assert_eq!(result, list![99i32, 2, 3]);
     Ok(())
 }
@@ -1479,7 +1479,7 @@ fn test_replace_at_index_first() -> Result<()> {
 fn test_replace_at_with_list() -> Result<()> {
     let lst = list![1i32, 2, 3];
     let replacement = list![10i32, 11];
-    let result = L::replaceAtWithList(Arc::clone(&replacement), 2, Arc::clone(&lst))?;
+    let result = L::replaceAtWithList(replacement.clone(), 2, lst.clone())?;
     assert!(result.len() > 0);
     Ok(())
 }
@@ -1488,7 +1488,7 @@ fn test_replace_at_with_list() -> Result<()> {
 #[test]
 fn test_replace_on_true() -> Result<()> {
     let lst = list![1i32, 2, 3];
-    let (result, replaced) = L::replaceOnTrue(99i32, Arc::clone(&lst), Arc::new(|x| Ok(x == 2)))?;
+    let (result, replaced) = L::replaceOnTrue(99i32, lst.clone(), Arc::new(|x| Ok(x == 2)))?;
     assert!(replaced);
     assert_eq!(result, list![1i32, 99, 3]);
     Ok(())
@@ -1498,14 +1498,14 @@ fn test_replace_on_true() -> Result<()> {
 #[test]
 fn test_rest_or_empty() -> Result<()> {
     let lst = list![1i32, 2, 3];
-    let result = L::restOrEmpty(Arc::clone(&lst))?;
+    let result = L::restOrEmpty(lst.clone())?;
     assert_eq!(result, list![2i32, 3]);
     Ok(())
 }
 #[test]
 fn test_rest_or_empty_empty() -> Result<()> {
-    let lst: Arc<List<i32>> = nil();
-    let result = L::restOrEmpty(Arc::clone(&lst))?;
+    let lst: List<i32> = nil();
+    let result = L::restOrEmpty(lst.clone())?;
     assert!(result.is_empty());
     Ok(())
 }
@@ -1514,7 +1514,7 @@ fn test_rest_or_empty_empty() -> Result<()> {
 #[test]
 fn test_second() -> Result<()> {
     let lst = list![1i32, 2, 3];
-    assert_eq!(L::second(Arc::clone(&lst))?, 2);
+    assert_eq!(L::second(lst.clone())?, 2);
     Ok(())
 }
 
@@ -1522,7 +1522,7 @@ fn test_second() -> Result<()> {
 #[test]
 fn test_separate1_on_true() {
     let lst = list![1i32, 2, 3];
-    let (a, b) = L::separate1OnTrue(Arc::clone(&lst), Arc::new(|x, _: i32| Ok(x % 2 == 0)), 0i32).unwrap();
+    let (a, b) = L::separate1OnTrue(lst.clone(), Arc::new(|x, _: i32| Ok(x % 2 == 0)), 0i32).unwrap();
     // separate functions use cons-accumulation (reversed output)
     assert_eq!(a.len(), 1);
     assert_eq!(b.len(), 2);
@@ -1532,7 +1532,7 @@ fn test_separate1_on_true() {
 #[test]
 fn test_separate_on_true() {
     let lst = list![1i32, 2, 3, 4];
-    let (a, b) = L::separateOnTrue(Arc::clone(&lst), Arc::new(is_even)).unwrap();
+    let (a, b) = L::separateOnTrue(lst.clone(), Arc::new(is_even)).unwrap();
     // separate functions use cons-accumulation (reversed output)
     assert_eq!(a.len(), 2);
     assert_eq!(b.len(), 2);
@@ -1542,7 +1542,7 @@ fn test_separate_on_true() {
 #[test]
 fn test_set() -> Result<()> {
     let lst = list![1i32, 2, 3];
-    let result = L::set(Arc::clone(&lst), 2, 99)?;
+    let result = L::set(lst.clone(), 2, 99)?;
     assert_eq!(result, list![1i32, 99, 3]);
     Ok(())
 }
@@ -1552,7 +1552,7 @@ fn test_set() -> Result<()> {
 fn test_set_difference() -> Result<()> {
     let a = list![1i32, 2, 3, 4];
     let b = list![3i32, 4, 5];
-    let result = L::setDifference(Arc::clone(&a), Arc::clone(&b))?;
+    let result = L::setDifference(a.clone(), b.clone())?;
     assert_eq!(result, list![1i32, 2]);
     Ok(())
 }
@@ -1562,7 +1562,7 @@ fn test_set_difference() -> Result<()> {
 fn test_set_difference_int_n() -> Result<()> {
     let a = list![1i32, 2, 3, 4];
     let b = list![3i32, 4, 5];
-    let result = L::setDifferenceIntN(Arc::clone(&a), Arc::clone(&b), 5)?;
+    let result = L::setDifferenceIntN(a.clone(), b.clone(), 5)?;
     assert!(result.len() <= 4);
     Ok(())
 }
@@ -1572,7 +1572,7 @@ fn test_set_difference_int_n() -> Result<()> {
 fn test_set_difference_on_true() -> Result<()> {
     let a = list![1i32, 2, 3];
     let b = list![2i32, 3];
-    let result = L::setDifferenceOnTrue(Arc::clone(&a), Arc::clone(&b), Arc::new(eq_i))?;
+    let result = L::setDifferenceOnTrue(a.clone(), b.clone(), Arc::new(eq_i))?;
     assert_eq!(result, list![1i32]);
     Ok(())
 }
@@ -1582,14 +1582,14 @@ fn test_set_difference_on_true() -> Result<()> {
 fn test_set_equal_on_true() {
     let a = list![1i32, 2, 3];
     let b = list![3i32, 1, 2];
-    assert!(L::setEqualOnTrue(Arc::clone(&a), Arc::clone(&b), Arc::new(eq_i)).unwrap());
+    assert!(L::setEqualOnTrue(a.clone(), b.clone(), Arc::new(eq_i)).unwrap());
 }
 
 // ── Sort ──
 #[test]
 fn test_sort() -> Result<()> {
     let lst = list![3i32, 1, 4, 1, 5, 9, 2, 6];
-    let result = L::sort(Arc::clone(&lst), Arc::new(less_i))?;
+    let result = L::sort(lst.clone(), Arc::new(less_i))?;
     assert_eq!(result, list![9i32, 6, 5, 4, 3, 2, 1, 1]);
     Ok(())
 }
@@ -1598,7 +1598,7 @@ fn test_sort() -> Result<()> {
 #[test]
 fn test_sorted_duplicates() -> Result<()> {
     let lst = list![1i32, 1, 2, 3, 3, 4];
-    let result = L::sortedDuplicates(Arc::clone(&lst), Arc::new(eq_i))?;
+    let result = L::sortedDuplicates(lst.clone(), Arc::new(eq_i))?;
     assert!(result.len() >= 0);
     Ok(())
 }
@@ -1607,7 +1607,7 @@ fn test_sorted_duplicates() -> Result<()> {
 #[test]
 fn test_sorted_list_all_unique() -> Result<()> {
     let lst = list![1i32, 2, 3];
-    assert!(L::sortedListAllUnique(Arc::clone(&lst), Arc::new(eq_i))?);
+    assert!(L::sortedListAllUnique(lst.clone(), Arc::new(eq_i))?);
     Ok(())
 }
 
@@ -1615,7 +1615,7 @@ fn test_sorted_list_all_unique() -> Result<()> {
 #[test]
 fn test_sorted_unique() -> Result<()> {
     let lst = list![1i32, 1, 2, 3, 3, 4];
-    let result = L::sortedUnique(Arc::clone(&lst), Arc::new(eq_i))?;
+    let result = L::sortedUnique(lst.clone(), Arc::new(eq_i))?;
     assert_eq!(result, list![1i32, 2, 3, 4]);
     Ok(())
 }
@@ -1624,7 +1624,7 @@ fn test_sorted_unique() -> Result<()> {
 #[test]
 fn test_sorted_unique_and_duplicates() -> Result<()> {
     let lst = list![1i32, 1, 2, 3, 3, 4];
-    let (unique, _dups) = L::sortedUniqueAndDuplicates(Arc::clone(&lst), Arc::new(eq_i))?;
+    let (unique, _dups) = L::sortedUniqueAndDuplicates(lst.clone(), Arc::new(eq_i))?;
     assert_eq!(unique, list![1i32, 2, 3, 4]);
     Ok(())
 }
@@ -1633,7 +1633,7 @@ fn test_sorted_unique_and_duplicates() -> Result<()> {
 #[test]
 fn test_sorted_unique_only_duplicates() -> Result<()> {
     let lst = list![1i32, 1, 2, 3, 3, 4];
-    let result = L::sortedUniqueOnlyDuplicates(Arc::clone(&lst), Arc::new(eq_i))?;
+    let result = L::sortedUniqueOnlyDuplicates(lst.clone(), Arc::new(eq_i))?;
     assert!(result.len() >= 0);
     Ok(())
 }
@@ -1642,7 +1642,7 @@ fn test_sorted_unique_only_duplicates() -> Result<()> {
 #[test]
 fn test_split() -> Result<()> {
     let lst = list![1i32, 2, 3, 4, 5];
-    let (a, b) = L::split(Arc::clone(&lst), 3)?;
+    let (a, b) = L::split(lst.clone(), 3)?;
     assert_eq!(a, list![1i32, 2, 3]);
     assert_eq!(b, list![4i32, 5]);
     Ok(())
@@ -1652,7 +1652,7 @@ fn test_split() -> Result<()> {
 #[test]
 fn test_split1_on_true() {
     let lst = list![1i32, 2, 3];
-    let (before, after) = L::split1OnTrue(Arc::clone(&lst), Arc::new(|x, _: i32| Ok(x == 2)), 0i32).unwrap();
+    let (before, after) = L::split1OnTrue(lst.clone(), Arc::new(|x, _: i32| Ok(x == 2)), 0i32).unwrap();
     assert_eq!(before.len() + after.len(), 3);
 }
 
@@ -1660,7 +1660,7 @@ fn test_split1_on_true() {
 #[test]
 fn test_split2_on_true() {
     let lst = list![1i32, 2, 3, 4];
-    let (before, after) = L::split2OnTrue(Arc::clone(&lst), Arc::new(|x, _a: i32, _b: i32| Ok(x == 3)), 0i32, 0i32).unwrap();
+    let (before, after) = L::split2OnTrue(lst.clone(), Arc::new(|x, _a: i32, _b: i32| Ok(x == 3)), 0i32, 0i32).unwrap();
     assert_eq!(before.len() + after.len(), 4);
 }
 
@@ -1668,7 +1668,7 @@ fn test_split2_on_true() {
 #[test]
 fn test_split_equal_parts() -> Result<()> {
     let lst = list![1i32, 2, 3, 4, 5, 6];
-    let result = L::splitEqualParts(Arc::clone(&lst), 2)?;
+    let result = L::splitEqualParts(lst.clone(), 2)?;
     assert_eq!(result.len(), 2);
     Ok(())
 }
@@ -1678,7 +1678,7 @@ fn test_split_equal_parts() -> Result<()> {
 fn test_split_equal_prefix() -> Result<()> {
     let a = list![1i32, 2, 3];
     let b = list![1i32, 2, 4];
-    let (prefix, _rest) = L::splitEqualPrefix(Arc::clone(&a), Arc::clone(&b), Arc::new(eq_i), nil())?;
+    let (prefix, _rest) = L::splitEqualPrefix(a.clone(), b.clone(), Arc::new(eq_i), nil())?;
     assert_eq!(prefix.len(), 2);
     Ok(())
 }
@@ -1687,7 +1687,7 @@ fn test_split_equal_prefix() -> Result<()> {
 #[test]
 fn test_split_last() -> Result<()> {
     let lst = list![1i32, 2, 3];
-    let (last, init) = L::splitLast(Arc::clone(&lst))?;
+    let (last, init) = L::splitLast(lst.clone())?;
     assert_eq!(last, 3);
     assert_eq!(init, list![1i32, 2]);
     Ok(())
@@ -1698,7 +1698,7 @@ fn test_split_last() -> Result<()> {
 fn test_split_on_bool_list() -> Result<()> {
     let lst = list![1i32, 2, 3, 4];
     let blist = list![false, true, false, true];
-    let (trues, falses) = L::splitOnBoolList(Arc::clone(&lst), Arc::clone(&blist))?;
+    let (trues, falses) = L::splitOnBoolList(lst.clone(), blist.clone())?;
     assert_eq!(trues, list![2i32, 4]);
     assert_eq!(falses, list![1i32, 3]);
     Ok(())
@@ -1708,7 +1708,7 @@ fn test_split_on_bool_list() -> Result<()> {
 #[test]
 fn test_split_on_first_match() -> Result<()> {
     let lst = list![1i32, 2, 3, 4];
-    let (before, after) = L::splitOnFirstMatch(Arc::clone(&lst), Arc::new(is_even))?;
+    let (before, after) = L::splitOnFirstMatch(lst.clone(), Arc::new(is_even))?;
     assert_eq!(before, list![1i32]);
     assert_eq!(after, list![2i32, 3, 4]);
     Ok(())
@@ -1718,7 +1718,7 @@ fn test_split_on_first_match() -> Result<()> {
 #[test]
 fn test_split_on_true() {
     let lst = list![1i32, 2, 3, 4];
-    let (trues, falses) = L::splitOnTrue(Arc::clone(&lst), Arc::new(is_even)).unwrap();
+    let (trues, falses) = L::splitOnTrue(lst.clone(), Arc::new(is_even)).unwrap();
     assert_eq!(trues, list![2i32, 4]);
     assert_eq!(falses, list![1i32, 3]);
 }
@@ -1727,7 +1727,7 @@ fn test_split_on_true() {
 #[test]
 fn test_splitr() -> Result<()> {
     let lst = list![1i32, 2, 3, 4, 5];
-    let (a, b) = L::splitr(Arc::clone(&lst), 3)?;
+    let (a, b) = L::splitr(lst.clone(), 3)?;
     assert_eq!(a.len() + b.len(), 5);
     Ok(())
 }
@@ -1736,7 +1736,7 @@ fn test_splitr() -> Result<()> {
 #[test]
 fn test_strip_last() -> Result<()> {
     let lst = list![1i32, 2, 3];
-    let result = L::stripLast(Arc::clone(&lst))?;
+    let result = L::stripLast(lst.clone())?;
     assert_eq!(result, list![1i32, 2]);
     Ok(())
 }
@@ -1745,7 +1745,7 @@ fn test_strip_last() -> Result<()> {
 #[test]
 fn test_strip_n() -> Result<()> {
     let lst = list![1i32, 2, 3, 4, 5];
-    let result = L::stripN(Arc::clone(&lst), 2)?;
+    let result = L::stripN(lst.clone(), 2)?;
     assert_eq!(result, list![3i32, 4, 5]);
     Ok(())
 }
@@ -1754,7 +1754,7 @@ fn test_strip_n() -> Result<()> {
 #[test]
 fn test_sublist() -> Result<()> {
     let lst = list![1i32, 2, 3, 4, 5];
-    let result = L::sublist(Arc::clone(&lst), 2, 3)?;
+    let result = L::sublist(lst.clone(), 2, 3)?;
     assert_eq!(result, list![2i32, 3, 4]);
     Ok(())
 }
@@ -1764,7 +1764,7 @@ fn test_sublist() -> Result<()> {
 fn test_thread() -> Result<()> {
     let a = list![1i32, 2, 3];
     let b = list![4i32, 5, 6];
-    let result = L::thread(Arc::clone(&a), Arc::clone(&b), nil())?;
+    let result = L::thread(a.clone(), b.clone(), nil())?;
     assert_eq!(result.len(), 6);
     Ok(())
 }
@@ -1775,7 +1775,7 @@ fn test_thread3_map() {
     let a = list![1i32, 2];
     let b = list![10i32, 20];
     let c = list![100i32, 200];
-    let result = L::thread3Map(Arc::clone(&a), Arc::clone(&b), Arc::clone(&c), Arc::new(|x, y, z| Ok(x + y + z))).unwrap();
+    let result = L::thread3Map(a.clone(), b.clone(), c.clone(), Arc::new(|x, y, z| Ok(x + y + z))).unwrap();
     assert_eq!(result, list![111i32, 222]);
 }
 
@@ -1785,7 +1785,7 @@ fn test_thread3_map_fold() -> Result<()> {
     let a = list![1i32, 2];
     let b = list![10i32, 20];
     let c = list![100i32, 200];
-    let (result, acc) = L::thread3MapFold(Arc::clone(&a), Arc::clone(&b), Arc::clone(&c), Arc::new(|x, y, z, fold: i32| Ok((x + y + z, fold + 1))), 0i32)?;
+    let (result, acc) = L::thread3MapFold(a.clone(), b.clone(), c.clone(), Arc::new(|x, y, z, fold: i32| Ok((x + y + z, fold + 1))), 0i32)?;
     assert_eq!(result, list![111i32, 222]);
     assert_eq!(acc, 2);
     Ok(())
@@ -1796,7 +1796,7 @@ fn test_thread3_map_fold() -> Result<()> {
 fn test_thread_fold() -> Result<()> {
     let a = list![1i32, 2, 3];
     let b = list![4i32, 5, 6];
-    let result = L::threadFold(Arc::clone(&a), Arc::clone(&b), Arc::new(|x, y, acc| Ok(acc + x + y)), 0i32)?;
+    let result = L::threadFold(a.clone(), b.clone(), Arc::new(|x, y, acc| Ok(acc + x + y)), 0i32)?;
     assert_eq!(result, 21);
     Ok(())
 }
@@ -1806,7 +1806,7 @@ fn test_thread_fold() -> Result<()> {
 fn test_thread_fold1() -> Result<()> {
     let a = list![1i32, 2];
     let b = list![3i32, 4];
-    let result = L::threadFold1(Arc::clone(&a), Arc::clone(&b), Arc::new(|x, y, _arg: i32, acc| Ok(acc + x + y)), 0i32, 0i32)?;
+    let result = L::threadFold1(a.clone(), b.clone(), Arc::new(|x, y, _arg: i32, acc| Ok(acc + x + y)), 0i32, 0i32)?;
     assert_eq!(result, 10);
     Ok(())
 }
@@ -1816,7 +1816,7 @@ fn test_thread_fold1() -> Result<()> {
 fn test_thread_fold2() -> Result<()> {
     let a = list![1i32];
     let b = list![2i32];
-    let result = L::threadFold2(Arc::clone(&a), Arc::clone(&b), Arc::new(|x, y, _a: i32, _b: i32, acc| Ok(acc + x + y)), 0i32, 0i32, 0i32)?;
+    let result = L::threadFold2(a.clone(), b.clone(), Arc::new(|x, y, _a: i32, _b: i32, acc| Ok(acc + x + y)), 0i32, 0i32, 0i32)?;
     assert_eq!(result, 3);
     Ok(())
 }
@@ -1826,7 +1826,7 @@ fn test_thread_fold2() -> Result<()> {
 fn test_thread_fold3() -> Result<()> {
     let a = list![1i32];
     let b = list![2i32];
-    let result = L::threadFold3(Arc::clone(&a), Arc::clone(&b), Arc::new(|x, y, _a: i32, _b: i32, _c: i32, acc| Ok(acc + x + y)), 0i32, 0i32, 0i32, 0i32)?;
+    let result = L::threadFold3(a.clone(), b.clone(), Arc::new(|x, y, _a: i32, _b: i32, _c: i32, acc| Ok(acc + x + y)), 0i32, 0i32, 0i32, 0i32)?;
     assert_eq!(result, 3);
     Ok(())
 }
@@ -1836,7 +1836,7 @@ fn test_thread_fold3() -> Result<()> {
 fn test_thread_map() {
     let a = list![1i32, 2, 3];
     let b = list![4i32, 5, 6];
-    let result = L::threadMap(Arc::clone(&a), Arc::clone(&b), Arc::new(|x, y| Ok(x + y))).unwrap();
+    let result = L::threadMap(a.clone(), b.clone(), Arc::new(|x, y| Ok(x + y))).unwrap();
     assert_eq!(result, list![5i32, 7, 9]);
 }
 
@@ -1845,7 +1845,7 @@ fn test_thread_map() {
 fn test_thread_map1() {
     let a = list![1i32, 2];
     let b = list![3i32, 4];
-    let result = L::threadMap1(Arc::clone(&a), Arc::clone(&b), Arc::new(|x, y, _arg: i32| Ok(x + y)), 0i32).unwrap();
+    let result = L::threadMap1(a.clone(), b.clone(), Arc::new(|x, y, _arg: i32| Ok(x + y)), 0i32).unwrap();
     assert_eq!(result, list![4i32, 6]);
 }
 
@@ -1854,7 +1854,7 @@ fn test_thread_map1() {
 fn test_thread_map1_0() -> Result<()> {
     let a = list![1i32, 2];
     let b = list![3i32, 4];
-    L::threadMap1_0(Arc::clone(&a), Arc::clone(&b), Arc::new(|_x, _y, _arg: i32| Ok(())), 0i32)?;
+    L::threadMap1_0(a.clone(), b.clone(), Arc::new(|_x, _y, _arg: i32| Ok(())), 0i32)?;
     Ok(())
 }
 
@@ -1863,7 +1863,7 @@ fn test_thread_map1_0() -> Result<()> {
 fn test_thread_map2() {
     let a = list![1i32];
     let b = list![2i32];
-    let result = L::threadMap2(Arc::clone(&a), Arc::clone(&b), Arc::new(|x, y, _a: i32, _b: i32| Ok(x + y)), 0i32, 0i32).unwrap();
+    let result = L::threadMap2(a.clone(), b.clone(), Arc::new(|x, y, _a: i32, _b: i32| Ok(x + y)), 0i32, 0i32).unwrap();
     assert_eq!(result, list![3i32]);
 }
 
@@ -1872,7 +1872,7 @@ fn test_thread_map2() {
 fn test_thread_map_fold() -> Result<()> {
     let a = list![1i32, 2];
     let b = list![3i32, 4];
-    let (result, acc) = L::threadMapFold(Arc::clone(&a), Arc::clone(&b), Arc::new(|x, y, fold: i32| Ok((x + y, fold + 1))), 0i32)?;
+    let (result, acc) = L::threadMapFold(a.clone(), b.clone(), Arc::new(|x, y, fold: i32| Ok((x + y, fold + 1))), 0i32)?;
     assert_eq!(result, list![4i32, 6]);
     assert_eq!(acc, 2);
     Ok(())
@@ -1883,7 +1883,7 @@ fn test_thread_map_fold() -> Result<()> {
 fn test_thread_map_list() {
     let a = list![list![1i32, 2]];
     let b = list![list![3i32, 4]];
-    let result = L::threadMapList(Arc::clone(&a), Arc::clone(&b), Arc::new(|x, y| Ok(x + y))).unwrap();
+    let result = L::threadMapList(a.clone(), b.clone(), Arc::new(|x, y| Ok(x + y))).unwrap();
     assert_eq!(result, list![list![4i32, 6]]);
 }
 
@@ -1892,7 +1892,7 @@ fn test_thread_map_list() {
 fn test_thread_map_list_2() -> Result<()> {
     let a = list![list![1i32, 2]];
     let b = list![list![3i32, 4]];
-    let (r1, _r2) = L::threadMapList_2(Arc::clone(&a), Arc::clone(&b), Arc::new(|x, y| Ok((x + y, x * y))))?;
+    let (r1, _r2) = L::threadMapList_2(a.clone(), b.clone(), Arc::new(|x, y| Ok((x + y, x * y))))?;
     assert_eq!(r1, list![list![4i32, 6]]);
     Ok(())
 }
@@ -1902,7 +1902,7 @@ fn test_thread_map_list_2() -> Result<()> {
 fn test_thread_map_2() -> Result<()> {
     let a = list![1i32, 2];
     let b = list![3i32, 4];
-    let (r1, r2) = L::threadMap_2(Arc::clone(&a), Arc::clone(&b), Arc::new(|x, y| Ok((x + y, x * y))))?;
+    let (r1, r2) = L::threadMap_2(a.clone(), b.clone(), Arc::new(|x, y| Ok((x + y, x * y))))?;
     assert_eq!(r1, list![4i32, 6]);
     assert_eq!(r2, list![3i32, 8]);
     Ok(())
@@ -1912,7 +1912,7 @@ fn test_thread_map_2() -> Result<()> {
 #[test]
 fn test_to_list_with_positions() {
     let lst = list![10i32, 20, 30];
-    let result = L::toListWithPositions(Arc::clone(&lst));
+    let result = L::toListWithPositions(lst.clone());
     assert_eq!(result.len(), 3);
 }
 
@@ -1920,14 +1920,14 @@ fn test_to_list_with_positions() {
 #[test]
 fn test_to_string() -> Result<()> {
     let lst = list![1i32, 2, 3];
-    let result = L::toStringCustom(Arc::clone(&lst), Arc::new(to_string_i32), arcstr::literal!(""), arcstr::literal!("{"), arcstr::literal!(", "), arcstr::literal!("}"), true, -1)?;
+    let result = L::toStringCustom(lst.clone(), Arc::new(to_string_i32), arcstr::literal!(""), arcstr::literal!("{"), arcstr::literal!(", "), arcstr::literal!("}"), true, -1)?;
     assert_eq!(&*result, "{1, 2, 3}");
     Ok(())
 }
 #[test]
 fn test_to_string_empty() -> Result<()> {
-    let lst: Arc<List<i32>> = nil();
-    let result = L::toStringCustom(Arc::clone(&lst), Arc::new(to_string_i32), arcstr::literal!(""), arcstr::literal!("{"), arcstr::literal!(", "), arcstr::literal!("}"), true, -1)?;
+    let lst: List<i32> = nil();
+    let result = L::toStringCustom(lst.clone(), Arc::new(to_string_i32), arcstr::literal!(""), arcstr::literal!("{"), arcstr::literal!(", "), arcstr::literal!("}"), true, -1)?;
     assert_eq!(&*result, "{}");
     Ok(())
 }
@@ -1937,8 +1937,8 @@ fn test_to_string_empty() -> Result<()> {
 fn test_transpose_list() -> Result<()> {
     let a = list![1i32, 2];
     let b = list![3i32, 4];
-    let lst = list![Arc::clone(&a), Arc::clone(&b)];
-    let result = L::transposeList(Arc::clone(&lst))?;
+    let lst = list![a.clone(), b.clone()];
+    let result = L::transposeList(lst.clone())?;
     assert_eq!(result.len(), 2);
     Ok(())
 }
@@ -1947,7 +1947,7 @@ fn test_transpose_list() -> Result<()> {
 #[test]
 fn test_trim() -> Result<()> {
     let lst = list![2i32, 1, 3, 4, 2];
-    let result = L::trim(Arc::clone(&lst), Arc::new(is_even))?;
+    let result = L::trim(lst.clone(), Arc::new(is_even))?;
     assert!(result.len() > 0);
     Ok(())
 }
@@ -1956,7 +1956,7 @@ fn test_trim() -> Result<()> {
 #[test]
 fn test_trim_to_length() -> Result<()> {
     let lst = list![1i32, 2, 3, 4, 5];
-    let result = L::trimToLength(Arc::clone(&lst), 3)?;
+    let result = L::trimToLength(lst.clone(), 3)?;
     // trimToLength keeps last N elements
     assert_eq!(result.len(), 3);
     Ok(())
@@ -1967,7 +1967,7 @@ fn test_trim_to_length() -> Result<()> {
 fn test_union() {
     let a = list![1i32, 2, 3];
     let b = list![3i32, 4, 5];
-    let result = L::union(Arc::clone(&a), Arc::clone(&b));
+    let result = L::union(a.clone(), b.clone());
     assert_eq!(result, list![1i32, 2, 3, 4, 5]);
 }
 
@@ -1976,7 +1976,7 @@ fn test_union() {
 fn test_union_append_list_on_true() {
     let a = list![1i32, 2];
     let b = list![2i32, 3];
-    let result = L::unionAppendListOnTrue(Arc::clone(&a), Arc::clone(&b), Arc::new(eq_i)).unwrap();
+    let result = L::unionAppendListOnTrue(a.clone(), b.clone(), Arc::new(eq_i)).unwrap();
     assert!(result.len() >= 2);
 }
 
@@ -1984,14 +1984,14 @@ fn test_union_append_list_on_true() {
 #[test]
 fn test_union_elt() {
     let lst = list![1i32, 2, 3];
-    let result = L::unionElt(4, Arc::clone(&lst));
+    let result = L::unionElt(4, lst.clone());
     // unionElt prepends new element if not present
     assert_eq!(result, list![4i32, 1, 2, 3]);
 }
 #[test]
 fn test_union_elt_exists() {
     let lst = list![1i32, 2, 3];
-    let result = L::unionElt(2, Arc::clone(&lst));
+    let result = L::unionElt(2, lst.clone());
     assert_eq!(result, list![1i32, 2, 3]);
 }
 
@@ -1999,7 +1999,7 @@ fn test_union_elt_exists() {
 #[test]
 fn test_union_elt_on_true() {
     let lst = list![1i32, 2, 3];
-    let result = L::unionEltOnTrue(4, Arc::clone(&lst), Arc::new(eq_i)).unwrap();
+    let result = L::unionEltOnTrue(4, lst.clone(), Arc::new(eq_i)).unwrap();
     // unionEltOnTrue prepends new element if not present
     assert_eq!(result, list![4i32, 1, 2, 3]);
 }
@@ -2009,7 +2009,7 @@ fn test_union_elt_on_true() {
 fn test_union_int_n() -> Result<()> {
     let a = list![1i32, 2, 3];
     let b = list![3i32, 4];
-    let result = L::unionIntN(Arc::clone(&a), Arc::clone(&b), 4)?;
+    let result = L::unionIntN(a.clone(), b.clone(), 4)?;
     assert_eq!(result, list![1i32, 2, 3, 4]);
     Ok(())
 }
@@ -2018,7 +2018,7 @@ fn test_union_int_n() -> Result<()> {
 #[test]
 fn test_union_list() -> Result<()> {
     let a = list![list![1i32, 2], list![2i32, 3]];
-    let result = L::unionList(Arc::clone(&a))?;
+    let result = L::unionList(a.clone())?;
     assert_eq!(result, list![1i32, 2, 3]);
     Ok(())
 }
@@ -2028,7 +2028,7 @@ fn test_union_list() -> Result<()> {
 fn test_union_on_true() {
     let a = list![1i32, 2];
     let b = list![2i32, 3];
-    let result = L::unionOnTrue(Arc::clone(&a), Arc::clone(&b), Arc::new(eq_i)).unwrap();
+    let result = L::unionOnTrue(a.clone(), b.clone(), Arc::new(eq_i)).unwrap();
     assert_eq!(result, list![1i32, 2, 3]);
 }
 
@@ -2036,7 +2036,7 @@ fn test_union_on_true() {
 #[test]
 fn test_union_on_true_list() -> Result<()> {
     let a = list![list![1i32, 2]];
-    let result = L::unionOnTrueList(Arc::clone(&a), Arc::new(|x: i32, y: i32| Ok(x == y)))?;
+    let result = L::unionOnTrueList(a.clone(), Arc::new(|x: i32, y: i32| Ok(x == y)))?;
     assert!(result.len() >= 0);
     Ok(())
 }
@@ -2045,7 +2045,7 @@ fn test_union_on_true_list() -> Result<()> {
 #[test]
 fn test_unique() {
     let lst = list![1i32, 2, 1, 3, 2];
-    let result = L::unique(Arc::clone(&lst));
+    let result = L::unique(lst.clone());
     assert_eq!(result, list![1i32, 2, 3]);
 }
 
@@ -2053,7 +2053,7 @@ fn test_unique() {
 #[test]
 fn test_unique_int_n() -> Result<()> {
     let lst = list![1i32, 2, 1, 3, 2];
-    let result = L::uniqueIntN(Arc::clone(&lst), 3)?;
+    let result = L::uniqueIntN(lst.clone(), 3)?;
     assert!(result.len() <= 3);
     Ok(())
 }
@@ -2062,7 +2062,7 @@ fn test_unique_int_n() -> Result<()> {
 #[test]
 fn test_unique_on_true() {
     let lst = list![1i32, 2, 1, 3];
-    let result = L::uniqueOnTrue(Arc::clone(&lst), Arc::new(eq_i)).unwrap();
+    let result = L::uniqueOnTrue(lst.clone(), Arc::new(eq_i)).unwrap();
     assert_eq!(result, list![1i32, 2, 3]);
 }
 
@@ -2070,7 +2070,7 @@ fn test_unique_on_true() {
 #[test]
 fn test_unzip() {
     let lst = list![(1i32, 10i32), (2i32, 20), (3i32, 30)];
-    let (a, b) = L::unzip(Arc::clone(&lst));
+    let (a, b) = L::unzip(lst.clone());
     assert_eq!(a, list![1i32, 2, 3]);
     assert_eq!(b, list![10i32, 20, 30]);
 }
@@ -2079,7 +2079,7 @@ fn test_unzip() {
 #[test]
 fn test_unzip3() {
     let lst = list![(1i32, 10i32, 100i32)];
-    let (a, b, c) = L::unzip3(Arc::clone(&lst));
+    let (a, b, c) = L::unzip3(lst.clone());
     assert_eq!(a, list![1i32]);
     assert_eq!(b, list![10i32]);
     assert_eq!(c, list![100i32]);
@@ -2089,7 +2089,7 @@ fn test_unzip3() {
 #[test]
 fn test_unzip_second() {
     let lst = list![(1i32, 10i32), (2i32, 20)];
-    let result = L::unzipSecond(Arc::clone(&lst));
+    let result = L::unzipSecond(lst.clone());
     assert_eq!(result, list![10i32, 20]);
 }
 
@@ -2098,7 +2098,7 @@ fn test_unzip_second() {
 fn test_zip() {
     let a = list![1i32, 2, 3];
     let b = list![10i32, 20, 30];
-    let result = L::zip(Arc::clone(&a), Arc::clone(&b));
+    let result = L::zip(a.clone(), b.clone());
     assert_eq!(result, list![(1i32, 10i32), (2i32, 20), (3i32, 30)]);
 }
 
@@ -2108,7 +2108,7 @@ fn test_zip3() {
     let a = list![1i32, 2];
     let b = list![10i32, 20];
     let c = list![100i32, 200];
-    let result = L::zip3(Arc::clone(&a), Arc::clone(&b), Arc::clone(&c));
+    let result = L::zip3(a.clone(), b.clone(), c.clone());
     assert_eq!(result, list![(1i32, 10i32, 100i32), (2i32, 20i32, 200)]);
 }
 
@@ -2116,7 +2116,7 @@ fn test_zip3() {
 #[test]
 fn test_select() {
     let lst = list![1i32, 2, 3, 4];
-    let result = L::select(Arc::clone(&lst), Arc::new(is_even)).unwrap();
+    let result = L::select(lst.clone(), Arc::new(is_even)).unwrap();
     assert_eq!(result, list![2i32, 4]);
 }
 
@@ -2124,7 +2124,7 @@ fn test_select() {
 #[test]
 fn test_select1() {
     let lst = list![2i32];
-    let result = L::select1(Arc::clone(&lst), Arc::new(|x, _: i32| Ok(x % 2 == 0)), 0i32).unwrap();
+    let result = L::select1(lst.clone(), Arc::new(|x, _: i32| Ok(x % 2 == 0)), 0i32).unwrap();
     assert_eq!(result, list![2i32]);
 }
 
@@ -2132,7 +2132,7 @@ fn test_select1() {
 #[test]
 fn test_select1r() {
     let lst = list![2i32, 4];
-    let result = L::select1r(Arc::clone(&lst), Arc::new(|_: i32, x| Ok(x % 2 == 0)), 0i32).unwrap();
+    let result = L::select1r(lst.clone(), Arc::new(|_: i32, x| Ok(x % 2 == 0)), 0i32).unwrap();
     assert_eq!(result, list![2i32, 4]);
 }
 
@@ -2140,7 +2140,7 @@ fn test_select1r() {
 #[test]
 fn test_select2() {
     let lst = list![2i32, 4];
-    let result = L::select2(Arc::clone(&lst), Arc::new(|x, _a: i32, _b: i32| Ok(x % 2 == 0)), 0i32, 0i32).unwrap();
+    let result = L::select2(lst.clone(), Arc::new(|x, _a: i32, _b: i32| Ok(x % 2 == 0)), 0i32, 0i32).unwrap();
     assert_eq!(result, list![2i32, 4]);
 }
 
@@ -2148,7 +2148,7 @@ fn test_select2() {
 #[test]
 fn test_all_combinations() -> Result<()> {
     let lst = list![list![1i32, 2], list![3i32, 4]];
-    let result = L::allCombinations(Arc::clone(&lst), None, sourceInfo!())?;
+    let result = L::allCombinations(lst.clone(), None, sourceInfo!())?;
     assert!(result.len() >= 0);
     Ok(())
 }
@@ -2156,29 +2156,29 @@ fn test_all_combinations() -> Result<()> {
 // ── Additional edge cases ──
 #[test]
 fn test_map_empty_list() {
-    let lst: Arc<List<i32>> = nil();
-    let result = L::map(Arc::clone(&lst), Arc::new(double)).unwrap();
+    let lst: List<i32> = nil();
+    let result = L::map(lst.clone(), Arc::new(double)).unwrap();
     assert!(result.is_empty());
 }
 
 #[test]
 fn test_fold_empty() {
-    let lst: Arc<List<i32>> = nil();
-    let result = L::fold(Arc::clone(&lst), Arc::new(|_, acc| Ok(acc)), 99i32).unwrap();
+    let lst: List<i32> = nil();
+    let result = L::fold(lst.clone(), Arc::new(|_, acc| Ok(acc)), 99i32).unwrap();
     assert_eq!(result, 99);
 }
 
 #[test]
 fn test_filter_empty_result() {
     let lst = list![1i32, 3, 5];
-    let result = L::filter(Arc::clone(&lst), Arc::new(|x| { if x % 2 == 0 { Ok(()) } else { return Err("skip") } }));
+    let result = L::filter(lst.clone(), Arc::new(|x| { if x % 2 == 0 { Ok(()) } else { return Err("skip") } }));
     assert!(result.is_empty());
 }
 
 #[test]
 fn test_union_elt_duplicate() {
     let lst = list![1i32, 2, 3];
-    let result = L::unionElt(2, Arc::clone(&lst));
+    let result = L::unionElt(2, lst.clone());
     assert_eq!(result, list![1i32, 2, 3]);
 }
 
@@ -2186,7 +2186,7 @@ fn test_union_elt_duplicate() {
 fn test_intersection_on_true_no_overlap() {
     let a = list![1i32, 2];
     let b = list![3i32, 4];
-    let result = L::intersectionOnTrue(Arc::clone(&a), Arc::clone(&b), Arc::new(eq_i)).unwrap();
+    let result = L::intersectionOnTrue(a.clone(), b.clone(), Arc::new(eq_i)).unwrap();
     assert!(result.is_empty());
 }
 
@@ -2194,15 +2194,15 @@ fn test_intersection_on_true_no_overlap() {
 fn test_set_difference_all_in_b() -> Result<()> {
     let a = list![1i32, 2];
     let b = list![1i32, 2, 3];
-    let result = L::setDifference(Arc::clone(&a), Arc::clone(&b))?;
+    let result = L::setDifference(a.clone(), b.clone())?;
     assert!(result.is_empty());
     Ok(())
 }
 
 #[test]
 fn test_sort_empty() -> Result<()> {
-    let lst: Arc<List<i32>> = nil();
-    let result = L::sort(Arc::clone(&lst), Arc::new(less_i))?;
+    let lst: List<i32> = nil();
+    let result = L::sort(lst.clone(), Arc::new(less_i))?;
     assert!(result.is_empty());
     Ok(())
 }
@@ -2210,7 +2210,7 @@ fn test_sort_empty() -> Result<()> {
 #[test]
 fn test_sort_single() -> Result<()> {
     let lst = list![42i32];
-    let result = L::sort(Arc::clone(&lst), Arc::new(less_i))?;
+    let result = L::sort(lst.clone(), Arc::new(less_i))?;
     assert_eq!(result, list![42i32]);
     Ok(())
 }
@@ -2218,20 +2218,20 @@ fn test_sort_single() -> Result<()> {
 #[test]
 fn test_count_zero() {
     let lst = list![1i32, 3, 5];
-    assert_eq!(L::count(Arc::clone(&lst), Arc::new(is_even)).unwrap(), 0);
+    assert_eq!(L::count(lst.clone(), Arc::new(is_even)).unwrap(), 0);
 }
 
 #[test]
 fn test_position_empty() {
-    let lst: Arc<List<i32>> = nil();
+    let lst: List<i32> = nil();
     // position returns Err when element not found (empty list)
-    assert!(L::position(1, Arc::clone(&lst)).is_err());
+    assert!(L::position(1, lst.clone()).is_err());
 }
 
 #[test]
 fn test_max_min_single() -> Result<()> {
     let lst = list![42i32];
-    assert_eq!(L::maxElement(Arc::clone(&lst), Arc::new(less_i))?, 42);
-    assert_eq!(L::minElement(Arc::clone(&lst), Arc::new(less_i))?, 42);
+    assert_eq!(L::maxElement(lst.clone(), Arc::new(less_i))?, 42);
+    assert_eq!(L::minElement(lst.clone(), Arc::new(less_i))?, 42);
     Ok(())
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/unittests/mutable_cycle_drop_tests.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/unittests/mutable_cycle_drop_tests.rs
@@ -189,7 +189,7 @@ fn content_shared_with_stack_survives_collect() {
     assert!(weak.upgrade().is_none());
 }
 
-// Cycle through a shared list spine: `cell → Arc<List<cell>> → cell`, with
+// Cycle through a shared list spine: `cell → List<cell> → cell`, with
 // the spine also referenced from the stack. Exercises the per-spine-cell
 // reporting in `List`'s MMTrace impl.
 #[test]
@@ -202,7 +202,7 @@ fn cycle_through_shared_list_spine() {
         #[allow(dead_code)]
         Many {
             probe: Arc<DropProbe>,
-            nodes: Arc<List<Mutable::Mutable<Arc<ListNode>>>>,
+            nodes: List<Mutable::Mutable<Arc<ListNode>>>,
         },
     }
     impl MMTrace for ListNode {


### PR DESCRIPTION
`metamodelica::List<T>` is now `Option<Arc<ListNode<T>>>`: the empty list is `None`, so `nil()`, list literals, `listReverse` and every list-typed `Default` stop allocating. `ListNode::{Cons, Nil}` is the heap cell; `List` derefs to it (a static `Nil` for the empty handle), so the generated `Deref @ ListNode::Cons {..}` patterns and `.as_ref()` scrutinees keep working. Two empty lists are now `referenceEq`, like `mmc_nil` in MMC.

`reverse` takes the list by value and relinks the uniquely owned prefix in place (`Arc::get_mut` decides; a shared suffix is copied), which the accumulate-then-`listReverse` idiom hits with a moved argument. `Dangerous.listReverseInPlace` is the same function; `listAppendDestroy` splices only when every cell is unique and copies otherwise, so it no longer mutates cells through raw pointers.

`Drop` stays an inline `strong_count == 1` check with the unlink loop out of line: handle drops are the hottest operation in the compiler, and running the loop on every drop cost more than the saved allocations.

`ScalableTestSuite ... DistributionSystemModelica_N_20_M_20`, translateModel, whole `omc` run under callgrind:

| metric             | before  | after   |
| ------------------ | ------- | ------- |
| instructions       | 29.3 G  | 27.2 G  |
| allocations        | 69.9 M  | 48.1 M  |
| translateModel     | 9.31 s  | 7.75 s  |
| max RSS            | 635 MB  | 587 MB  |

Generated C is byte-identical. mmtorust: the type and pattern emitters drop the `Arc<>` and name `ListNode`; hand-written crates follow.

Assisted-by: Claude Fable 5.1

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
