### PR TITLE
Avoid unnecessary OMEdit recompilation

### DIFF
--- a/OMCompiler/Compiler/CMakeLists.txt
+++ b/OMCompiler/Compiler/CMakeLists.txt
@@ -183,8 +183,6 @@ macro(add_compile_step mo_source_file)
                                                    ${CMAKE_CURRENT_BINARY_DIR}/c_files/${file_name_no_ext}_records.c)
 endmacro(add_compile_step)
 
-
-
 # OpenModelicaScriptingAPI.mo (a compiler source) stays in Script/; the C++ Qt
 # files go under the build tree (OMEditLIB reads OMC_SCRIPTING_API_QT_DIR), so C
 # and Rust builds don't fight over Script/.
@@ -200,18 +198,14 @@ add_custom_command(
 
     COMMAND ${OMC_EXE} -g=MetaModelica -n=1 ${CMAKE_CURRENT_SOURCE_DIR}/Script/OpenModelicaScriptingAPI.mos
     COMMAND ${CMAKE_COMMAND} -E make_directory ${OMC_SCRIPTING_API_QT_DIR}
-    COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_SOURCE_DIR}/Script/OpenModelicaScriptingAPIQt.cpp ${OMC_SCRIPTING_API_QT_DIR}/OpenModelicaScriptingAPIQt.cpp
-    COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_SOURCE_DIR}/Script/OpenModelicaScriptingAPIQt.h ${OMC_SCRIPTING_API_QT_DIR}/OpenModelicaScriptingAPIQt.h
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/Script/OpenModelicaScriptingAPIQt.cpp ${OMC_SCRIPTING_API_QT_DIR}/OpenModelicaScriptingAPIQt.cpp
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/Script/OpenModelicaScriptingAPIQt.h ${OMC_SCRIPTING_API_QT_DIR}/OpenModelicaScriptingAPIQt.h
 
     OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/Script/OpenModelicaScriptingAPI.mo
-    OUTPUT ${OMC_SCRIPTING_API_QT_DIR}/OpenModelicaScriptingAPIQt.cpp
-    OUTPUT ${OMC_SCRIPTING_API_QT_DIR}/OpenModelicaScriptingAPIQt.h
+           ${OMC_SCRIPTING_API_QT_DIR}/OpenModelicaScriptingAPIQt.cpp
+           ${OMC_SCRIPTING_API_QT_DIR}/OpenModelicaScriptingAPIQt.h
     COMMENT "Generating OpenModelicaScriptingAPI.mo + Qt API"
 )
-
-
-
-
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/.cmake/template_compilation.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/.cmake/meta_modelica_source_list.cmake)

--- a/OMCompiler/Compiler/Script/OpenModelicaScriptingAPI.mos
+++ b/OMCompiler/Compiler/Script/OpenModelicaScriptingAPI.mos
@@ -12,8 +12,12 @@ if bool then
   else
     exit(1);
   end if;
-  writeFile("OpenModelicaScriptingAPIQt.cpp", b);
-  writeFile("OpenModelicaScriptingAPIQt.h", c);
+  OpenModelica.Scripting.writeFile("OpenModelicaScriptingAPIQt.tmp.cpp", b);
+  bool := OpenModelica.Scripting.compareFilesAndMove("OpenModelicaScriptingAPIQt.tmp.cpp", "OpenModelicaScriptingAPIQt.cpp");
+  OpenModelica.Scripting.deleteFile("OpenModelicaScriptingAPIQt.tmp.cpp");
+  OpenModelica.Scripting.writeFile("OpenModelicaScriptingAPIQt.tmp.h", c);
+  bool := OpenModelica.Scripting.compareFilesAndMove("OpenModelicaScriptingAPIQt.tmp.h", "OpenModelicaScriptingAPIQt.h");
+  OpenModelica.Scripting.deleteFile("OpenModelicaScriptingAPIQt.tmp.h");
 end if;
 if not bool then
   print("Failed to generate OpenModelicaScriptingAPI; falling back to old generated one until new tarball exists: " + getErrorString());

--- a/OMCompiler/Compiler/boot/CMakeLists.txt
+++ b/OMCompiler/Compiler/boot/CMakeLists.txt
@@ -78,14 +78,26 @@ set_target_properties(bomc
 )
 
 # It also wants to have these builtin files in ../lib/ relative to its location.
-add_custom_command (
-    TARGET bomc
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/../FrontEnd/ModelicaBuiltin.mo ${CMAKE_CURRENT_BINARY_DIR}/bootstrapped/lib/omc/ModelicaBuiltin.mo
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/../FrontEnd/MetaModelicaBuiltin.mo ${CMAKE_CURRENT_BINARY_DIR}/bootstrapped/lib/omc/MetaModelicaBuiltin.mo
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/../NFFrontEnd/NFModelicaBuiltin.mo ${CMAKE_CURRENT_BINARY_DIR}/bootstrapped/lib/omc/NFModelicaBuiltin.mo
-    COMMENT "Copying (NF/Meta/Modelica)Builtin.mo files for the bootstrapped omc.")
+set(BOOTSTRAP_BUILTIN_FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/bootstrapped/lib/omc/ModelicaBuiltin.mo
+    ${CMAKE_CURRENT_BINARY_DIR}/bootstrapped/lib/omc/MetaModelicaBuiltin.mo
+    ${CMAKE_CURRENT_BINARY_DIR}/bootstrapped/lib/omc/NFModelicaBuiltin.mo)
 
+add_custom_command(
+    OUTPUT ${BOOTSTRAP_BUILTIN_FILES}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/bootstrapped/lib/omc
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/../FrontEnd/ModelicaBuiltin.mo ${CMAKE_CURRENT_BINARY_DIR}/bootstrapped/lib/omc/ModelicaBuiltin.mo
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/../FrontEnd/MetaModelicaBuiltin.mo ${CMAKE_CURRENT_BINARY_DIR}/bootstrapped/lib/omc/MetaModelicaBuiltin.mo
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/../NFFrontEnd/NFModelicaBuiltin.mo ${CMAKE_CURRENT_BINARY_DIR}/bootstrapped/lib/omc/NFModelicaBuiltin.mo
+    DEPENDS
+        ${CMAKE_CURRENT_SOURCE_DIR}/../FrontEnd/ModelicaBuiltin.mo
+        ${CMAKE_CURRENT_SOURCE_DIR}/../FrontEnd/MetaModelicaBuiltin.mo
+        ${CMAKE_CURRENT_SOURCE_DIR}/../NFFrontEnd/NFModelicaBuiltin.mo
+    COMMENT "Copying (NF/Meta/Modelica)Builtin.mo files for the bootstrapped omc."
+)
+
+add_custom_target(copy_bootstrap_builtins DEPENDS ${BOOTSTRAP_BUILTIN_FILES})
+add_dependencies(bomc copy_bootstrap_builtins)
 
 # On Windows it also needs to have the dlls it depends on (remember bomc is being used without being installed)
 # think of this as a manual install for it. Luckily it depends only on just two dlls for now,


### PR DESCRIPTION
Use `compareFilesAndMove` for Qt C++ files (was unconditional writeFile, always updating timestamps) Use `copy_if_different` instead of rename
Fix copying of builtin files for bomc