### PR TITLE
wasm-jit: discrete NLS unknowns, ext objects, $pDER

### DIFF
--- a/OMCompiler/Compiler/BackEnd/CommonSubExpression.mo
+++ b/OMCompiler/Compiler/BackEnd/CommonSubExpression.mo
@@ -130,6 +130,8 @@ protected
   list<BackendDAE.EqSystem> eqSystems = {};
   String daeTypeStr = BackendDump.printBackendDAEType2String(inDAE.shared.backendDAEType);
   Boolean isSimulationDAE = stringEq(daeTypeStr, "simulation");
+  // A Jacobian's own globalKnownVars never reach SimCode, so a call there stays an equation.
+  Boolean allowGlobalKnown = not stringEq(daeTypeStr, "jacobian");
 
   HashSet.HashSet globalKnownVarHT;
 
@@ -206,7 +208,7 @@ algorithm
       end if;
 
       // Phase 4: Create CSE equations
-      (orderedEqs_new, orderedVars, globalKnownVars) := createCseEquations(exarray, orderedEqs_new, orderedVars, globalKnownVars, globalKnownVarHT);
+      (orderedEqs_new, orderedVars, globalKnownVars) := createCseEquations(exarray, orderedEqs_new, orderedVars, globalKnownVars, globalKnownVarHT, allowGlobalKnown);
 
       syst.orderedEqs := orderedEqs_new;
       syst.orderedVars := orderedVars;
@@ -484,6 +486,7 @@ protected function createCseEquations
   input output BackendDAE.Variables orderedVars;
   input output BackendDAE.Variables globalKnownVars;
   input output HashSet.HashSet globalKnownVarHT;
+  input Boolean allowGlobalKnown;
 protected
   DAE.Exp cse, call;
   BackendDAE.Equation eq;
@@ -505,7 +508,7 @@ algorithm
     end if;
 
     eq := BackendEquation.generateEquation(cse, call);
-    (globalKnownVarHT, globalKnownVars, orderedVars, eqRedundant, isGlobalKnown) := isEquationRedundant_flatten(eq, globalKnownVarHT, globalKnownVars, orderedVars);
+    (globalKnownVarHT, globalKnownVars, orderedVars, eqRedundant, isGlobalKnown) := isEquationRedundant_flatten(eq, globalKnownVarHT, globalKnownVars, orderedVars, allowGlobalKnown);
 
     if debug then print("\ndebug 1 - eq redundant?\n"); end if;
     if not eqRedundant then
@@ -1013,6 +1016,7 @@ protected function isEquationRedundant_flatten
   input output HashSet.HashSet globalKnownVarHT;
   input output BackendDAE.Variables globalKnownVars;
   input output BackendDAE.Variables orderedVars;
+  input Boolean allowGlobalKnown;
   output Boolean outB "true if 'x=x', else false";
   output Boolean isGlobalKnown = false;
 algorithm
@@ -1028,7 +1032,7 @@ algorithm
       algorithm
         isRedundant := ExpressionBasics.expEqual(exp1, exp2);
         if not isRedundant then
-          isGlobalKnown := allArgsInGlobalKnownVars({exp2}, globalKnownVarHT);
+          isGlobalKnown := allowGlobalKnown and allArgsInGlobalKnownVars({exp2}, globalKnownVarHT);
           if isGlobalKnown then
             globalKnownVarHT := addConstantCseVarsToGlobalKnownVarHT(exp1, globalKnownVarHT);
           end if;
@@ -1046,7 +1050,7 @@ algorithm
     algorithm
       isRedundant := ExpressionBasics.expEqual(exp1, exp2);
       if not isRedundant then
-        isGlobalKnown := allArgsInGlobalKnownVars({exp2}, globalKnownVarHT);
+        isGlobalKnown := allowGlobalKnown and allArgsInGlobalKnownVars({exp2}, globalKnownVarHT);
         if isGlobalKnown then
           for expMem in lhs loop
             // create variable with bind exp
@@ -1067,7 +1071,7 @@ algorithm
       algorithm
         isRedundant := ExpressionBasics.expEqual(exp1, exp2);
         if not isRedundant then
