### PR TITLE
FMU: terminate() at initialization ends the run

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/cs.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/cs.rs
@@ -66,10 +66,13 @@ pub fn simulate(
     let mut cancelled = false;
     if event_mode {
         let info = event_iteration(as_common(inst))?;
+        // `terminate()` from an initial equation ends the run at `startTime`, as it
+        // does outside an FMU; the row below is the result.
         if info.terminate {
-            return Err(Error::TerminatedAtInit);
+            terminated_at = Some(opts.start_time);
+        } else {
+            inst.enter_step_mode()?;
         }
-        inst.enter_step_mode()?;
     }
     rec.snapshot_parameters(as_common(inst))?;
     rec.sample(as_common(inst), opts.start_time)?;
@@ -77,7 +80,7 @@ pub fn simulate(
     let deadline = Deadline::arm(opts);
     let mut t = opts.start_time;
     let mut grid = opts.grid(step).skip(1);
-    let mut next = grid.next();
+    let mut next = if terminated_at.is_some() { None } else { grid.next() };
     while let Some(target) = next {
         if deadline.expired() {
             return Err(Error::Alarm);

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/lib.rs
@@ -46,8 +46,6 @@ pub enum Error {
     Solver(&'static str),
     /// The FMU's own simulation runtime reported a failure.
     Simulation(String),
-    /// The FMU asked for termination during initialization.
-    TerminatedAtInit,
     /// `-alarm=N` expired.
     Alarm,
     Cancelled,
@@ -69,9 +67,6 @@ impl std::fmt::Display for Error {
             Error::Io(m) => write!(f, "{m}"),
             Error::Solver(m) => write!(f, "{m}"),
             Error::Simulation(m) => write!(f, "{m}"),
-            Error::TerminatedAtInit => {
-                write!(f, "the FMU requested termination during initialization")
-            }
             Error::Alarm => write!(f, "simulation aborted (-alarm)"),
             Error::Cancelled => write!(f, "cancelled"),
         }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/me.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/me.rs
@@ -49,6 +49,22 @@ pub struct Run {
     pub retries: u64,
 }
 
+/// A run that ended before its first step.
+fn terminated_at_init(recorder: Recorder, at: f64) -> Run {
+    Run {
+        recorder,
+        terminated_at: Some(at),
+        cancelled: false,
+        steps: 0,
+        calls: 0,
+        jacobians: 0,
+        state_events: 0,
+        time_events: 0,
+        event_times: Vec::new(),
+        retries: 0,
+    }
+}
+
 /// The two shapes fmi-ls-dae's `<ModelStructure>` can state a DAE in.
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum DaeForm {
@@ -770,8 +786,14 @@ pub fn simulate(
         let common: &mut dyn Fmi3 = inst;
         event_iteration(common)?
     };
+    // `terminate()` from an initial equation ends the run at `startTime`, as it
+    // does outside an FMU; the initial row is the result.
     if info.terminate {
-        return Err(Error::TerminatedAtInit);
+        let common: &mut dyn Fmi3 = inst;
+        rec.snapshot_parameters(common)?;
+        rec.sample(common, opts.start_time)?;
+        common.terminate()?;
+        return Ok(terminated_at_init(rec, opts.start_time));
     }
     inst.enter_continuous_time_mode()?;
 

--- a/testsuite/openmodelica/fmi/CoSimulation/3.0/Makefile
+++ b/testsuite/openmodelica/fmi/CoSimulation/3.0/Makefile
@@ -9,7 +9,8 @@ fmi3_wasm_daemode.mos \
 fmi3_wasm_error_reason.mos \
 fmi3_wasm_solver_absent.mos \
 fmi3_wasm_solver_libraries.mos \
-fmi3_wasm_solver_me.mos
+fmi3_wasm_solver_me.mos \
+fmi3_wasm_terminate_init.mos
 
 # Dependency files that are not .mo .mos or Makefile
 # Add them here or they will be cleaned.

--- a/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_terminate_init.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_terminate_init.mos
@@ -1,0 +1,52 @@
+// name: fmi3_wasm_terminate_init.mos
+// keywords: FMI 3.0 export wasm Co-Simulation Model Exchange terminate
+// status: correct
+// suite: wasm
+// teardown_command: rm -rf M_terminit* om-wasm-include-*
+//
+// `terminate()` from an initial equation ends the run at `startTime`; outside an
+// FMU that is a success, so it has to be one through both FMI faces as well.
+
+setCommandLineOptions("--simCodeTarget=wasm-jit"); getErrorString();
+loadString("model TerminateAtInit
+  Real x(start = 1.0, fixed = true);
+equation
+  der(x) = -x;
+initial algorithm
+  terminate(\"nothing left to simulate\");
+end TerminateAtInit;"); getErrorString();
+buildModelFMU(TerminateAtInit, fileNamePrefix="M_terminit", fmuType="me_cs", version="3.0", platforms={"wasm"}); getErrorString();
+simulate(TerminateAtInit, stopTime=1.0, numberOfIntervals=10, resimulateExecutable="M_terminit.fmu", simflags="-s fmi3:cs"); getErrorString();
+simulate(TerminateAtInit, stopTime=1.0, numberOfIntervals=10, resimulateExecutable="M_terminit.fmu", simflags="-s fmi3:me"); getErrorString();
+// Result:
+// true
+// ""
+// true
+// ""
+// "M_terminit.fmu"
+// "Notification: Building FMU for platform 'wasm' (1/1).
+// Notification: Finished FMU for platform 'wasm' (1/1).
+// "
+// record SimulationResult
+//     resultFile = "M_terminit.fmu_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 10, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'TerminateAtInit', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s fmi3:cs'",
+//     messages = "LOG_STDOUT        | info    | wasm artifact loaded (compiled from the component)
+// LOG_STDOUT        | info    | CoSimulation instantiated
+// [<interactive>:6:3-6:40:writable]Modelica Terminate: nothing left to simulate!
+// LOG_STDOUT        | info    | CoSimulation run: 0 communication steps, 0 events, 0 early returns, 1 samples
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// record SimulationResult
+//     resultFile = "M_terminit.fmu_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 10, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'TerminateAtInit', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s fmi3:me'",
+//     messages = "LOG_STDOUT        | info    | wasm artifact loaded (compiled from the component)
+// LOG_STDOUT        | info    | ModelExchange instantiated
+// [<interactive>:6:3-6:40:writable]Modelica Terminate: nothing left to simulate!
+// LOG_STDOUT        | info    | ModelExchange run: 0 steps, 0 evaluations, 0 Jacobians, 0 state events, 0 time events, 1 samples
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult


### PR DESCRIPTION
`terminate()` from an initial equation ends the run at `startTime`; the standalone driver reports it and finishes successfully. Both FMI masters instead turned the first event iteration's terminate flag into an error, so a model like

    MessagePack.Examples.TestCreateAndReadFile

-- whose whole test is an `initial algorithm terminate(...)` -- failed through `-s fmi3:cs` and `-s fmi3:me` while its plain run passed.

Record the initial row, call `fmi3Terminate` and report the run as ended at `startTime`, as the non-FMU paths do.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
