### PR TITLE
Check spatialDistribution rules

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -151,6 +151,7 @@ public
       case "scalar" then typeScalarCall(call, context, info);
       case "shiftSample" then typeShiftSampleCall(call, context, info);
       case "smooth" then typeSmoothCall(call, context, info);
+      case "spatialDistribution" then typeSpatialDistribution(call, context, info);
       case "String" then typeStringCall(call, context, info);
       case "subSample" then typeSubSampleCall(call, context, info);
       case "superSample" then typeSuperSampleCall(call, context, info);
@@ -2260,6 +2261,27 @@ protected
     Structural.markExp(factor);
     callExp := Expression.CALL(ty_call);
   end typeSuperSampleCall;
+
+  function typeSpatialDistribution
+    input Call call;
+    input InstContext.Type context;
+    input SourceInfo info;
+    output Expression callExp;
+    output Type ty;
+    output Variability var;
+    output Purity purity;
+  protected
+    Call ty_call;
+  algorithm
+    if InstContext.inSubexpression(context) or InstContext.inAlgorithm(context) then
+      Error.addSourceMessage(Error.SPATIAL_DISTRIBUTION_CONTEXT, {}, info);
+      fail();
+    end if;
+
+    ty_call as Call.TYPED_CALL(ty = ty, var = var, purity = purity) :=
+      Call.typeMatchNormalCall(call, context, info, vectorize = false);
+    callExp := Expression.CALL(ty_call);
+  end typeSpatialDistribution;
 
   function typePureCall
     input Call call;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -1872,6 +1872,7 @@ algorithm
         e1 := flattenExp(eq.lhs, prefix, info);
         e2 := flattenExp(eq.rhs, prefix, info);
         ty := flattenType(eq.ty, prefix, info);
+        checkEqualityEquation(e1, e2, eq.source);
       then
         Equation.EQUALITY(e1, e2, ty, eq.scope, eq.source, eq.scalarizeMode) :: equations;
 
@@ -1930,6 +1931,50 @@ algorithm
     else eq :: equations;
   end match;
 end flattenEquation;
+
+function checkEqualityEquation
+  input Expression lhs;
+  input Expression rhs;
+  input DAE.ElementSource src;
+protected
+  Expression out0, out1, pos_vel;
+  Call call;
+algorithm
+  () := match (lhs, rhs)
+    // spatialDistribution has special rules on how its outputs can be used.
+    case (Expression.TUPLE(elements = {out0, out1}), Expression.CALL(call))
+      guard (Expression.isWildCref(out0) or Expression.isWildCref(out1)) and
+            Call.isNamed(call, "spatialDistribution")
+      algorithm
+        // The second output may not be ignored.
+        if Expression.isWildCref(out1) then
+          Error.addSourceMessage(Error.SPATIAL_DISTRIBUTION_IGNORED_OUT1, {}, ElementSource.getInfo(src));
+          fail();
+        end if;
+
+        // The first output may only be ignored if positiveVelocity is true.
+        {_, _, _, pos_vel, _, _} := Call.arguments(call);
+        Structural.markExp(pos_vel);
+        pos_vel := Ceval.tryEvalExp(pos_vel);
+
+        if not Expression.isTrue(pos_vel) then
+          Error.addSourceMessage(Error.SPATIAL_DISTRIBUTION_IGNORED_OUT0, {}, ElementSource.getInfo(src));
+          fail();
+        end if;
+      then
+        ();
+
+    // spatialDistribution may be wrapped in a noEvent.
+    case (Expression.TUPLE(), Expression.CALL(call))
+      guard Call.isNamed(call, "noEvent")
+      algorithm
+        checkEqualityEquation(lhs, listHead(Call.arguments(call)), src);
+      then
+        ();
+
+    else ();
+  end match;
+end checkEqualityEquation;
 
 function flattenIfEquation
   input Equation eq;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -1948,6 +1948,8 @@ uniontype Function
           case "shiftSample" then true;
           // Needs to check that second argument is real or array of real or record of reals.
           case "smooth" then true;
+          // May only be used in certain context, and has other special rules.
+          case "spatialDistribution" then true;
           case "subSample" then true;
           // needs unboxing and return type fix.
           case "superSample" then true;

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -922,6 +922,12 @@ public constant ErrorTypes.Message NON_POSITIVE_NTH_ROOT = ErrorTypes.MESSAGE(42
   "Invalid operation nthRoot(v = %s, n = %s), n must be a positive integer.");
 public constant ErrorTypes.Message NEGATIVE_NTH_ROOT = ErrorTypes.MESSAGE(423, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   "Invalid operation nthRoot(v = %s, n = %s), v must be non-negative when n is even.");
+public constant ErrorTypes.Message SPATIAL_DISTRIBUTION_CONTEXT = ErrorTypes.MESSAGE(424, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
+  "spatialDistribution may only be used as the right hand side of an equation.");
+public constant ErrorTypes.Message SPATIAL_DISTRIBUTION_IGNORED_OUT0 = ErrorTypes.MESSAGE(425, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
+  "The first output of spatialDistribution may only be ignored if positiveVelocity is true.");
+public constant ErrorTypes.Message SPATIAL_DISTRIBUTION_IGNORED_OUT1 = ErrorTypes.MESSAGE(426, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
+  "The second output of spatialDistribution may not be ignored.");
 
 public constant ErrorTypes.Message INITIALIZATION_NOT_FULLY_SPECIFIED = ErrorTypes.MESSAGE(496, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
   "The initial conditions are not fully specified. %s.");

