### PR TITLE
Fix Rust result reader configuration/build on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,13 +96,27 @@ omc_add_to_report(OM_ENABLE_OMNOTEBOOK)
 omc_add_to_report(OM_ENABLE_OMEDIT)
 omc_add_to_report(OM_ENABLE_OMSENS_QT)
 omc_add_to_report(OM_OMOPTIM_ENABLE)
+# libomc_result is built with cargo, which a C-only toolchain does not have (the
+# OMDev Windows build is one), so both options default to whether cargo is on
+# PATH rather than to plain ON. Without it the build falls back to the C readers
+# and writers, which cannot handle .arrow. Turning either option on explicitly
+# without a cargo is still a hard error, see rust_result_reader.cmake.
+find_program(CARGO_EXECUTABLE cargo)
+if(CARGO_EXECUTABLE)
+  set(OM_RUST_RESULT_DEFAULT ON)
+else()
+  set(OM_RUST_RESULT_DEFAULT OFF)
+  message(STATUS "cargo not found: defaulting OM_RUST_RESULT_READERS/OM_RUST_RESULT_WRITERS to OFF. "
+                 "The C result readers and writers can not read or write .arrow result files; "
+                 "install a stable Rust toolchain to get them.")
+endif()
 # The GUI clients read result files through libomc_result (needs cargo); OFF
 # compiles the C readers (OM_LEGACY_RESULT_READERS), which cannot open .arrow.
-cmake_dependent_option(OM_RUST_RESULT_READERS "Read result files in the GUI clients through the Rust omc_result library." ON "NOT OM_OMC_WASM;OM_ENABLE_GUI_CLIENTS" OFF)
+cmake_dependent_option(OM_RUST_RESULT_READERS "Read result files in the GUI clients through the Rust omc_result library." ${OM_RUST_RESULT_DEFAULT} "NOT OM_OMC_WASM;OM_ENABLE_GUI_CLIENTS" OFF)
 omc_add_to_report(OM_RUST_RESULT_READERS)
 # The C simulation runtime writes its result files through the same library;
 # OFF keeps the C writers, which cannot write .arrow.
-cmake_dependent_option(OM_RUST_RESULT_WRITERS "Write result files from the C simulation runtime through the Rust omc_result library." ON "NOT OM_OMC_WASM" OFF)
+cmake_dependent_option(OM_RUST_RESULT_WRITERS "Write result files from the C simulation runtime through the Rust omc_result library." ${OM_RUST_RESULT_DEFAULT} "NOT OM_OMC_WASM" OFF)
 omc_add_to_report(OM_RUST_RESULT_WRITERS)
 
 ## Use ccache to speedup compilation! It is important to use ccache if you can.

--- a/OMCompiler/Compiler/.cmake/rust_result_reader.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_result_reader.cmake
@@ -7,9 +7,10 @@ function(omc_result_reader_library)
   find_program(CARGO_EXECUTABLE cargo)
   if(NOT CARGO_EXECUTABLE)
     message(FATAL_ERROR
-      "OM_RUST_RESULT_READERS/OM_RUST_RESULT_WRITERS is ON but cargo was not found. Install a "
-      "stable Rust toolchain, or configure with -DOM_RUST_RESULT_READERS=OFF "
-      "-DOM_RUST_RESULT_WRITERS=OFF to use the C result readers and writers.")
+      "OM_RUST_RESULT_READERS/OM_RUST_RESULT_WRITERS was turned on explicitly, but cargo was "
+      "not found (both default to OFF without one). Install a stable Rust toolchain, or "
+      "configure with -DOM_RUST_RESULT_READERS=OFF -DOM_RUST_RESULT_WRITERS=OFF to use the C "
+      "result readers and writers, which can not handle .arrow.")
   endif()
   set(_workspace ${CMAKE_CURRENT_SOURCE_DIR}/OMCompiler/SimulationRuntime/rust)
   set(_crate ${_workspace}/openmodelica_result_capi)

