### PR TITLE
Document the Rust toolchain build dependency

### DIFF
--- a/OMCompiler/README.Linux.md
+++ b/OMCompiler/README.Linux.md
@@ -5,6 +5,7 @@
 - [1 Build dependencies](#1-build-dependencies)
   - [1.1 Debian/Ubuntu](#11-debianubuntu)
   - [1.2 Linux/BSD](#12-linuxbsd)
+  - [1.3 Rust toolchain](#13-rust-toolchain)
 - [2 Compile OpenModelica](#2-compile-openmodelica)
   - [2.1 CMake build](#21-cmake-build)
   - [2.2 Make build](#22-make-build)
@@ -97,6 +98,47 @@ First you need to install the dependencies:
 - ncurses, readline (optional, used by OMShell-terminal)
 - OpenSceneGraph (optional, used by OMEdit)
 - Qt6 or Qt5, Webkit, QtOpenGL (optional, used by OMEdit)
+- rustc and cargo (optional if you disable it; see [1.3 Rust toolchain](#13-rust-toolchain)
+for how to install or disable)
+
+### 1.3 Rust toolchain
+
+Parts of OpenModelica are written in Rust, so `cargo` and `rustc` are needed for
+a default build: the C simulation runtime writes its result files through
+`libomc_result` (`OM_RUST_RESULT_WRITERS`) and the GUI clients read them back
+through the same library (`OM_RUST_RESULT_READERS`). Both are on by default and
+CMake stops at configure time if `cargo` is not on the `PATH`.
+
+Any reasonably recent stable toolchain will do. The crates use the 2024 edition,
+so `rustc`/`cargo` 1.85 or newer:
+
+```bash
+sudo apt-get install rustc cargo
+cargo --version
+```
+
+If your distribution packages something older (Ubuntu 24.04 for instance),
+install [rustup](https://rustup.rs) and let it manage the toolchain instead:
+
+```bash
+sudo apt-get install rustup
+# Or, if there is no rustup package:
+# curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup default stable
+```
+
+To build without Rust, turn both options off. You then lose the `.arrow` result
+format; the C readers and writers handle `.mat`, `.csv` and `.plt` only:
+
+```bash
+cmake -S . -B build_cmake -DOM_RUST_RESULT_READERS=OFF -DOM_RUST_RESULT_WRITERS=OFF
+```
+
+Two larger Rust components are off by default. `-DOM_ENABLE_RUST_SIM_RUNTIME=ON`
+builds the simulation runtime `--simCodeTarget=C+Rust` links, and also works
+with a stable toolchain. `-DOM_OMC_ENABLE_RUST=ON` builds the compiler itself as
+the Rust port, which needs the pinned nightly toolchain described in
+[Compiler/OpenModelica.rs/README.md](Compiler/OpenModelica.rs/README.md).
 
 ## 2 Compile OpenModelica
 
@@ -211,4 +253,4 @@ and then sent us an email at
 
 --------------
 
-Last updated 2026-02-16.
+Last updated 2026-09-07.

--- a/README.cmake.md
+++ b/README.cmake.md
@@ -96,6 +96,11 @@ dependencies (If you need help, follow the instructions
 [quick start](#1-quick-start) section above or choose your own combination of
 [configuration options](#4-configuration-options) (e.g. build type, generator, install dir ...).
 
+Note that a default build needs `cargo` and `rustc` on the `PATH` for the Rust
+result-file library (see
+[1.3 Rust toolchain](https://github.com/OpenModelica/OpenModelica/blob/master/OMCompiler/README.Linux.md#13-rust-toolchain)).
+A stable toolchain of version 1.85 or newer is enough.
+
 ### 3.2.1 QTWebKit
 
 Note that most of the latest Linux releases do not support Qt5 QTWebKit anymore so one needs to configure with Qt6
@@ -285,6 +290,8 @@ The main ones (with their default values) are
 OM_USE_CCACHE=ON
 OM_ENABLE_GUI_CLIENTS=ON
 OM_ENABLE_ENCRYPTION=OFF
+OM_RUST_RESULT_READERS=ON
+OM_RUST_RESULT_WRITERS=ON
 OM_OMC_ENABLE_CPP_RUNTIME=ON
 OM_OMC_ENABLE_FORTRAN=ON
 OM_OMC_ENABLE_OPTIMIZATION=ON
@@ -308,6 +315,17 @@ their dependencies) such as the Qt libs, OpenSceneGraph, OpenThreads ...
 encryption support. Note that, for this to work, you need an additional module which is
 not distributed in the default OpenModelcia source repository. Contact the OpenModelica
 team if you need encryption support.
+
+`OM_RUST_RESULT_WRITERS` makes the C simulation runtime write result files through
+`libomc_result`, the Rust result-file library, and `OM_RUST_RESULT_READERS` makes the GUI
+clients read them back through it. Both need `cargo` on the `PATH` (a stable toolchain of
+version 1.85 or newer). Turning them off falls back to the C readers and writers, which
+cannot handle the `.arrow` format.
+
+The Rust port of the compiler itself (`OM_OMC_ENABLE_RUST`) and the Rust simulation runtime
+that `--simCodeTarget=C+Rust` links (`OM_ENABLE_RUST_SIM_RUNTIME`) are separate options,
+both off by default. `OM_OMC_ENABLE_RUST` needs a pinned nightly toolchain; see
+[OMCompiler/Compiler/OpenModelica.rs/README.md](OMCompiler/Compiler/OpenModelica.rs/README.md).
 
 ### 4.1.2. OpenModelica/OMCompiler Options
 


### PR DESCRIPTION
A default CMake build needs cargo and rustc: the C simulation runtime writes result files through libomc_result (OM_RUST_RESULT_WRITERS) and the GUI clients read them back through it (OM_RUST_RESULT_READERS), both ON by default, and configure fails outright when cargo is missing.

Add a Rust toolchain section to README.Linux.md covering the stable 1.85+ (2024 edition) requirement, the rustup fallback for distributions packaging something older, and the -DOM_RUST_RESULT_*=OFF opt-out. It also separates the two opt-in components: OM_ENABLE_RUST_SIM_RUNTIME still only needs stable, while OM_OMC_ENABLE_RUST needs the pinned nightly.

Document the same two options in README.cmake.md.

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
