### PR TITLE
FMI driver: zstd on the streamed FileMeta

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/record.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/record.rs
@@ -405,7 +405,7 @@ impl Recorder {
                 &col_types,
                 arrow::block_rows(0),
                 arrow::no_strings(),
-                &arrow::FileMeta { span: Some((start, stop)), units: &defs },
+                &arrow::FileMeta { span: Some((start, stop)), units: &defs, zstd: None },
             );
             StreamKind::Arrow(s)
         } else {


### PR DESCRIPTION
`FileMeta` gained a `zstd` field, but the streaming writer in `record.rs` was added on master in parallel and kept the two-field literal, so master does not build:

    error[E0063]: missing field `zstd` in initializer of `FileMeta<'_>`
       --> openmodelica_fmi_driver/src/record.rs:408

`None` matches the non-streaming sibling in the same file and the other hosts (`sim_meta::result`, `result_files::file`).

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