--- a/testsuite/flattening/modelica/built-in-functions/Makefile
+++ b/testsuite/flattening/modelica/built-in-functions/Makefile
@@ -64,6 +64,13 @@ Sign.mo \
 Sin.mo \
 Sinh.mo \
 Skew.mo \
+SpatialDistribution1.mo \
+SpatialDistribution2.mo \
+SpatialDistribution3.mo \
+SpatialDistribution4.mo \
+SpatialDistribution5.mo \
+SpatialDistribution6.mo \
+SpatialDistribution7.mo \
 Sqrt.mo \
 Sum.mo \
 SumArray.mo \

--- a/testsuite/flattening/modelica/built-in-functions/SpatialDistribution1.mo
+++ b/testsuite/flattening/modelica/built-in-functions/SpatialDistribution1.mo
@@ -1,0 +1,30 @@
+// name:     SpatialDistribution1
+// keywords: builtin
+// status:   correct
+//
+// Test builtin function spatialDistribution.
+//
+
+model SpatialDistribution1
+  Real x;
+  Real v = 1;
+  Real in0 = time;
+  Real out0;
+  Real out1;
+equation
+  der(x) = v;
+  (out0, out1) = spatialDistribution(in0, 0.0, x, true, {0.0, 1.0}, {0.0, 0.0});
+end SpatialDistribution1;
+
+// Result:
+// class SpatialDistribution1
+//   Real x;
+//   Real v = 1.0;
+//   Real in0 = time;
+//   Real out0;
+//   Real out1;
+// equation
+//   der(x) = v;
+//   (out0, out1) = spatialDistribution(in0, 0.0, x, true, {0.0, 1.0}, {0.0, 0.0});
+// end SpatialDistribution1;
+// endResult

--- a/testsuite/flattening/modelica/built-in-functions/SpatialDistribution2.mo
+++ b/testsuite/flattening/modelica/built-in-functions/SpatialDistribution2.mo
@@ -1,0 +1,27 @@
+// name:     SpatialDistribution2
+// keywords: builtin
+// status:   incorrect
+//
+// Test builtin function spatialDistribution.
+//
+
+model SpatialDistribution2
+  Real x;
+  Real v = 1;
+  Real in0 = time;
+  Real out0;
+  Real out1;
+equation
+  der(x) = v;
+  out0 = out1 + spatialDistribution(in0, 0.0, x, true, {0.0, 1.0}, {0.0, 0.0});
+end SpatialDistribution2;
+
+// Result:
+// Error processing file: SpatialDistribution2.mo
+// [flattening/modelica/built-in-functions/SpatialDistribution2.mo:16:3-16:79:writable] Error: spatialDistribution may only be used as the right hand side of an equation.
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/built-in-functions/SpatialDistribution3.mo
+++ b/testsuite/flattening/modelica/built-in-functions/SpatialDistribution3.mo
@@ -1,0 +1,28 @@
+// name:     SpatialDistribution3
+// keywords: builtin
+// status:   correct
+//
+// Test builtin function spatialDistribution.
+//
+
+model SpatialDistribution3
+  Real x;
+  Real v = 1;
+  Real in0 = time;
+  Real out1;
+equation
+  der(x) = v;
+  (, out1) = spatialDistribution(in0, 1.0, x, true, {0.0, 1.0}, {0.0, 0.0});
+end SpatialDistribution3;
+
+// Result:
+// class SpatialDistribution3
+//   Real x;
+//   Real v = 1.0;
+//   Real in0 = time;
+//   Real out1;
+// equation
+//   der(x) = v;
+//   (_, out1) = spatialDistribution(in0, 1.0, x, true, {0.0, 1.0}, {0.0, 0.0});
+// end SpatialDistribution3;
+// endResult