-          isGlobalKnown := allArgsInGlobalKnownVars({exp2}, globalKnownVarHT);
+          isGlobalKnown := allowGlobalKnown and allArgsInGlobalKnownVars({exp2}, globalKnownVarHT);
           if isGlobalKnown then
             globalKnownVarHT := addConstantCseVarsToGlobalKnownVarHT(exp1, globalKnownVarHT);
           end if;

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit.rs
@@ -60,7 +60,7 @@ use crate::CodegenWasmJitFunctions::{
     ProfPlan, ScatterGroup, SimCtx, SimSlot, WTy, WTyVal, compile_function, compile_linear_system, compile_linear_system_analytic,
     compile_linear_system_analytic_csc, compile_linear_system_symbolic,
     ClockInit, ClockUpdate,
-    NlsResidual, NlsResiduals, backup_known_outputs, residual_rows, restore_known_outputs,
+    IterSlot, NlsResidual, NlsResiduals, backup_known_outputs, residual_rows, restore_known_outputs,
     emit_nls_load_body, emit_nls_jac_body, emit_nls_jac_csc_body, nls_use_sparse,
     emit_entwined_assign, emit_generic_assign, emit_resizable_assign,
     emit_nls_residual_body, emit_solve_nls_call, external_import_sig, external_known,
@@ -3806,6 +3806,8 @@ pub(crate) struct SimVarMap {
     consts: Arc<HashMap<String, Arc<DAE::Exp>>>,
     const_groups: Arc<HashMap<String, ConstGroup>>,
     const_acc: HashMap<String, Vec<(Vec<i32>, Arc<DAE::Exp>, WTy)>>,
+    /// External object cref key -> the mangled name of its class's destructor.
+    extobj_dtors: Arc<HashMap<String, String>>,
     /// Transient accumulator: base cref key -> the scalarized elements seen.
     /// Finalized into `array_groups` / `scatter_groups` at the end of
     /// [`build_var_map`].
@@ -4287,6 +4289,7 @@ fn build_var_map(
         consts: Arc::default(),
         const_groups: Arc::default(),
         const_acc: HashMap::new(),
+        extobj_dtors: Arc::default(),
         array_acc: HashMap::new(),
         terminate_off: layout.terminate_off,
         terminal_off: layout.terminal_off,
@@ -4488,6 +4491,7 @@ fn build_var_map(
     // frees the native object. No result column.
     for (i, sv) in lst(&vars.extObjVars).enumerate() {
         insert_var(&mut map, sv, layout.eobj_off + (i as u32) * 4, WTy::I32, false)?;
+        Arc::make_mut(&mut map.extobj_dtors).insert(sim_cref_key(&sv.name)?, extobj_destructor_key(sv)?);
     }
 
     // Compile-time constants (real / integer / boolean): no SimData slot — their
@@ -6199,25 +6203,6 @@ fn build_sim_model(
         bodies.push(f);
         eq_base + 8
     };
-    // C's `updateBoundParameters` prologue: an existing object is destructed before
-    // its constructor runs again.
-    let destruct_existing_idx = {
-        use we::Instruction as I;
-        let idx = import_base + bodies.len() as u32;
-        let mut f = we::Function::new([(1, we::ValType::I32)]);
-        for &(didx, slot) in &destruct_calls {
-            f.instruction(&I::LocalGet(0));
-            f.instruction(&I::I32Load(crate::CodegenWasmJitFunctions::mem_arg(slot, 2)));
-            f.instruction(&I::LocalTee(1));
-            f.instruction(&I::If(we::BlockType::Empty));
-            f.instruction(&I::LocalGet(1));
-            f.instruction(&I::Call(didx));
-            f.instruction(&I::End);
-        }
-        f.instruction(&I::End);
-        bodies.push(f);
-        idx
-    };
 
     // --- Nonlinear-system callbacks: per system a `residual`/`load` function.
     // The module's `start` (built last, shared with the closure thunks) appends
@@ -6398,9 +6383,6 @@ fn build_sim_model(
     let update_bound_params_idx = {
         let idx = import_base + bodies.len() as u32;
         splits.push(build_split_fn("functionUpdateBoundParameters", &eq_units(&param_eqs), 1, eqfn_type, &[], &[], &var_map, &eq_index, &by_name, &mut literals, &mut bodies, &mut pool, false)?);
-        if !destruct_calls.is_empty() {
-            splits.last_mut().expect("just pushed").pre_calls.push(destruct_existing_idx);
-        }
         idx
     };
     // The optimizer's per-real-variable attributes (C reads them out of the
@@ -6564,10 +6546,9 @@ fn build_sim_model(
     functions.function(meta_fn_type); // om_meta_ptr
     functions.function(meta_fn_type); // om_meta_len
     // Optional eq functions — always emitted (order must match the `bodies` pushes:
-    // destructors, destruct-existing, nls callbacks, initSample, zc, statesetJac,
+    // destructors, nls callbacks, initSample, zc, statesetJac,
     // lambda0, …, then the closure thunks and `start` below).
     functions.function(eqfn_type); // callExternalObjectDestructors
-    functions.function(eqfn_type); // the `functionUpdateBoundParameters` prologue
     if let Some((residual_type, load_type, strict_type)) = nls_types {
         for sys in &nls_systems {
             functions.function(residual_type);
@@ -8167,6 +8148,7 @@ pub(crate) fn sim_ctx(var_map: &SimVarMap) -> SimCtx {
         scatter_groups: var_map.scatter_groups.clone(),
         consts: var_map.consts.clone(),
         const_groups: var_map.const_groups.clone(),
+        extobj_dtors: var_map.extobj_dtors.clone(),
         terminate_off: var_map.terminate_off,
         terminal_off: var_map.terminal_off,
         initial_off: var_map.initial_off,
@@ -9814,7 +9796,7 @@ fn real_alg_vars(vars: &SimCodeVar::SimVars) -> Vec<&SimCodeVar::SimVar> {
         .collect()
 }
 
-/// Map each scalar real variable's cref key to its `(nominal, min, max)` attributes,
+/// Map each scalar Real (and Integer) variable's cref key to its `(nominal, min, max)` attributes,
 /// defaulting to `(1.0, -inf, +inf)` where unset or non-constant.
 fn build_nls_nominal_map(vars: &SimCodeVar::SimVars) -> HashMap<String, (f64, f64, f64)> {
     let mut map = HashMap::new();
@@ -9823,6 +9805,7 @@ fn build_nls_nominal_map(vars: &SimCodeVar::SimVars) -> HashMap<String, (f64, f6
         .chain(lst(&vars.derivativeVars))
         .chain(lst(&vars.algVars))
         .chain(lst(&vars.discreteAlgVars))
+        .chain(lst(&vars.intAlgVars))
         .chain(lst(&vars.paramVars))
         .chain(lst(&vars.aliasVars));
     for sv in all {
@@ -10089,25 +10072,27 @@ fn nls_jac_usable(nlsystem: &SimCode::NonlinearSystem) -> bool {
 /// The `SimData` slot a torn system's iteration variable reads and writes. An
 /// initialization system can solve for a start value, and C's `cref` makes
 /// `$START.<var>` an lvalue into that variable's `attribute.start` — its start
-/// slot here. `Ok(None)` leaves naming the system to the caller.
+/// slot here. A discrete (Integer/Boolean) unknown the tearing could not avoid
+/// keeps its own type: C truncates the solver's `x` on write and widens on
+/// read. `Ok(None)` leaves naming the system to the caller.
 pub(crate) fn iteration_var_slot(
     vars: &HashMap<String, SimSlot>,
     start_slots: &HashMap<String, u32>,
     cr: &Arc<DAE::ComponentRef>,
-) -> Result<Option<u32>> {
+) -> Result<Option<IterSlot>> {
     let key = sim_cref_key(cr)?;
     if let Some(off) = key.strip_prefix("$START.").and_then(|k| start_slots.get(k)) {
-        return Ok(Some(*off));
+        return Ok(Some(IterSlot { off: *off, wty: WTy::F64 }));
     }
     match vars.get(&key) {
         None => Ok(None),
-        Some(slot) if slot.wty != WTy::F64 => {
+        Some(slot) if slot.heap => {
             record_error(format!(
-                "CodegenWasmJit: torn-system unknown `{key}` is not a Real variable"
+                "CodegenWasmJit: torn-system unknown `{key}` is not a numeric variable"
             ));
-            Err("CodegenWasmJit: torn-system unknown is not a Real variable")
+            Err("CodegenWasmJit: torn-system unknown is not a numeric variable")
         }
-        Some(slot) => Ok(Some(slot.off)),
+        Some(slot) => Ok(Some(IterSlot { off: slot.off, wty: slot.wty })),
     }
 }
 
@@ -10894,16 +10879,15 @@ fn build_nls_fns(
         nlsystem.index
     ));
     let (inner, residuals, iter_vars) = nls_parts(nlsystem)?;
-    // Resolve each unknown to its (real) SimData slot offset.
-    let mut slots: Vec<u32> = Vec::with_capacity(iter_vars.len());
+    let mut slots: Vec<IterSlot> = Vec::with_capacity(iter_vars.len());
     for cr in &iter_vars {
         if is_homotopy_lambda(Some(cr)) {
-            slots.push(var_map.lambda_off);
+            slots.push(IterSlot { off: var_map.lambda_off, wty: WTy::F64 });
             continue;
         }
-        let off = iteration_var_slot(&var_map.vars, &var_map.start_slots, cr)?
+        let slot = iteration_var_slot(&var_map.vars, &var_map.start_slots, cr)?
             .ok_or("CodegenWasmJit: nonlinear-system unknown has no slot")?;
-        slots.push(off);
+        slots.push(slot);
     }
     let mk_sim = || sim_ctx(var_map);
     let finish = |ctx: FnCtx| -> we::Function {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -352,6 +352,10 @@ pub(crate) const RT_BUILTINS: &[(&str, &[WTy], &[WTy])] = &[
     ("rt_str_data", &[WTy::I32], &[WTy::I32]),
     ("rt_concat", &[WTy::I32, WTy::I32], &[WTy::I32]),
     ("rt_streq", &[WTy::I32, WTy::I32], &[WTy::I32]),
+    ("rt_extobj_arg_f64", &[WTy::I32, WTy::I32, WTy::F64], &[WTy::I32]),
+    ("rt_extobj_arg_i32", &[WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
+    ("rt_extobj_arg_str", &[WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
+    ("rt_extobj_arg_arr", &[WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
     ("rt_strcmp", &[WTy::I32, WTy::I32], &[WTy::I32]),
     ("rt_substring", &[WTy::I32, WTy::I32, WTy::I32], &[WTy::I32]),
     ("rt_int_string", &[WTy::I32], &[WTy::I32]),
@@ -1461,6 +1465,8 @@ pub(crate) struct SimCtx {
     /// literal, as in C's `varArrayNameValues`.
     pub(crate) consts: Arc<HashMap<String, Arc<DAE::Exp>>>,
     pub(crate) const_groups: Arc<HashMap<String, ConstGroup>>,
+    /// External object cref key -> the mangled name of its class's destructor.
+    pub(crate) extobj_dtors: Arc<HashMap<String, String>>,
     /// `SimData` byte offset of the `terminate` flag, written by a fired
     /// `terminate(...)` when-operator (see `lower_when_op`).
     pub(crate) terminate_off: u32,
@@ -6345,6 +6351,16 @@ fn emit_sim_const_index_error(ctx: &mut FnCtx, cref: &DAE::ComponentRef, key: &s
     Ok(Some(group.wty))
 }
 
+/// A Jacobian column array element (`x.$pDER<M>.dummyVar<M>[i]`) no column
+/// equation defines: the backend kept only the elements that depend on the seeds,
+/// so the rest are structurally zero.
+fn is_jac_column_elem_key(key: &str) -> bool {
+    let Some(stem) = key.strip_suffix(']') else { return false };
+    let Some((base, _)) = stem.rsplit_once('[') else { return false };
+    let Some((qual, last)) = base.rsplit_once('.') else { return false };
+    last.starts_with("dummyVar") && qual.rsplit('.').next().is_some_and(|m| m.starts_with("$pDER"))
+}
+
 fn const_index_value(exp: &DAE::Exp) -> Option<i32> {
     match exp {
         DAE::Exp::ICONST { integer } => Some(*integer),
@@ -6915,6 +6931,10 @@ fn compile_sim_cref_read(ctx: &mut FnCtx, cref: &DAE::ComponentRef) -> Result<Op
             if let Some(wty) = emit_sim_const_index_error(ctx, cref, &key)? {
                 return Ok(Some(wty));
             }
+            if is_jac_column_elem_key(&key) {
+                ctx.emit(we::Instruction::F64Const(0.0.into()));
+                return Ok(Some(WTy::F64));
+            }
             crate::CodegenWasmJit::record_error(format!(
                 "CodegenWasmJit: simulation reference to unknown variable `{key}`{}",
                 fn_context()
@@ -7102,6 +7122,14 @@ fn compile_sim_cref_assign(ctx: &mut FnCtx, cref: &DAE::ComponentRef, rhs: RhsSo
         ctx.emit(we::Instruction::I32Store(mem_arg(slot.off, 2)));
         return Ok(true);
     }
+    if let Some(dtor) = ctx.sim()?.extobj_dtors.get(&key).cloned() {
+        if let RhsSource::Exp(e) = &rhs {
+            let e: &DAE::Exp = e;
+            if let DAE::Exp::CALL { expLst, .. } = e {
+                return emit_extobj_construct(ctx, slot.off, &dtor, expLst, RhsSource::Exp(e));
+            }
+        }
+    }
     // Stack order for a store is [addr, value]: push the base, evaluate the rhs,
     // coerce to the slot type, then store at the constant offset.
     ctx.emit(we::Instruction::LocalGet(data));
@@ -7111,6 +7139,67 @@ fn compile_sim_cref_assign(ctx: &mut FnCtx, cref: &DAE::ComponentRef, rhs: RhsSo
         WTy::F64 => ctx.emit(we::Instruction::F64Store(mem_arg(slot.off, 3))),
         WTy::I32 => ctx.emit(we::Instruction::I32Store(mem_arg(slot.off, 2))),
     }
+    Ok(true)
+}
+
+/// `obj := Ctor(args)`: an external object is constructed once. The runtime keeps
+/// the arguments the live object was built from (`rt_extobj_arg_*`, keyed by slot
+/// and position); when every argument compares equal the object is kept, otherwise
+/// the old one is destructed before the constructor runs. An argument of a type the
+/// runtime cannot compare (a record) always forces reconstruction.
+fn emit_extobj_construct(
+    ctx: &mut FnCtx,
+    off: u32,
+    dtor: &str,
+    args: &List<Arc<DAE::Exp>>,
+    rhs: RhsSource,
+) -> Result<bool> {
+    use we::Instruction as I;
+    let didx = ctx.by_name.get(dtor).ok_or("CodegenWasmJit: external-object destructor was not compiled")?.index;
+    let data = ctx.sim()?.data_local;
+    let same = ctx.alloc_temp(WTy::I32);
+    ctx.emit(I::LocalGet(data));
+    ctx.emit(I::I32Load(mem_arg(off, 2)));
+    ctx.emit(I::I32Const(0));
+    ctx.emit(I::I32Ne);
+    ctx.emit(I::LocalSet(same));
+    for (pos, arg) in args.iter().enumerate() {
+        let (rt_fn, wty) = match exp_sigty(arg) {
+            Ok(SigTy::Real) => ("rt_extobj_arg_f64", WTy::F64),
+            Ok(SigTy::Int | SigTy::Bool | SigTy::Ptr) => ("rt_extobj_arg_i32", WTy::I32),
+            Ok(SigTy::Str) => ("rt_extobj_arg_str", WTy::I32),
+            Ok(SigTy::Array { .. }) => ("rt_extobj_arg_arr", WTy::I32),
+            _ => {
+                ctx.emit(I::I32Const(0));
+                ctx.emit(I::LocalSet(same));
+                continue;
+            }
+        };
+        ctx.emit(I::LocalGet(same));
+        ctx.emit(I::I32Const(off as i32));
+        ctx.emit(I::I32Const(pos as i32));
+        let w = compile_exp(ctx, arg)?;
+        coerce(ctx, w, wty);
+        ctx.emit(I::Call(rt_index(rt_fn)?));
+        ctx.emit(I::I32And);
+        ctx.emit(I::LocalSet(same));
+    }
+    ctx.emit(I::LocalGet(same));
+    ctx.emit(I::I32Eqz);
+    ctx.emit(I::If(we::BlockType::Empty));
+    let old = ctx.alloc_temp(WTy::I32);
+    ctx.emit(I::LocalGet(data));
+    ctx.emit(I::I32Load(mem_arg(off, 2)));
+    ctx.emit(I::LocalTee(old));
+    ctx.emit(I::If(we::BlockType::Empty));
+    ctx.emit(I::LocalGet(old));
+    ctx.emit(I::Call(didx));
+    ctx.emit(I::End);
+    ctx.emit(I::LocalGet(data));
+    let rw = rhs.push(ctx)?;
+    coerce(ctx, rw, WTy::I32);
+    ctx.emit(I::I32Store(mem_arg(off, 2)));
+    ctx.emit(I::End);
     Ok(true)
 }
 
@@ -7752,7 +7841,7 @@ pub(crate) use generic_calls::{
 #[path = "CodegenWasmJitFunctions/sim_systems.rs"]
 mod sim_systems;
 pub(crate) use sim_systems::{
-    LSS_MAX_DENSITY, LSS_MIN_SIZE, NLSS_MAX_DENSITY, NLSS_MIN_SIZE, NlsResidual, NlsResiduals,
+    LSS_MAX_DENSITY, LSS_MIN_SIZE, NLSS_MAX_DENSITY, NLSS_MIN_SIZE, IterSlot, NlsResidual, NlsResiduals,
     backup_known_outputs, residual_rows, restore_known_outputs,
     compile_linear_system, compile_linear_system_analytic, compile_linear_system_analytic_csc,
     compile_linear_system_symbolic, emit_linz_jac_body, emit_nls_jac_body, emit_nls_jac_csc_body,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions/sim_systems.rs
@@ -109,6 +109,41 @@ pub(crate) enum NlsResiduals {
     InverseAlgorithm(Vec<Arc<DAE::ComponentRef>>),
 }
 
+/// A torn system's iteration variable: its `SimData` slot and the slot's type.
+/// The solver's `x` is f64 throughout; a discrete unknown is truncated on the
+/// way in and widened on the way out, as C's implicit conversions do.
+#[derive(Clone, Copy)]
+pub(crate) struct IterSlot {
+    pub(crate) off: u32,
+    pub(crate) wty: WTy,
+}
+
+/// `slot = x[j]` (wasm locals: 0 = `SimData`, `x_local` = the `x` pointer).
+fn emit_x_to_slot(ctx: &mut FnCtx, x_local: u32, j: usize, slot: IterSlot) {
+    use we::Instruction as I;
+    ctx.emit(I::LocalGet(0));
+    ctx.emit(I::LocalGet(x_local));
+    ctx.emit(I::F64Load(mem_arg((j as u32) * 8, 3)));
+    coerce(ctx, WTy::F64, slot.wty);
+    match slot.wty {
+        WTy::F64 => ctx.emit(I::F64Store(mem_arg(slot.off, 3))),
+        _ => ctx.emit(I::I32Store(mem_arg(slot.off, 2))),
+    }
+}
+
+/// `x[j] = slot`.
+fn emit_slot_to_x(ctx: &mut FnCtx, x_local: u32, j: usize, slot: IterSlot) {
+    use we::Instruction as I;
+    ctx.emit(I::LocalGet(x_local));
+    ctx.emit(I::LocalGet(0));
+    match slot.wty {
+        WTy::F64 => ctx.emit(I::F64Load(mem_arg(slot.off, 3))),
+        _ => ctx.emit(I::I32Load(mem_arg(slot.off, 2))),
+    }
+    coerce(ctx, slot.wty, WTy::F64);
+    ctx.emit(I::F64Store(mem_arg((j as u32) * 8, 3)));
+}
+
 /// Emit the body of a nonlinear system's `residual(sim_data, x, r)` callback
 /// (wasm locals: 0 = `SimData`, 1 = `x` pointer, 2 = `r` pointer). Copies the
 /// `n` unknowns from `x` into their `slots`, runs the inner (torn) equations via
@@ -117,7 +152,7 @@ pub(crate) enum NlsResiduals {
 pub(crate) fn emit_nls_residual_body(
     ctx: &mut FnCtx,
     eq_index: i32,
-    slots: &[u32],
+    slots: &[IterSlot],
     residuals: &NlsResiduals,
     lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
 ) -> Result<()> {
@@ -135,11 +170,8 @@ pub(crate) fn emit_nls_residual_body(
             ctx.emit(I::Call(rt_index("rt_prof_add_ncall")?));
         }
     }
-    for (j, &off) in slots.iter().enumerate() {
-        ctx.emit(I::LocalGet(0)); // SimData
-        ctx.emit(I::LocalGet(1)); // x
-        ctx.emit(I::F64Load(mem_arg((j as u32) * 8, 3)));
-        ctx.emit(I::F64Store(mem_arg(off, 3)));
+    for (j, &slot) in slots.iter().enumerate() {
+        emit_x_to_slot(ctx, 1, j, slot);
     }
     let residuals = match residuals {
         NlsResiduals::Explicit(r) => r,
@@ -362,13 +394,9 @@ fn emit_for_residual(
 /// Emit the body of a nonlinear system's `load(sim_data, x)` callback (wasm
 /// locals: 0 = `SimData`, 1 = `x` pointer): copy the current unknown `slots` into
 /// `x`, the warm start `rt_solve_nls` reads.
-pub(crate) fn emit_nls_load_body(ctx: &mut FnCtx, slots: &[u32]) -> Result<()> {
-    use we::Instruction as I;
-    for (j, &off) in slots.iter().enumerate() {
-        ctx.emit(I::LocalGet(1)); // x
-        ctx.emit(I::LocalGet(0)); // SimData
-        ctx.emit(I::F64Load(mem_arg(off, 3)));
-        ctx.emit(I::F64Store(mem_arg((j as u32) * 8, 3)));
+pub(crate) fn emit_nls_load_body(ctx: &mut FnCtx, slots: &[IterSlot]) -> Result<()> {
+    for (j, &slot) in slots.iter().enumerate() {
+        emit_slot_to_x(ctx, 1, j, slot);
     }
     Ok(())
 }
@@ -383,7 +411,7 @@ pub(crate) fn emit_nls_load_body(ctx: &mut FnCtx, slots: &[u32]) -> Result<()> {
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn emit_nls_jac_body(
     ctx: &mut FnCtx,
-    iter_slots: &[u32],
+    iter_slots: &[IterSlot],
     seed_offs: &[u32],
     result_offs: &[u32],
     lower_inner: &mut dyn FnMut(&mut FnCtx) -> Result<()>,
@@ -395,11 +423,8 @@ pub(crate) fn emit_nls_jac_body(
     // (C's `n × (n+1)` `fJac`).
     let n_cols = iter_slots.len();
     let n_rows = result_offs.len();
-    for (j, &off) in iter_slots.iter().enumerate() {
-        ctx.emit(I::LocalGet(0));
-        ctx.emit(I::LocalGet(1));
-        ctx.emit(I::F64Load(mem_arg((j as u32) * 8, 3)));
-        ctx.emit(I::F64Store(mem_arg(off, 3)));
+    for (j, &slot) in iter_slots.iter().enumerate() {
+        emit_x_to_slot(ctx, 1, j, slot);
     }
     lower_inner(ctx)?;
     lower_constant(ctx)?;
@@ -437,7 +462,7 @@ pub(crate) fn emit_nls_jac_body(
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn emit_nls_jac_csc_body(
     ctx: &mut FnCtx,
-    iter_slots: &[u32],
+    iter_slots: &[IterSlot],
     seed_offs: &[u32],
     result_offs: &[u32],
     colptr: &[i32],
@@ -463,11 +488,8 @@ pub(crate) fn emit_nls_jac_csc_body(
         color_ptr[c + 1] = color_cols.len() as i32;
     }
 
-    for (j, &off) in iter_slots.iter().enumerate() {
-        ctx.emit(I::LocalGet(0));
-        ctx.emit(I::LocalGet(1));
-        ctx.emit(I::F64Load(mem_arg((j as u32) * 8, 3)));
-        ctx.emit(I::F64Store(mem_arg(off, 3)));
+    for (j, &slot) in iter_slots.iter().enumerate() {
+        emit_x_to_slot(ctx, 1, j, slot);
     }
     lower_inner(ctx)?;
     lower_constant(ctx)?;
@@ -731,13 +753,16 @@ pub(crate) fn compile_linear_system(
     if residual_rows(residuals) != Some(n) {
         return Err("CodegenWasmJit: linear system unknown/residual count mismatch");
     }
-    // Resolve each unknown to its (real) SimData slot offset.
+    // The probe loop indexes the unknowns at run time, so they must all be f64.
     let mut slots: Vec<u32> = Vec::with_capacity(n);
     for cr in iter_vars {
         let sim = ctx.sim()?;
-        let off = crate::CodegenWasmJit::iteration_var_slot(&sim.vars, &sim.start_slots, cr)?
+        let slot = crate::CodegenWasmJit::iteration_var_slot(&sim.vars, &sim.start_slots, cr)?
             .ok_or("CodegenWasmJit: linear-system unknown has no slot")?;
-        slots.push(off);
+        if slot.wty != WTy::F64 {
+            return Err("CodegenWasmJit: linear-system unknown is not a Real variable");
+        }
+        slots.push(slot.off);
     }
     let data = ctx.sim()?.data_local;
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit_runtime/src/lib.rs
@@ -2207,6 +2207,90 @@ pub extern "C" fn rt_streq(a: u32, b: u32) -> i32 {
     (unsafe { str_bytes(a) == str_bytes(b) }) as i32
 }
 
+// The arguments the live external object in a `SimData` slot was constructed
+// with, one entry per (slot, position). A constructor re-run with equal
+// arguments keeps the object (they can be very expensive to build).
+enum ExtObjArg {
+    Bits(u64),
+    Str(u32),
+    Arr(u32),
+}
+struct ExtObjArgs(core::cell::UnsafeCell<alloc::vec::Vec<((u32, u32), ExtObjArg)>>);
+// Single-threaded wasm: no concurrent access.
+unsafe impl Sync for ExtObjArgs {}
+static EXTOBJ_ARGS: ExtObjArgs = ExtObjArgs(core::cell::UnsafeCell::new(alloc::vec::Vec::new()));
+
+/// Compare `new` with the stored argument and replace it; 1 when equal. Takes
+/// ownership of a heap handle.
+fn extobj_arg_same(slot: u32, pos: u32, new: ExtObjArg) -> i32 {
+    let table = unsafe { &mut *EXTOBJ_ARGS.0.get() };
+    let entry = table.iter_mut().find(|(k, _)| *k == (slot, pos));
+    let same = match (&entry, &new) {
+        (Some((_, ExtObjArg::Bits(a))), ExtObjArg::Bits(b)) => a == b,
+        (Some((_, ExtObjArg::Str(a))), ExtObjArg::Str(b)) => unsafe { str_bytes(*a) == str_bytes(*b) },
+        (Some((_, ExtObjArg::Arr(a))), ExtObjArg::Arr(b)) => arr_same(*a, *b),
+        _ => false,
+    };
+    match entry {
+        Some(e) => match core::mem::replace(&mut e.1, new) {
+            ExtObjArg::Str(old) => rt_release(old),
+            ExtObjArg::Arr(old) => rt_array_release(old),
+            ExtObjArg::Bits(_) => {}
+        },
+        None => table.push(((slot, pos), new)),
+    }
+    same as i32
+}
+
+/// Same shape, element kind and elements (strings by content, nested arrays
+/// recursively); records are never equal.
+fn arr_same(a: u32, b: u32) -> bool {
+    if a == 0 || b == 0 {
+        return a == b;
+    }
+    unsafe {
+        let kind = load_u32(a + ARR_KIND_OFF);
+        let ndims = load_u32(a + ARR_NDIMS_OFF);
+        let total = load_u32(a + ARR_TOTAL_OFF);
+        if kind != load_u32(b + ARR_KIND_OFF) || ndims != load_u32(b + ARR_NDIMS_OFF) || total != load_u32(b + ARR_TOTAL_OFF) {
+            return false;
+        }
+        if (0..ndims).any(|d| load_u32(a + ARR_DIMS_OFF + 4 * d) != load_u32(b + ARR_DIMS_OFF + 4 * d)) {
+            return false;
+        }
+        let (da, db) = (arr_data(a), arr_data(b));
+        match kind {
+            EK_STR => (0..total).all(|i| str_bytes(load_u32(da + 4 * i)) == str_bytes(load_u32(db + 4 * i))),
+            EK_ARRAY => (0..total).all(|i| arr_same(load_u32(da + 4 * i), load_u32(db + 4 * i))),
+            EK_RECORD => false,
+            _ => {
+                let n = (total * elem_stride(kind)) as usize;
+                core::slice::from_raw_parts(da as *const u8, n) == core::slice::from_raw_parts(db as *const u8, n)
+            }
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_extobj_arg_f64(slot: u32, pos: u32, v: f64) -> i32 {
+    extobj_arg_same(slot, pos, ExtObjArg::Bits(v.to_bits()))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_extobj_arg_i32(slot: u32, pos: u32, v: i32) -> i32 {
+    extobj_arg_same(slot, pos, ExtObjArg::Bits(v as u32 as u64))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_extobj_arg_str(slot: u32, pos: u32, s: u32) -> i32 {
+    extobj_arg_same(slot, pos, ExtObjArg::Str(s))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_extobj_arg_arr(slot: u32, pos: u32, a: u32) -> i32 {
+    extobj_arg_same(slot, pos, ExtObjArg::Arr(a))
+}
+
 /// `stringCompare(a, b)` → -1 / 0 / 1 (lexicographic over bytes).
 #[unsafe(no_mangle)]
 pub extern "C" fn rt_strcmp(a: u32, b: u32) -> i32 {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_wasm_jit/src/model.rs
@@ -306,9 +306,14 @@ impl ExtIncludes {
         if archives {
             cmd.args(&self.archives);
         }
+        // A system soname goes back to `-l<name>`: the linker then also accepts a
+        // `lib<name>.a`, which is all glibc 2.34+ has for `pthread`.
+        let (prefix, suffix) = (std::env::consts::DLL_PREFIX, std::env::consts::DLL_SUFFIX);
         for lib in &self.libs {
             if lib.contains(['/', '\\']) {
                 cmd.arg(lib);
+            } else if let Some(name) = lib.strip_prefix(prefix).and_then(|l| l.strip_suffix(suffix)) {
+                cmd.arg(format!("-l{name}"));
             } else {
                 cmd.arg(format!("-l:{lib}"));
             }

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -3514,12 +3514,19 @@ template generateStaticInitialData(list<ComponentRef> crefs, String indexName, S
           sysData->min[i]     = getMinFromScalarIdx(data->simulationInfo, data->modelData, VAR_TYPE_REAL, <%kind%>, <%crefIndexWithComment(cr)%>);
           sysData->max[i++]   = getMaxFromScalarIdx(data->simulationInfo, data->modelData, VAR_TYPE_REAL, <%kind%>, <%crefIndexWithComment(cr)%>);
           >>
+      case SIMVAR(type_=T_INTEGER(__)) then
+        <<
+        <%cComment%>
+        sysData->nominal[i] = 1.0;
+        sysData->min[i]     = <%crefAttributes(cr)%>.min;
+        sysData->max[i++]   = <%crefAttributes(cr)%>.max;
+        >>
       else
         <<
         <%cComment%>
-        sysData->nominal[i] = <%crefAttributes(cr)%>.nominal;
-        sysData->min[i]     = <%crefAttributes(cr)%>.min;
-        sysData->max[i++]   = <%crefAttributes(cr)%>.max;
+        sysData->nominal[i] = 1.0;
+        sysData->min[i]     = -DBL_MAX;
+        sysData->max[i++]   = DBL_MAX;
         >>
 
   ;separator="\n")


### PR DESCRIPTION
Fixes found on three library models the wasm-jit lane rejected.

`AixLib...BuildingHeating` has a torn nonlinear system whose tearing could not avoid an Integer iteration variable. The NLS callbacks assumed every unknown slot is an f64; `IterSlot` now carries the slot type and the residual, load and Jacobian bodies truncate on the way in and widen on the way out, as C's implicit conversions do. The same model links its `Include` sources against `pthread`, which resolves to a system soname: that is passed back as `-lpthread` so the linker also accepts the static stub glibc 2.34+ ships.

External objects are constructed once. Their constructor can end up in the initial equations (here a socket whose buffer size is a discrete variable), which global homotopy re-runs per lambda step, so the socket was rebound and the run died. A constructor assignment now hands each argument to the runtime (`rt_extobj_arg_*`, keyed by slot and position), which compares it with the arguments the live object was built from: equal arguments keep the object, otherwise the old one is destructed before the constructor runs. Strings compare by content and arrays element-wise; a record argument always reconstructs. The `functionUpdateBoundParameters` prologue that destructed every object unconditionally is gone, as it would leave dangling handles.

`Dynawo...WT4ACurrentSource2015` reads `u.$pDERNLSJac2.dummyVar[k+1]` with a constant `k`; the backend only keeps the `$pDER` elements that depend on the seeds, so a missing one is structurally zero and now reads as 0. (C emits an undeclared dotted identifier there.)

`Chemical.Examples.WaterVaporization`: `wrapFunctionCalls` on a Jacobian DAE turned a literal-only call into a Jacobian-local parameter, which SimCode never sees (`$cse7` undeclared in both targets). The globally known promotion is disabled for the Jacobian DAE type so the call stays an equation.

CodegenC emitted `.attribute.nominal` for Integer and Boolean NLS unknowns, a field those attribute structs lack; Integer unknowns use nominal 1 with their min/max, Boolean ones nominal 1 unbounded.

Assisted-by: Claude Fable 5.1

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
