### PR TITLE
Tpl: hand-written Rust text engine

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -357,6 +357,7 @@ openmodelica_simcode_util/Cargo.toml
 openmodelica_susan/Cargo.toml
 openmodelica_susan/src/main.rs
 openmodelica_tpl/Cargo.toml
+openmodelica_tpl/src/Tpl.handwritten.rs
 openmodelica_util/Cargo.toml
 openmodelica_util/build.rs
 openmodelica_util/src/Autoconf.rs

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
@@ -52,6 +52,56 @@ const EXTERNAL_DEFAULTABLE_QNAMES: &[&str] = &[
     "SOURCEINFO", "SourceInfo",
 ];
 
+/// A package can hand-write part of itself in `<Package>.handwritten.rs` next
+/// to the generated `<Package>.rs`. Its leading comment lines name the .mo
+/// items it takes over:
+///
+/// ```text
+/// // mmtorust-replaces: Text emptyTxt writeTok    (defined in the file, re-exported)
+/// // mmtorust-drops: tokString blockString        (made obsolete, not generated)
+/// ```
+///
+/// The generated file skips both and re-exports the first set from the
+/// hand-written module, so callers keep their `Package::item` paths.
+/// Fallibility and the other analyses still come from the .mo declarations,
+/// so the Rust signatures must agree with them.
+#[derive(Clone, Default)]
+struct HandwrittenItems {
+    replaces: Vec<String>,
+    drops: HashSet<String>,
+}
+
+impl HandwrittenItems {
+    fn read(dir: &str, name: &str) -> std::io::Result<Self> {
+        let path = format!("{dir}/{name}.handwritten.rs");
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Self::default()),
+            Err(e) => return Err(e),
+        };
+        let mut items = Self::default();
+        for line in content.lines() {
+            if let Some(rest) = line.strip_prefix("// mmtorust-replaces:") {
+                items.replaces.extend(rest.split_whitespace().map(str::to_owned));
+            } else if let Some(rest) = line.strip_prefix("// mmtorust-drops:") {
+                items.drops.extend(rest.split_whitespace().map(str::to_owned));
+            }
+        }
+        if items.replaces.is_empty() && items.drops.is_empty() {
+            return Err(std::io::Error::other(format!("{path} declares no `// mmtorust-replaces:` or `// mmtorust-drops:` items")));
+        }
+        Ok(items)
+    }
+
+    fn contains(&self, name: &str) -> bool {
+        self.drops.contains(name) || self.replaces.iter().any(|n| n == name)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.replaces.is_empty() && self.drops.is_empty()
+    }
+}
+
 /// Top-level package names whose generated `.rs` is *skipped* in the driver
 /// and replaced by a hand-written file (see the `match *name` near
 /// `dir_classes` in the driver). Types declared inside these packages get no