--- a/testsuite/flattening/modelica/built-in-functions/SpatialDistribution4.mo
+++ b/testsuite/flattening/modelica/built-in-functions/SpatialDistribution4.mo
@@ -1,0 +1,27 @@
+// name:     SpatialDistribution4
+// keywords: builtin
+// status:   incorrect
+//
+// Test builtin function spatialDistribution.
+//
+
+model SpatialDistribution4
+  Real x;
+  Real v = 1;
+  Real in0 = time;
+  Real out0;
+  Real out1;
+equation
+  der(x) = v;
+  (, out1) = spatialDistribution(in0, 0.0, x, false, {0.0, 1.0}, {0.0, 0.0});
+end SpatialDistribution4;
+
+// Result:
+// Error processing file: SpatialDistribution4.mo
+// [flattening/modelica/built-in-functions/SpatialDistribution4.mo:16:3-16:77:writable] Error: The first output of spatialDistribution may only be ignored if positiveVelocity is true.
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/built-in-functions/SpatialDistribution5.mo
+++ b/testsuite/flattening/modelica/built-in-functions/SpatialDistribution5.mo
@@ -1,0 +1,27 @@
+// name:     SpatialDistribution5
+// keywords: builtin
+// status:   incorrect
+//
+// Test builtin function spatialDistribution.
+//
+
+model SpatialDistribution5
+  Real x;
+  Real v = 1;
+  Real in0 = time;
+  Real out0;
+  Real out1;
+equation
+  der(x) = v;
+  (out0, ) = spatialDistribution(in0, 0.0, x, true, {0.0, 1.0}, {0.0, 0.0});
+end SpatialDistribution5;
+
+// Result:
+// Error processing file: SpatialDistribution5.mo
+// [flattening/modelica/built-in-functions/SpatialDistribution5.mo:16:3-16:76:writable] Error: The second output of spatialDistribution may not be ignored.
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/built-in-functions/SpatialDistribution6.mo
+++ b/testsuite/flattening/modelica/built-in-functions/SpatialDistribution6.mo
@@ -1,0 +1,30 @@
+// name:     SpatialDistribution6
+// keywords: builtin
+// status:   correct
+//
+// Test builtin function spatialDistribution.
+//
+
+model SpatialDistribution6
+  Real x;
+  Real v = 1;
+  Real in0 = time;
+  Real out0;
+  Real out1;
+equation
+  der(x) = v;
+  (out0, out1) = noEvent(spatialDistribution(in0, 0.0, x, true, {0.0, 1.0}, {0.0, 0.0}));
+end SpatialDistribution6;
+
+// Result:
+// class SpatialDistribution6
+//   Real x;
+//   Real v = 1.0;
+//   Real in0 = time;
+//   Real out0;
+//   Real out1;
+// equation
+//   der(x) = v;
+//   (out0, out1) = noEvent(spatialDistribution(in0, 0.0, x, true, {0.0, 1.0}, {0.0, 0.0}));
+// end SpatialDistribution6;
+// endResult

--- a/testsuite/flattening/modelica/built-in-functions/SpatialDistribution7.mo
+++ b/testsuite/flattening/modelica/built-in-functions/SpatialDistribution7.mo
@@ -1,0 +1,27 @@
+// name:     SpatialDistribution7
+// keywords: builtin
+// status:   incorrect
+//
+// Test builtin function spatialDistribution.
+//
+
+model SpatialDistribution7
+  Real x;
+  Real v = 1;
+  Real in0 = time;
+  Real out0;
+  Real out1;
+equation
+  der(x) = v;
+  (, out1) = noEvent(spatialDistribution(in0, 0.0, x, false, {0.0, 1.0}, {0.0, 0.0}));
+end SpatialDistribution7;
+
+// Result:
+// Error processing file: SpatialDistribution7.mo
+// [flattening/modelica/built-in-functions/SpatialDistribution7.mo:16:3-16:86:writable] Error: The first output of spatialDistribution may only be ignored if positiveVelocity is true.
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/simulation/modelica/built_in_functions/spatialDistribution/singleOutputSpatialDistribution.mos
+++ b/testsuite/simulation/modelica/built_in_functions/spatialDistribution/singleOutputSpatialDistribution.mos
@@ -8,13 +8,10 @@
 // pointer and the runtime must not dereference it.
 // Regression test for #15431.
 
-loadModel(Modelica); getErrorString();
-
 // Only the first output is used, second output pointer is NULL.
 loadString("
   model SingleOutputFirst
     \"Only uses the first output of spatialDistribution (negative velocity).\"
-  extends Modelica.Icons.Example;
   Real input_ = time*2;
   Real leftOutput;
   constant Real[:] initialPoints(each min = 0, each max = 1) = {0.0, 1.0};
@@ -33,19 +30,16 @@ end SingleOutputFirst;"); getErrorString();
 loadString("
   model SingleOutputSecond
     \"Only uses the second output of spatialDistribution (positive velocity).\"
-  extends Modelica.Icons.Example;
   Real input_ = time*2;
   Real rightOutput;
   constant Real[:] initialPoints(each min = 0, each max = 1) = {0.0, 1.0};
   constant Real[:] initialValues = {1.0, 1.0};
   Real v;
-  Boolean posV;
   Real x(start=0, fixed=true);
 equation
   v = der(x);
   v = 1;
-  posV = v >= 0;
-  (, rightOutput) = spatialDistribution(input_, input_, x, posV, initialPoints, initialValues);
+  (, rightOutput) = spatialDistribution(input_, input_, x, true, initialPoints, initialValues);
 end SingleOutputSecond;"); getErrorString();
 
 simulate(SingleOutputFirst, stopTime=2.0); getErrorString();
@@ -59,8 +53,6 @@ val(rightOutput, 1.0);
 val(rightOutput, 2.0);
 
 // Result:
-// true
-// ""
 // true
 // ""
 // true


### PR DESCRIPTION
- Check that spatialDistribution is only used as the rhs of an equation.
- Check that the outputs of spatialDistribution aren't ignored except when doing so is allowed.

Fixes #16098