--- a/OMCompiler/README.Windows.md
+++ b/OMCompiler/README.Windows.md
@@ -5,17 +5,16 @@
 - [1 MSYS Environments](#1-msys-environments)
   - [1.1 General Notes](#11-general-notes)
   - [1.2 Install OMDev packages](#12-install-omdev)
-  - [1.3 Install MSYS2](#13-install-msys2)
-  - [1.4 Install Additional Programs](#14-install-additional-programs)
+  - [1.3 Install Additional Programs](#13-install-additional-programs)
+  - [1.4 Rust toolchain](#14-rust-toolchain)
   - [1.5 Environment Variables](#15-environment-variables)
-  - [1.6 Rust toolchain](#16-rust-toolchain)
 - [2 Compile OpenModelica](#2-compile-openmodelica)
   - [2.1 MSYS and CMake](#21-msys-and-cmake)
 - [3 Installer](#3-installer)
 - [4 Test Suite](#4-test-suite)
 - [5 Troubleshooting](#5-troubleshooting)
 
-# 1 MSYS Environments
+## 1 MSYS Environments
 
 We use Linux tools provided by [MSYS2](https://www.msys2.org/) to compile OpenModelica on
 Windows.
@@ -28,53 +27,101 @@ the first time use OMDev.
 > If you have an older version of OMDev installed it's best to delete `OMDev` and start
 > with a fresh clone following the below instructions.
 
-  1. OMDev package: MSYS2 with
-    [UCRT64 environment](https://www.msys2.org/docs/environments/).
-    Follow the instructions in [1.2 Install OMDev](#12-install-omdev).
-  2. Installed [MSYS2](https://www.msys2.org/) with
-    [UCRT64 environment](https://www.msys2.org/docs/environments/).
-    Follow the instructions in [1.3 Install MSYS2](#13-install-msys2).
+1. OMDev package: MSYS2 with
+  [UCRT64 environment](https://www.msys2.org/docs/environments/).
+  Follow the instructions in [1.2 Install OMDev](#12-install-omdev).
+2. Installed [MSYS2](https://www.msys2.org/) with
+  [UCRT64 environment](https://www.msys2.org/docs/environments/).
+  You need to install all necessary packages yourself.
 
+### 1.1 General Notes
 
-## 1.1 General Notes
+- Install Git for Windows [git-scm.com](https://git-scm.com/downloads)
 
-  - Install Git for Windows https://git-scm.com/downloads
-    Do not install git using pacman in MSYS, it does not work correctly!
-  - Make sure you git clone with the correct line endings, run in a (Git Bash) terminal:
-    ```bash
-      git config --global core.eol lf
-      git config --global core.autocrlf input
-    ```
+  > [!CAUTION]
+  > Do not install git using pacman in MSYS, it does not work correctly!
 
-## 1.2 Install OMDev
+- Make sure you git clone with the correct line endings, run in a (Git Bash) terminal:
 
-  - Clone OMDev into a directory without any spaces in the path. We recommend to use
-    `C:\OMDev\`.
+  ```bash
+    git config --global core.eol lf
+    git config --global core.autocrlf input
+  ```
 
-    Run the following in a Git Bash:
-    ```bash
-      cd /c/
-      git clone --depth 1 -b master --single-branch https://gitlab.liu.se/OpenModelica/OMDevUCRT.git OMDev
-    ```
+### 1.2 Install OMDev
 
-  - Define a Windows environment variable `OMDEV` pointing to the OMDev directory.
-    Restart or logout/login to make it available.
+- Clone OMDev into a directory without any spaces in the path.
+  We recommend to use `C:\OMDev\`.
 
-  - Follow the instructions in the `%OMDEV%\INSTALL.md` file.
+  Run the following in a Git Bash:
 
-## 1.4 Install Additional Programs
+  ```bash
+    cd /c/
+    git clone --depth 1 -b master --single-branch https://gitlab.liu.se/OpenModelica/OMDevUCRT.git OMDev
+  ```
+
+- Define a Windows environment variable `OMDEV` pointing to the OMDev directory.
+  Restart or logout/login to make it available.
+
+- Follow the instructions in the `%OMDEV%\INSTALL.md` file.
+
+### 1.3 Install Additional Programs
 
 Install the following programs:
 
-  - [Git](https://git-scm.com/downloads) (should already be installed)
-  - [Java SE Development Kit](https://www.oracle.com/java/technologies/downloads/) (for javac)
-  - [TortoiseSVN](https://tortoisesvn.net/), SVN tool for Windows
-  - [CMake](https://cmake.org/download/) (>= v3.21)
-  - [rustup](https://rustup.rs) (optional if you disable it; see
-    [1.6 Rust toolchain](#16-rust-toolchain) for which toolchain to pick and how to
-    disable)
+- [Git](https://git-scm.com/downloads) (should already be installed)
+- [Java SE Development Kit](https://www.oracle.com/java/technologies/downloads/) (for javac)
+- [TortoiseSVN](https://tortoisesvn.net/), SVN tool for Windows
+- [CMake](https://cmake.org/download/) (>= v3.21)
+- [rustup](https://rustup.rs) (optional if you disable it; see
+  [1.4 Rust toolchain](#14-rust-toolchain) for which toolchain to pick and how to
+  disable)
 
-## 1.5 Environment Variables
+### 1.4 Rust toolchain
+
+The C simulation runtime writes result files through the Rust `libomc_result`
+(`OM_RUST_RESULT_WRITERS`) and the GUI clients read them back through it
+(`OM_RUST_RESULT_READERS`). If disabled the C runtime falls back to the C
+readers and writers, which cannot handle `.arrow`.
+
+The crates use the 2024 edition, so `cargo`/`rustc` 1.85 or newer. Install
+[rustup](https://rustup.rs) from Windows (not through pacman), with
+`winget install Rustlang.Rustup` or `rustup-init.exe`.
+
+> [!NOTE]
+> MSYS only sees it if you set `MSYS2_PATH_TYPE=inherit` (see
+> [1.5 Environment Variables](#15-environment-variables)) or add
+> `%USERPROFILE%\.cargo\bin` to the `PATH` inside the shell.
+
+The Rust library is linked into the C/C++ binaries, so the ABIs have to match.
+`rustup` installs the **MSVC** toolchain by default, so an OMDev build has to
+install and select the GNU one:
+
+| Building with          | Toolchain to select             |
+|------------------------|---------------------------------|
+| OMDev / MSYS2 (UCRT64) | `stable-x86_64-pc-windows-gnu`  |
+| MSVC                   | `stable-x86_64-pc-windows-msvc` |
+
+```bash
+cd /path/to/OpenModelica   # override set applies to this directory only
+rustup toolchain install stable-x86_64-pc-windows-gnu
+rustup override set stable-x86_64-pc-windows-gnu
+cargo -vV   # the host: line must end in -gnu here, -msvc for MSVC
+```
+
+To build without Rust readers and writer at all:
+
+```bash
+cmake -S . -B build_cmake -Wno-dev -G "MSYS Makefiles" \
+  -DOM_RUST_RESULT_READERS=OFF -DOM_RUST_RESULT_WRITERS=OFF
+```
+
+Two larger components are off by default: `-DOM_ENABLE_RUST_SIM_RUNTIME=ON` (the
+runtime `--simCodeTarget=C+Rust` links, stable is enough) and
+`-DOM_OMC_ENABLE_RUST=ON` (the compiler as the Rust port, needs the pinned
+nightly in [Compiler/OpenModelica.rs/README.md](Compiler/OpenModelica.rs/README.md)).
+
+### 1.5 Environment Variables
 
 Export the path to your tools: git, svn, java/javac and cmake.
 Define environment variables pointing to your OMDev directory as well as the MSYS2
@@ -96,82 +143,17 @@ You can add this to your `.bashrc` file
 
 Additional remarks:
 
-  - MSYS doesn't use the Windows PATH variable.
-    If you want to use it define a Windows environment variable called
-    `MSYS2_PATH_TYPE=inherit`.
-    But be very careful you don't have any MINGW directories in you Windows PATH, e.g.
-    coming from Git.
-  - MSYS doesn't use the Windows TEMP directory but `C:\OMDev\tools\msys\tmp`
-    You change this in `C:\OMDev\tools\msys\etc\profile`, but it can have unexpected side effects.
-  - If you want to use the msys shell from Windows command line  make sure you set
-    environment variable `MSYSTEM=UCRT64` or call `C:\OMDev\tools\msys\ucrt64.exe`.
+- MSYS doesn't use the Windows PATH variable.
+  If you want to use it define a Windows environment variable called
+  `MSYS2_PATH_TYPE=inherit`.
+  But be very careful you don't have any MINGW directories in you Windows PATH, e.g.
+  coming from Git.
+- MSYS doesn't use the Windows TEMP directory but `C:\OMDev\tools\msys\tmp`
+  You change this in `C:\OMDev\tools\msys\etc\profile`, but it can have unexpected side effects.
+- If you want to use the msys shell from Windows command line  make sure you set
+  environment variable `MSYSTEM=UCRT64` or call `C:\OMDev\tools\msys\ucrt64.exe`.
 
-## 1.6 Rust toolchain
-
-Parts of OpenModelica are written in Rust: the C simulation runtime writes its
-result files through `libomc_result` (`OM_RUST_RESULT_WRITERS`) and the GUI
-clients read them back through the same library (`OM_RUST_RESULT_READERS`). Both
-options default to whether `cargo` is found on the `PATH`, so a toolchain-less
-build still configures -- it falls back to the C readers and writers, which
-handle `.mat`, `.csv` and `.plt` but not `.arrow`, and CMake says so with a
-`STATUS` line. Turning either option on explicitly without a `cargo` is a hard
-error.
-
-The crates use the 2024 edition, so `rustc`/`cargo` 1.85 or newer. Install
-[rustup](https://rustup.rs) on Windows (not through pacman) with `winget install
-Rustlang.Rustup`, or by running `rustup-init.exe` from the rustup page.
-
-> [!NOTE]
-> MSYS does not inherit the Windows `PATH` unless you set `MSYS2_PATH_TYPE=inherit`
-> (see [1.5 Environment Variables](#15-environment-variables)). If `cargo --version`
-> works in a Windows shell but not in the MSYS2 one, that is why; either set that
-> variable or add `%USERPROFILE%\.cargo\bin` to the `PATH` inside MSYS.
-
-### Pick the toolchain matching your C/C++ compiler
-
-The Rust library is linked straight into the C/C++ binaries, so the Rust ABI has
-to be the one your compiler uses. The two Windows ABIs are not interchangeable:
-they disagree on the C runtime and on how the import library is named
-(`libomc_result.dll.a` for GNU, `omc_result.dll.lib` for MSVC).
-
-| Building with | Toolchain to select |
-|---------------|---------------------|
-| OMDev / MSYS2 (UCRT64 or MINGW64), the setup this file describes | `stable-x86_64-pc-windows-gnu` |
-| MSVC | `stable-x86_64-pc-windows-msvc` |
-
-A stock rustup on Windows installs the **MSVC** toolchain by default, so an OMDev
-build needs the GNU one installed and selected explicitly. `override set` records
-the choice for this directory, so run it in your OpenModelica checkout and it will
-not disturb other projects:
-
-```bash
-cd /path/to/OpenModelica
-rustup toolchain install stable-x86_64-pc-windows-gnu
-rustup override set stable-x86_64-pc-windows-gnu
-# Check what cargo will actually build for:
-cargo -vV
-```
-
-The `host:` line of `cargo -vV` is the triple that matters; it must end in `-gnu`
-for an OMDev build and in `-msvc` for an MSVC build. A mismatch shows up later as
-a link failure or as a missing artifact ("No rule to make target ...
-omc_result.dll").
-
-To build without Rust at all, turn both options off. You then lose the `.arrow`
-result format:
-
-```bash
-cmake -S . -B build_cmake -Wno-dev -G "MSYS Makefiles" \
-  -DOM_RUST_RESULT_READERS=OFF -DOM_RUST_RESULT_WRITERS=OFF
-```
-
-Two larger Rust components are off by default. `-DOM_ENABLE_RUST_SIM_RUNTIME=ON`
-builds the simulation runtime `--simCodeTarget=C+Rust` links, and also works with
-a stable toolchain. `-DOM_OMC_ENABLE_RUST=ON` builds the compiler itself as the
-Rust port, which needs the pinned nightly toolchain described in
-[Compiler/OpenModelica.rs/README.md](Compiler/OpenModelica.rs/README.md).
-
-# 2 Compile OpenModelica
+## 2 Compile OpenModelica
 
 On Windows, CMake is the only supported way to build OpenModelica. Follow the
 instructions in [MSYS and CMake](#21-msys-and-cmake).
@@ -190,14 +172,13 @@ cd build_cmake
 make -j<Nr. of cores> install -Oline
 ```
 
-# 3 Installer
+## 3 Installer
 
 To build the OpenModelica releases and installer NSIS is used.
 If you need to know more checkout
 [OpenModelicaSetup/BuildWindowsRelease.sh](https://github.com/OpenModelica/OpenModelicaSetup#readme)
 
-
-# 4 Test Suite
+## 4 Test Suite
 
 Many of the tests inside the test suite are OS dependent and will only work on a Linux OS.
 Nonetheless you can run the test suite, but a lot of failing tests should be expected.
@@ -211,7 +192,7 @@ cd testsuite/partest
 ./runtests.pl
 ```
 
-# 5 Troubleshooting
+## 5 Troubleshooting
 
 If something does not work check the following:
 

--- a/OMCompiler/README.Windows.md
+++ b/OMCompiler/README.Windows.md
@@ -8,6 +8,7 @@
   - [1.3 Install MSYS2](#13-install-msys2)
   - [1.4 Install Additional Programs](#14-install-additional-programs)
   - [1.5 Environment Variables](#15-environment-variables)
+  - [1.6 Rust toolchain](#16-rust-toolchain)
 - [2 Compile OpenModelica](#2-compile-openmodelica)
   - [2.1 MSYS and CMake](#21-msys-and-cmake)
 - [3 Installer](#3-installer)
@@ -69,6 +70,9 @@ Install the following programs:
   - [Java SE Development Kit](https://www.oracle.com/java/technologies/downloads/) (for javac)
   - [TortoiseSVN](https://tortoisesvn.net/), SVN tool for Windows
   - [CMake](https://cmake.org/download/) (>= v3.21)
+  - [rustup](https://rustup.rs) (optional if you disable it; see
+    [1.6 Rust toolchain](#16-rust-toolchain) for which toolchain to pick and how to
+    disable)
 
 ## 1.5 Environment Variables
 
@@ -101,6 +105,71 @@ Additional remarks:
     You change this in `C:\OMDev\tools\msys\etc\profile`, but it can have unexpected side effects.
   - If you want to use the msys shell from Windows command line  make sure you set
     environment variable `MSYSTEM=UCRT64` or call `C:\OMDev\tools\msys\ucrt64.exe`.
+
+## 1.6 Rust toolchain
+
+Parts of OpenModelica are written in Rust: the C simulation runtime writes its
+result files through `libomc_result` (`OM_RUST_RESULT_WRITERS`) and the GUI
+clients read them back through the same library (`OM_RUST_RESULT_READERS`). Both
+options default to whether `cargo` is found on the `PATH`, so a toolchain-less
+build still configures -- it falls back to the C readers and writers, which
+handle `.mat`, `.csv` and `.plt` but not `.arrow`, and CMake says so with a
+`STATUS` line. Turning either option on explicitly without a `cargo` is a hard
+error.
+
+The crates use the 2024 edition, so `rustc`/`cargo` 1.85 or newer. Install
+[rustup](https://rustup.rs) on Windows (not through pacman) with `winget install
+Rustlang.Rustup`, or by running `rustup-init.exe` from the rustup page.
+
+> [!NOTE]
+> MSYS does not inherit the Windows `PATH` unless you set `MSYS2_PATH_TYPE=inherit`
+> (see [1.5 Environment Variables](#15-environment-variables)). If `cargo --version`
+> works in a Windows shell but not in the MSYS2 one, that is why; either set that
+> variable or add `%USERPROFILE%\.cargo\bin` to the `PATH` inside MSYS.
+
+### Pick the toolchain matching your C/C++ compiler
+
+The Rust library is linked straight into the C/C++ binaries, so the Rust ABI has
+to be the one your compiler uses. The two Windows ABIs are not interchangeable:
+they disagree on the C runtime and on how the import library is named
+(`libomc_result.dll.a` for GNU, `omc_result.dll.lib` for MSVC).
+
+| Building with | Toolchain to select |
+|---------------|---------------------|
+| OMDev / MSYS2 (UCRT64 or MINGW64), the setup this file describes | `stable-x86_64-pc-windows-gnu` |
+| MSVC | `stable-x86_64-pc-windows-msvc` |
+
+A stock rustup on Windows installs the **MSVC** toolchain by default, so an OMDev
+build needs the GNU one installed and selected explicitly. `override set` records
+the choice for this directory, so run it in your OpenModelica checkout and it will
+not disturb other projects:
+
+```bash
+cd /path/to/OpenModelica
+rustup toolchain install stable-x86_64-pc-windows-gnu
+rustup override set stable-x86_64-pc-windows-gnu
+# Check what cargo will actually build for:
+cargo -vV
+```
+
+The `host:` line of `cargo -vV` is the triple that matters; it must end in `-gnu`
+for an OMDev build and in `-msvc` for an MSVC build. A mismatch shows up later as
+a link failure or as a missing artifact ("No rule to make target ...
+omc_result.dll").
+
+To build without Rust at all, turn both options off. You then lose the `.arrow`
+result format:
+
+```bash
+cmake -S . -B build_cmake -Wno-dev -G "MSYS Makefiles" \
+  -DOM_RUST_RESULT_READERS=OFF -DOM_RUST_RESULT_WRITERS=OFF
+```
+
+Two larger Rust components are off by default. `-DOM_ENABLE_RUST_SIM_RUNTIME=ON`
+builds the simulation runtime `--simCodeTarget=C+Rust` links, and also works with
+a stable toolchain. `-DOM_OMC_ENABLE_RUST=ON` builds the compiler itself as the
+Rust port, which needs the pinned nightly toolchain described in
+[Compiler/OpenModelica.rs/README.md](Compiler/OpenModelica.rs/README.md).
 
 # 2 Compile OpenModelica
 
@@ -155,4 +224,4 @@ If something does not work check the following:
 
 --------------
 
-Last updated 2026-08-18.
+Last updated 2026-09-08.

--- a/OMCompiler/README.md
+++ b/OMCompiler/README.md
@@ -1,4 +1,5 @@
 # OMCompiler
+
 The OpenModelica Compiler is the core of the OpenModelica project, which is an open-source
 Modelica-based modeling and simulation environment intended for industrial and academic
 usage.

--- a/README.cmake.md
+++ b/README.cmake.md
@@ -27,7 +27,7 @@
 - [5. Integration with Editors/Tools](#5-integration-with-editorstools)
 - [6. Running Tests (rtest)](#6-running-tests-rtest)
 
-# 1. Quick start
+## 1. Quick start
 
 We recommend you read the instructions for your Operating System as they contain some tips
 and workarounds for some common pitfalls.
@@ -52,7 +52,8 @@ cmake --build build_cmake --target install --parallel <Nr. of cores>
 By default, if you do not specify anything, the configuration will chose an installation
 directory named `install_cmake` inside of your build dir.
 
-# 2. ccache
+## 2. ccache
+
 [ccache](https://ccache.dev/) is a compiler cache. It speeds up recompilation by caching
 previous compilations and detecting when the same compilation is being done again.
 
@@ -66,32 +67,34 @@ these types of recompilations to a no-op.
 It is available for Linux (of course) and, fortunately, for MSYS/UCRT64 as well
 (mingw-w64-ucrt-x86_64-ccache).
 
-# 3. Usage
-## 3.1. General Notes
+## 3. Usage
+
+### 3.1. General Notes
 
 - In source build is not recommended. Always create a dedicated build directory, e.g.
   `OpenModelica/build_cmake`
 
 - Add `-Wno-dev` to your CMake configuration command to silence CMake warnings from
   3rdParty libraries.
-  ```
+
+  ```sh
   cmake .. -Wno-dev
   ```
 
- - Your build directory should NOT be a directory named `build` in the root OpenModelica
-   directory.
+- Your build directory should NOT be a directory named `build` in the root OpenModelica
+  directory.
 
-   The reason for this suggestion is that the `autotools + Makefile` build system we have
-   now uses this `build` directory for _installation_. Therefore, if you plan to fallback
-   to the autotools build at some point or you want to switch back and forth between the
-   CMake and autotools build systems (perhaps to cross check something), then it is
-   probably a good idea to make sure that they do not overwrite eachother's outputs.
+  The reason for this suggestion is that the `autotools + Makefile` build system we have
+  now uses this `build` directory for _installation_. Therefore, if you plan to fallback
+  to the autotools build at some point or you want to switch back and forth between the
+  CMake and autotools build systems (perhaps to cross check something), then it is
+  probably a good idea to make sure that they do not overwrite eachother's outputs.
 
-## 3.2. Linux
+### 3.2. Linux
 
-There is nothing special to be done for linux. Once you have installed all the
-dependencies (If you need help, follow the instructions
-[here](https://github.com/OpenModelica/OpenModelica/blob/master/OMCompiler/README.Linux.md)
+There is nothing special to be done for Linux. Once you have installed all the
+dependencies (If you need help, follow the instructions in
+[OMCompiler/README.Linux.md](https://github.com/OpenModelica/OpenModelica/blob/master/OMCompiler/README.Linux.md)
 **excluding** the configuration steps, `autoconf`, ...), you can follow the instruction in
 [quick start](#1-quick-start) section above or choose your own combination of
 [configuration options](#4-configuration-options) (e.g. build type, generator, install dir ...).
@@ -101,49 +104,52 @@ result-file library (see
 [1.3 Rust toolchain](https://github.com/OpenModelica/OpenModelica/blob/master/OMCompiler/README.Linux.md#13-rust-toolchain)).
 A stable toolchain of version 1.85 or newer is enough.
 
-### 3.2.1 QTWebKit
+#### 3.2.1 QTWebKit
 
 Note that most of the latest Linux releases do not support Qt5 QTWebKit anymore so one needs to configure with Qt6
 
-  ```
-  cmake -S . -B build_cmake -DOM_QT_MAJOR_VERSION=6
-  ```
+```sh
+cmake -S . -B build_cmake -DOM_QT_MAJOR_VERSION=6
+```
 
+### 3.3. macOS
 
-## 3.3. macOS
+#### 3.3.1 Setup
 
-### 3.3.1 Setup
-On macOS you need to install: XCode and `MacPorts`. It is possible to use `homebrew` instead of `MacPorts`. However you will not be able to build the Graphical Clients (e.g., `OMEdit`) with just `homebrew` because one of the dependencies, `QTWebKit`, is not available through `homebrew` any longer.
+On macOS you need to install: XCode and `MacPorts`.
+It is possible to use `homebrew` instead of `MacPorts`.
+However you will not be able to build the Graphical Clients (e.g., `OMEdit`) with just `homebrew` because one of the dependencies, `QTWebKit`, is not available through `homebrew` any longer.
 
 First you need to install XCode
 
-  ```sh
-  xcode-select –-install
-  ```
-#### 3.3.1.1 MacPorts
+```sh
+xcode-select –-install
+```
+
+##### 3.3.1.1 MacPorts
 
 Next install `MacPorts` by following the instructions on https://guide.macports.org/#installing.macports.
 
 Once XCode and macports are installed, you need to install the dependencies for OpenModelica using `MacPorts`:
 
-  ```sh
-  sudo port install curl libiconv gettext flex cmake ccache qt5 qt5-qtwebkit autoconf boost OpenSceneGraph openjdk11
-  ```
+```sh
+sudo port install curl libiconv gettext flex cmake ccache qt5 qt5-qtwebkit autoconf boost OpenSceneGraph openjdk11
+```
 
-#### 3.3.1.2 Homebrew
+##### 3.3.1.2 Homebrew
 
 If you want to use only `homebrew` instead of `MacPorts` (remember that you will not be able to build the GUI clients this way), then follow the instructions on https://brew.sh/ to install homebrew. Once that is done, install the dependencies for OpenModelica using `homebrew`:
 
-  ```sh
-  brew install autoconf automake openjdk pkg-config cmake make ccache
-  echo 'export PATH="/opt/homebrew/opt/openjdk/bin:$PATH"' >> ~/.zshrc
-  ```
+```sh
+brew install autoconf automake openjdk pkg-config cmake make ccache
+echo 'export PATH="/opt/homebrew/opt/openjdk/bin:$PATH"' >> ~/.zshrc
+```
 
-### 3.3.2 Building
+#### 3.3.2 Building
 
 Optionally, You can also install `gfortran` if you plan to use OpenModelica for dynamic optimization purposes.
 
-> **Note**
+> [!NOTE]
 > If you install and use `gfortran`, it is recommended that you also use `gcc` and `g++`
 > (instead of `clang` and `clang++`).
 
@@ -151,20 +157,20 @@ If you cannot (M1 Mac does not have libquadmath) or do not want to use `gfortran
 
 You can now configure and compile OpenModelica as:
 
-  ```sh
-  # With MacPorts and Fortran available. This assumes MacPorts is installing packages to its default location /opt/local
-  cmake -S . -B build_cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_Fortran_COMPILER=gfortran -DCMAKE_PREFIX_PATH=/opt/local
-  # (M1 Mac does not have libquadmath)
-  # With MacPorts and Fortran NOT available. This assumes MacPorts is installing packages to its default location /opt/local
-  cmake -S . -B build_cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DOM_OMC_ENABLE_FORTRAN=OFF -DOM_OMC_ENABLE_OPTIMIZATION=OFF -DOM_OMC_ENABLE_MOO=OFF -DCMAKE_PREFIX_PATH=/opt/local
-  # With homebrew, you also need to disable the graphical clients. This assumes homebrew is installing packages to its default location /usr/local/opt/
-  cmake -S . -B build_cmake -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER=clang++ -DOM_OMC_ENABLE_FORTRAN=OFF -DOM_OMC_ENABLE_OPTIMIZATION=OFF -DOM_OMC_ENABLE_MOO=OFF -D OM_ENABLE_GUI_CLIENTS=OFF -DCMAKE_PREFIX_PATH=/usr/local/opt/
-  ```
+```sh
+# With MacPorts and Fortran available. This assumes MacPorts is installing packages to its default location /opt/local
+cmake -S . -B build_cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_Fortran_COMPILER=gfortran -DCMAKE_PREFIX_PATH=/opt/local
+# (M1 Mac does not have libquadmath)
+# With MacPorts and Fortran NOT available. This assumes MacPorts is installing packages to its default location /opt/local
+cmake -S . -B build_cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DOM_OMC_ENABLE_FORTRAN=OFF -DOM_OMC_ENABLE_OPTIMIZATION=OFF -DOM_OMC_ENABLE_MOO=OFF -DCMAKE_PREFIX_PATH=/opt/local
+# With homebrew, you also need to disable the graphical clients. This assumes homebrew is installing packages to its default location /usr/local/opt/
+cmake -S . -B build_cmake -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER=clang++ -DOM_OMC_ENABLE_FORTRAN=OFF -DOM_OMC_ENABLE_OPTIMIZATION=OFF -DOM_OMC_ENABLE_MOO=OFF -D OM_ENABLE_GUI_CLIENTS=OFF -DCMAKE_PREFIX_PATH=/usr/local/opt/
+```
 
-> **Warning**
+> [!WARNING]
 > Always specify your C, C++, and Fortran (optional) compilers explicitly on macOS.
 
-> **Warning**
+> [!WARNING]
 > This applies **even when you want to use the systems default compiler**. The reason for
 > this is that `cmake` does not use the default compiler `/usr/bin/c++` or `clang++`, but
 > an a version inside of XCode that disables the default include directories.
@@ -172,13 +178,13 @@ You can now configure and compile OpenModelica as:
 Once configuration finishes successfully you can build OpenModelica as you would on any
 unix system, e.g.,
 
-  ```sh
-  cmake --build build_cmake --parallel <Nr. of cores> --target install
-  # Default install dir is a directory named install_cmake inside the build directory.
-  ./build_cmake/install_cmake/bin/omc --help
-  ```
+```sh
+cmake --build build_cmake --parallel <Nr. of cores> --target install
+# Default install dir is a directory named install_cmake inside the build directory.
+./build_cmake/install_cmake/bin/omc --help
+```
 
-### 3.3.3 Common macOS issues
+#### 3.3.3 Common macOS issues
 
 If you encounter some errors while configuring, building, or simulating-with OpenModelica read on below. On macOS there are a few pitfalls/issues which need attention.
 
@@ -190,14 +196,16 @@ If you encounter some errors while configuring, building, or simulating-with Ope
   Port qt5 contains:
     /opt/local/share/doc/qt5/README.txt
   ```
+
   to see the directory. Then add the base directory of the result (/opt/local by default) to CMAKE_PREFIX_PATH by specifying
 
   ```sh
-  $ cmake ... -DCMAKE_PREFIX_PATH=/opt/local ...
+  cmake ... -DCMAKE_PREFIX_PATH=/opt/local ...
   ```
 
 - If your compilation fails because of linking issues with `libiconv``:
-  ```sh
+
+  ```text
   [ 30%] Linking CXX executable bootstrapped/bin/bomc
   ld: warning: dylib (/opt/homebrew/lib/libintl.dylib) was built for newer macOS version (13.0) than being linked (12.3)
   Undefined symbols for architecture arm64:
@@ -214,11 +222,10 @@ If you encounter some errors while configuring, building, or simulating-with Ope
   the compilation might be using `libiconv` from XCode (which contains functions not prefixed with `lib`, i.e., `_iconv_open` instead of `_libiconv_open`). Try reconfiguring OpenModelica by adding the MacPorts base directory as a prefix path for CMake.
 
   ```sh
-  $ cmake ... -DCMAKE_PREFIX_PATH=/opt/local ...
+  cmake ... -DCMAKE_PREFIX_PATH=/opt/local ...
   ```
 
   This will give it priority over the XCode one and CMake will pick up the MacPorts `libiconv`.
-
 
 - If your compilation fails because of linking issues such as these:
 
@@ -229,11 +236,13 @@ If you encounter some errors while configuring, building, or simulating-with Ope
   ```export PATH=/usr/bin:/bin:/usr/sbin:/sbin:$PATH```
 
   then clean OpenModelica
+
   ```sh
   cd OpenModelica
   git clean -ffdx
   git submodule foreach --recursive git clean -ffdx
   ```
+
   and start again with the commands above.
 
 - If building simulation code fails because your compiler cannot find ```stdio.h``` then do one of the following:
@@ -251,14 +260,14 @@ If you encounter some errors while configuring, building, or simulating-with Ope
     export PATH=/usr/bin:/bin:/usr/sbin:/sbin:$PATH
     ```
 
-## 3.4. Windows MSYS/UCRT64
+### 3.4. Windows MSYS/UCRT64
 
 There is nothing special about MSYS/UCRT64 if you are familiar with it. Just a few hints:
 
-  - The generator should be "MSYS Makefiles". This is not what CMake chooses by default
-    for Windows.
-  - You might want to make sure the output colors do not get mingled for Makefile target
-    generation.
+- The generator should be "MSYS Makefiles". This is not what CMake chooses by default
+  for Windows.
+- You might want to make sure the output colors do not get mingled for Makefile target
+  generation.
 
 Considering these, your final configure and build lines would be
 
@@ -271,21 +280,24 @@ make -j9 install -Oline
 # Default install dir is a directory named install_cmake inside the build directory.
 ./install_cmake/bin/omc --help
 ```
-> **Note**
+
+> [!NOTE]
 > `-Oline` instructs GNU Make to print outputs one line at a time, makeing sure ANSI color
 > codes do not get interleaved.
 
-> **Note**
+> [!NOTE]
 > With `-Oline` added, a Makefile step is printed once it is **completed**, not when it is
 > issued. So if you see something taking a long time, it is probably the thing that is
 > printed right after which is actually the culprit.
 
-# 4. Configuration Options.
+## 4. Configuration Options.
 
-## 4.1. OpenModelica Specific Configuration Options
+### 4.1. OpenModelica Specific Configuration Options
+
 There are a handful OpenModelica specific options that you can adjust to your needs.
 
 The main ones (with their default values) are
+
 ```cmake
 OM_USE_CCACHE=ON
 OM_ENABLE_GUI_CLIENTS=ON
@@ -301,7 +313,7 @@ OM_OMEDIT_ENABLE_TESTS=OFF
 OM_OMSHELL_ENABLE_TERMINAL=ON
 ```
 
-### 4.1.1. OpenModelica Options
+#### 4.1.1. OpenModelica Options
 
 `OM_USE_CCACHE` option is for enabling/disabling ccache support as explained in
 [2. ccache](#2-ccache). It is recommended that you install ccache and set this to ON.
@@ -325,9 +337,9 @@ cannot handle the `.arrow` format.
 The Rust port of the compiler itself (`OM_OMC_ENABLE_RUST`) and the Rust simulation runtime
 that `--simCodeTarget=C+Rust` links (`OM_ENABLE_RUST_SIM_RUNTIME`) are separate options,
 both off by default. `OM_OMC_ENABLE_RUST` needs a pinned nightly toolchain; see
-[OMCompiler/Compiler/OpenModelica.rs/README.md](OMCompiler/Compiler/OpenModelica.rs/README.md).
+[4.1.2](#412-openmodelicaomcompiler-options).
 
-### 4.1.2. OpenModelica/OMCompiler Options
+#### 4.1.2. OpenModelica/OMCompiler Options
 
 `OM_OMC_ENABLE_CPP_RUNTIME` allows you to enable/disable the building of the C++ based
 simulation runtime. This requires multiple Boost library components (file_system,
@@ -344,20 +356,25 @@ MOO (`OM_OMC_ENABLE_MOO`).
 `OM_OMC_ENABLE_MOO` allows you to enable/disable support for dynamic optimization
 support with MOO. Enabling this requires having a working Fortran compiler.
 
-### 4.1.3. OpenModelica/OMEdit Options
+`OM_OMC_ENABLE_RUST` (`OFF` by default) builds the Rust (mmtorust) port of `omc` instead of
+the bootstrapped C one. It needs `rustup` and the pinned nightly toolchain, not the stable
+one used for the Rust result files; see
+[OMCompiler/Compiler/OpenModelica.rs/README.md](OMCompiler/Compiler/OpenModelica.rs/README.md).
+
+#### 4.1.3. OpenModelica/OMEdit Options
 
 `OM_OMEDIT_ENABLE_TESTS` Enable testing and build the OMEdit Testsuite.
 
 `OM_OMEDIT_INSTALL_RUNTIME_DLLS` allows you to enable/disable the installation of the
 required runtime DLLs for MSYS/UCRT64 builds.
 
-### 4.1.4. OpenModelica/OMShell Options
+#### 4.1.4. OpenModelica/OMShell Options
 
 `OM_OMSHELL_ENABLE_TERMINAL` allows you to enable/disable the building of the
 OMShell-terminal command-line REPL application. This requires the GNU readline library.
 Note that this is different from the Qt based OMShell GUI application.
 
-### 4.1.4. Other OpenModleica specific Options
+#### 4.1.4. Other OpenModleica specific Options
 
 There are also some additional options that are kept as a migration step to maintain the
 similarity with the `autotools` build system.
@@ -369,8 +386,9 @@ OM_OMC_USE_LAPACK=ON
 These options are not guaranteed to work properly if they are changed from their default
 values as of now.
 
-## 4.2. Useful CMake Configuration Options
-### 4.2.1. Disabling Colors for Makefile Generators
+### 4.2. Useful CMake Configuration Options
+
+#### 4.2.1. Disabling Colors for Makefile Generators
 
 If you do not like colors you can disable them.
 
@@ -380,7 +398,7 @@ cmake .. -DCMAKE_COLOR_MAKEFILE=OFF
 
 This can be useful if you want to redirect output to a file for example.
 
-### 4.2.2 Enabling Verbose Output
+#### 4.2.2 Enabling Verbose Output
 
 Sometimes you might want to get a verbose output to see what CMake is actually doing and
 what exact commands it is issuing.
@@ -402,7 +420,6 @@ make VERBOSE=1
 The above two approaches have the advantage of allowing you to get verbose output only
 when you want it.
 
-
 If you instead want to see verbose output every time you compile any change then you can
 tell CMake at configure time to always do that:
 
@@ -410,7 +427,7 @@ tell CMake at configure time to always do that:
 cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON
 ```
 
-# 5. Integration with Editors/Tools
+## 5. Integration with Editors/Tools
 
 The CMake configuration is set to always generate the compile command-line for each target
 it discovers in to a file named `compile_commands.json`. This file is known and understood
@@ -425,7 +442,7 @@ Some editors and tools will check for the existence of this file automatically. 
 is recommended that you check your editor instructions to see if you can take advantage of
 it.
 
-# 6. Running Tests (rtest)
+## 6. Running Tests (rtest)
 
 Running the entirety of the OpenModelica testsuite is a complicated process and outside
 the scope for now.

--- a/README.md
+++ b/README.md
@@ -36,20 +36,13 @@ git submodule foreach --recursive 'git remote set-url --push origin `git config 
 ```
 
 If you are a developer and want to update your local git repository to the latest
-developments or latest heads, use:
+developments use:
 
 ```bash
 # After cloning
 cd OpenModelica
 git checkout master
 git pull
-# To checkout the latest master on each submodule run
-# you will need to merge each submodule, but your changes will remain
-git submodule foreach --recursive "git checkout master && git pull"
-
-# Running master on all submodules might lead to build errors
-# so use this to make sure you force all submodules to the commits
-# from the OpenModelica glue project which are properly tested
 git submodule update --force --init --recursive
 ```
 
@@ -60,7 +53,8 @@ clicking the Fork button in the GitHub web interface).
 If you do not checkout the repositories for some GUI clients (such as OMOptim.git), these
 directories will be ignored by autoconf and skipped during compilation.
 
-To checkout a specific version of OpenModelica, say tag v1.16.2 do:
+To checkout a specific version of OpenModelica, say tag `v1.16.2` do:
+
 ```bash
 git clone --recurse-submodules https://github.com/OpenModelica/OpenModelica.git
 cd OpenModelica
@@ -104,71 +98,6 @@ We automatically generate nightly builds for
 them directly if you just want to run the latest development version of OpenModelica without
 the effort of compiling the sources yourself.
 
-## How to run
-
-Here is a short example session.
-This example uses [OMShell-terminal](OMShell), but OMShell, mos-scripts, or OMNotebook
-work the same way.
-
-```
-$ cd trunk/build/bin
-$ ./OMShell-terminal
-OMShell Copyright 1997-2015, Open Source Modelica Consortium (OSMC)
-Distributed under OSMC-PL and AGPL3, see www.openmodelica.org
-
-To get help on using OMShell and OpenModelica, type "help()" and press enter
-Started server using:omc -d=interactive > /tmp/omshell.log 2>&1 &
->>> loadModel(Modelica)
-true
->>> getErrorString()
-""
->> instantiateModel(Modelica.Electrical.Analog.Basic.Resistor)
-"class Modelica.Electrical.Analog.Basic.Resistor \"Ideal linear electrical resistor\"
-  Real v(quantity = \"ElectricPotential\", unit = \"V\") \"Voltage drop between the two pins (= p.v - n.v)\";
-  Real i(quantity = \"ElectricCurrent\", unit = \"A\") \"Current flowing from pin p to pin n\";
-  Real p.v(quantity = \"ElectricPotential\", unit = \"V\") \"Potential at the pin\";
-  Real p.i(quantity = \"ElectricCurrent\", unit = \"A\") \"Current flowing into the pin\";
-  Real n.v(quantity = \"ElectricPotential\", unit = \"V\") \"Potential at the pin\";
-  Real n.i(quantity = \"ElectricCurrent\", unit = \"A\") \"Current flowing into the pin\";
-  parameter Boolean useHeatPort = false \"=true, if HeatPort is enabled\";
-  parameter Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = T_ref \"Fixed device temperature if useHeatPort = false\";
-  Real LossPower(quantity = \"Power\", unit = \"W\") \"Loss power leaving component via HeatPort\";
-  Real T_heatPort(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature of HeatPort\";
-  parameter Real R(quantity = \"Resistance\", unit = \"Ohm\", start = 1.0) \"Resistance at temperature T_ref\";
-  parameter Real T_ref(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 300.15 \"Reference temperature\";
-  parameter Real alpha(quantity = \"LinearTemperatureCoefficient\", unit = \"1/K\") = 0.0 \"Temperature coefficient of resistance (R_actual = R*(1 + alpha*(T_heatPort - T_ref))\";
-  Real R_actual(quantity = \"Resistance\", unit = \"Ohm\") \"Actual resistance = R*(1 + alpha*(T_heatPort - T_ref))\";
-equation
-  assert(1.0 + alpha * (T_heatPort - T_ref) >= 1e-15, \"Temperature outside scope of model!\");
-  R_actual = R * (1.0 + alpha * (T_heatPort - T_ref));
-  v = R_actual * i;
-  LossPower = v * i;
-  v = p.v - n.v;
-  0.0 = p.i + n.i;
-  i = p.i;
-  T_heatPort = T;
-  p.i = 0.0;
-  n.i = 0.0;
-end Modelica.Electrical.Analog.Basic.Resistor;
-"
->> a:=1:5;
->> b:=3:8
-{3,4,5,6,7,8}
->>> a*b
-
->>> getErrorString()
-"[<interactive>:1:1-1:0:writable] Error: Incompatible argument types to operation scalar product in component <NO COMPONENT>, left type: Integer[5], right type: Integer[6]
-[<interactive>:1:1-1:0:writable] Error: Incompatible argument types to operation scalar product in component <NO COMPONENT>, left type: Real[5], right type: Real[6]
-[<interactive>:1:1-1:0:writable] Error: Cannot resolve type of expression a * b. The operands have types Integer[5], Integer[6] in component <NO COMPONENT>.
-"
->> b:=3:7;
->> a*b
-85
->>> listVariables()
-{b, a}
->>
-```
-
 ## How to contribute to the OpenModelica Compiler
 
 The long-term development of OpenModelica is supported by a non-profit organization - the
@@ -191,4 +120,4 @@ For a complete list of all publications related to OpenModelica see
 [doc/bibliography/openmodelica.bib](./doc/bibliography/openmodelica.bib).
 
 ------------
-Last updated: 2023-06-21
+Last updated: 2026-09-08

--- a/testsuite/partest/runtests.pl
+++ b/testsuite/partest/runtests.pl
@@ -111,8 +111,9 @@ my %suite_enabled = (
                       # opt-in like wasm rather than off-by-build.
   arrow        => 1,  # Needs the Rust result library libomc_result, which reads
                       # and writes the arrow format (OM_RUST_RESULT_READERS/
-                      # OM_RUST_RESULT_WRITERS). Every CMake build has it; the
-                      # autotools build is the one that turns this off.
+                      # OM_RUST_RESULT_WRITERS). A CMake build has it wherever
+                      # cargo is on PATH, which is what those options default to;
+                      # a build without a Rust toolchain turns this off.
   # Not part of the testsuite: the tests a makefile lists as failing, not
   # compiling, not simulating or needing a manual setup. They are the tests that
   # fail, hang or eat the machine, so they are opt-in and rtest skips them too


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/commit/3b0041ba99401a31520ef450e936dbf5a64907b7 broke the Windows builds:

```
CMake Error at OMCompiler/Compiler/.cmake/rust_result_reader.cmake:9 (message):
  OM_RUST_RESULT_READERS/OM_RUST_RESULT_WRITERS is ON but cargo was not
  found.  Install a stable Rust toolchain, or configure with
  -DOM_RUST_RESULT_READERS=OFF -DOM_RUST_RESULT_WRITERS=OFF to use the C
  result readers and writers.
Call Stack (most recent call first):
  CMakeLists.txt:291 (omc_result_reader_library)
-- Configuring incomplete, errors occurred!
script returned exit code 1
```

`rust_result_reader.cmake` fails the configure with a FATAL_ERROR when cargo is missing, and both options that reach it default to ON. The OMDev Windows build has no Rust toolchain (as of now),  so every CMake build there stops at

```
OM_RUST_RESULT_READERS/OM_RUST_RESULT_WRITERS is ON but cargo was not found.
```

### Purpose

* Make `find_program(CARGO_EXECUTABLE cargo)` at the top level drive the default of OM_RUST_RESULT_READERS and OM_RUST_RESULT_WRITERS instead.
* Update README for Windows builds