@@ -423,6 +473,9 @@ struct GenCtx {
     /// `pub(crate)`. Populated by [`crate::visibility::analyze`]; consulted by
     /// [`emit_function`] when choosing the visibility keyword.
     keep_public: BTreeSet<String>,
+    /// Items of this package provided by a hand-written sibling file, see
+    /// [`HandwrittenItems`]. Skipped by [`emit_node`].
+    handwritten: HandwrittenItems,
     /// While true, [`Self::type_vis`] forces `pub` regardless of the analysis.
     /// Set around emitting a single-record uniontype's backing struct, whose
     /// `pub type <record> = <struct>;` alias is always emitted `pub`: a
@@ -711,6 +764,7 @@ impl GenCtx {
             variant_shapes: HashMap::new(),
             fallible_functions,
             keep_public: BTreeSet::new(),
+            handwritten: HandwrittenItems::default(),
             force_pub_type: false,
             partial_eq_required,
             reference_eq_required,
@@ -1753,7 +1807,8 @@ pub fn generate_all(hier: &InstanceHierarchy<'_>, output_dir: &str) -> std::io::
             eprintln!("[mmtorust] codegen start {file_path}");
         }
         let file_t0 = std::time::Instant::now();
-        let (content, file_missing) = generate_file(name, node, &crate_map, current_crate, &nullable_global_roots, &top_level_uniontype_names, hier.recursive_types.clone(), hier.types_containing_mutable.clone(), hier.types_containing_array.clone(), hier.types_containing_dyn_fn.clone(), hier.types_directly_containing_dyn_fn.clone(), &no_mod_uniontypes, &hier.top_level, &fn_type_vars, &hier.fallible_functions, &hier.keep_public, &hier.partial_eq_required, &hier.reference_eq_required, &hier.default_required, &defaultable_struct_qnames, &types_needing_default, &copy_type_qnames);
+        let handwritten = HandwrittenItems::read(dir, name)?;
+        let (content, file_missing) = generate_file(name, node, &crate_map, current_crate, &nullable_global_roots, &top_level_uniontype_names, hier.recursive_types.clone(), hier.types_containing_mutable.clone(), hier.types_containing_array.clone(), hier.types_containing_dyn_fn.clone(), hier.types_directly_containing_dyn_fn.clone(), &no_mod_uniontypes, &hier.top_level, &fn_type_vars, &hier.fallible_functions, &hier.keep_public, &hier.partial_eq_required, &hier.reference_eq_required, &hier.default_required, &defaultable_struct_qnames, &types_needing_default, &copy_type_qnames, &handwritten);
         if !file_missing.is_empty() {
             missing_imports.lock().unwrap().extend(file_missing);
         }
@@ -2323,9 +2378,10 @@ fn collect_no_mod_uniontypes(nodes: &BTreeMap<String, NameNode<'_>>, prefix: &st
     }
 }
 
-fn generate_file<'a>(top_name: &str, node: &NameNode<'_>, crate_map: &BTreeMap<String, String>, current_crate: Option<String>, nullable_global_roots: &HashSet<String>, top_level_uniontype_names: &HashSet<String>, recursive_types: BTreeSet<String>, types_containing_mutable: BTreeSet<String>, types_containing_array: BTreeSet<String>, types_containing_dyn_fn: BTreeSet<String>, types_directly_containing_dyn_fn: BTreeSet<String>, no_mod_uniontypes: &HashSet<String>, top_level: &'a BTreeMap<String, NameNode<'a>>, fn_type_vars: &BTreeMap<String, Vec<String>>, fallible_functions: &BTreeSet<String>, keep_public: &BTreeSet<String>, partial_eq_required: &BTreeMap<String, HashSet<String>>, reference_eq_required: &BTreeMap<String, HashSet<String>>, default_required: &BTreeMap<String, HashSet<String>>, defaultable_struct_qnames: &HashSet<String>, types_needing_default: &HashSet<String>, copy_type_qnames: &HashSet<String>) -> (String, BTreeSet<String>) {
+fn generate_file<'a>(top_name: &str, node: &NameNode<'_>, crate_map: &BTreeMap<String, String>, current_crate: Option<String>, nullable_global_roots: &HashSet<String>, top_level_uniontype_names: &HashSet<String>, recursive_types: BTreeSet<String>, types_containing_mutable: BTreeSet<String>, types_containing_array: BTreeSet<String>, types_containing_dyn_fn: BTreeSet<String>, types_directly_containing_dyn_fn: BTreeSet<String>, no_mod_uniontypes: &HashSet<String>, top_level: &'a BTreeMap<String, NameNode<'a>>, fn_type_vars: &BTreeMap<String, Vec<String>>, fallible_functions: &BTreeSet<String>, keep_public: &BTreeSet<String>, partial_eq_required: &BTreeMap<String, HashSet<String>>, reference_eq_required: &BTreeMap<String, HashSet<String>>, default_required: &BTreeMap<String, HashSet<String>>, defaultable_struct_qnames: &HashSet<String>, types_needing_default: &HashSet<String>, copy_type_qnames: &HashSet<String>, handwritten: &HandwrittenItems) -> (String, BTreeSet<String>) {
     let mut ctx = GenCtx::new(top_name, current_crate, crate_map.clone(), nullable_global_roots.clone(), top_level_uniontype_names.clone(), recursive_types, types_containing_mutable, types_containing_array, types_containing_dyn_fn, types_directly_containing_dyn_fn, fn_type_vars.clone(), fallible_functions.clone(), partial_eq_required.clone(), reference_eq_required.clone(), default_required.clone(), defaultable_struct_qnames.clone(), types_needing_default.clone(), copy_type_qnames.clone());
     ctx.keep_public = keep_public.clone();
+    ctx.handwritten = handwritten.clone();
     ctx.no_mod_uniontypes = no_mod_uniontypes.clone();
     if let NodeKind::Class(c) = &node.kind {
         // Diagnostics (`sourceInfo()`) report the .mo relative to
@@ -2457,6 +2513,12 @@ use arcstr::{{ArcStr, literal, format}};
     if !ctx.unqual_modules.is_empty() || !ctx.named.is_empty() || !ctx.implicit_modules.is_empty() {
         writeln!(out).unwrap();
     }
+    if !handwritten.is_empty() {
+        writeln!(out, "#[path = \"{top_name}.handwritten.rs\"]\nmod handwritten;").unwrap();
+        if !handwritten.replaces.is_empty() {
+            writeln!(out, "pub use handwritten::{{{}}};\n", handwritten.replaces.join(", ")).unwrap();
+        }
+    }
     out.push_str(&body);
     // Strict-import check: `implicit_modules` holds the top-level packages this
     // file references in emitted code but does not explicitly import (a plain
@@ -2477,6 +2539,9 @@ use arcstr::{{ArcStr, literal, format}};
 // ── Node emission ─────────────────────────────────────────────────────────────
 
 fn emit_node<'a>(out: &mut String, name: &str, node: &NameNode<'_>, indent: &str, ctx: &mut GenCtx, top_level: &'a BTreeMap<String, NameNode<'a>>) {
+    if ctx.current_path.is_empty() && name != ctx.top_name && ctx.handwritten.contains(name) {
+        return;
+    }
     if let NodeKind::Component(m) = &node.kind {
         if m.variability == Absyn::Variability::CONST
             // `override_default_exp` wins over the AST default. It carries the

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_tpl/src/Tpl.handwritten.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_tpl/src/Tpl.handwritten.rs
@@ -1,0 +1,946 @@
+// mmtorust-replaces: Text emptyTxt isEmpty writeStr writeTok writeText softNewLine
+// mmtorust-replaces: newLine pushBlock popBlock pushIter popIter nextIter getIteri_i0
+// mmtorust-replaces: textStringBuf strTokText textStrTok stringText strTokString
+// mmtorust-replaces: redirectToFile closeFile
+// mmtorust-drops: writeChars writeLineOrStr takeLineOrString isAtStartOfLine
+// mmtorust-drops: isAtStartOfLineTok tokensString tokensFile tokString tokFileText
+// mmtorust-drops: tokFile stringListString stringListFile blockString
+// mmtorust-drops: iterSeparatorString iterSeparatorAlignWrapString iterAlignWrapString
+// mmtorust-drops: tryWrapString blockFile iterSeparatorFile iterSeparatorAlignWrapFile
+// mmtorust-drops: iterAlignWrapFile tryWrapFile getTextOpaqueFile stringFile
+// mmtorust-drops: newlineFile textFileTell handleTok
+//
+// The text engine of Tpl.mo. A text is a (buffer, length) view of an
+// append-only token vector: appending to the handle that owns the tip pushes
+// in place, appending to any other handle copies its prefix first, so clones
+// are O(1) and the persistent semantics of Tpl.mo's cons list hold.
+
+use std::sync::{Arc, LazyLock, Mutex};
+use metamodelica::gc::{MMTrace, MMVisitor};
+use super::*;
+use metamodelica::List;
+
+#[derive(Clone)]
+enum Tok {
+    NewLine,
+    Str(ArcStr),
+    Line(ArcStr),
+    Block(Toks, Arc<BlockType>),
+    /// ST_STRING_LIST or ST_BLOCK built by generated code.
+    Mm(Arc<StringToken>),
+}
+
+impl Tok {
+    fn from_mm(tok: &Arc<StringToken>) -> Tok {
+        match &**tok {
+            StringToken::ST_NEW_LINE => Tok::NewLine,
+            StringToken::ST_STRING { value } => Tok::Str(value.clone()),
+            StringToken::ST_LINE { line } => Tok::Line(line.clone()),
+            _ => Tok::Mm(tok.clone()),
+        }
+    }
+
+    fn to_mm(&self) -> Arc<StringToken> {
+        match self {
+            Tok::NewLine => interned_ST_NEW_LINE(),
+            Tok::Str(s) => Arc::new(StringToken::ST_STRING { value: s.clone() }),
+            Tok::Line(s) => Arc::new(StringToken::ST_LINE { line: s.clone() }),
+            Tok::Block(toks, bt) => Arc::new(StringToken::ST_BLOCK { tokens: toks.to_mm_list(), blockType: bt.clone() }),
+            Tok::Mm(t) => t.clone(),
+        }
+    }
+
+    fn at_start_of_line(&self) -> bool {
+        match self {
+            Tok::NewLine | Tok::Line(_) => true,
+            Tok::Str(_) => false,
+            Tok::Block(toks, _) => toks.last().is_some_and(|t| t.at_start_of_line()),
+            Tok::Mm(t) => mm_at_start_of_line(t),
+        }
+    }
+}
+
+fn mm_at_start_of_line(tok: &Arc<StringToken>) -> bool {
+    match &**tok {
+        StringToken::ST_NEW_LINE | StringToken::ST_LINE { .. } => true,
+        StringToken::ST_STRING_LIST { lastHasNewLine, .. } => *lastHasNewLine,
+        // the list is reversed: its head is the last token
+        StringToken::ST_BLOCK { tokens, .. } => match &**tokens {
+            ListNode::Cons { head, .. } => mm_at_start_of_line(head),
+            ListNode::Nil => false,
+        },
+        StringToken::ST_STRING { .. } => false,
+    }
+}
+
+impl MMTrace for Tok {
+    fn mm_accept(&self, v: &mut dyn MMVisitor) -> std::result::Result<(), ()> {
+        match self {
+            Tok::NewLine | Tok::Str(_) | Tok::Line(_) => Ok(()),
+            Tok::Block(toks, bt) => {
+                toks.mm_accept(v)?;
+                bt.mm_accept(v)
+            }
+            Tok::Mm(t) => t.mm_accept(v),
+        }
+    }
+}
+
+type Buf = Mutex<Vec<Tok>>;
+
+/// The tokens of a text in output order: a prefix view of a shared buffer.
+#[derive(Clone, Default)]
+struct Toks {
+    buf: Option<Arc<Buf>>,
+    len: usize,
+}
+
+impl Toks {
+    fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    fn get(&self, i: usize) -> Tok {
+        self.buf.as_ref().unwrap().lock().unwrap()[i].clone()
+    }
+
+    fn last(&self) -> Option<Tok> {
+        if self.len == 0 { None } else { Some(self.get(self.len - 1)) }
+    }
+
+    fn push(&mut self, tok: Tok) {
+        if let Some(buf) = &self.buf {
+            let mut v = buf.lock().unwrap();
+            if v.len() == self.len {
+                v.push(tok);
+            } else {
+                let mut copy = Vec::with_capacity(self.len + 8);
+                copy.extend_from_slice(&v[..self.len]);
+                copy.push(tok);
+                drop(v);
+                self.buf = Some(Arc::new(Mutex::new(copy)));
+            }
+        } else {
+            let mut v = Vec::with_capacity(8);
+            v.push(tok);
+            self.buf = Some(Arc::new(Mutex::new(v)));
+        }
+        self.len += 1;
+    }
+
+    fn same_buf(&self, other: &Toks) -> bool {
+        matches!((&self.buf, &other.buf), (Some(a), Some(b)) if Arc::ptr_eq(a, b))
+    }
+
+    fn snapshot(&self) -> Toks {
+        if self.len == 0 {
+            return Toks::default();
+        }
+        let v = self.buf.as_ref().unwrap().lock().unwrap()[..self.len].to_vec();
+        Toks { buf: Some(Arc::new(Mutex::new(v))), len: self.len }
+    }
+
+    /// `Tpl.Tokens` keeps the tokens reversed.
+    fn to_mm_list(&self) -> Tokens {
+        let mut lst = nil();
+        for i in 0..self.len {
+            lst = cons(self.get(i).to_mm(), lst);
+        }
+        lst
+    }
+}
+
+impl MMTrace for Toks {
+    fn mm_accept(&self, v: &mut dyn MMVisitor) -> std::result::Result<(), ()> {
+        let Some(buf) = &self.buf else { return Ok(()) };
+        if !v.visit_shared(Arc::as_ptr(buf) as *const (), Arc::strong_count(buf), "Tpl::Toks") {
+            return Ok(());
+        }
+        let r = match buf.try_lock() {
+            Ok(g) => g.iter().try_for_each(|t| t.mm_accept(v)),
+            Err(_) => Err(()),
+        };
+        v.leave_shared();
+        r
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct MemText {
+    toks: Toks,
+    /// Open blocks, innermost first: the tokens written before the block was
+    /// pushed, and the block type.
+    stack: List<(Toks, Arc<BlockType>)>,
+}
+
+struct FileBlock {
+    bt: Arc<BlockType>,
+    nchars: i32,
+    aind: i32,
+    isstart: bool,
+    /// Bytes written when the block was pushed; tells whether it is still empty.
+    tell: i64,
+    /// Separator to write before the next token of an iteration.
+    septok: Option<Arc<StringToken>>,
+}
+
+struct FileState {
+    nchars: i32,
+    aind: i32,
+    isstart: bool,
+    written: i64,
+    /// Open blocks, innermost last.
+    blocks: Vec<FileBlock>,
+}
+
+pub struct FileText {
+    file: File::File,
+    state: Mutex<FileState>,
+}
+
+#[derive(Clone)]
+pub enum Text {
+    Mem(MemText),
+    File(Arc<FileText>),
+}
+
+impl Default for Text {
+    fn default() -> Self {
+        Text::Mem(MemText::default())
+    }
+}
+
+impl std::fmt::Debug for Text {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Text::Mem(m) => write!(f, "MEM_TEXT({} tokens, {} open blocks)", m.toks.len, listLength(m.stack.clone())),
+            Text::File(t) => write!(f, "FILE_TEXT({:?})", t.file),
+        }
+    }
+}
+
+impl MMTrace for Text {
+    fn mm_accept(&self, v: &mut dyn MMVisitor) -> std::result::Result<(), ()> {
+        match self {
+            Text::Mem(m) => {
+                m.toks.mm_accept(v)?;
+                m.stack.mm_accept(v)
+            }
+            Text::File(t) => {
+                if !v.visit_shared(Arc::as_ptr(t) as *const (), Arc::strong_count(t), "Tpl::FileText") {
+                    return Ok(());
+                }
+                let r = match t.state.try_lock() {
+                    Ok(g) => g.blocks.iter().try_for_each(|b| {
+                        b.bt.mm_accept(v)?;
+                        b.septok.mm_accept(v)
+                    }),
+                    Err(_) => Err(()),
+                };
+                v.leave_shared();
+                r
+            }
+        }
+    }
+}
+
+pub static emptyTxt: LazyLock<Text> = LazyLock::new(Text::default);
+
+fn mem(toks: Toks) -> Text {
+    Text::Mem(MemText { toks, stack: nil() })
+}
+
+fn trace_fail(msg: &'static str) -> &'static str {
+    if Flags::isSet(Flags::FAILTRACE.clone()).unwrap_or(false) {
+        let _ = Debug::trace(ArcStr::from(msg));
+    }
+    "fail"
+}
+
+pub fn isEmpty(txt: Text) -> bool {
+    match &txt {
+        Text::Mem(m) => m.toks.is_empty(),
+        Text::File(_) => false,
+    }
+}
+
+pub fn writeStr(mut inText: Text, inStr: ArcStr) -> Result<Text> {
+    if inStr.is_empty() {
+        return Ok(inText);
+    }
+    if !inStr.as_bytes().contains(&b'\n') {
+        match &mut inText {
+            Text::Mem(m) => m.toks.push(Tok::Str(inStr)),
+            Text::File(f) => stringFile(&f.file, &mut f.state.lock().unwrap(), &inStr, false)?,
+        }
+        return Ok(inText);
+    }
+    writeChars(inText, &inStr)
+}
+
+/// A string with new-lines becomes lines (`ST_LINE`, "\r\n" normalised to
+/// "\n") and bare new-lines; a trailing segment without new-line stays a
+/// string.
+fn writeChars(mut inText: Text, s: &str) -> Result<Text> {
+    let mut rest = s;
+    while !rest.is_empty() {
+        if let Some(r) = rest.strip_prefix('\n') {
+            newLine_inplace(&mut inText)?;
+            rest = r;
+        } else if let Some(r) = rest.strip_prefix("\r\n") {
+            newLine_inplace(&mut inText)?;
+            rest = r;
+        } else {
+            match rest.find('\n') {
+                None => {
+                    writeLineOrStr(&mut inText, ArcStr::from(rest), false)?;
+                    rest = "";
+                }
+                Some(p) => {
+                    let seg_end = if rest.as_bytes()[p - 1] == b'\r' { p - 1 } else { p };
+                    let mut line = String::with_capacity(seg_end + 1);
+                    line.push_str(&rest[..seg_end]);
+                    line.push('\n');
+                    writeLineOrStr(&mut inText, ArcStr::from(line), true)?;
+                    rest = &rest[p + 1..];
+                }
+            }
+        }
+    }
+    Ok(inText)
+}
+
+fn writeLineOrStr(txt: &mut Text, s: ArcStr, is_line: bool) -> Result<()> {
+    if s.is_empty() {
+        return Ok(());
+    }
+    match txt {
+        Text::Mem(m) => m.toks.push(if is_line { Tok::Line(s) } else { Tok::Str(s) }),
+        Text::File(f) => stringFile(&f.file, &mut f.state.lock().unwrap(), &s, is_line)?,
+    }
+    Ok(())
+}
+
+pub fn writeTok(mut inText: Text, inToken: Arc<StringToken>) -> Result<Text> {
+    match &*inToken {
+        StringToken::ST_BLOCK { tokens, .. } if tokens.is_empty() => return Ok(inText),
+        StringToken::ST_STRING { value } if value.is_empty() => return Ok(inText),
+        _ => {}
+    }
+    match &mut inText {
+        Text::Mem(m) => m.toks.push(Tok::from_mm(&inToken)),
+        Text::File(f) => {
+            let st = &mut *f.state.lock().unwrap();
+            tokFileText(&f.file, st, &Tok::from_mm(&inToken), true)?;
+        }
+    }
+    Ok(inText)
+}
+
+pub fn writeText(mut inText: Text, inTextToWrite: Text) -> Result<Text> {
+    let Text::Mem(other) = inTextToWrite else {
+        return Err(trace_fail("-!!!Tpl.writeText failed - incomplete text was passed to be written\n"));
+    };
+    if other.toks.is_empty() {
+        return Ok(inText);
+    }
+    if !other.stack.is_empty() {
+        return Err(trace_fail("-!!!Tpl.writeText failed - incomplete text was passed to be written\n"));
+    }
+    match &mut inText {
+        Text::Mem(m) => {
+            // Embedding a text into its own buffer would make the buffer refer to itself.
+            let toks = if m.toks.same_buf(&other.toks) { other.toks.snapshot() } else { other.toks };
+            m.toks.push(Tok::Block(toks, interned_BT_TEXT()));
+        }
+        Text::File(f) => {
+            let st = &mut *f.state.lock().unwrap();
+            for i in 0..other.toks.len {
+                tokFileText(&f.file, st, &other.toks.get(i), true)?;
+            }
+        }
+    }
+    Ok(inText)
+}
+
+pub fn softNewLine(mut inText: Text) -> Result<Text> {
+    match &mut inText {
+        Text::Mem(m) => {
+            if let Some(last) = m.toks.last() && !last.at_start_of_line() {
+                m.toks.push(Tok::NewLine);
+            }
+        }
+        Text::File(f) => {
+            let st = &mut *f.state.lock().unwrap();
+            if !st.isstart {
+                newlineFile(&f.file, st)?;
+            }
+        }
+    }
+    Ok(inText)
+}
+
+pub fn newLine(mut inText: Text) -> Result<Text> {
+    newLine_inplace(&mut inText)?;
+    Ok(inText)
+}
+
+fn newLine_inplace(txt: &mut Text) -> Result<()> {
+    match txt {
+        Text::Mem(m) => m.toks.push(Tok::NewLine),
+        Text::File(f) => newlineFile(&f.file, &mut f.state.lock().unwrap())?,
+    }
+    Ok(())
+}
+
+pub fn pushBlock(mut txt: Text, inBlockType: Arc<BlockType>) -> Result<Text> {
+    match &mut txt {
+        Text::Mem(m) => {
+            let toks = std::mem::take(&mut m.toks);
+            m.stack = cons((toks, inBlockType), std::mem::take(&mut m.stack));
+        }
+        Text::File(f) => pushBlockFile(&mut f.state.lock().unwrap(), inBlockType),
+    }
+    Ok(txt)
+}
+
+fn pushBlockFile(st: &mut FileState, bt: Arc<BlockType>) {
+    let (nchars, aind, isstart) = (st.nchars, st.aind, st.isstart);
+    st.blocks.push(FileBlock { bt: bt.clone(), nchars, aind, isstart, tell: st.written, septok: None });
+    match &*bt {
+        BlockType::BT_INDENT { width } => {
+            st.nchars = nchars + width;
+            st.aind = aind + width;
+        }
+        BlockType::BT_ABS_INDENT { width } => {
+            if isstart {
+                st.nchars = 0;
+            }
+            st.aind = *width;
+        }
+        BlockType::BT_REL_INDENT { offset } => st.aind = aind + offset,
+        BlockType::BT_ANCHOR { offset } => st.aind = nchars + offset,
+        _ => {}
+    }
+}
+
+pub fn popBlock(mut txt: Text) -> Result<Text> {
+    match &mut txt {
+        Text::Mem(m) => {
+            let (mut outer, bt) = match &*m.stack {
+                ListNode::Cons { head, .. } => head.clone(),
+                ListNode::Nil => return Err(trace_fail("-!!!Tpl.popBlock failed - probably pushBlock and popBlock are not well balanced !\n")),
+            };
+            let inner = std::mem::take(&mut m.toks);
+            if !inner.is_empty() {
+                outer.push(Tok::Block(inner, bt));
+            }
+            m.toks = outer;
+            m.stack = listRest(std::mem::take(&mut m.stack))?;
+        }
+        Text::File(f) => {
+            let st = &mut *f.state.lock().unwrap();
+            let Some(blk) = st.blocks.pop() else {
+                return Err(trace_fail("-!!!Tpl.popBlock failed - probably pushBlock and popBlock are not well balanced !\n"));
+            };
+            match &*blk.bt {
+                BlockType::BT_INDENT { .. } => {
+                    if st.isstart {
+                        st.nchars = blk.nchars;
+                    }
+                    st.aind = blk.aind;
+                }
+                BlockType::BT_ABS_INDENT { .. } | BlockType::BT_REL_INDENT { .. } | BlockType::BT_ANCHOR { .. } => {
+                    if st.isstart && st.written == blk.tell {
+                        st.nchars = blk.nchars;
+                    } else if st.isstart {
+                        st.nchars = blk.aind;
+                    }
+                    st.aind = blk.aind;
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(txt)
+}
+
+pub fn pushIter(mut txt: Text, inIterOptions: Arc<IterOptions>) -> Result<Text> {
+    let i0 = inIterOptions.startIndex0;
+    match &mut txt {
+        Text::Mem(m) => {
+            let toks = std::mem::take(&mut m.toks);
+            let iter = Arc::new(BlockType::BT_ITER { options: inIterOptions, index0: Mutable::create(i0) });
+            let stack = std::mem::take(&mut m.stack);
+            m.stack = cons((Toks::default(), iter), cons((toks, interned_BT_TEXT()), stack));
+        }
+        Text::File(f) => {
+            if inIterOptions.alignNum != 0 || inIterOptions.wrapWidth != 0 {
+                Error::addInternalError(literal!("Tpl.mo FILE_TEXT does not support aligning or wrapping elements"), metamodelica::sourceInfo!("Template/Tpl.mo"))?;
+                return Err("fail");
+            }
+            let iter = Arc::new(BlockType::BT_ITER { options: inIterOptions, index0: Mutable::create(i0) });
+            pushBlockFile(&mut f.state.lock().unwrap(), iter);
+        }
+    }
+    Ok(txt)
+}
+
+pub fn popIter(mut txt: Text) -> Result<Text> {
+    const MSG: &str = "-!!!Tpl.popIter failed - probably pushIter and popIter are not well balanced or something was written between the last nextIter and popIter ?\n";
+    match &mut txt {
+        Text::Mem(m) => {
+            if !m.toks.is_empty() {
+                return Err(trace_fail(MSG));
+            }
+            let (items, bt, mut outer, rest) = match &*m.stack {
+                ListNode::Cons { head: (items, bt), tail } => match &**tail {
+                    ListNode::Cons { head: (outer, _), tail: rest } => (items.clone(), bt.clone(), outer.clone(), rest.clone()),
+                    ListNode::Nil => return Err(trace_fail(MSG)),
+                },
+                ListNode::Nil => return Err(trace_fail(MSG)),
+            };
+            if !items.is_empty() {
+                outer.push(Tok::Block(items, bt));
+            }
+            m.toks = outer;
+            m.stack = rest;
+        }
+        Text::File(f) => {
+            if f.state.lock().unwrap().blocks.pop().is_none() {
+                return Err(trace_fail(MSG));
+            }
+        }
+    }
+    Ok(txt)
+}
+
+pub fn nextIter(mut txt: Text) -> Result<Text> {
+    fn non_iteration() -> &'static str {
+        let _ = Error::addInternalError(literal!("-!!!Tpl.nextIter failed - nextIter was called in a non-iteration context?"), metamodelica::sourceInfo!("Template/Tpl.mo"));
+        "fail"
+    }
+    match &mut txt {
+        Text::Mem(m) => {
+            let (mut items, bt, rest) = match &*m.stack {
+                ListNode::Cons { head: (items, bt), tail } if matches!(&**bt, BlockType::BT_ITER { .. }) => (items.clone(), bt.clone(), tail.clone()),
+                _ => return Err(non_iteration()),
+            };
+            let BlockType::BT_ITER { options, index0 } = &*bt else { unreachable!() };
+            let item = if m.toks.is_empty() {
+                options.empty.as_ref().map(Tok::from_mm)
+            } else if m.toks.len == 1 {
+                Some(m.toks.get(0))
+            } else {
+                Some(Tok::Block(std::mem::take(&mut m.toks), interned_BT_TEXT()))
+            };
+            if let Some(item) = item {
+                Mutable::update(index0.clone(), Mutable::access(index0.clone()) + 1);
+                items.push(item);
+                m.toks = Toks::default();
+                m.stack = cons((items, bt), rest);
+            }
+        }
+        Text::File(f) => {
+            let st = &mut *f.state.lock().unwrap();
+            let Some(blk) = st.blocks.last() else { return Err(non_iteration()) };
+            let (bt, blk_tell) = (blk.bt.clone(), blk.tell);
+            let BlockType::BT_ITER { options, index0 } = &*bt else { return Err(non_iteration()) };
+            let tellpos = st.written;
+            let have_token = if blk_tell != tellpos {
+                st.blocks.last_mut().unwrap().tell = tellpos;
+                true
+            } else {
+                match &options.empty {
+                    None => false,
+                    Some(emptok) => {
+                        Mutable::update(index0.clone(), Mutable::access(index0.clone()) + 1);
+                        tokFileText(&f.file, st, &Tok::from_mm(emptok), true)?;
+                        true
+                    }
+                }
+            };
+            if have_token {
+                let cur = Mutable::access(index0.clone());
+                st.blocks.last_mut().unwrap().septok = options.separator.clone();
+                Mutable::update(index0.clone(), cur + 1);
+            }
+        }
+    }
+    Ok(txt)
+}
+
+pub fn getIteri_i0(inText: Text) -> Result<i32> {
+    const MSG: &str = "-!!!Tpl.getIter_i0 failed - getIter_i0 was called in a non-iteration context ? \n";
+    match &inText {
+        Text::Mem(m) => match &*m.stack {
+            ListNode::Cons { head: (_, bt), .. } => match &**bt {
+                BlockType::BT_ITER { index0, .. } => Ok(Mutable::access(index0.clone())),
+                _ => Err(trace_fail(MSG)),
+            },
+            ListNode::Nil => Err(trace_fail(MSG)),
+        },
+        Text::File(f) => {
+            let st = f.state.lock().unwrap();
+            match st.blocks.last().map(|b| &*b.bt) {
+                Some(BlockType::BT_ITER { index0, .. }) => Ok(Mutable::access(index0.clone())),
+                _ => Err(trace_fail(MSG)),
+            }
+        }
+    }
+}
+
+// ── rendering ────────────────────────────────────────────────────────────────
+
+trait Sink {
+    fn write(&mut self, s: &str);
+    fn space(&mut self, n: i32);
+    fn pos(&self) -> i64;
+    /// Position after a string written at the start of a line: the C runtime
+    /// measures the print buffer but computes it for files, which differs for
+    /// a negative indent.
+    fn start_pos(&self, nchars: i32, len: i32, written: i32) -> i32;
+}
+
+struct BufSink<'a>(&'a mut String);
+
+impl Sink for BufSink<'_> {
+    fn write(&mut self, s: &str) {
+        self.0.push_str(s);
+    }
+    fn space(&mut self, n: i32) {
+        for _ in 0..n {
+            self.0.push(' ');
+        }
+    }
+    fn pos(&self) -> i64 {
+        self.0.len() as i64
+    }
+    fn start_pos(&self, _nchars: i32, _len: i32, written: i32) -> i32 {
+        written
+    }
+}
+
+struct FileSink<'a> {
+    file: &'a File::File,
+    written: &'a mut i64,
+    err: Option<&'static str>,
+}
+
+impl FileSink<'_> {
+    fn check(&mut self, r: Result<()>) {
+        if let Err(e) = r && self.err.is_none() {
+            self.err = Some(e);
+        }
+    }
+}
+
+impl Sink for FileSink<'_> {
+    fn write(&mut self, s: &str) {
+        *self.written += s.len() as i64;
+        let r = File::write_str(self.file, s);
+        self.check(r);
+    }
+    fn space(&mut self, n: i32) {
+        *self.written += n.max(0) as i64;
+        let r = File::write_space(self.file, n);
+        self.check(r);
+    }
+    fn pos(&self) -> i64 {
+        *self.written
+    }
+    fn start_pos(&self, nchars: i32, len: i32, _written: i32) -> i32 {
+        nchars + len
+    }
+}
+
+/// The token source of a block: a text buffer, or a `Tpl.Tokens` list in
+/// output order.
+enum Items<'a> {
+    Buf(&'a Toks),
+    Vec(Vec<Tok>),
+}
+
+impl Items<'_> {
+    fn len(&self) -> usize {
+        match self {
+            Items::Buf(t) => t.len,
+            Items::Vec(v) => v.len(),
+        }
+    }
+    fn get(&self, i: usize) -> Tok {
+        match self {
+            Items::Buf(t) => t.get(i),
+            Items::Vec(v) => v[i].clone(),
+        }
+    }
+    fn from_mm_list(toks: &Tokens) -> Items<'static> {
+        let mut v: Vec<Tok> = toks.iter().map(Tok::from_mm).collect();
+        v.reverse();
+        Items::Vec(v)
+    }
+}
+
+type Pos = (i32, bool, i32);
+
+fn tok<S: Sink>(s: &mut S, t: &Tok, (nchars, isstart, aind): Pos) -> Pos {
+    match t {
+        Tok::NewLine => {
+            s.write("\n");
+            (aind, true, aind)
+        }
+        Tok::Str(str) => {
+            if isstart {
+                let p0 = s.pos();
+                s.space(nchars);
+                s.write(str);
+                (s.start_pos(nchars, str.len() as i32, (s.pos() - p0) as i32), false, aind)
+            } else {
+                s.write(str);
+                (nchars + str.len() as i32, false, aind)
+            }
+        }
+        Tok::Line(str) => {
+            if isstart {
+                s.space(nchars);
+            }
+            s.write(str);
+            (aind, true, aind)
+        }
+        Tok::Block(toks, bt) => block(s, bt, &Items::Buf(toks), (nchars, isstart, aind)),
+        Tok::Mm(t) => match &**t {
+            StringToken::ST_STRING_LIST { strList, .. } => stringList(s, strList, (nchars, isstart, aind)),
+            StringToken::ST_BLOCK { tokens, blockType } => block(s, blockType, &Items::from_mm_list(tokens), (nchars, isstart, aind)),
+            _ => tok(s, &Tok::from_mm(t), (nchars, isstart, aind)),
+        },
+    }
+}
+
+fn tokens<S: Sink>(s: &mut S, items: &Items, from: usize, mut pos: Pos) -> Pos {
+    for i in from..items.len() {
+        pos = tok(s, &items.get(i), pos);
+    }
+    pos
+}
+
+fn stringList<S: Sink>(s: &mut S, strs: &List<ArcStr>, (mut nchars, mut isstart, aind): Pos) -> Pos {
+    for str in strs {
+        if str.is_empty() {
+            continue;
+        }
+        let has_nl = str.ends_with('\n');
+        if isstart {
+            let p0 = s.pos();
+            s.space(nchars);
+            s.write(str);
+            let written = (s.pos() - p0) as i32;
+            nchars = if has_nl { aind } else { s.start_pos(nchars, str.len() as i32, written) };
+        } else {
+            s.write(str);
+            nchars = if has_nl { aind } else { nchars + str.len() as i32 };
+        }
+        isstart = has_nl;
+    }
+    (aind, isstart, aind)
+}
+
+fn block<S: Sink>(s: &mut S, bt: &BlockType, items: &Items, (nchars, isstart, aind): Pos) -> Pos {
+    // Every indenting block pops its indent when it ends at the start of a line.
+    let indented = |s: &mut S, pos: Pos| -> Pos {
+        let p0 = s.pos();
+        let (tsnchars, st, _) = tokens(s, items, 0, pos);
+        let nc = if isstart && s.pos() == p0 { nchars } else if st { aind } else { tsnchars };
+        (nc, st, aind)
+    };
+    match bt {
+        BlockType::BT_TEXT => tokens(s, items, 0, (nchars, isstart, aind)),
+        BlockType::BT_INDENT { width: w } => {
+            if isstart {
+                let (tsnchars, st, _) = tokens(s, items, 0, (w + nchars, true, w + aind));
+                (if st { nchars } else { tsnchars }, st, aind)
+            } else {
+                s.space(*w);
+                let (tsnchars, st, _) = tokens(s, items, 0, (w + nchars, false, w + aind));
+                (if st { aind } else { tsnchars }, st, aind)
+            }
+        }
+        BlockType::BT_ABS_INDENT { width: w } => {
+            if isstart { indented(s, (0, true, *w)) } else { indented(s, (nchars, false, *w)) }
+        }
+        BlockType::BT_REL_INDENT { offset: w } => indented(s, (nchars, isstart, aind + w)),
+        BlockType::BT_ANCHOR { offset: w } => indented(s, (nchars, isstart, nchars + w)),
+        BlockType::BT_ITER { options, .. } => {
+            if items.len() == 0 {
+                return (nchars, isstart, aind);
+            }
+            let o = &**options;
+            match (&o.separator, o.alignNum, o.wrapWidth) {
+                (None, 0, 0) => tokens(s, items, 0, (nchars, isstart, aind)),
+                (Some(sep), 0, 0) => {
+                    let (mut pos, mut st, a) = tok(s, &items.get(0), (nchars, isstart, aind));
+                    let mut ai = a;
+                    for i in 1..items.len() {
+                        (pos, st, ai) = tok(s, &Tok::from_mm(sep), (pos, st, ai));
+                        (pos, st, ai) = tok(s, &items.get(i), (pos, st, ai));
+                    }
+                    (pos, st, a)
+                }
+                (Some(sep), anum, wwidth) => {
+                    let (mut pos, mut st, a) = tok(s, &items.get(0), (nchars, isstart, aind));
+                    let mut ai = a;
+                    let mut idx = 1 + o.alignOfset;
+                    for i in 1..items.len() {
+                        let septok = if anum != 0 && idx > 0 && intMod(idx, anum) == 0 { &o.alignSeparator } else { sep };
+                        (pos, st, ai) = tok(s, &Tok::from_mm(septok), (pos, st, ai));
+                        if wwidth > 0 && pos >= wwidth {
+                            (pos, st, ai) = tok(s, &Tok::from_mm(&o.wrapSeparator), (pos, st, ai));
+                        }
+                        (pos, st, ai) = tok(s, &items.get(i), (pos, st, ai));
+                        idx += 1;
+                    }
+                    (pos, st, a)
+                }
+                (None, anum, wwidth) => {
+                    let (mut pos, mut st, mut ai) = (nchars, isstart, aind);
+                    let mut idx = o.alignOfset;
+                    for i in 0..items.len() {
+                        if anum != 0 && idx > 0 && intMod(idx, anum) == 0 {
+                            (pos, st, ai) = tok(s, &Tok::from_mm(&o.alignSeparator), (pos, st, ai));
+                            if wwidth > 0 && pos >= wwidth {
+                                (pos, st, ai) = tok(s, &Tok::from_mm(&o.wrapSeparator), (pos, st, ai));
+                            }
+                        } else if wwidth > 0 && pos >= wwidth {
+                            (pos, st, ai) = tok(s, &Tok::from_mm(&o.wrapSeparator), (pos, st, ai));
+                        }
+                        (pos, st, ai) = tok(s, &items.get(i), (pos, st, ai));
+                        idx += 1;
+                    }
+                    (pos, st, aind)
+                }
+            }
+        }
+    }
+}
+
+pub fn textStringBuf(inText: Text) -> Result<()> {
+    let Text::Mem(m) = &inText else {
+        return Err(trace_fail("-!!!Tpl.textString failed.\n"));
+    };
+    if !m.stack.is_empty() {
+        return Err(trace_fail("-!!!Tpl.textString failed - a non-comlete text was given.\n"));
+    }
+    Print::with_buf(|buf| {
+        tokens(&mut BufSink(buf), &Items::Buf(&m.toks), 0, (0, true, 0));
+    });
+    Ok(())
+}
+
+pub fn strTokText(inStringToken: Arc<StringToken>) -> Text {
+    let mut toks = Toks::default();
+    toks.push(Tok::from_mm(&inStringToken));
+    mem(toks)
+}
+
+pub fn textStrTok(inText: Text) -> Result<Arc<StringToken>> {
+    match &inText {
+        Text::Mem(m) if m.toks.is_empty() => Ok(Arc::new(StringToken::ST_STRING { value: literal!("") })),
+        Text::Mem(m) if m.stack.is_empty() => Ok(Arc::new(StringToken::ST_BLOCK { tokens: m.toks.to_mm_list(), blockType: interned_BT_TEXT() })),
+        _ => Err(trace_fail("-!!!Tpl.textStrTok failed - incomplete text was passed to be converted.\n")),
+    }
+}
+
+pub fn stringText(inString: ArcStr) -> Text {
+    let mut toks = Toks::default();
+    toks.push(Tok::Str(inString));
+    mem(toks)
+}
+
+pub fn strTokString(inStringToken: Arc<StringToken>) -> Result<ArcStr> {
+    textString(strTokText(inStringToken))
+}
+
+// ── FILE_TEXT ────────────────────────────────────────────────────────────────
+
+pub fn redirectToFile(text: Text, fileName: ArcStr) -> Result<Text> {
+    let file = File::File(File::noReference())?;
+    if Testsuite::isRunning()? {
+        System::appendFile(Testsuite::getTempFilesFile()?, arcstr::format!("{fileName}\n"))?;
+    }
+    File::open(file.clone(), fileName, File::Mode::Write)?;
+    // The registry reference keeps the file flushed at exit like the C runtime's refcount.
+    File::getReference(file.clone());
+    let out = Text::File(Arc::new(FileText {
+        file,
+        state: Mutex::new(FileState { nchars: 0, aind: 0, isstart: true, written: 0, blocks: Vec::new() }),
+    }));
+    writeText(out, text)
+}
+
+pub fn closeFile(text: Text) -> Result<Text> {
+    let Text::File(f) = &text else {
+        Error::addInternalError(literal!("tokFile got non-file text input"), metamodelica::sourceInfo!("Template/Tpl.mo"))?;
+        return Err("fail");
+    };
+    let _ = File::releaseReference(f.file.clone());
+    File::flush(&f.file)?;
+    Ok(emptyTxt.clone())
+}
+
+/// Writes the pending iteration separator, then the token.
+fn tokFileText(file: &File::File, st: &mut FileState, t: &Tok, handle: bool) -> Result<()> {
+    if handle {
+        handleTok(file, st)?;
+    }
+    let mut sink = FileSink { file, written: &mut st.written, err: None };
+    let (nchars, isstart, aind) = tok(&mut sink, t, (st.nchars, st.isstart, st.aind));
+    if let Some(e) = sink.err {
+        return Err(e);
+    }
+    st.nchars = nchars;
+    st.isstart = isstart;
+    st.aind = aind;
+    Ok(())
+}
+
+fn handleTok(file: &File::File, st: &mut FileState) -> Result<()> {
+    let sep = match st.blocks.last_mut() {
+        Some(blk) if matches!(&*blk.bt, BlockType::BT_ITER { .. }) => blk.septok.take(),
+        _ => None,
+    };
+    match sep {
+        Some(sep) => tokFileText(file, st, &Tok::from_mm(&sep), false),
+        None => Ok(()),
+    }
+}
+
+/// Like ST_STRING or ST_LINE.
+fn stringFile(file: &File::File, st: &mut FileState, s: &str, line: bool) -> Result<()> {
+    handleTok(file, st)?;
+    let nchars = st.nchars;
+    if !line {
+        if st.isstart {
+            st.written += nchars.max(0) as i64;
+            File::write_space(file, nchars)?;
+            st.isstart = false;
+        }
+        st.nchars = nchars + s.len() as i32;
+    } else {
+        if st.isstart {
+            st.written += nchars.max(0) as i64;
+            File::write_space(file, nchars)?;
+        } else {
+            st.isstart = true;
+        }
+        st.nchars = st.aind;
+    }
+    st.written += s.len() as i64;
+    File::write_str(file, s)
+}
+
+fn newlineFile(file: &File::File, st: &mut FileState) -> Result<()> {
+    st.written += 1;
+    File::write_str(file, "\n")?;
+    st.nchars = st.aind;
+    st.isstart = true;
+    Ok(())
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/File.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/File.rs
@@ -484,6 +484,14 @@ pub fn releaseReference(file: File) -> Result<()> {
 }
 
 pub fn writeSpace(file: File, n: i32) -> Result<()> {
+    write_space(&file, n)
+}
+
+pub fn write_str(file: &File, s: &str) -> Result<()> {
+    file.inner.lock().unwrap().write_bytes(s.as_bytes(), "write")
+}
+
+pub fn write_space(file: &File, n: i32) -> Result<()> {
     const BLANKS: [u8; 64] = [b' '; 64];
     let mut guard = file.inner.lock().unwrap();
     let mut left = n.max(0) as usize;
@@ -492,6 +500,18 @@ pub fn writeSpace(file: File, n: i32) -> Result<()> {
         guard.write_bytes(&BLANKS[..k], "writeSpace")?;
         left -= k;
     }
+    Ok(())
+}
+
+/// Flushes buffered output so a reader that follows sees the whole file.
+pub fn flush(file: &File) -> Result<()> {
+    let mut guard = file.inner.lock().unwrap();
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(f) = guard.file.as_mut() {
+        f.flush().map_err(|_| "File.flush: write failed")?;
+    }
+    #[cfg(target_arch = "wasm32")]
+    guard.flush_to_vfs();
     Ok(())
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Print.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/Print.rs
@@ -15,7 +15,6 @@
 #![allow(non_snake_case)]
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::Write as _;
 
@@ -26,8 +25,9 @@ use arcstr::ArcStr;
 struct PrintState {
     buf: String,
     err_buf: String,
-    saved: HashMap<i32, String>,
-    next_handle: i32,
+    /// Saved buffers by handle, the handle being the lowest free slot as in
+    /// `printimpl.c`.
+    saved: Vec<Option<String>>,
 }
 
 thread_local! {
@@ -67,6 +67,11 @@ pub fn printBuf(inString: ArcStr) -> Result<()> {
     Ok(())
 }
 
+/// Runs `f` on the print buffer itself; `f` must not call back into `Print`.
+pub fn with_buf<R>(f: impl FnOnce(&mut String) -> R) -> R {
+    with(|s| f(&mut s.buf))
+}
+
 pub fn printBufNewLine() -> Result<()> {
     with(|s| s.buf.push('\n'));
     Ok(())
@@ -93,7 +98,7 @@ pub fn printErrorBuf(inString: ArcStr) -> Result<()> {
 /// entry so handles are single-use.
 pub fn restoreBuf(handle: i32) -> Result<()> {
     with(|s| {
-        if let Some(prev) = s.saved.remove(&handle) {
+        if let Some(prev) = s.saved.get_mut(handle as usize).and_then(Option::take) {
             s.buf = prev;
         }
     });
@@ -106,14 +111,17 @@ pub fn restoreBuf(handle: i32) -> Result<()> {
 /// the saved text back.
 pub fn saveAndClearBuf() -> Result<i32> {
     Ok(with(|s| {
-        s.next_handle = s.next_handle.wrapping_add(1);
-        if s.next_handle == 0 {
-            s.next_handle = 1;
-        }
-        let h = s.next_handle;
         let prev = std::mem::take(&mut s.buf);
-        s.saved.insert(h, prev);
-        h
+        match s.saved.iter().position(Option::is_none) {
+            Some(h) => {
+                s.saved[h] = Some(prev);
+                h as i32
+            }
+            None => {
+                s.saved.push(Some(prev));
+                (s.saved.len() - 1) as i32
+            }
+        }
     }))
 }
 

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util/src/System.rs
@@ -164,7 +164,11 @@ pub fn strcmp_offset(string1: ArcStr, offset1: i32, length1: i32, string2: ArcSt
 }
 
 pub fn stringFind(r#str: ArcStr, searchStr: ArcStr) -> Result<i32> {
-    Ok(r#str.find(searchStr.as_str()).map(|i| i as i32).unwrap_or(-1))
+    let found = match searchStr.as_bytes() {
+        [c] if c.is_ascii() => r#str.find(*c as char),
+        _ => r#str.find(searchStr.as_str()),
+    };
+    Ok(found.map(|i| i as i32).unwrap_or(-1))
 }
 
 pub fn stringFindString(r#str: ArcStr, searchStr: ArcStr) -> ArcStr {

--- a/OMCompiler/Compiler/Template/Tpl.mo
+++ b/OMCompiler/Compiler/Template/Tpl.mo
@@ -1941,6 +1941,16 @@ algorithm
 end strTokText;
 
 
+public function isEmpty
+  input Text txt;
+  output Boolean b;
+algorithm
+  b := match txt
+    case MEM_TEXT(tokens = {}) then true;
+    else false;
+  end match;
+end isEmpty;
+
 public function textStrTok
   input Text inText;
   output StringToken outStringToken;

--- a/OMCompiler/Compiler/Template/TplAbsyn.mo
+++ b/OMCompiler/Compiler/Template/TplAbsyn.mo
@@ -1159,6 +1159,10 @@ algorithm
         //  = adaptTextToString(argval, stmts, locals, tplPackage);
         (_,exptype,_) := argval;
         exptype := deAliasedType(exptype, astDefs);
+        if isTextType(exptype) then
+          (stmts, locals, argval) := textConditionToIsEmpty(argval, stmts, locals);
+          exp := emptyExpression;
+        end if;
         mcases
           := elabCasesFromCondition(exptype, isnot, rhsval, tbranch, ebranch, tplPackage);
         ( argvals, fname, iargs, oargs, scEnv, accMMDecls)
@@ -4148,6 +4152,35 @@ algorithm
   end matchcontinue;
 end isAlwaysMatchedBool;
 
+protected function isTextType
+  input TypeSignature ts;
+  output Boolean b;
+algorithm
+  b := match ts
+    case TEXT_TYPE() then true;
+    else false;
+  end match;
+end isTextType;
+
+protected function textConditionToIsEmpty
+  "A Text condition tests emptiness through Tpl.isEmpty, so the generated
+   code does not depend on the representation of Text."
+  input tuple<MMExp, TypeSignature, SourceInfo> inArgValue;
+  input output list<MMExp> stmts;
+  input output TypedIdents locals;
+  output tuple<MMExp, TypeSignature, SourceInfo> outArgValue;
+protected
+  MMExp mmexp;
+  SourceInfo sinfo;
+  Ident retid;
+algorithm
+  (mmexp, _, sinfo) := inArgValue;
+  retid := returnTempVarNamePrefix + intString(listLength(locals));
+  locals := addLocalValue(retid, BOOLEAN_TYPE(), locals);
+  stmts := MM_ASSIGN({retid}, MM_FN_CALL(PATH_IDENT("Tpl", IDENT("isEmpty")), {mmexp})) :: stmts;
+  outArgValue := (MM_IDENT(IDENT(retid)), BOOLEAN_TYPE(), sinfo);
+end textConditionToIsEmpty;
+
 public function adaptTextToString
   input tuple<MMExp, TypeSignature, SourceInfo> inArgValue;
   input Expression inArgExp;
@@ -4258,13 +4291,10 @@ algorithm
       then
        casesForTrueFalseCondition(isnot, LITERAL_MATCH("false", BOOLEAN_TYPE()), tbranch, ebranchOpt);
 
+    // the condition value is Tpl.isEmpty(text), see textConditionToIsEmpty
     case (TEXT_TYPE(), isnot, NONE(), tbranch, ebranchOpt)
       then
-       casesForTrueFalseCondition(isnot,
-          //MEM_TEXT( tokens = {} )
-          RECORD_MATCH( PATH_IDENT("Tpl", IDENT("MEM_TEXT")),
-                        {("tokens",LIST_MATCH({}))} ),
-          tbranch, ebranchOpt);
+       casesForTrueFalseCondition(isnot, LITERAL_MATCH("true", BOOLEAN_TYPE()), tbranch, ebranchOpt);
 
     else
       algorithm
@@ -6734,7 +6764,7 @@ end pathIdentString;
 
 
 protected
-constant Tpl.Text eTxt = Tpl.MEM_TEXT({}, {});
+constant Tpl.Text eTxt = Tpl.emptyTxt;
 
 public function typeSignatureString
   input TypeSignature inTS;

--- a/OMCompiler/Compiler/Template/TplMain.mo
+++ b/OMCompiler/Compiler/Template/TplMain.mo
@@ -58,7 +58,7 @@ public import TplAbsyn;
 public import TplCodegen;
 
 protected
-constant Tpl.Text emptyTxt = Tpl.MEM_TEXT({}, {});
+constant Tpl.Text emptyTxt = Tpl.emptyTxt;
 constant SourceInfo dsi = TplAbsyn.dummySourceInfo;
 
 public function main


### PR DESCRIPTION
The Rust omc's templates phase was 2.3x the C omc's while the frontend, backend and SimCode phases were at parity: Tpl's persistent reversed cons list costs an allocation per token, a copy of every block when it is rendered (`listReverse` of a shared list) and a handle drop for each of the clones the generated code makes around every `writeTok`.

`Tpl.mo` keeps that implementation for the C build and stays the source of the types and signatures. For Rust, the text engine (the MEM_TEXT/FILE_TEXT representation and every function that looks inside it) is now `openmodelica_tpl/src/Tpl.handwritten.rs`:

* A text is a `(buffer, length)` view of an append-only token vector. Appending to the handle that owns the buffer's tip pushes in place; appending to any other handle copies its prefix first. Clones are O(1) and never copy, so the persistent semantics hold even for the `txt = f(txt.clone())` pattern the generated code uses everywhere. Blocks are nested buffers and embedded texts are shared by handle.
* One generic renderer serves the Print buffer and file output, with the C runtime's two position formulas kept apart.
* FILE_TEXT keeps its state in one mutex and holds the `File` handle instead of resolving a registry entry per token.

mmtorust learns a partial hand-written package: a
`<Package>.handwritten.rs` next to the generated file lists the items it defines (`// mmtorust-replaces:`, skipped and re-exported) and the ones it makes obsolete (`// mmtorust-drops:`, skipped). Fallibility and the other analyses still come from the .mo declarations.

Susan lowered `if text then` to a `Tpl.MEM_TEXT(tokens = {})` pattern, which exposes the representation. It now evaluates `Tpl.isEmpty(text)` into a temporary and matches the Boolean; like `adaptTextToString` it must replace the match argument by `emptyExpression`, otherwise a `<%text%>` inside the branch is bound to the Boolean. The C build only picks this up once the bomc sources are regenerated; both shapes compile against `Tpl.mo`.

Also: `Print.saveAndClearBuf` uses a slot table like `printimpl.c` instead of a hash map, and `System.stringFind` uses the byte search for one-character needles (the `"\n"` probe in `writeStr` was 4 % of the templates phase through the two-way searcher).

Generated code is byte-identical (C, FMI 2.0/3.0, XML dump; only GUIDs and timestamps differ). `DistributionSystemModelica_N_20_M_20`:

| phase (Rust omc) | before  | after   | C omc   |
| ---------------- | ------: | ------: | ------: |
| Templates, wall  | 1.97 s  | 1.0 s   | 1.14 s  |
| Templates, Ir    | 5.45 G  | 3.62 G  |         |

Assisted-by: Claude Fable 5.1

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
