### PR TITLE
mmtorust: rewrite matchcontinue that are match

### DIFF
--- a/OMCompiler/Compiler/.cmake/rust_src_files.txt
+++ b/OMCompiler/Compiler/.cmake/rust_src_files.txt
@@ -58,6 +58,7 @@ mmtorust/src/fallibility.rs
 mmtorust/src/fix.rs
 mmtorust/src/hierarchy.rs
 mmtorust/src/main.rs
+mmtorust/src/mc_disjoint.rs
 mmtorust/src/mutable_cycles.rs
 mmtorust/src/scripting_api_qt.rs
 mmtorust/src/typedexp.rs

--- a/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -675,25 +675,17 @@ protected function replaceFinalVars
   input BackendVarTransform.VariableReplacements inRepl;
   output BackendDAE.Variables outVars;
   output BackendVarTransform.VariableReplacements outRepl;
+protected
+  Integer numrepl;
+  BackendDAE.Variables globalKnownVars1;
+  BackendVarTransform.VariableReplacements repl1;
 algorithm
-  (outVars,outRepl) := matchcontinue(inNumRepl,inVars,inRepl)
-    local
-      Integer numrepl;
-      BackendDAE.Variables globalKnownVars,globalKnownVars1,globalKnownVars2;
-      BackendVarTransform.VariableReplacements repl,repl1,repl2;
-
-    case(numrepl,globalKnownVars,repl)
-      algorithm
-      true := intEq(0,numrepl);
-    then (globalKnownVars,repl);
-
-    case(_,globalKnownVars,repl)
-      algorithm
-      (globalKnownVars1, (repl1,numrepl)) := BackendVariable.traverseBackendDAEVarsWithUpdate(globalKnownVars,replaceFinalVarTraverser,(repl,0));
-      (globalKnownVars2, repl2) := replaceFinalVars(numrepl,globalKnownVars1,repl1);
-    then (globalKnownVars2,repl2);
-
-  end matchcontinue;
+  if intEq(0,inNumRepl) then
+    (outVars,outRepl) := (inVars,inRepl);
+  else
+    (globalKnownVars1, (repl1,numrepl)) := BackendVariable.traverseBackendDAEVarsWithUpdate(inVars,replaceFinalVarTraverser,(inRepl,0));
+    (outVars,outRepl) := replaceFinalVars(numrepl,globalKnownVars1,repl1);
+  end if;
 end replaceFinalVars;
 
 

--- a/OMCompiler/Compiler/BackEnd/EvaluateFunctions.mo
+++ b/OMCompiler/Compiler/BackEnd/EvaluateFunctions.mo
@@ -983,21 +983,7 @@ author:Waurich TUD 2014-05"
   input DAE.Element e;
   output list<DAE.ComponentRef> eLst;
 algorithm
-  eLst := matchcontinue e
-    local
-      DAE.ComponentRef cref;
-      list<DAE.ComponentRef> lst;
-    case _
-      algorithm
-        false := isNotComplexVar(e);
-        lst := getScalarsForComplexVar(e);
-      then
-        lst;
-    else
-      algorithm
-        cref := DAEUtil.varCref(e);
-      then {cref};
-  end matchcontinue;
+  eLst := if isNotComplexVar(e) then {DAEUtil.varCref(e)} else getScalarsForComplexVar(e);
 end expandComplexElementsToCrefs;
 
 protected function hasAssertFold "fold function to check if a list of stmts has an assert.

--- a/OMCompiler/Compiler/BackEnd/HpcOmScheduler.mo
+++ b/OMCompiler/Compiler/BackEnd/HpcOmScheduler.mo
@@ -757,17 +757,15 @@ protected function getCommunicationObjBetweenMergedTasks1 "author: Waurich TUD 2
   input HpcOmTaskGraph.Communication iCommunication;
   output HpcOmTaskGraph.Communication oCommunication;
 algorithm
- oCommunication := matchcontinue(parentCommCost, iCommunication)
+ oCommunication := match(parentCommCost, iCommunication)
    local
     Integer nV1,nV2,childNode; //sum of {numOfIntegers,numOfFloats,numOfBoolean, numOfStrings}
     list<Integer> ints1,ints2,fl1,fl2,b1,b2,s1,s2;
     Real reqT1,reqT2;
-   case(HpcOmTaskGraph.COMMUNICATION(nV1,ints1,fl1,b1,s1,childNode,reqT1), HpcOmTaskGraph.COMMUNICATION(nV2,ints2,fl2,b2,s2,_,reqT2))
-     algorithm
-       true := listMember(childNode,tasks);
+   case(HpcOmTaskGraph.COMMUNICATION(nV1,ints1,fl1,b1,s1,childNode,reqT1), HpcOmTaskGraph.COMMUNICATION(nV2,ints2,fl2,b2,s2,_,reqT2)) guard listMember(childNode,tasks)
      then HpcOmTaskGraph.COMMUNICATION(nV1+nV2,listAppend(ints1,ints2),listAppend(fl1,fl2),listAppend(b1,b2),listAppend(s1,s2),childNode,reqT1+reqT2);
    else iCommunication;
- end matchcontinue;
+ end match;
 end getCommunicationObjBetweenMergedTasks1;
 
 protected function convertCommunicationToCommInfo "author: marcusw
@@ -6226,27 +6224,18 @@ protected function getPredecessorCalcTask "author:Waurich TUD 2013-11
   input list<HpcOmSimCode.Task> threadIn;
   input Integer indexIn;
   output HpcOmSimCode.Task taskOut;
+protected
+  Integer index;
+  HpcOmSimCode.Task preTask;
 algorithm
-  taskOut := matchcontinue indexIn
-    local
-      Boolean isCalc;
-      Integer index;
-      HpcOmSimCode.Task preTask;
-    case _
-      algorithm
-        true := indexIn==1;
-      then
-        HpcOmSimCode.TASKEMPTY();
-    case _
-      algorithm
-        true := indexIn >= 2;
-        index := indexIn-1;
-        preTask := listGet(threadIn,index);
-        isCalc := isCalcTask(preTask);
-        preTask := if boolNot(isCalc) then getPredecessorCalcTask(threadIn,index) else preTask;
-      then
-        preTask;
-  end matchcontinue;
+  if indexIn == 1 then
+    taskOut := HpcOmSimCode.TASKEMPTY();
+  else
+    true := indexIn >= 2;
+    index := indexIn-1;
+    preTask := listGet(threadIn,index);
+    taskOut := if isCalcTask(preTask) then preTask else getPredecessorCalcTask(threadIn,index);
+  end if;
 end getPredecessorCalcTask;
 
 protected function updateTimeFinished "author:Waurich TUD 2013-11

--- a/OMCompiler/Compiler/BackEnd/HpcOmTaskGraph.mo
+++ b/OMCompiler/Compiler/BackEnd/HpcOmTaskGraph.mo
@@ -3433,20 +3433,11 @@ protected function nextGreaterPowerOf2_impl
   input Real n;
   input Integer pow;
   output Integer powOf2;
+protected
+  Real p;
 algorithm
-  powOf2 := matchcontinue pow
-  local
-    Integer n2;
-  case _
-    algorithm
-      true := n <=. realPow(2.0,intReal(pow));
-    then realInt(realPow(2.0,intReal(pow)));
-  case _
-    algorithm
-      true := n >. realPow(2.0,intReal(pow));
-      n2 := nextGreaterPowerOf2_impl(n,pow+1);
-    then n2;
-  end matchcontinue;
+  p := realPow(2.0,intReal(pow));
+  powOf2 := if n <= p then realInt(p) else nextGreaterPowerOf2_impl(n,pow+1);
 end nextGreaterPowerOf2_impl;
 
 public function mergeSimpleNodes "author: Waurich TUD 2013-07
@@ -3687,17 +3678,13 @@ protected
   tuple<Integer, Real> head;
   list<tuple<Integer, Real>> rest;
 algorithm
-  oHighestTuple := matchcontinue(iExecCosts, iHighestTuple)
-    case((head as (_,currentCost))::rest, (_,highestCost))
-      algorithm
-        true := realGt(currentCost, highestCost);
+  oHighestTuple := match(iExecCosts, iHighestTuple)
+    case((head as (_,currentCost))::rest, (_,highestCost)) guard realGt(currentCost, highestCost)
       then getHighestExecCost(rest, head);
-    case((head as (_,currentCost))::rest, (_,highestCost))
-      algorithm
-        true := realGt(currentCost, highestCost);
+    case(_::rest, _)
       then getHighestExecCost(rest, iHighestTuple);
     else iHighestTuple;
-  end matchcontinue;
+  end match;
 end getHighestExecCost;
 
 public function contractNodesInGraph "author: marcusw
@@ -4062,14 +4049,7 @@ protected function compareListLengthOnTrue "author: Waurich TUD 2013-07
   input list<Integer> inLst;
   output Boolean equalLength;
 algorithm
-  equalLength := matchcontinue inLst
-    case _
-      algorithm
-        true := intEq(inValue,listLength(inLst));
-      then
-        true;
-    else false;
-  end matchcontinue;
+  equalLength := intEq(inValue,listLength(inLst));
 end compareListLengthOnTrue;
 
 protected function getMergedSystemData "author: Waurich TUD 2013-07
@@ -5127,23 +5107,14 @@ protected
   BackendDAE.StrongComponents comps;
   list<tuple<BackendDAE.EqSystem,Integer>> eqSysts;
 algorithm
-  oNodeComps_Mapping := matchcontinue iNodeComps_Mapping
-    case (nodeIdx,(comps,eqSysts))
-      algorithm
-        true := intGe(nodeMark,0);
-      then ((nodeIdx+1,(comps,eqSysts)));
-    case (nodeIdx,(comps,eqSysts))
-      algorithm
-        true := intEq(nodeMark,-2);
-      then ((nodeIdx+1,(comps,eqSysts)));
-    case (nodeIdx,(comps,eqSysts))
-      algorithm
-        comp := arrayGet(systComps,nodeIdx);
-        eqSyst := arrayGet(iCompEqSysMapping,nodeIdx);
-        comps := comp :: comps;
-        eqSysts := eqSyst :: eqSysts;
-      then ((nodeIdx+1,(comps,eqSysts)));
-  end matchcontinue;
+  (nodeIdx,(comps,eqSysts)) := iNodeComps_Mapping;
+  if not (intGe(nodeMark,0) or intEq(nodeMark,-2)) then
+    comp := arrayGet(systComps,nodeIdx);
+    eqSyst := arrayGet(iCompEqSysMapping,nodeIdx);
+    comps := comp :: comps;
+    eqSysts := eqSyst :: eqSysts;
+  end if;
+  oNodeComps_Mapping := ((nodeIdx+1,(comps,eqSysts)));
 end getGraphComponents2;
 
 protected function componentsEqual "author: marcusw
@@ -5328,15 +5299,13 @@ protected
   list<Integer> criticalPath;
   list<tuple<Real,list<Integer>>> rest;
 algorithm
-  oLongestPathIndex := matchcontinue iCriticalPaths
-    case (cpCost, criticalPath)::rest
-      algorithm
-        true := realGt(cpCost, iLongestPath);
+  oLongestPathIndex := match iCriticalPaths
+    case (cpCost, criticalPath)::rest guard realGt(cpCost, iLongestPath)
       then getCriticalPath2(rest, iListIdx+1, cpCost, iListIdx);
     case (cpCost, criticalPath)::rest
       then getCriticalPath2(rest, iListIdx+1, iLongestPath, iLongestPathIndex);
     else iLongestPathIndex;
-  end matchcontinue;
+  end match;
 end getCriticalPath2;
 
 protected function addUpExeCostsForNode "author: marcusw
@@ -5789,15 +5758,13 @@ protected
   Communication head;
   Communications rest;
 algorithm
-  oHighestTuple := matchcontinue(iCommCosts, iHighestTuple)
-    case((head as COMMUNICATION(requiredTime=currentCost))::rest, COMMUNICATION(requiredTime=highestCost))
-      algorithm
-        true := realGt(currentCost, highestCost);
+  oHighestTuple := match(iCommCosts, iHighestTuple)
+    case((head as COMMUNICATION(requiredTime=currentCost))::rest, COMMUNICATION(requiredTime=highestCost)) guard realGt(currentCost, highestCost)
       then getHighestCommCost(rest, head);
     case(head::rest,_)
       then getHighestCommCost(rest, iHighestTuple);
     else iHighestTuple;
-  end matchcontinue;
+  end match;
 end getHighestCommCost;
 
 public function sumUpExeCosts "author: Waurich TUD 2014-07
@@ -6578,15 +6545,13 @@ protected
   Integer eqIdx, sccIdx;
   list<tuple<Integer,Integer>> rest;
 algorithm
-  oIndex := matchcontinue iEquationSccMapping
-    case (eqIdx,sccIdx)::rest
-      algorithm
-        true := intGt(sccIdx,iHighestIndex);
+  oIndex := match iEquationSccMapping
+    case (eqIdx,sccIdx)::rest guard intGt(sccIdx,iHighestIndex)
       then findHighestSccIdxInMapping(rest,sccIdx);
     case (eqIdx,sccIdx)::rest
       then findHighestSccIdxInMapping(rest,iHighestIndex);
     else iHighestIndex;
-  end matchcontinue;
+  end match;
 end findHighestSccIdxInMapping;
 
 protected function removeDummyStateFromMapping "author: marcusw
@@ -6606,10 +6571,8 @@ protected
   Integer eqIdx,sccIdx;
   tuple<Integer,Integer> newElem;
 algorithm
-  oNewList := matchcontinue iTuple
-    case (eqIdx,sccIdx)
-      algorithm
-        true := intEq(sccIdx,1);
+  oNewList := match iTuple
+    case (eqIdx,sccIdx) guard intEq(sccIdx,1)
       then iNewList;
     case (eqIdx,sccIdx)
       algorithm
@@ -6619,7 +6582,7 @@ algorithm
       algorithm
         print("removeDummyStateFromMapping1 failed\n");
     then iNewList;
-  end matchcontinue;
+  end match;
 end removeDummyStateFromMapping1;
 
 protected function convertToSccSimEqMapping "author: marcusw

--- a/OMCompiler/Compiler/BackEnd/Matching.mo
+++ b/OMCompiler/Compiler/BackEnd/Matching.mo
@@ -4333,19 +4333,10 @@ protected function PR_Global_Relabel_init_l_label
   input Integer max;
   input array<Integer> l_label;
 algorithm
-  () := matchcontinue l_label
-    case _
-      algorithm
-        true := intGt(i,ne);
-      then
-        ();
-    else
-      algorithm
-        arrayUpdate(l_label,i,max);
-        PR_Global_Relabel_init_l_label(i+1,ne,max,l_label);
-      then
-        ();
-  end matchcontinue;
+  if not intGt(i,ne) then
+    arrayUpdate(l_label,i,max);
+    PR_Global_Relabel_init_l_label(i+1,ne,max,l_label);
+  end if;
 end PR_Global_Relabel_init_l_label;
 
 protected function PR_Global_Relabel_init_r_label
@@ -4835,27 +4826,18 @@ protected function ks_rand_cheapmatching1
   input BackendDAE.AdjacencyMatrixT mT;
   input array<Integer> ass1 "eqn := ass1[var]";
   input array<Integer> ass2 "var := ass2[eqn]";
+protected
+  list<Integer> onecolums1,onerows1;
+  Integer c;
+  Boolean b;
 algorithm
-  () := matchcontinue ass2
-    local
-      list<Integer> onecolums1,onerows1;
-      Integer c;
-      Boolean b;
-      case _
-        algorithm
-          false := intLe(i,ne);
-        then
-          ();
-      case _
-        algorithm
-          ks_rand_match(onerows,onecolums,row_degrees,col_degrees,mT,m,ass2,ass1);
-          c := randarr[i];
-          b := intLt(ass1[c],0) and intGt(col_degrees[c],0);
-          (onecolums1,onerows1) := ks_rand_cheapmatching2(b,c,col_degrees,row_degrees,randarr,m,mT,ass1,ass2);
-          ks_rand_cheapmatching1(i+1,ne,onecolums1,onerows1,col_degrees,row_degrees,randarr,m,mT,ass1,ass2);
-        then
-          ();
-    end matchcontinue;
+  if intLe(i,ne) then
+    ks_rand_match(onerows,onecolums,row_degrees,col_degrees,mT,m,ass2,ass1);
+    c := randarr[i];
+    b := intLt(ass1[c],0) and intGt(col_degrees[c],0);
+    (onecolums1,onerows1) := ks_rand_cheapmatching2(b,c,col_degrees,row_degrees,randarr,m,mT,ass1,ass2);
+    ks_rand_cheapmatching1(i+1,ne,onecolums1,onerows1,col_degrees,row_degrees,randarr,m,mT,ass1,ass2);
+  end if;
 end ks_rand_cheapmatching1;
 
 protected function ks_rand_cheapmatching2
@@ -6595,23 +6577,15 @@ protected function checkAssignment
   input array<Integer> ass2 "var := ass2[eqn]";
   input list<Integer> inUnassigned;
   output list<Integer> outUnassigned;
+protected
+  list<Integer> unassigned;
 algorithm
-  outUnassigned := matchcontinue inUnassigned
-    local
-      Integer r;
-      list<Integer> unassigned;
-    case _
-      algorithm
-        true := intGt(indx,ne);
-      then
-        inUnassigned;
-    case _
-      algorithm
-        r := ass1[indx];
-        unassigned := List.consOnTrue(intLt(r,0), indx, inUnassigned);
-      then
-        checkAssignment(indx+1,ne,ass1,ass2,unassigned);
-  end matchcontinue;
+  if intGt(indx,ne) then
+    outUnassigned := inUnassigned;
+  else
+    unassigned := List.consOnTrue(intLt(ass1[indx],0), indx, inUnassigned);
+    outUnassigned := checkAssignment(indx+1,ne,ass1,ass2,unassigned);
+  end if;
 end checkAssignment;
 
 protected function getAssignment
@@ -6622,11 +6596,8 @@ protected function getAssignment
   output array<Integer> ass1 "ass[eqnindx]=varindx";
   output array<Integer> ass2 "ass[varindx]=eqnindx";
 algorithm
-  (ass1,ass2) := matchcontinue(clearMatching, iSyst)
-    case(false, BackendDAE.EQSYSTEM(matching=BackendDAE.MATCHING(ass1=ass1,ass2=ass2)))
-      algorithm
-        true := intGe(nVars,arrayLength(ass1));
-        true := intGe(nEqns,arrayLength(ass2));
+  (ass1,ass2) := match(clearMatching, iSyst)
+    case(false, BackendDAE.EQSYSTEM(matching=BackendDAE.MATCHING(ass1=ass1,ass2=ass2))) guard intGe(nVars,arrayLength(ass1)) and intGe(nEqns,arrayLength(ass2))
       then
         (ass2,ass1);
     else
@@ -6635,7 +6606,7 @@ algorithm
         ass1 := arrayCreate(nVars,-1);
       then
         (ass2,ass1);
-  end matchcontinue;
+  end match;
 end getAssignment;
 
 // =============================================================================

--- a/OMCompiler/Compiler/BackEnd/OnRelaxation.mo
+++ b/OMCompiler/Compiler/BackEnd/OnRelaxation.mo
@@ -1566,7 +1566,7 @@ protected function makeGausEliminationRow "author: Frenkel TUD 2012-05"
   output DAE.Exp outExp;
   output DAE.Exp outExp1;
 algorithm
-  (outExp, outExp1) := matchcontinue lst
+  (outExp, outExp1) := match lst
     local
       Integer c;
       DAE.Exp e, e1, b;
@@ -1574,9 +1574,7 @@ algorithm
     case {}
       then
         (inExp, DAE.RCONST(0.0));
-    case (c, e)::_
-      algorithm
-        true := intGt(c, size);
+    case (c, e)::_ guard intGt(c, size)
       then
         (inExp, e);
     case (c, e)::rest
@@ -1587,7 +1585,7 @@ algorithm
         (e1, b) := makeGausEliminationRow(rest, size, vars, e1);
       then
         (e1, b);
-  end matchcontinue;
+  end match;
 end makeGausEliminationRow;
 
 protected function makeGausElimination "author: Frenkel TUD 2012-05"
@@ -1597,26 +1595,20 @@ protected function makeGausElimination "author: Frenkel TUD 2012-05"
   input array<DAE.Exp> vars;
   input list<BackendDAE.Equation> iAcc;
   output list<BackendDAE.Equation> oAcc;
+protected
+  DAE.Exp e, b;
+  BackendDAE.Equation eqn;
 algorithm
-  oAcc := matchcontinue iAcc
-    local
-      DAE.Exp e, b;
-      BackendDAE.Equation eqn;
-    case _
-      algorithm
-        true := intGt(row, size);
-      then
-        listReverse(iAcc);
-    case _
-      algorithm
-        (e, b) := makeGausEliminationRow(matrix[row], size, vars, DAE.RCONST(0.0));
-        //(e, _) = ExpressionSimplify.simplify(e);
-        //(b, _) = ExpressionSimplify.simplify(b);
-        //  BackendDump.debugStrExpStrExpStr(("", e, " = ", b, "\n"));
-        eqn := BackendDAE.EQUATION(e, b, DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_UNKNOWN);
-      then
-        makeGausElimination(row+1, size, matrix, vars, eqn::iAcc);
-  end matchcontinue;
+  if intGt(row, size) then
+    oAcc := listReverse(iAcc);
+  else
+    (e, b) := makeGausEliminationRow(matrix[row], size, vars, DAE.RCONST(0.0));
+    //(e, _) = ExpressionSimplify.simplify(e);
+    //(b, _) = ExpressionSimplify.simplify(b);
+    //  BackendDump.debugStrExpStrExpStr(("", e, " = ", b, "\n"));
+    eqn := BackendDAE.EQUATION(e, b, DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_UNKNOWN);
+    oAcc := makeGausElimination(row+1, size, matrix, vars, eqn::iAcc);
+  end if;
 end makeGausElimination;
 
 protected function dumpMatrix "author: Frenkel TUD 2012-05"
@@ -1624,17 +1616,11 @@ protected function dumpMatrix "author: Frenkel TUD 2012-05"
   input Integer size;
   input array<list<tuple<Integer, DAE.Exp>>> matrix;
 algorithm
-  () := matchcontinue matrix
-    case _ algorithm
-      true := intGt(row, size);
-    then ();
-
-    case _ algorithm
-      print(intString(row) + ": ");
-      BackendDump.debuglst(matrix[row], dumpMatrix1, ", ", "\n");
-      dumpMatrix(row+1, size, matrix);
-    then ();
-  end matchcontinue;
+  if not intGt(row, size) then
+    print(intString(row) + ": ");
+    BackendDump.debuglst(matrix[row], dumpMatrix1, ", ", "\n");
+    dumpMatrix(row+1, size, matrix);
+  end if;
 end dumpMatrix;
 
 protected function dumpMatrix1 "author: Frenkel TUD 2012-05"
@@ -2953,20 +2939,11 @@ protected function getOrphans "author: Frenkel TUD 2011-05"
   input list<Integer> inOrphans;
   output list<Integer> outOrphans;
 algorithm
-  outOrphans := matchcontinue inOrphans
-    local
-      list<Integer> orphans;
-    case _
-      algorithm
-        true := intGt(indx, size);
-      then
-        inOrphans;
-    case _
-      algorithm
-        orphans := List.consOnTrue(intLt(ass[indx], 1), indx, inOrphans);
-      then
-        getOrphans(indx+1, size, ass, orphans);
-  end matchcontinue;
+  if intGt(indx, size) then
+    outOrphans := inOrphans;
+  else
+    outOrphans := getOrphans(indx+1, size, ass, List.consOnTrue(intLt(ass[indx], 1), indx, inOrphans));
+  end if;
 end getOrphans;
 
 protected function expHasCref "author: Frenkel TUD 2012-05

--- a/OMCompiler/Compiler/BackEnd/Uncertainties.mo
+++ b/OMCompiler/Compiler/BackEnd/Uncertainties.mo
@@ -2360,21 +2360,20 @@ protected function pickReductionCandidates
   input list<tuple<list<Integer>,list<Integer>>> elems;
   output list<list<Integer>> elemsOut;
 algorithm
-elemsOut:=matchcontinue elems
+elemsOut:=match elems
   local
     list<Integer> occurrence,vars;
     list<tuple<list<Integer>,list<Integer>>> tail;
     list<list<Integer>> newElems;
   case {} then {};
-  case (occurrence,vars)::tail
+  case (occurrence,vars)::tail guard listLength(vars)>1 and listLength(occurrence)>1
     algorithm
-      true := listLength(vars)>1 and listLength(occurrence)>1;
       newElems := pickReductionCandidates(tail);
     then
       vars::newElems;
   case _::tail
      then pickReductionCandidates(tail);
-end matchcontinue;
+end match;
 end pickReductionCandidates;
 
 protected function reduceVariables
@@ -2419,24 +2418,21 @@ protected function reduceVariablesInMatrix
   input Integer count;
   output ExtAdjacencyMatrix mOut;
 algorithm
-  mOut:=matchcontinue candidates
+  mOut:=match candidates
     local
       list<Integer> candidate,variables;
       Integer temp;
       list<list<Integer>> candidatesTail;
       ExtAdjacencyMatrix newM;
-    case {}
+    case {} guard count>0
       algorithm
-        true:=count>0;
         print("Warning: The system of equations is under-determined. The results may be incorrect.\n");
         then
           m;
     case {}
         then
           m;
-    case _
-      algorithm
-        true:=intEq(count,0);
+    case _ guard intEq(count,0)
       then m;
     case candidate::candidatesTail
       algorithm
@@ -2447,7 +2443,7 @@ algorithm
         newM := removeVarsNotInSet(m,variables);
         newM := reduceVariablesInMatrix(newM,candidatesTail,count-1);
       then newM;
-  end matchcontinue;
+  end match;
 end reduceVariablesInMatrix;
 
 protected function findReductionCantidates
@@ -3026,19 +3022,11 @@ protected function fixUnderdeterminedSystem
    input Integer neqs;
    output list<list<Integer>> mOut;
 algorithm
-  mOut:=matchcontinue neqs
-     local
-        list<Integer> dummyEq;
-        list<list<Integer>> new_m;
-     case _
-        algorithm
-          true:=intGt(nvars,neqs);
-          dummyEq:=List.intRange(nvars);
-          new_m:=fixUnderdeterminedSystem(listAppend(m,{dummyEq}),nvars,neqs+1);
-        then new_m;
-     case _
-           then m;
-  end matchcontinue;
+  if intGt(nvars,neqs) then
+    mOut:=fixUnderdeterminedSystem(listAppend(m,{List.intRange(nvars)}),nvars,neqs+1);
+  else
+    mOut:=m;
+  end if;
 end fixUnderdeterminedSystem;
 
 protected function getExtAdjacencyMatrix

--- a/OMCompiler/Compiler/BackEnd/Vectorization.mo
+++ b/OMCompiler/Compiler/BackEnd/Vectorization.mo
@@ -949,18 +949,16 @@ protected function getArrayVars
   input tuple<list<BackendDAE.Var>,list<BackendDAE.Var>> tplIn; //non-array vars,arrayVars
   output tuple<list<BackendDAE.Var>,list<BackendDAE.Var>> tplOut;
 algorithm
-  tplOut := matchcontinue(varIn,tplIn)
+  tplOut := match(varIn,tplIn)
     local
       DAE.ComponentRef cref;
       list<BackendDAE.Var> varLstIn, arrVarLstIn;
-  case(BackendDAE.VAR(varName=cref),(varLstIn, arrVarLstIn))
-    algorithm
-    true := ComponentReference.isArrayElement(cref);
+  case(BackendDAE.VAR(varName=cref),(varLstIn, arrVarLstIn)) guard ComponentReference.isArrayElement(cref)
   then(varLstIn, varIn::arrVarLstIn);
   case(_,(varLstIn, arrVarLstIn))
     algorithm
   then(varIn::varLstIn, arrVarLstIn);
-  end matchcontinue;
+  end match;
 end getArrayVars;
 
 protected function dispatchLoopEquations
@@ -1074,7 +1072,7 @@ public function insertSUMexp "exp traversal function for insertSUMexp"
   output DAE.Exp expOut;
   output tuple<DAE.ComponentRef, DAE.Exp> tplOut;
 algorithm
-  (expOut,tplOut) := matchcontinue(expIn,tplIn)
+  (expOut,tplOut) := match(expIn,tplIn)
     local
       DAE.ComponentRef cref0,cref1;
       DAE.Exp repl, exp1, exp2;
@@ -1088,13 +1086,11 @@ algorithm
      algorithm
        (exp1,_) := insertSUMexp(exp1,tplIn);
      then(DAE.UNARY(op,exp1),tplIn);
-   case(DAE.CREF(componentRef=cref1),(cref0,repl))
-     algorithm
-       true := crefPartlyEqual(cref0,cref1);
+   case(DAE.CREF(componentRef=cref1),(cref0,repl)) guard crefPartlyEqual(cref0,cref1)
      then(repl,tplIn);
    else
      then (expIn,tplIn);
-   end matchcontinue;
+   end match;
 end insertSUMexp;
 
 protected function getIndexSubScript

--- a/OMCompiler/Compiler/BackEnd/XMLDump.mo
+++ b/OMCompiler/Compiler/BackEnd/XMLDump.mo
@@ -2463,18 +2463,9 @@ protected function dumpMatching1
   input Integer voffset;
   input Integer eoffset;
 algorithm
-   ():=
-  matchcontinue eoffset
-  case _
-    algorithm
-      false := intGt(arrayLength(v),0);
-    then();
-  case _
-    algorithm
-      true := intGt(arrayLength(v),0);
-      Array.fold(v,dumpMatching2,(1,voffset,eoffset));
-  then();
-    end matchcontinue;
+  if intGt(arrayLength(v),0) then
+    Array.fold(v,dumpMatching2,(1,voffset,eoffset));
+  end if;
 end dumpMatching1;
 
 

--- a/OMCompiler/Compiler/FFrontEnd/FMod.mo
+++ b/OMCompiler/Compiler/FFrontEnd/FMod.mo
@@ -165,14 +165,12 @@ protected function compactSubMod2
   output SCode.SubMod outMod;
   output Boolean outFound;
 algorithm
-  (outMod, outFound) := matchcontinue(inExistingMod, inNewMod)
+  (outMod, outFound) := match(inExistingMod, inNewMod)
     local
       String name1, name2;
       SCode.SubMod submod;
 
-    case (SCode.NAMEMOD(ident = name1), SCode.NAMEMOD(ident = name2))
-      algorithm
-        false := stringEqual(name1, name2);
+    case (SCode.NAMEMOD(ident = name1), SCode.NAMEMOD(ident = name2)) guard not stringEqual(name1, name2)
       then
         (inExistingMod, false);
 
@@ -182,7 +180,7 @@ algorithm
       then
         (submod, true);
 
-  end matchcontinue;
+  end match;
 end compactSubMod2;
 
 protected function mergeSubModsInSameScope

--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -1622,18 +1622,16 @@ public function pathSuffixOf "returns true if suffix_path is a suffix of path"
   input Absyn.Path path;
   output Boolean res;
 algorithm
-  res := matchcontinue path
+  res := match path
   local Absyn.Path p;
-    case _
-      algorithm
-      true := pathEqual(suffix_path,path);
+    case _ guard pathEqual(suffix_path,path)
       then true;
     case Absyn.FULLYQUALIFIED(path = p)
       then pathSuffixOf(suffix_path,p);
     case Absyn.QUALIFIED(path = p)
       then pathSuffixOf(suffix_path,p);
     else false;
-  end matchcontinue;
+  end match;
 end pathSuffixOf;
 
 public function pathSuffixOfr "returns true if suffix_path is a suffix of path"
@@ -5859,26 +5857,22 @@ protected function partsHasLocalClass
   input list<Absyn.ClassPart> inParts;
   output Boolean res;
 algorithm
-  res := matchcontinue inParts
+  res := match inParts
     local
       list<Absyn.ElementItem> elts;
       list<Absyn.ClassPart> parts;
 
-    case Absyn.PUBLIC(elts) :: _
-      algorithm
-        true := eltsHasLocalClass(elts);
+    case Absyn.PUBLIC(elts) :: _ guard eltsHasLocalClass(elts)
       then
         true;
 
-    case Absyn.PROTECTED(elts) :: _
-      algorithm
-        true := eltsHasLocalClass(elts);
+    case Absyn.PROTECTED(elts) :: _ guard eltsHasLocalClass(elts)
       then
         true;
 
     case _ :: parts then partsHasLocalClass(parts);
     else false;
-  end matchcontinue;
+  end match;
 end partsHasLocalClass;
 
 protected function eltsHasLocalClass

--- a/OMCompiler/Compiler/FrontEnd/ConnectionGraph.mo
+++ b/OMCompiler/Compiler/FrontEnd/ConnectionGraph.mo
@@ -1307,7 +1307,7 @@ public function merge
   input ConnectionGraph inGraph2;
   output ConnectionGraph outGraph;
 algorithm
-  outGraph := matchcontinue(inGraph1, inGraph2)
+  outGraph := match(inGraph1, inGraph2)
     local
       Boolean updateGraph, updateGraph1, updateGraph2;
       DefiniteRoots definiteRoots, definiteRoots1, definiteRoots2;
@@ -1327,9 +1327,7 @@ algorithm
         inGraph2;
 
     // they are equal, return any
-    case (_, _)
-      algorithm
-        true := valueEq(inGraph1, inGraph2);
+    case (_, _) guard valueEq(inGraph1, inGraph2)
       then
         inGraph1;
 
@@ -1350,7 +1348,7 @@ algorithm
         connections    := List.union(connections1, connections2);
       then
         GRAPH(updateGraph,definiteRoots,potentialRoots,uniqueRoots,branches,connections);
-  end matchcontinue;
+  end match;
 end merge;
 
 /***********************************************************************************************************************/

--- a/OMCompiler/Compiler/FrontEnd/ExpressionDump.mo
+++ b/OMCompiler/Compiler/FrontEnd/ExpressionDump.mo
@@ -1671,27 +1671,25 @@ public function parenthesize
   input Boolean rightOpParenthesis "true for right hand side operators";
   output String outString;
 algorithm
-  outString := matchcontinue (inString1,inInteger2,inInteger3,rightOpParenthesis)
+  outString := match (inString1,inInteger2,inInteger3,rightOpParenthesis)
     local
       String str_1,str;
       Integer pparent,pexpr;
 
     // expr, prio. parent expr, prio. expr
-    case (str,pparent,pexpr,_)
+    case (str,pparent,pexpr,_) guard (pparent > pexpr)
       algorithm
-        true := (pparent > pexpr);
         str_1 := stringAppendList({"(",str,")"});
       then str_1;
 
     // If priorites are equal and str is from right hand side, parenthesize to make left associative
-    case (str,pparent,pexpr,true)
+    case (str,pparent,pexpr,true) guard (pparent == pexpr)
       algorithm
-        true := (pparent == pexpr);
         str_1 := stringAppendList({"(",str,")"});
       then
         str_1;
     case (str,_,_,_) then str;
-  end matchcontinue;
+  end match;
 end parenthesize;
 
 public function clockKindString "

--- a/OMCompiler/Compiler/FrontEnd/FUnit.mo
+++ b/OMCompiler/Compiler/FrontEnd/FUnit.mo
@@ -877,7 +877,7 @@ protected function popUnit
   output list<String> outCharList;
   output String outUnit;
 algorithm
-  (outCharList, outUnit) := matchcontinue inCharList
+  (outCharList, outUnit) := match inCharList
     local
       String s1, s2;
       list<String> strRest;
@@ -885,18 +885,16 @@ algorithm
     case {}
     then ({}, "");
 
-    case s1::strRest algorithm
-      true := (stringCompare(s1, "a") >= 0) and (stringCompare(s1, "z") <= 0);
+    case s1::strRest guard (stringCompare(s1, "a") >= 0) and (stringCompare(s1, "z") <= 0) algorithm
       (strRest, s2) := popUnit(strRest);
     then (strRest, s1 + s2);
 
-    case s1::strRest algorithm
-      true := (stringCompare(s1, "A") >= 0) and (stringCompare(s1, "Z") <= 0) ;
+    case s1::strRest guard (stringCompare(s1, "A") >= 0) and (stringCompare(s1, "Z") <= 0) algorithm
       (strRest, s2) := popUnit(strRest);
     then (strRest, s1 + s2);
 
     else (inCharList, "");
-  end matchcontinue;
+  end match;
 end popUnit;
 
 protected function popNumber

--- a/OMCompiler/Compiler/FrontEnd/InstSection.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstSection.mo
@@ -3950,29 +3950,14 @@ protected function checkConnectTypesDirection
   input DAE.ComponentRef inRhsCref;
   input SourceInfo inInfo;
 algorithm
-  () := matchcontinue inInfo
-    local
-      String cref_str1, cref_str2;
-
-    // Two connectors with the same directions but different faces or different
-    // directions may be connected.
-    case _
-      algorithm
-        false := isSignalSource(inLhsDirection, inLhsFace, inLhsVisibility) and
-                isSignalSource(inRhsDirection, inRhsFace, inRhsVisibility);
-      then
-        ();
-
-    else
-      algorithm
-        cref_str1 := ComponentReferenceBasics.printComponentRefStr(inLhsCref);
-        cref_str2 := ComponentReferenceBasics.printComponentRefStr(inRhsCref);
-        Error.addSourceMessage(Error.CONNECT_TWO_SOURCES,
-          {cref_str1, cref_str2}, inInfo);
-      then
-        ();
-
-  end matchcontinue;
+  // Two connectors with the same directions but different faces or different
+  // directions may be connected.
+  if isSignalSource(inLhsDirection, inLhsFace, inLhsVisibility) and
+     isSignalSource(inRhsDirection, inRhsFace, inRhsVisibility) then
+    Error.addSourceMessage(Error.CONNECT_TWO_SOURCES,
+      {ComponentReferenceBasics.printComponentRefStr(inLhsCref),
+       ComponentReferenceBasics.printComponentRefStr(inRhsCref)}, inInfo);
+  end if;
 end checkConnectTypesDirection;
 
 protected function isSignalSource

--- a/OMCompiler/Compiler/FrontEnd/InstUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstUtil.mo
@@ -3109,25 +3109,11 @@ public function checkFunctionVarType
   input String inVarName;
   input SourceInfo inInfo;
 algorithm
-  () := matchcontinue inInfo
-    local
-      String ty_str;
-
-    case _
-      algorithm
-        true := Types.isValidFunctionVarType(inType);
-      then
-        ();
-
-    else
-      algorithm
-        ty_str := TypesDump.getTypeName(inType);
-        Error.addSourceMessage(Error.INVALID_FUNCTION_VAR_TYPE,
-          {ty_str, inVarName}, inInfo);
-      then
-        fail();
-
-  end matchcontinue;
+  if not Types.isValidFunctionVarType(inType) then
+    Error.addSourceMessage(Error.INVALID_FUNCTION_VAR_TYPE,
+      {TypesDump.getTypeName(inType), inVarName}, inInfo);
+    fail();
+  end if;
 end checkFunctionVarType;
 
 public function liftNonBasicTypes
@@ -3140,15 +3126,13 @@ public function liftNonBasicTypes
   input DAE.Dimension dimt;
   output DAE.Type outTp;
 algorithm
-  outTp:= matchcontinue tp
+  outTp:= match tp
     local DAE.Type ty;
-    case DAE.T_SUBTYPE_BASIC(complexType = ty)
-      algorithm
-        false := listEmpty(TypesDump.getDimensions(ty));
+    case DAE.T_SUBTYPE_BASIC(complexType = ty) guard not listEmpty(TypesDump.getDimensions(ty))
       then
         tp;
     else Types.liftArray(tp, dimt);
-  end matchcontinue;
+  end match;
 end liftNonBasicTypes;
 
 public function checkHigherVariability
@@ -5699,32 +5683,23 @@ public function sortInnerFirstTplLstElementMod
   elements first in the given list of elements"
   input list<tuple<SCode.Element, DAE.Mod>> inTplLstElementMod;
   output list<tuple<SCode.Element, DAE.Mod>> outTplLstElementMod;
+protected
+  list<tuple<SCode.Element, DAE.Mod>> innerElts, innerouterElts, otherElts, innerModelicaServices, innerModelica, innerOthers;
 algorithm
-  outTplLstElementMod := matchcontinue inTplLstElementMod
-    local
-      list<tuple<SCode.Element, DAE.Mod>> innerElts, innerouterElts, otherElts, sorted, innerModelicaServices, innerModelica, innerOthers;
+  // no sorting if we don't have any inner/outer in the model
+  if not System.getHasInnerOuterDefinitions() then
+    outTplLstElementMod := inTplLstElementMod;
+    return;
+  end if;
 
-    // no sorting if we don't have any inner/outer in the model
-    case _
-      algorithm
-        false := System.getHasInnerOuterDefinitions();
-      then
-        inTplLstElementMod;
+  // split into inner, inner outer and other elements
+  (innerElts, innerouterElts, otherElts) := splitInnerAndOtherTplLstElementMod(inTplLstElementMod);
+  // sort the inners to put Modelica types first!
+  (innerModelicaServices, innerModelica, innerOthers) := splitInners(innerElts, {}, {}, {});
 
-    // do sorting only if we have inner-outer
-    case _
-      algorithm
-        // split into inner, inner outer and other elements
-        (innerElts, innerouterElts, otherElts) := splitInnerAndOtherTplLstElementMod(inTplLstElementMod);
-        // sort the inners to put Modelica types first!
-        (innerModelicaServices, innerModelica, innerOthers) := splitInners(innerElts, {}, {}, {});
-
-        // put the inner elements first
-        // put the innerouter elements second
-        sorted := listAppend(innerModelicaServices, listAppend(innerModelica, listAppend(innerOthers, listAppend(innerouterElts, otherElts))));
-      then
-        sorted;
-  end matchcontinue;
+  // put the inner elements first
+  // put the innerouter elements second
+  outTplLstElementMod := listAppend(innerModelicaServices, listAppend(innerModelica, listAppend(innerOthers, listAppend(innerouterElts, otherElts))));
 end sortInnerFirstTplLstElementMod;
 
 protected function splitInners
@@ -7169,21 +7144,10 @@ public function selectModifiers
   output DAE.Mod bindingMod;
   output DAE.Mod classMod;
 algorithm
-  (bindingMod, classMod) := matchcontinue typePath
-    local
-    // if the thing we got from merging is a redeclare
-    // for a component of a basic type, skip it!
-    case _
-      algorithm
-        true := redeclareBasicType(fromMerging);
-      then
-        (fromRedeclareType, fromRedeclareType);
-
-    // any other is fine!
-    else
-      then
-        (fromMerging, fromRedeclareType);
-  end matchcontinue;
+  // if the thing we got from merging is a redeclare
+  // for a component of a basic type, skip it!
+  bindingMod := if redeclareBasicType(fromMerging) then fromRedeclareType else fromMerging;
+  classMod := fromRedeclareType;
 end selectModifiers;
 
 public function redeclareBasicType

--- a/OMCompiler/Compiler/FrontEnd/Lookup.mo
+++ b/OMCompiler/Compiler/FrontEnd/Lookup.mo
@@ -2402,23 +2402,10 @@ public function selectUpdatedEnv
   input FCore.Graph inOldEnv;
   output FCore.Graph outEnv;
 algorithm
-  outEnv := matchcontinue inOldEnv
-    // return old if is top scope!
-    case _
-      algorithm
-        true := FGraph.isTopScope(inNewEnv);
-      then
-        inOldEnv;
-    // if they point to the same env, return the new one
-    case _
-      algorithm
-        true := stringEq(FGraph.getGraphNameStr(inNewEnv),
-                        FGraph.getGraphNameStr(inOldEnv));
-      then
-        inNewEnv;
-
-    else inOldEnv;
-  end matchcontinue;
+  // return the new env only if it is not top scope and points to the same env
+  outEnv := if not FGraph.isTopScope(inNewEnv) and
+               stringEq(FGraph.getGraphNameStr(inNewEnv), FGraph.getGraphNameStr(inOldEnv))
+            then inNewEnv else inOldEnv;
 end selectUpdatedEnv;
 
 protected function buildRecordType ""

--- a/OMCompiler/Compiler/FrontEnd/Mod.mo
+++ b/OMCompiler/Compiler/FrontEnd/Mod.mo
@@ -1873,7 +1873,7 @@ same as modEqual with the difference that we allow:
   input DAE.Mod mod2;
   output Boolean equal;
 algorithm
-  equal := matchcontinue(mod1,mod2)
+  equal := match(mod1,mod2)
     local
       SCode.Final f1,f2;
       SCode.Each each1,each2;
@@ -1883,34 +1883,21 @@ algorithm
     // adrpo: handle non-overlap: final parameter Real eAxis_ia[3](each final unit="1") = {1,2,3};
     //        mod1 = final each unit="1" mod2 = final = {1,2,3}
     //        otherwise we get an error as: Error: Variable eAxis_ia: trying to override final variable ...
-    case(DAE.MOD(f1,_,_,NONE(),_),DAE.MOD(f2,SCode.NOT_EACH(),{},SOME(_),_))
-      algorithm
-        true := SCodeUtil.finalEqual(f1, f2);
+    case(DAE.MOD(f1,_,_,NONE(),_),DAE.MOD(f2,SCode.NOT_EACH(),{},SOME(_),_)) guard SCodeUtil.finalEqual(f1, f2)
       then
         true;
 
-    case(DAE.MOD(binding = eqmod1),DAE.MOD(_,SCode.NOT_EACH(),{},eqmod2,_))
-      algorithm
-        true := eqModSubsetOrEqual(eqmod1,eqmod2);
+    case(DAE.MOD(binding = eqmod1),DAE.MOD(_,SCode.NOT_EACH(),{},eqmod2,_)) guard eqModSubsetOrEqual(eqmod1,eqmod2)
       then
         true;
 
     // handle subset equal
-    case(DAE.MOD(f1,each1,submods1,eqmod1,_),DAE.MOD(f2,each2,submods2,eqmod2,_))
-      algorithm
-        true := SCodeUtil.finalEqual(f1, f2);
-        true := SCodeUtil.eachEqual(each1,each2);
-        true := subModsEqual(submods1,submods2);
-        true := eqModSubsetOrEqual(eqmod1,eqmod2);
+    case(DAE.MOD(f1,each1,submods1,eqmod1,_),DAE.MOD(f2,each2,submods2,eqmod2,_)) guard SCodeUtil.finalEqual(f1, f2) and SCodeUtil.eachEqual(each1,each2) and subModsEqual(submods1,submods2) and eqModSubsetOrEqual(eqmod1,eqmod2)
       then
         true;
 
     // two exactly the same mod, return just one! (used when it is REDECL or a submod is REDECL)
-    case(DAE.REDECL(f1, each1),DAE.REDECL(f2, each2))
-      algorithm
-        true := SCodeUtil.finalEqual(f1, f2);
-        true := SCodeUtil.eachEqual(each1, each2);
-        true := SCodeUtil.elementEqual(mod1.element, mod2.element);
+    case(DAE.REDECL(f1, each1),DAE.REDECL(f2, each2)) guard SCodeUtil.finalEqual(f1, f2) and SCodeUtil.eachEqual(each1, each2) and SCodeUtil.elementEqual(mod1.element, mod2.element)
       then
         true;
 
@@ -1918,7 +1905,7 @@ algorithm
 
     else false;
 
-  end matchcontinue;
+  end match;
 end modSubsetOrEqualOrNonOverlap;
 
 protected function eqModSubsetOrEqual "
@@ -2589,22 +2576,20 @@ protected function getUnelabedSubMod2
   input SCode.Ident inIdent;
   output SCode.Mod outMod;
 algorithm
-  outMod := matchcontinue inSubMods
+  outMod := match inSubMods
     local
       SCode.Ident id;
       SCode.Mod m;
       list<SCode.SubMod> rest_mods;
 
-    case SCode.NAMEMOD(ident = id, mod = m) :: _
-      algorithm
-        true := stringEqual(id, inIdent);
+    case SCode.NAMEMOD(ident = id, mod = m) :: _ guard stringEqual(id, inIdent)
       then
         m;
 
     case _ :: rest_mods
       then getUnelabedSubMod2(rest_mods, inIdent);
 
-  end matchcontinue;
+  end match;
 end getUnelabedSubMod2;
 
 public function isUntypedMod

--- a/OMCompiler/Compiler/FrontEnd/NFSCodeEnv.mo
+++ b/OMCompiler/Compiler/FrontEnd/NFSCodeEnv.mo
@@ -1277,7 +1277,7 @@ public function envPrefixOf2
   input Env inEnv;
   output Boolean outIsPrefix;
 algorithm
-  outIsPrefix := matchcontinue(inPrefixEnv, inEnv)
+  outIsPrefix := match(inPrefixEnv, inEnv)
     local
       String n1, n2;
       Env rest1, rest2;
@@ -1287,14 +1287,12 @@ algorithm
     case (FRAME(name = NONE()) :: rest1, FRAME(name = NONE()) :: rest2)
       then envPrefixOf2(rest1, rest2);
 
-    case (FRAME(name = SOME(n1)) :: rest1, FRAME(name = SOME(n2)) :: rest2)
-      algorithm
-        true := stringEqual(n1, n2);
+    case (FRAME(name = SOME(n1)) :: rest1, FRAME(name = SOME(n2)) :: rest2) guard stringEqual(n1, n2)
       then
         envPrefixOf2(rest1, rest2);
 
     else false;
-  end matchcontinue;
+  end match;
 end envPrefixOf2;
 
 public function envScopeNames
@@ -1343,15 +1341,14 @@ public function envEqualPrefix2
   input Env inAccumEnv;
   output Env outPrefix;
 algorithm
-  outPrefix := matchcontinue(inEnv1, inEnv2)
+  outPrefix := match(inEnv1, inEnv2)
     local
       String name1, name2;
       Env env, rest_env1, rest_env2;
       Frame frame;
 
-    case ((frame as FRAME(name = SOME(name1))) :: rest_env1, FRAME(name = SOME(name2)) :: rest_env2)
+    case ((frame as FRAME(name = SOME(name1))) :: rest_env1, FRAME(name = SOME(name2)) :: rest_env2) guard stringEq(name1, name2)
       algorithm
-        true := stringEq(name1, name2);
         env := envEqualPrefix2(rest_env1, rest_env2, frame :: inAccumEnv);
       then
         env;
@@ -1361,7 +1358,7 @@ algorithm
 
     else inAccumEnv;
 
-  end matchcontinue;
+  end match;
 end envEqualPrefix2;
 
 public function getItemInfo

--- a/OMCompiler/Compiler/FrontEnd/Patternm.mo
+++ b/OMCompiler/Compiler/FrontEnd/Patternm.mo
@@ -124,22 +124,20 @@ protected function findFieldExpInList "author: KS
   output Absyn.Exp outExp;
   output list<Absyn.NamedArg> outNamedArgList;
 algorithm
-  (outExp,outNamedArgList) := matchcontinue (firstFieldName,namedArgList)
+  (outExp,outNamedArgList) := match (firstFieldName,namedArgList)
     local
       Absyn.Exp e;
       Absyn.Ident localFieldName,aName;
       list<Absyn.NamedArg> rest;
       Absyn.NamedArg first;
     case (_,{}) then (Absyn.CREF(Absyn.WILD()),{});
-    case (localFieldName,Absyn.NAMEDARG(aName,e) :: rest)
-      algorithm
-        true := stringEq(localFieldName,aName);
+    case (localFieldName,Absyn.NAMEDARG(aName,e) :: rest) guard stringEq(localFieldName,aName)
       then (e,rest);
     case (localFieldName,first::rest)
       algorithm
         (e,rest) := findFieldExpInList(localFieldName,rest);
       then (e,first::rest);
-  end matchcontinue;
+  end match;
 end findFieldExpInList;
 
 protected function checkInvalidPatternNamedArgs
@@ -661,21 +659,11 @@ protected function validUniontype
   input SourceInfo info;
   input Absyn.Exp lhs;
 algorithm
-  () := matchcontinue lhs
-    local
-      String s,s1,s2;
-    case _
-      algorithm
-        true := AbsynUtil.pathEqual(path1,path2);
-      then ();
-    else
-      algorithm
-        s := Dump.printExpStr(lhs);
-        s1 := AbsynUtil.pathString(path1);
-        s2 := AbsynUtil.pathString(path2);
-        Error.addSourceMessage(Error.META_CONSTRUCTOR_NOT_PART_OF_UNIONTYPE, {s,s1,s2}, info);
-      then fail();
-  end matchcontinue;
+  if not AbsynUtil.pathEqual(path1,path2) then
+    Error.addSourceMessage(Error.META_CONSTRUCTOR_NOT_PART_OF_UNIONTYPE,
+      {Dump.printExpStr(lhs), AbsynUtil.pathString(path1), AbsynUtil.pathString(path2)}, info);
+    fail();
+  end if;
 end validUniontype;
 
 public function elabMatchExpression

--- a/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
@@ -960,7 +960,7 @@ protected function subModsEqual
   input list<SCode.SubMod>  inSubModLst2;
   output Boolean equal;
 algorithm
-  equal := matchcontinue(inSubModLst1,inSubModLst2)
+  equal := match(inSubModLst1,inSubModLst2)
     local
       SCode.Ident id1,id2;
       SCode.Mod mod1,mod2;
@@ -968,16 +968,12 @@ algorithm
 
     case ({},{}) then true;
 
-    case (SCode.NAMEMOD(id1,mod1)::subModLst1,SCode.NAMEMOD(id2,mod2)::subModLst2)
-        algorithm
-          true := stringEq(id1,id2);
-          true := modEqual(mod1,mod2);
-          true := subModsEqual(subModLst1,subModLst2);
+    case (SCode.NAMEMOD(id1,mod1)::subModLst1,SCode.NAMEMOD(id2,mod2)::subModLst2) guard stringEq(id1,id2) and modEqual(mod1,mod2) and subModsEqual(subModLst1,subModLst2)
         then
           true;
 
     else false;
-  end matchcontinue;
+  end match;
 end subModsEqual;
 
 protected function subscriptsEqual
@@ -2789,7 +2785,7 @@ public function replaceableEqual "Returns true if two replaceable attributes are
   input SCode.Replaceable r2;
   output Boolean equal;
 algorithm
-  equal := matchcontinue(r1,r2)
+  equal := match(r1,r2)
     local
       Absyn.Path p1, p2;
       SCode.Mod m1, m2;
@@ -2797,10 +2793,7 @@ algorithm
     case(SCode.NOT_REPLACEABLE(),SCode.NOT_REPLACEABLE()) then true;
 
     case(SCode.REPLACEABLE(SOME(SCode.CONSTRAINCLASS(constrainingClass = p1, modifier = m1))),
-         SCode.REPLACEABLE(SOME(SCode.CONSTRAINCLASS(constrainingClass = p2, modifier = m2))))
-      algorithm
-        true := AbsynUtil.pathEqual(p1, p2);
-        true := modEqual(m1, m2);
+         SCode.REPLACEABLE(SOME(SCode.CONSTRAINCLASS(constrainingClass = p2, modifier = m2)))) guard AbsynUtil.pathEqual(p1, p2) and modEqual(m1, m2)
       then
         true;
 
@@ -2808,7 +2801,7 @@ algorithm
 
     else false;
 
-  end matchcontinue;
+  end match;
 end replaceableEqual;
 
 public function prefixesEqual "Returns true if two prefixes are equal"
@@ -4207,7 +4200,7 @@ protected function removeSub
   input list<SCode.SubMod> inOld;
   output list<SCode.SubMod> outSubs;
 algorithm
-  outSubs := matchcontinue(inSub, inOld)
+  outSubs := match(inSub, inOld)
     local
       list<SCode.SubMod> rest;
       SCode.Ident id1, id2;
@@ -4215,9 +4208,7 @@ algorithm
 
     case (_, {}) then inOld;
 
-    case (SCode.NAMEMOD(ident = id1), SCode.NAMEMOD(ident = id2)::rest)
-      algorithm
-        true := stringEqual(id1, id2);
+    case (SCode.NAMEMOD(ident = id1), SCode.NAMEMOD(ident = id2)::rest) guard stringEqual(id1, id2)
       then
         rest;
 
@@ -4226,7 +4217,7 @@ algorithm
         rest := removeSub(inSub, rest);
       then
         s::rest;
-  end matchcontinue;
+  end match;
 end removeSub;
 
 public function mergeComponentModifiers

--- a/OMCompiler/Compiler/FrontEnd/Types.mo
+++ b/OMCompiler/Compiler/FrontEnd/Types.mo
@@ -896,22 +896,17 @@ public function dimensionsKnown
   input DAE.Type inType;
   output Boolean outRes;
 algorithm
-  outRes := matchcontinue inType
+  outRes := match inType
     local
       DAE.Dimension d;
       DAE.Dimensions dims;
       Type tp;
 
-    case DAE.T_ARRAY(dims = d::dims, ty = tp)
-      algorithm
-        true := Expression.dimensionKnown(d);
-        true := dimensionsKnown(DAE.T_ARRAY(tp, dims));
+    case DAE.T_ARRAY(dims = d::dims, ty = tp) guard Expression.dimensionKnown(d) and dimensionsKnown(DAE.T_ARRAY(tp, dims))
       then
         true;
 
-    case DAE.T_ARRAY(dims = {}, ty = tp)
-      algorithm
-        true := dimensionsKnown(tp);
+    case DAE.T_ARRAY(dims = {}, ty = tp) guard dimensionsKnown(tp)
       then
         true;
 
@@ -922,7 +917,7 @@ algorithm
       then dimensionsKnown(tp);
 
     else true;
-  end matchcontinue;
+  end match;
 end dimensionsKnown;
 
 public function getDimensionSizes "Return the dimension sizes of a Type."
@@ -1583,18 +1578,16 @@ protected function subtypeTypelist "PR. function: subtypeTypelist
   input Boolean requireRecordNamesEqual;
   output Boolean outBoolean;
 algorithm
-  outBoolean := matchcontinue (inTypeLst1, inTypeLst2)
+  outBoolean := match (inTypeLst1, inTypeLst2)
     local
       Type t1,t2;
       list<DAE.Type> rest1,rest2;
 
     case ({}, {}) then true;
-    case ((t1 :: rest1), (t2 :: rest2))
-      algorithm
-        true := subtype(t1, t2, requireRecordNamesEqual);
+    case ((t1 :: rest1), (t2 :: rest2)) guard subtype(t1, t2, requireRecordNamesEqual)
       then subtypeTypelist(rest1, rest2, requireRecordNamesEqual);
     else false;  /* default */
-  end matchcontinue;
+  end match;
 end subtypeTypelist;
 
 protected function subtypeVarlist "This function checks if the Var list in the first list is a
@@ -1767,15 +1760,13 @@ protected function lookupComponent2 "This function finds a named Var in a list o
   input String inIdent;
   output DAE.Var outVar;
 algorithm
-  outVar := matchcontinue (inVarLst,inIdent)
+  outVar := match (inVarLst,inIdent)
     local
       DAE.Var v;
       String n,m;
       list<DAE.Var> vs;
 
-    case (((v as DAE.TYPES_VAR(name = n)) :: _),m)
-      algorithm
-        true := stringEq(n, m);
+    case (((v as DAE.TYPES_VAR(name = n)) :: _),m) guard stringEq(n, m)
       then
         v;
 
@@ -1784,7 +1775,7 @@ algorithm
         v := lookupComponent2(vs, n);
       then
         v;
-  end matchcontinue;
+  end match;
 end lookupComponent2;
 
 public function makeArray "This function makes an array type given a Type and an Absyn.ArrayDim"
@@ -1938,7 +1929,7 @@ public function liftArrayRight "This function adds an array dimension to *the ri
   input DAE.Dimension inIntegerOption;
   output DAE.Type outType;
 algorithm
-  outType := matchcontinue (inType,inIntegerOption)
+  outType := match (inType,inIntegerOption)
     local
       Type ty_1,ty;
       DAE.Dimension dim;
@@ -1954,16 +1945,15 @@ algorithm
       then
         DAE.T_ARRAY(ty_1, {dim});
 
-    case(DAE.T_SUBTYPE_BASIC(ci,varlst,ty,ec),d)
+    case(DAE.T_SUBTYPE_BASIC(ci,varlst,ty,ec),d) guard not listEmpty(TypesDump.getDimensions(ty))
       algorithm
-        false := listEmpty(TypesDump.getDimensions(ty));
         ty_1 := liftArrayRight(ty,d);
       then DAE.T_SUBTYPE_BASIC(ci,varlst,ty_1,ec);
 
     case (tty,d)
       then
         DAE.T_ARRAY(tty,{d});
-  end matchcontinue;
+  end match;
 end liftArrayRight;
 
 public function unliftArray "This function turns an array of a type into that type."
@@ -2546,7 +2536,7 @@ protected function makeReturnType "author: LS
   input list<DAE.Var> inVarLst;
   output DAE.Type outType;
 algorithm
-  outType := matchcontinue inVarLst
+  outType := match inVarLst
     local
       Type ty;
       Var var;
@@ -2564,7 +2554,7 @@ algorithm
       then DAE.T_TUPLE(
         list(makeReturnTypeSingle(v) for v in vl),
         SOME(list(TypesDump.getVarName(v) for v in vl)));
-  end matchcontinue;
+  end match;
 end makeReturnType;
 
 protected function makeReturnTypeSingle "author: LS
@@ -3194,22 +3184,19 @@ protected function varsElabEquivalent
   input DAE.Var inVar2;
   output Boolean isEqual;
 algorithm
-  isEqual := matchcontinue(inVar1, inVar2)
+  isEqual := match(inVar1, inVar2)
     local
       DAE.Ident id1, id2;
       DAE.Type ty1, ty2;
 
     case (DAE.TYPES_VAR(name = id1, ty = ty1),
-          DAE.TYPES_VAR(name = id2, ty = ty2))
-      algorithm
-        true := stringEqual(id1, id2);
-        true := typesElabEquivalent(ty1, ty2);
+          DAE.TYPES_VAR(name = id2, ty = ty2)) guard stringEqual(id1, id2) and typesElabEquivalent(ty1, ty2)
       then
         true;
 
     else false;
 
-  end matchcontinue;
+  end match;
 end varsElabEquivalent;
 
 public function matchProp
@@ -6765,16 +6752,14 @@ public function allHaveBindings
   input list<DAE.Var> inVars;
   output Boolean b;
 algorithm
-  b := matchcontinue inVars
+  b := match inVars
     local
       DAE.Var v;
       list<DAE.Var> rest;
 
     case {} then true;
 
-    case v::_
-      algorithm
-        false := hasBinding(v);
+    case v::_ guard not hasBinding(v)
       then
         false;
 
@@ -6785,7 +6770,7 @@ algorithm
       then
         true;
 
-  end matchcontinue;
+  end match;
 end allHaveBindings;
 
 public function hasBinding
@@ -6803,20 +6788,10 @@ public function typeErrorSanityCheck
   input String inType2;
   input SourceInfo inInfo;
 algorithm
-  () := matchcontinue inInfo
-    case _
-      algorithm
-        false := stringEq(inType1, inType2);
-      then
-        ();
-
-    else
-      algorithm
-        Error.addSourceMessage(Error.ERRONEOUS_TYPE_ERROR, {inType1}, inInfo);
-      then
-        fail();
-
-  end matchcontinue;
+  if stringEq(inType1, inType2) then
+    Error.addSourceMessage(Error.ERRONEOUS_TYPE_ERROR, {inType1}, inInfo);
+    fail();
+  end if;
 end typeErrorSanityCheck;
 
 public function dimNotFixed

--- a/OMCompiler/Compiler/FrontEnd/UnitChecker.mo
+++ b/OMCompiler/Compiler/FrontEnd/UnitChecker.mo
@@ -284,7 +284,7 @@ protected function isSpecUnitEq "checks if twp spec units are equal (presupposed
   input UnitAbsyn.SpecUnit insu2;
   output Boolean res;
 algorithm
-  res := matchcontinue(insu1,insu2)
+  res := match(insu1,insu2)
     local
       Boolean r1;
       Integer i1a,i1b,i2a,i2b;
@@ -303,16 +303,14 @@ algorithm
         r1 := isSpecUnitEq(UnitAbsyn.SPECUNIT({},rest1),UnitAbsyn.SPECUNIT({},{}));
       then r1;
 
-    case(UnitAbsyn.SPECUNIT(_,MMath.RATIONAL(i1a,i1b)::rest1), UnitAbsyn.SPECUNIT(_,MMath.RATIONAL(i2a,i2b)::rest2))
+    case(UnitAbsyn.SPECUNIT(_,MMath.RATIONAL(i1a,i1b)::rest1), UnitAbsyn.SPECUNIT(_,MMath.RATIONAL(i2a,i2b)::rest2)) guard intEq(i1a, i2a) and intEq(i1b, i2b)
       algorithm
-        true := intEq(i1a, i2a);
-        true := intEq(i1b, i2b);
         r1 := isSpecUnitEq(UnitAbsyn.SPECUNIT({},rest1),UnitAbsyn.SPECUNIT({},rest2));
       then r1;
 
     else
       then false;
-  end matchcontinue;
+  end match;
 end isSpecUnitEq;
 
 protected function unifyunits
@@ -767,7 +765,7 @@ protected function getParam "returns the next param in list and removes it from 
   output MMath.Rational outexpo;
   output list<tuple<MMath.Rational,UnitAbsyn.TypeParameter>> outparams;
 algorithm
-  (found,outexpo,outparams) := matchcontinue inparams
+  (found,outexpo,outparams) := match inparams
     local
       list<tuple<MMath.Rational,UnitAbsyn.TypeParameter>> rest,rest2;
       Integer loc2;
@@ -777,9 +775,7 @@ algorithm
 
     case {} then (false,MMath.RATIONAL(1,1),{});
 
-    case (expo,UnitAbsyn.TYPEPARAMETER(_,loc2))::rest
-      algorithm
-        true := intEq(loc2, loc);
+    case (expo,UnitAbsyn.TYPEPARAMETER(_,loc2))::rest guard intEq(loc2, loc)
       then
         (true,expo,rest);
 
@@ -794,7 +790,7 @@ algorithm
         true := Flags.isSet(Flags.FAILTRACE);
         Debug.trace("UnitChecker::getParam() failed\n");
       then fail();
-  end matchcontinue;
+  end match;
 end getParam;
 
 protected function normalizeParamsValues "normalize the values that the the list of unit parameters points at"

--- a/OMCompiler/Compiler/NFFrontEnd/NFUnit.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFUnit.mo
@@ -902,7 +902,7 @@ protected function popUnit
   output list<String> outCharList;
   output String outUnit;
 algorithm
-  (outCharList, outUnit) := matchcontinue inCharList
+  (outCharList, outUnit) := match inCharList
     local
       String s1, s2;
       list<String> strRest;
@@ -910,18 +910,16 @@ algorithm
     case {}
     then ({}, "");
 
-    case s1::strRest algorithm
-      true := (stringCompare(s1, "a") >= 0) and (stringCompare(s1, "z") <= 0);
+    case s1::strRest guard (stringCompare(s1, "a") >= 0) and (stringCompare(s1, "z") <= 0) algorithm
       (strRest, s2) := popUnit(strRest);
     then (strRest, s1 + s2);
 
-    case s1::strRest algorithm
-      true := (stringCompare(s1, "A") >= 0) and (stringCompare(s1, "Z") <= 0) ;
+    case s1::strRest guard (stringCompare(s1, "A") >= 0) and (stringCompare(s1, "Z") <= 0) algorithm
       (strRest, s2) := popUnit(strRest);
     then (strRest, s1 + s2);
 
     else (inCharList, "");
-  end matchcontinue;
+  end match;
 end popUnit;
 
 protected function popNumber

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/fallibility.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/fallibility.rs
@@ -283,6 +283,28 @@ pub struct FallibilityInfo {
     /// by the `--fix` rewriter (`crate::fix`) to locate and rewrite the
     /// `matchcontinue`/`end matchcontinue` keywords in the `.mo` source.
     pub matchcontinue_as_match_locs: Vec<Absyn::Info>,
+    /// Per flagged `matchcontinue`, the leading `true := COND;` statements to
+    /// turn into `guard`s first — parallel to [`Self::matchcontinue_as_match`]
+    /// and empty for the ones that need only the keyword rewrite.
+    pub matchcontinue_guard_hoists: Vec<Vec<GuardHoist>>,
+    /// One line per `matchcontinue` that could *not* be rewritten, naming the
+    /// first arm that keeps it alive and why. Written out by `--mc-report`;
+    /// the raw material for deciding which fallibility source to attack next.
+    pub mc_report: Vec<String>,
+}
+
+/// One `matchcontinue` arm's `true := COND;` prefix, to be rewritten as a
+/// `guard` on the arm's pattern. Consumed by `crate::fix`.
+#[derive(Clone, Debug)]
+pub struct GuardHoist {
+    /// Span of the case pattern; the guard is inserted right after its end.
+    pub pattern_info: Absyn::Info,
+    /// The statements to delete, in source order, each with the polarity it
+    /// asserted (`false` means the condition must be negated as a guard).
+    pub stmts: Vec<(Absyn::Info, bool)>,
+    /// They were the arm's *only* statements, so its `algorithm` keyword goes
+    /// too.
+    pub drops_section: bool,
 }
 
 // ── Walk state ───────────────────────────────────────────────────────────────
@@ -299,12 +321,18 @@ struct Walk {
     /// MM names from the source (e.g. "List.map", "foo", "intAdd"). They are
     /// resolved against the hierarchy in [`resolve_called_qname`].
     calls: BTreeSet<String>,
-    /// True if the body contains a `match`/`matchcontinue` expression — a
-    /// fail-on-no-match is observable to callers.
-    has_match: bool,
+    /// Pattern-coverage keys of every `match` in the body that the syntactic
+    /// check could not prove exhaustive, one entry per `match`. Constructor
+    /// patterns need the hierarchy to resolve, so the verdict is re-taken in
+    /// [`resolve_walk`]; a `match` still not exhaustive there fails when no arm
+    /// matches, which is observable to callers.
+    match_keys: Vec<Vec<CoverKey>>,
     /// True if the body contains an explicit `fail()` call outside a catch
     /// boundary.  (Catch boundaries are not yet tracked; see module docs.)
     has_fail: bool,
+    /// Human-readable labels for what made this walk fallible, for the
+    /// `--mc-report` diagnostic. Never consulted by the verdict itself.
+    reasons: BTreeSet<&'static str>,
     /// True if the body calls *through a function value* — i.e. invokes one of
     /// the function's own function-typed parameters/locals (a callback), or a
     /// function-typed field of such a local. Every function value in our
@@ -367,6 +395,21 @@ struct McLint {
     /// All arms, in source order; the last element is the matchcontinue's last
     /// arm (whose fallibility the lint deliberately ignores).
     arms: Vec<Walk>,
+    /// The same arms, but scanned as if each one's leading `true := COND;`
+    /// statements had been rewritten as a `guard` (see
+    /// [`Walk::scan_class_part_hoisting_guards`]).
+    hoisted: Vec<Walk>,
+    /// The source edits that rewrite would take, one per arm that has such a
+    /// prefix. Empty when nothing needs hoisting; `None` when some arm that
+    /// does already carries a `guard` we would have to merge with.
+    guard_hoists: Option<Vec<GuardHoist>>,
+    /// The cases and their shared binding scope, for the pattern-disjointness
+    /// route to the same verdict ([`crate::mc_disjoint`]); constructor names
+    /// need the hierarchy, so it is decided in [`resolve_walk`].
+    cases: metamodelica::List<Arc<Absyn::Case>>,
+    scope: BTreeSet<String>,
+    /// The last arm is an `else`.
+    has_else: bool,
 }
 
 /// Safety obligation for one `matchcontinue` expression: it cannot fail iff
@@ -481,6 +524,7 @@ impl Walk {
                 //                                sub-pattern
                 if exp_is_refutable_lhs(assignComponent) {
                     self.has_fail = true;
+                    self.reasons.insert("refutable `:=` pattern");
                 }
                 self.scan_exp(assignComponent);
                 self.scan_exp(value);
@@ -531,6 +575,7 @@ impl Walk {
                 // body: regardless of what it does, the failure clause can
                 // raise the failure that escapes upward.
                 self.has_fail = true;
+                self.reasons.insert("failure(...) clause");
             }
             Absyn::Algorithm::ALG_TRY { body: _, elseBody } => {
                 // `try BODY else ELSE end try;` catches a failure raised by
@@ -563,6 +608,7 @@ impl Walk {
                 for s in &**subs {
                     if let Absyn::Subscript::SUBSCRIPT { subscript } = &**s {
                         self.has_fail = true;
+                        self.reasons.insert("array subscript");
                         self.scan_exp(subscript);
                     }
                 }
@@ -590,6 +636,7 @@ impl Walk {
                 // `GenCtx::q` will panic on the analysis/codegen mismatch.
                 if matches!(op, Absyn::Operator::DIV | Absyn::Operator::DIV_EW) {
                     self.has_fail = true;
+                    self.reasons.insert("real division");
                 }
                 self.scan_exp(exp1); self.scan_exp(exp2);
             }
@@ -650,8 +697,9 @@ impl Walk {
                     // so the surrounding function stays infallible. See
                     // codegen `cases_exhaustive` for the typed-IR
                     // counterpart; the two must agree.
-                    if !match_is_exhaustive(cases, localDecls, &self.outer_scope) {
-                        self.has_match = true;
+                    let keys = match_cover_keys(cases, localDecls, &self.outer_scope);
+                    if !cover_keys_exhaustive(&keys) {
+                        self.match_keys.push(keys);
                     }
                     // A failure inside a `match` arm (guard, body, or result)
                     // escapes the match — there is no fall-through to the
@@ -738,27 +786,68 @@ impl Walk {
                     // which omit guarded arms entirely — so a fallible guard keeps
                     // the arm fallible and suppresses the (then-unsound) suggestion.
                     let mut lint_arms: Vec<Walk> = Vec::new();
+                    let mut lint_hoisted: Vec<Walk> = Vec::new();
+                    let mut guard_hoists: Option<Vec<GuardHoist>> = Some(Vec::new());
                     let mut lint_info: Option<Absyn::Info> = None;
-                    for case in &**cases {
-                        let (case_decls, guard, pattern, class_part, result, info) = match &**case {
-                            Absyn::Case::CASE { pattern, patternGuard, localDecls: case_decls, classPart, result, info, .. } =>
-                                (case_decls, patternGuard.as_deref(), Some(&**pattern), classPart, result, info),
+                    let last_case = (&**cases).into_iter().count().saturating_sub(1);
+                    for (case_ix, case) in (&**cases).into_iter().enumerate() {
+                        let (case_decls, guard, pattern, class_part, result, info, pattern_info) = match &**case {
+                            Absyn::Case::CASE { pattern, patternGuard, localDecls: case_decls, classPart, result, info, patternInfo, .. } =>
+                                (case_decls, patternGuard.as_deref(), Some(&**pattern), classPart, result, info, Some(patternInfo)),
                             Absyn::Case::ELSE { localDecls: case_decls, classPart, result, info, .. } =>
-                                (case_decls, None, None, classPart, result, info),
+                                (case_decls, None, None, classPart, result, info, None),
                         };
                         if lint_info.is_none() { lint_info = Some(info.clone()); }
                         let mut scope = match_scope.clone();
                         collect_local_decl_names(case_decls, &mut scope);
-                        let mut sub = Walk { outer_scope: scope, ..Walk::default() };
+                        let mut sub = Walk { outer_scope: scope.clone(), ..Walk::default() };
                         if let Some(g) = guard { sub.scan_exp(g); }
                         if let Some(p) = pattern { sub.scan_exp(p); }
                         sub.scan_local_decl_defaults(case_decls);
                         sub.scan_class_part(class_part);
                         sub.scan_exp(result);
                         lint_arms.push(sub);
+                        if case_ix < last_case
+                            && let (Some(pat_info), Absyn::ClassPart::ALGORITHMS { contents }) =
+                                (pattern_info, &**class_part)
+                        {
+                            let stmts: Vec<(Absyn::Info, bool)> = (&**contents).into_iter()
+                                .map_while(|it| boolean_assert(it))
+                                .map(|(_, asserted, info)| (info.clone(), asserted))
+                                .collect();
+                            let drops_section = stmts.len() == (&**contents).into_iter().count();
+                            if !stmts.is_empty() {
+                                match (&mut guard_hoists, guard.is_some()) {
+                                    // Merging with an existing guard would need
+                                    // the guard's own span, which Absyn does not
+                                    // carry; leave the whole matchcontinue alone.
+                                    (slot, true) => *slot = None,
+                                    (Some(v), false) =>
+                                        v.push(GuardHoist {
+                                            pattern_info: pat_info.clone(), stmts, drops_section }),
+                                    (None, false) => {}
+                                }
+                            }
+                        }
+                        let mut hoisted = Walk { outer_scope: scope, ..Walk::default() };
+                        if let Some(g) = guard { hoisted.scan_exp(g); }
+                        if let Some(p) = pattern { hoisted.scan_exp(p); }
+                        hoisted.scan_local_decl_defaults(case_decls);
+                        hoisted.scan_class_part_hoisting_guards(class_part, true);
+                        hoisted.scan_exp(result);
+                        lint_hoisted.push(hoisted);
                     }
                     if let Some(info) = lint_info {
-                        self.mc_lints.push(McLint { info, arms: lint_arms });
+                        self.mc_lints.push(McLint {
+                            info,
+                            arms: lint_arms,
+                            hoisted: lint_hoisted,
+                            guard_hoists,
+                            cases: (*cases).clone(),
+                            scope: match_scope,
+                            has_else: (&**cases).into_iter().last()
+                                .is_some_and(|c| matches!(&**c, Absyn::Case::ELSE { .. })),
+                        });
                     }
                 }
             }
@@ -792,8 +881,25 @@ impl Walk {
     }
 
     fn scan_class_part(&mut self, part: &Absyn::ClassPart) {
+        self.scan_class_part_hoisting_guards(part, false);
+    }
+
+    /// `hoist_guards` models rewriting the arm's leading `true := COND;` /
+    /// `false := COND;` statements as a `guard`: the statements' own
+    /// fall-through is dropped (a guard belongs to the pattern, so a `match`
+    /// falls through on it too) while `COND` is still scanned, since a *failing*
+    /// guard expression propagates and would make the rewrite unsound.
+    fn scan_class_part_hoisting_guards(&mut self, part: &Absyn::ClassPart, hoist_guards: bool) {
         if let Absyn::ClassPart::ALGORITHMS { contents } = part {
-            for it in &**contents { self.scan_algorithm_item(it); }
+            let mut leading = hoist_guards;
+            for it in &**contents {
+                if leading && let Some(cond) = boolean_assert_cond(it) {
+                    self.scan_exp(cond);
+                    continue;
+                }
+                leading = false;
+                self.scan_algorithm_item(it);
+            }
         }
         // EQUATIONS / EXTERNAL / etc. are not introduced inside match-case
         // class parts by the parser we use; if a future grammar revision
@@ -823,6 +929,7 @@ impl Walk {
     fn record_call(&mut self, name: &str) {
         if name == "fail" {
             self.has_fail = true;
+            self.reasons.insert("fail()");
         }
         // A call whose first dotted segment names one of this function's own
         // parameters/locals is a call *through a function value*: you can only
@@ -836,9 +943,26 @@ impl Walk {
         let first_seg = name.split('.').next().unwrap_or(name);
         if self.outer_scope.contains(first_seg) {
             self.calls_fn_value = true;
+            self.reasons.insert("call through a function value");
         }
         self.calls.insert(name.to_owned());
     }
+}
+
+/// The `COND` of a leading `true := COND;` / `false := COND;` statement — the
+/// MetaModelica idiom for "this arm only applies when COND holds", written
+/// before `guard` existed. Returns `None` for anything else.
+fn boolean_assert_cond(item: &Absyn::AlgorithmItem) -> Option<&Absyn::Exp> {
+    boolean_assert(item).map(|(cond, _, _)| cond)
+}
+
+/// As [`boolean_assert_cond`], plus the asserted polarity (`false :=` needs the
+/// condition negated when it becomes a guard) and the statement's source span.
+fn boolean_assert(item: &Absyn::AlgorithmItem) -> Option<(&Absyn::Exp, bool, &Absyn::Info)> {
+    let Absyn::AlgorithmItem::ALGORITHMITEM { algorithm_, info, .. } = item else { return None };
+    let Absyn::Algorithm::ALG_ASSIGN { assignComponent, value } = &**algorithm_ else { return None };
+    let Absyn::Exp::BOOL { value: asserted } = **assignComponent else { return None };
+    Some((value, asserted, info))
 }
 
 /// True when an expression used on the LHS of a MetaModelica `:=` assignment
@@ -877,7 +1001,7 @@ fn exp_is_refutable_lhs(e: &Absyn::Exp) -> bool {
 ///
 /// Lexer comment / TEXT / DEFINEUNIT items are silently skipped — they
 /// don't introduce variable bindings.
-fn collect_local_decl_names(
+pub(crate) fn collect_local_decl_names(
     decls: &metamodelica::List<std::sync::Arc<Absyn::ElementItem>>,
     out: &mut BTreeSet<String>,
 ) {
@@ -925,7 +1049,7 @@ fn collect_local_decl_names(
 /// This is the sound replacement for the historical "first letter
 /// uppercase ⇒ constructor" heuristic — we now consult the actual
 /// declared scope.
-fn absyn_pat_is_irrefutable(e: &Absyn::Exp, binding_names: &BTreeSet<String>) -> bool {
+pub(crate) fn absyn_pat_is_irrefutable(e: &Absyn::Exp, binding_names: &BTreeSet<String>) -> bool {
     use Absyn::Exp::*;
     match e {
         CREF { componentRef } => match componentRef.as_ref() {
@@ -965,7 +1089,7 @@ fn absyn_pat_is_full_some(e: &Absyn::Exp, binding_names: &BTreeSet<String>) -> b
 /// the whole-match check ([`match_is_exhaustive`]) and the per-arm-subset
 /// check for `matchcontinue` safety ([`mc_check_is_safe`]) share one
 /// definition of what covers what.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum CoverKey {
     /// Matches every value of the scrutinee type: `else`, `_`, a declared
     /// variable binding, as-patterns and tuples of irrefutable patterns.
@@ -982,8 +1106,17 @@ enum CoverKey {
     BoolTrue,
     /// Literal `false`.
     BoolFalse,
-    /// Every other shape — constructor patterns, literals, partial
-    /// cons/SOME, … — contributes no type-independent coverage.
+    /// A record-constructor pattern `C(<all sub-patterns irrefutable>)`, holding
+    /// the callee name exactly as written. Name resolution needs the hierarchy,
+    /// which the syntactic walk does not have, so it stays raw until
+    /// [`resolve_cover_key`] turns it into [`CoverKey::Variant`].
+    Ctor(String),
+    /// A resolved [`CoverKey::Ctor`]: record `variant` of uniontype `union_`,
+    /// which has `total` records in all. Carrying `total` lets
+    /// [`cover_keys_exhaustive`] decide coverage without the hierarchy.
+    Variant { union_: String, variant: String, total: usize },
+    /// Every other shape — literals, partial cons/SOME, constructor patterns
+    /// with a refutable sub-pattern, … — contributes no coverage.
     Other,
 }
 
@@ -1005,6 +1138,8 @@ fn pat_cover_key(e: &Absyn::Exp, binding_names: &BTreeSet<String>) -> CoverKey {
     // the literal form here — `{l}` is therefore ARRAY/LIST with a single
     // element and does NOT contribute to Cons coverage.
     match e {
+        // `x as PAT` matches exactly what `PAT` matches.
+        Absyn::Exp::AS { exp, .. } => pat_cover_key(exp, binding_names),
         Absyn::Exp::ARRAY { arrayExp } if arrayExp.is_empty() => CoverKey::NilList,
         Absyn::Exp::LIST { exps } if exps.is_empty() => CoverKey::NilList,
         Absyn::Exp::CONS { head, rest }
@@ -1017,8 +1152,46 @@ fn pat_cover_key(e: &Absyn::Exp, binding_names: &BTreeSet<String>) -> CoverKey {
         _ if absyn_pat_is_full_some(e, binding_names) => CoverKey::FullSome,
         Absyn::Exp::BOOL { value: true } => CoverKey::BoolTrue,
         Absyn::Exp::BOOL { value: false } => CoverKey::BoolFalse,
+        Absyn::Exp::CALL { function_, functionArgs, .. } => {
+            let Absyn::FunctionArgs::FUNCTIONARGS { args, argNames } = &**functionArgs
+                else { return CoverKey::Other };
+            // A constructor pattern matches every value of its variant only if
+            // each listed sub-pattern does. Omitted named fields bind nothing
+            // and so never restrict the match.
+            let all_irrefutable = (&**args).into_iter().all(|a| absyn_pat_is_irrefutable(a, binding_names))
+                && (&**argNames).into_iter().all(|n| absyn_pat_is_irrefutable(&n.argValue, binding_names));
+            if all_irrefutable { CoverKey::Ctor(cref_to_dotted(function_.as_ref())) }
+            else { CoverKey::Other }
+        }
         _ => CoverKey::Other,
     }
+}
+
+/// Resolve a [`CoverKey::Ctor`]'s raw callee name: a record of a uniontype
+/// becomes [`CoverKey::Variant`], anything else [`CoverKey::Other`]. Records
+/// outside a uniontype stay unresolved, matching codegen's `pats_cover_ty`.
+fn resolve_cover_key(
+    key: &CoverKey,
+    top_level: &BTreeMap<String, NameNode<'_>>,
+    caller_qname: &str,
+) -> CoverKey {
+    let CoverKey::Ctor(raw) = key else { return key.clone() };
+    let Some((qname, node)) = resolve_call_node(raw, top_level, caller_qname) else {
+        return CoverKey::Other;
+    };
+    let NodeKind::Class(rc) = &node.kind else { return CoverKey::Other };
+    if !matches!(rc.restriction, Absyn::Restriction::R_RECORD | Absyn::Restriction::R_METARECORD { .. }) {
+        return CoverKey::Other;
+    }
+    let Some((union_, _)) = qname.rsplit_once('.') else { return CoverKey::Other };
+    let Some(unode) = crate::hierarchy::lookup_node(union_, top_level) else { return CoverKey::Other };
+    let NodeKind::Class(uc) = &unode.kind else { return CoverKey::Other };
+    if !matches!(uc.restriction, Absyn::Restriction::R_UNIONTYPE) { return CoverKey::Other; }
+    let total = unode.children.values().filter(|c| matches!(&c.kind,
+        NodeKind::Class(c) if matches!(c.restriction,
+            Absyn::Restriction::R_RECORD | Absyn::Restriction::R_METARECORD { .. }))).count();
+    if total == 0 { return CoverKey::Other; }
+    CoverKey::Variant { union_: union_.to_owned(), variant: rc.name.clone(), total }
 }
 
 /// Does a set of unguarded patterns (classified by [`pat_cover_key`])
@@ -1027,27 +1200,37 @@ fn pat_cover_key(e: &Absyn::Exp, binding_names: &BTreeSet<String>) -> CoverKey {
 ///   * `{}` (Nil) + `_ :: _` with both subpatterns irrefutable → List
 ///   * `NONE()` + `SOME(_)` with irrefutable inner → Option
 ///   * boolean literals `true` and `false` → Bool
+///   * every record of one uniontype, as resolved [`CoverKey::Variant`]s
 ///
-/// TODO: uniontype / record exhaustiveness — requires looking up the
-/// scrutinee's type to enumerate constructors, which needs the typed IR.
-/// See the typedexp::TypedPat counterpart in codegen (`pats_cover_ty`) for
-/// the analogous gap.
+/// Unresolved [`CoverKey::Ctor`]s never cover anything, so calling this on the
+/// raw keys straight out of the walk is sound — just less precise than after
+/// [`resolve_cover_key`].
 fn cover_keys_exhaustive(keys: &[CoverKey]) -> bool {
     use CoverKey::*;
-    keys.contains(&Irrefutable)
+    if keys.contains(&Irrefutable)
         || (keys.contains(&NilList) && keys.contains(&FullCons))
         || (keys.contains(&NoneOpt) && keys.contains(&FullSome))
         || (keys.contains(&BoolTrue) && keys.contains(&BoolFalse))
+    {
+        return true;
+    }
+    let mut seen: BTreeMap<&str, (BTreeSet<&str>, usize)> = BTreeMap::new();
+    for k in keys {
+        if let Variant { union_, variant, total } = k {
+            let e = seen.entry(union_).or_insert_with(|| (BTreeSet::new(), *total));
+            e.0.insert(variant);
+        }
+    }
+    seen.values().any(|(vs, total)| vs.len() >= *total)
 }
 
-/// Does an Absyn case set exhaustively cover the scrutinee? See
-/// [`cover_keys_exhaustive`] for the recognised shapes. Cases with a guard
-/// never contribute coverage — a guard can fail.
-fn match_is_exhaustive(
+/// Coverage keys of an Absyn case set, for [`cover_keys_exhaustive`]. Cases
+/// with a guard never contribute coverage — a guard can fail.
+fn match_cover_keys(
     cases: &metamodelica::List<Arc<Absyn::Case>>,
     match_local_decls: &metamodelica::List<std::sync::Arc<Absyn::ElementItem>>,
     outer_scope: &BTreeSet<String>,
-) -> bool {
+) -> Vec<CoverKey> {
     // The full set of names in scope as variable bindings for any pattern
     // in this match: outer scope (function inputs/outputs/protected) ∪
     // match-level localDecls ∪ per-case localDecls.  Built once for the
@@ -1055,7 +1238,7 @@ fn match_is_exhaustive(
     let mut match_scope: BTreeSet<String> = outer_scope.clone();
     collect_local_decl_names(match_local_decls, &mut match_scope);
 
-    let keys: Vec<CoverKey> = cases.into_iter().filter_map(|c| match &**c {
+    cases.into_iter().filter_map(|c| match &**c {
         Absyn::Case::ELSE { .. } => Some(CoverKey::Irrefutable),
         Absyn::Case::CASE { pattern, patternGuard, localDecls, .. } if patternGuard.is_none() => {
             let mut scope = match_scope.clone();
@@ -1063,8 +1246,7 @@ fn match_is_exhaustive(
             Some(pat_cover_key(pattern.as_ref(), &scope))
         }
         _ => None,
-    }).collect();
-    cover_keys_exhaustive(&keys)
+    }).collect()
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -1072,7 +1254,7 @@ fn match_is_exhaustive(
 /// Return the dotted MM-side name for a `ComponentRef` (e.g. `List.map`).
 /// Mirrors `typedexp::cref_to_dotted` but kept private here so the analysis
 /// is independent of the typed-IR module's surface.
-fn cref_to_dotted(cref: &Absyn::ComponentRef) -> String {
+pub(crate) fn cref_to_dotted(cref: &Absyn::ComponentRef) -> String {
     match cref {
         Absyn::ComponentRef::CREF_IDENT { name, .. } => name.to_string(),
         Absyn::ComponentRef::CREF_QUAL { name, componentRef, .. } => {
@@ -1305,6 +1487,7 @@ pub fn analyze(hier: &InstanceHierarchy<'_>) -> FallibilityInfo {
                 .unwrap_or_else(|| external_c_calls::lookup_or_panic(c_name, qname));
             if matches!(f, Fallibility::Fallible) {
                 rs.always = true;
+                rs.reasons.insert(format!("fallible external {c_name}"));
             }
         }
         // `function Foo = Bar(...)` aliases have no body of their own; their
@@ -1319,6 +1502,7 @@ pub fn analyze(hier: &InstanceHierarchy<'_>) -> FallibilityInfo {
             } else if let Some(b) = builtin_fallibility(base)
                 && matches!(b, Fallibility::Fallible) {
                     rs.always = true;
+                    rs.reasons.insert(format!("alias of fallible builtin {base}"));
                 }
         }
         // A body-less function that `extends` a partial base inlines that
@@ -1364,17 +1548,50 @@ pub fn analyze(hier: &InstanceHierarchy<'_>) -> FallibilityInfo {
     // the result is already deterministically ordered by FQN then position.
     let mut matchcontinue_as_match: Vec<String> = Vec::new();
     let mut matchcontinue_as_match_locs: Vec<Absyn::Info> = Vec::new();
+    let mut matchcontinue_guard_hoists: Vec<Vec<GuardHoist>> = Vec::new();
+    let mut mc_report: Vec<String> = Vec::new();
     for (qname, rs) in &resolved {
         for lint in &rs.mc_lints {
             // Skip the final arm: a failure there can't fall through to anything.
             let non_last = lint.arms.len().saturating_sub(1);
-            if lint.arms[..non_last].iter().all(|arm| !sources_fallible(arm, &fallible)) {
-                matchcontinue_as_match.push(format!(
-                    "warning: matchcontinue in `{qname}` ({}:{}:{}) has no fallible arm before its last — rewrite it as `match`",
+            let hoists = lint.guard_hoists.clone().unwrap_or_default();
+            let why = if lint.arms[..non_last].iter().all(|arm| !sources_fallible(arm, &fallible)) {
+                "has no fallible arm before its last"
+            } else if lint.disjoint {
+                "has pairwise disjoint case patterns"
+            } else if lint.guard_hoists.is_some()
+                && !hoists.is_empty()
+                && lint.hoisted[..non_last].iter().all(|arm| !sources_fallible(arm, &fallible))
+            {
+                "only falls through on `true := …` asserts — make them `guard`s"
+            } else {
+                // The arms do carry hoistable `true := …` prefixes, so what
+                // blocks them is the rest of their bodies.
+                let hoistable = lint.guard_hoists.is_some() && !hoists.is_empty();
+                let mut blockers: BTreeSet<String> = BTreeSet::new();
+                let mut n_blocking = 0;
+                for arm in &lint.arms[..non_last] {
+                    if sources_fallible(arm, &fallible) {
+                        n_blocking += 1;
+                        blockers.extend(why_fallible(arm, &fallible));
+                    }
+                }
+                mc_report.push(format!(
+                    "{}:{}:{}\t{qname}\tarms={}\telse={}\tblocking={n_blocking}\thoistable={}\t{}",
                     lint.info.fileName, lint.info.lineNumberStart, lint.info.columnNumberStart,
+                    lint.arms.len(), if lint.has_else { 1 } else { 0 },
+                    if hoistable { 1 } else { 0 },
+                    blockers.into_iter().collect::<Vec<_>>().join(", "),
                 ));
-                matchcontinue_as_match_locs.push(lint.info.clone());
-            }
+                continue;
+            };
+            matchcontinue_as_match.push(format!(
+                "warning: matchcontinue in `{qname}` ({}:{}:{}) {why} — rewrite it as `match`",
+                lint.info.fileName, lint.info.lineNumberStart, lint.info.columnNumberStart,
+            ));
+            matchcontinue_as_match_locs.push(lint.info.clone());
+            matchcontinue_guard_hoists.push(
+                if why.starts_with("only falls through") { hoists } else { Vec::new() });
         }
     }
 
@@ -1384,7 +1601,19 @@ pub fn analyze(hier: &InstanceHierarchy<'_>) -> FallibilityInfo {
         external_functions: external_count,
         matchcontinue_as_match,
         matchcontinue_as_match_locs,
+        matchcontinue_guard_hoists,
+        mc_report,
     }
+}
+
+/// Why is this arm fallible under the current `fallible` set? Diagnostic only.
+fn why_fallible(rs: &ResolvedSources, fallible: &BTreeSet<String>) -> Vec<String> {
+    let mut v: Vec<String> = rs.reasons.iter().cloned().collect();
+    v.extend(rs.edges.iter().filter(|t| fallible.contains(*t)).map(|t| format!("calls {t}")));
+    if rs.mc.iter().any(|mc| !mc_check_is_safe(mc, fallible)) {
+        v.push("nested matchcontinue may fail".to_owned());
+    }
+    v
 }
 
 // ── Source resolution & fixed-point evaluation ───────────────────────────────
@@ -1399,6 +1628,8 @@ struct ResolvedSources {
     /// functions, a fallible registry classification (set by the caller in
     /// [`analyze`]).
     always: bool,
+    /// Labels explaining `always`, for the `--mc-report` diagnostic only.
+    reasons: BTreeSet<String>,
     /// FQNs of user-defined callees; fallible iff any of them is.
     edges: BTreeSet<String>,
     /// Per-`matchcontinue` safety obligations (see [`McCheck`]).
@@ -1419,6 +1650,12 @@ struct ResolvedMcCheck {
 struct ResolvedMcLint {
     info: Absyn::Info,
     arms: Vec<ResolvedSources>,
+    hoisted: Vec<ResolvedSources>,
+    guard_hoists: Option<Vec<GuardHoist>>,
+    has_else: bool,
+    /// The case patterns are pairwise disjoint, which makes the matchcontinue a
+    /// `match` on its own — see [`crate::mc_disjoint`].
+    disjoint: bool,
 }
 
 /// Resolve a [`Walk`]'s raw callee names (recursively through its
@@ -1432,9 +1669,18 @@ fn resolve_walk(
     walks: &BTreeMap<String, Walk>,
 ) -> ResolvedSources {
     let mut rs = ResolvedSources {
-        always: w.has_fail || w.has_match || w.calls_fn_value,
+        always: w.has_fail || w.calls_fn_value,
+        reasons: w.reasons.iter().map(|r| (*r).to_owned()).collect(),
         ..ResolvedSources::default()
     };
+    for keys in &w.match_keys {
+        let resolved: Vec<CoverKey> = keys.iter()
+            .map(|k| resolve_cover_key(k, top_level, caller_qname)).collect();
+        if !cover_keys_exhaustive(&resolved) {
+            rs.always = true;
+            rs.reasons.insert("non-exhaustive `match`".to_owned());
+        }
+    }
     for raw in &w.calls {
         // Resolve user-defined callee first: a user function shadows any
         // same-named builtin (e.g. `exp` inside `Template.TplMain`
@@ -1459,6 +1705,7 @@ fn resolve_walk(
                 // fallible regardless of the underlying C symbol's own
                 // classification. Mark the caller fallible to match.
                 rs.always = true;
+                rs.reasons.insert(format!("ExternalObject constructor {target}"));
                 continue;
             }
             // Resolved to some other non-function node (record/type
@@ -1480,6 +1727,7 @@ fn resolve_walk(
         if let Some(b) = builtin_fallibility(raw).or_else(|| builtin_fallibility(bare)) {
             if matches!(b, Fallibility::Fallible) {
                 rs.always = true;
+                rs.reasons.insert(format!("fallible builtin {bare}"));
             }
             continue;
         }
@@ -1496,7 +1744,10 @@ fn resolve_walk(
     for mc in &w.mc_checks {
         rs.mc.push(ResolvedMcCheck {
             candidates: mc.candidates.iter()
-                .map(|(key, sub)| (*key, resolve_walk(sub, caller_qname, top_level, walks)))
+                .map(|(key, sub)| (
+                    resolve_cover_key(key, top_level, caller_qname),
+                    resolve_walk(sub, caller_qname, top_level, walks),
+                ))
                 .collect(),
         });
     }
@@ -1506,6 +1757,13 @@ fn resolve_walk(
             arms: lint.arms.iter()
                 .map(|sub| resolve_walk(sub, caller_qname, top_level, walks))
                 .collect(),
+            hoisted: lint.hoisted.iter()
+                .map(|sub| resolve_walk(sub, caller_qname, top_level, walks))
+                .collect(),
+            guard_hoists: lint.guard_hoists.clone(),
+            has_else: lint.has_else,
+            disjoint: crate::mc_disjoint::cases_pairwise_disjoint(
+                &lint.cases, &lint.scope, top_level, caller_qname),
         });
     }
     rs
@@ -1532,7 +1790,7 @@ fn sources_fallible(rs: &ResolvedSources, fallible: &BTreeSet<String>) -> bool {
 fn mc_check_is_safe(mc: &ResolvedMcCheck, fallible: &BTreeSet<String>) -> bool {
     let keys: Vec<CoverKey> = mc.candidates.iter()
         .filter(|(_, sub)| !sources_fallible(sub, fallible))
-        .map(|(key, _)| *key)
+        .map(|(key, _)| key.clone())
         .collect();
     cover_keys_exhaustive(&keys)
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/fix.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/fix.rs
@@ -11,6 +11,13 @@
 //! `end matchcontinue` → `end match`). Both rewrites are the same token
 //! edit: a 13-byte `matchcontinue` becomes the 5-byte `match`.
 //!
+//! Some of those `matchcontinue`s first need their arms' leading
+//! `true := COND;` statements turned into `guard COND` (see
+//! [`crate::fallibility::GuardHoist`]) — the same fall-through, expressed as
+//! part of the pattern so `match` performs it too. `COND` is taken verbatim from
+//! the statement's own source span rather than unparsed from the AST, so the
+//! rewrite preserves the author's formatting.
+//!
 //! Every edit is sanity-checked against the source bytes before being applied;
 //! if a file's `match`/`matchcontinue` nesting does not balance (a lexer/source
 //! surprise) the whole file is left untouched and a warning is printed, so a
@@ -19,6 +26,8 @@
 use std::collections::BTreeMap;
 
 use openmodelica_ast::Absyn;
+
+use crate::fallibility::GuardHoist;
 
 /// Keyword token kinds the rewriter tracks. Openers are `match`/`matchcontinue`;
 /// closers are the `match`/`matchcontinue` word of an `end match`/
@@ -233,14 +242,18 @@ pub struct FixStats {
 /// Rewrite every flagged `matchcontinue` (given as its first arm's `Info`) to a
 /// plain `match` in its `.mo` source. Files are read, edited and written once;
 /// a file whose nesting does not balance is left untouched.
-pub fn apply_match_fixes(locs: &[Absyn::Info]) -> std::io::Result<FixStats> {
+pub fn apply_match_fixes(
+    locs: &[Absyn::Info],
+    hoists: &[Vec<GuardHoist>],
+) -> std::io::Result<FixStats> {
     // Group anchors by source file.
-    let mut by_file: BTreeMap<String, Vec<(i32, i32)>> = BTreeMap::new();
-    for info in locs {
+    let mut by_file: BTreeMap<String, Vec<(i32, i32, &[GuardHoist])>> = BTreeMap::new();
+    for (i, info) in locs.iter().enumerate() {
         by_file
             .entry(info.fileName.to_string())
             .or_default()
-            .push((info.lineNumberStart, info.columnNumberStart));
+            .push((info.lineNumberStart, info.columnNumberStart,
+                   hoists.get(i).map(|v| &v[..]).unwrap_or(&[])));
     }
 
     let mut stats = FixStats::default();
@@ -256,10 +269,14 @@ pub fn apply_match_fixes(locs: &[Absyn::Info]) -> std::io::Result<FixStats> {
             }
         };
 
-        // Collect the byte offsets of the `matchcontinue` tokens to rewrite
-        // (opener + matching `end matchcontinue`), deduplicated.
-        let mut edits: Vec<usize> = Vec::new();
-        for &(line, col) in anchors {
+        let lines = LineIndex::new(&src);
+
+        // Collect every byte-range replacement for this file: the two
+        // `matchcontinue` keywords per flagged expression, plus the guard
+        // hoists (an insertion after a pattern, a deletion per statement).
+        let mut edits: Vec<(usize, usize, String)> = Vec::new();
+        let mut rewritten = 0;
+        for &(line, col, hoists) in anchors {
             let Some(r) = enclosing_mc(&regions, line, col) else {
                 eprintln!("[mmtorust --fix] {file}:{line}:{col}: no enclosing matchcontinue found; skipped");
                 stats.skipped += 1;
@@ -273,23 +290,194 @@ pub fn apply_match_fixes(locs: &[Absyn::Info]) -> std::io::Result<FixStats> {
                 stats.skipped += 1;
                 continue;
             }
-            edits.push(r.open_byte);
-            edits.push(r.close_byte);
+            let guard_edits = match guard_edits(&src, &lines, hoists) {
+                Ok(e) => e,
+                Err(e) => {
+                    eprintln!("[mmtorust --fix] {file}:{line}:{col}: {e}; skipped");
+                    stats.skipped += 1;
+                    continue;
+                }
+            };
+            edits.push((r.open_byte, r.open_byte + MATCHCONTINUE.len(), MATCH.to_owned()));
+            edits.push((r.close_byte, r.close_byte + MATCHCONTINUE.len(), MATCH.to_owned()));
+            edits.extend(guard_edits);
+            rewritten += 1;
         }
         if edits.is_empty() {
             continue;
         }
-        edits.sort_unstable();
+        edits.sort_unstable_by_key(|e| e.0);
         edits.dedup();
 
         // Apply from the end so earlier offsets stay valid.
         let mut out = src.clone();
-        for &off in edits.iter().rev() {
-            out.replace_range(off..off + MATCHCONTINUE.len(), MATCH);
+        for (start, end, text) in edits.iter().rev() {
+            out.replace_range(*start..*end, text);
         }
         std::fs::write(file, out)?;
         stats.files_changed += 1;
-        stats.rewritten += edits.len() / 2;
+        stats.rewritten += rewritten;
     }
     Ok(stats)
+}
+
+/// Byte offsets of each line start, for turning a `SourceInfo`'s 1-based
+/// line/column into a byte offset.
+struct LineIndex {
+    starts: Vec<usize>,
+}
+
+impl LineIndex {
+    fn new(src: &str) -> Self {
+        let mut starts = vec![0usize];
+        starts.extend(src.match_indices('\n').map(|(i, _)| i + 1));
+        LineIndex { starts }
+    }
+
+    /// Offset of the character at 1-based `line`/`col`.
+    fn offset(&self, line: i32, col: i32) -> Option<usize> {
+        let start = *self.starts.get((line as usize).checked_sub(1)?)?;
+        Some(start + (col as usize).checked_sub(1)?)
+    }
+}
+
+/// Turn one flagged `matchcontinue`'s [`GuardHoist`]s into byte-range edits:
+/// the `guard` insertion after each arm's pattern, and the deletion of the
+/// `true := COND;` statements it came from.
+fn guard_edits(
+    src: &str,
+    lines: &LineIndex,
+    hoists: &[GuardHoist],
+) -> Result<Vec<(usize, usize, String)>, String> {
+    let mut edits = Vec::new();
+    for h in hoists {
+        let mut conds: Vec<String> = Vec::new();
+        for (info, asserted) in &h.stmts {
+            let start = lines.offset(info.lineNumberStart, info.columnNumberStart)
+                .ok_or("statement start out of range")?;
+            // `columnNumberEnd` addresses the statement's last character.
+            let end = lines.offset(info.lineNumberEnd, info.columnNumberEnd)
+                .map(|o| o + 1)
+                .filter(|o| *o <= src.len())
+                .ok_or("statement end out of range")?;
+            let stmt = src.get(start..end).ok_or("statement span is not a char boundary")?;
+            let cond = stmt
+                .strip_suffix(';').unwrap_or(stmt)
+                .split_once(":=").ok_or_else(|| format!("not an assignment: {stmt:?}"))?
+                .1.trim();
+            if cond.is_empty() {
+                return Err(format!("empty condition in {stmt:?}"));
+            }
+            // A `//` comment inside the condition would swallow the rest of the
+            // line once the text moves onto the `case` line.
+            if cond.contains("//") || cond.contains("/*") {
+                return Err(format!("condition carries a comment: {cond:?}"));
+            }
+            // `not` binds tighter than `and`, and a lone condition needs no
+            // bracket at all, so parenthesise only what would otherwise regroup.
+            let bracketed = if is_atom(cond) { cond.to_owned() } else { format!("({cond})") };
+            conds.push(if *asserted {
+                if h.stmts.len() == 1 { cond.to_owned() } else { bracketed }
+            } else {
+                format!("not {bracketed}")
+            });
+            // Swallow the rest of the line when the statement is alone on it, so
+            // deleting it does not leave a blank line behind.
+            let mut cut = end;
+            while src.as_bytes().get(cut) == Some(&b' ') || src.as_bytes().get(cut) == Some(&b'\t') {
+                cut += 1;
+            }
+            if src.as_bytes().get(cut) == Some(&b'\n') {
+                let mut line_start = start;
+                while line_start > 0 && src.as_bytes()[line_start - 1] != b'\n' {
+                    line_start -= 1;
+                }
+                if src[line_start..start].trim().is_empty() {
+                    edits.push((line_start, cut + 1, String::new()));
+                    continue;
+                }
+            }
+            edits.push((start, cut, String::new()));
+        }
+        // A `SourceInfo`'s end column addresses the token *after* the span, so
+        // back up over the whitespace to land right behind the pattern text.
+        let after = lines.offset(h.pattern_info.lineNumberEnd, h.pattern_info.columnNumberEnd)
+            .filter(|o| *o <= src.len())
+            .ok_or("pattern end out of range")?;
+        let mut at = after;
+        while at > 0 && src.as_bytes()[at - 1].is_ascii_whitespace() {
+            at -= 1;
+        }
+        // Landing behind a comment would bury the guard inside it.
+        let line_start = src[..at].rfind('\n').map_or(0, |i| i + 1);
+        if src[line_start..at].contains("//") || src[..at].ends_with("*/") {
+            return Err("pattern is followed by a comment".to_owned());
+        }
+        let mut guard = (at, at, format!(" guard {}", conds.join(" and ")));
+        if h.drops_section {
+            // Every statement went into the guard; drop the now-empty
+            // `algorithm` keyword (and its line, if it has one to itself).
+            let rest = src.get(after..).ok_or("pattern end is not a char boundary")?;
+            let off = after + rest.find("algorithm").ok_or("no `algorithm` keyword after the pattern")?;
+            let mut end = off + "algorithm".len();
+            while matches!(src.as_bytes().get(end), Some(b' ' | b'\t')) {
+                end += 1;
+            }
+            let kw_line_start = src[..off].rfind('\n').map_or(0, |i| i + 1);
+            if src.as_bytes().get(end) == Some(&b'\n') && src[kw_line_start..off].trim().is_empty() {
+                edits.push((kw_line_start, end + 1, String::new()));
+            } else {
+                // The keyword shares the pattern's line: fold it into the guard
+                // insertion, which also eats the space that preceded it.
+                guard.1 = end;
+            }
+        }
+        edits.push(guard);
+    }
+    Ok(edits)
+}
+
+/// Does `cond` bind tightly enough to sit under `not` / beside `and` unbracketed?
+/// True for a name, a literal, a parenthesised expression, and a single call —
+/// anything whose text cannot be regrouped by a surrounding operator.
+fn is_atom(cond: &str) -> bool {
+    let b = cond.as_bytes();
+    let mut i = 0;
+    if b.first().is_some_and(|c| c.is_ascii_digit() || *c == b'"') {
+        // A number or string literal, provided it is the whole condition.
+        return !cond[1..].contains(|c: char| c.is_whitespace());
+    }
+    if b.first().is_some_and(|c| is_ident_start(*c)) {
+        while i < b.len() && (is_ident_cont(b[i]) || b[i] == b'.') {
+            i += 1;
+        }
+        if i == b.len() {
+            return true;
+        }
+    } else if b.first() != Some(&b'(') {
+        return false;
+    }
+    // A trailing (or leading) parenthesised group must close exactly at the end.
+    if b.get(i) != Some(&b'(') {
+        return false;
+    }
+    let mut depth = 0usize;
+    let mut in_str = false;
+    while i < b.len() {
+        match b[i] {
+            b'"' if !in_str => in_str = true,
+            b'"' => in_str = false,
+            b'\\' if in_str => i += 1,
+            b'(' if !in_str => depth += 1,
+            b')' if !in_str => {
+                depth -= 1;
+                if depth == 0 {
+                    return i + 1 == b.len();
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    false
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/main.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/main.rs
@@ -15,11 +15,12 @@ mod validate;
 mod dep_analysis;
 mod unused_functions;
 mod const_patterns;
+mod mc_disjoint;
 mod mutable_cycles;
 mod scripting_api_qt;
 use rayon::prelude::*;
 
-fn start_compilation(results: Vec<Absyn::Program>, fix: bool) {
+fn start_compilation(results: Vec<Absyn::Program>, fix: bool, mc_report_path: Option<String>) {
     let mut failures = 0;
     let t0 = std::time::Instant::now();
     let mut all_classes: Vec<MM::Class> = Vec::new();
@@ -91,6 +92,15 @@ fn start_compilation(results: Vec<Absyn::Program>, fix: bool) {
     for w in &info.matchcontinue_as_match {
         eprintln!("{w}");
     }
+    // `--mc-report <file>`: dump one line per matchcontinue the lint could not
+    // clear, with the arm that blocks it and why (see `fallibility::mc_report`).
+    if let Some(path) = mc_report_path {
+        match std::fs::write(&path, info.mc_report.join("\n") + "\n") {
+            Ok(()) => println!("--mc-report: wrote {} line(s) to {path}", info.mc_report.len()),
+            Err(e) => eprintln!("--mc-report: {path}: {e}"),
+        }
+        if !fix { return; }
+    }
     if !info.matchcontinue_as_match.is_empty() {
         println!(
             "Fallibility analysis: {} matchcontinue expression(s) could be rewritten as `match`",
@@ -102,7 +112,7 @@ fn start_compilation(results: Vec<Absyn::Program>, fix: bool) {
     // the MetaModelica sources and stop (no code generation). The user then
     // verifies the rewrites by rebuilding the boot compiler / running tests.
     if fix {
-        match fix::apply_match_fixes(&info.matchcontinue_as_match_locs) {
+        match fix::apply_match_fixes(&info.matchcontinue_as_match_locs, &info.matchcontinue_guard_hoists) {
             Ok(s) => println!(
                 "--fix: rewrote {} matchcontinue → match across {} file(s); {} skipped",
                 s.rewritten, s.files_changed, s.skipped,
@@ -414,6 +424,10 @@ fn main() {
     // `--fix` rewrites provably-safe `matchcontinue`s to `match` in the sources
     // (see `crate::fix`) instead of generating code.
     let fix = args.iter().any(|a| a == "--fix");
+    let mc_report_path: Option<String> = args.iter()
+        .position(|a| a == "--mc-report")
+        .and_then(|i| args.get(i + 1))
+        .cloned();
     // `--sources <file>` reads the list of MetaModelica files to transpile from
     // `<file>` instead of the default `compilerSources.txt`. This is how the
     // build transpiles only the subset needed to build the Susan binary
@@ -488,6 +502,6 @@ fn main() {
         Some("unused-functions") => run_unused_functions(parsed),
         Some("const-patterns") => run_const_patterns(parsed),
         Some("mutable-cycles") => run_mutable_cycles(parsed),
-        _ => start_compilation(parsed, fix),
+        _ => start_compilation(parsed, fix, mc_report_path),
     }
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/mc_disjoint.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/mc_disjoint.rs
@@ -1,0 +1,164 @@
+//! "This `matchcontinue` is a `match`", decided from the patterns alone.
+//!
+//! When no two case patterns can match the same value, an arm's fall-through
+//! can never reach an arm that matches, so the construct fails as a whole —
+//! exactly what `match` does, whatever the arms call. That makes this check
+//! complementary to the fallibility-based one in [`crate::fallibility`].
+//!
+//! [`pats_disjoint`] mirrors `Patternm.patternsDoNotOverlap`, which the
+//! frontend already applies over the elaborated `DAE.Pattern`. Anything
+//! unrecognised is reported as overlapping.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use openmodelica_ast::Absyn;
+
+use crate::fallibility::{absyn_pat_is_irrefutable, collect_local_decl_names, cref_to_dotted};
+use crate::hierarchy::NameNode;
+use crate::typedexp::resolve_call_node;
+
+/// Are the case patterns of a `matchcontinue` pairwise disjoint? `scope` is the
+/// binding scope shared by every case (function components plus the match's own
+/// `local` declarations); each case's own `local`s are layered on per case.
+pub(crate) fn cases_pairwise_disjoint(
+    cases: &metamodelica::List<Arc<Absyn::Case>>,
+    scope: &BTreeSet<String>,
+    top_level: &BTreeMap<String, NameNode<'_>>,
+    caller_qname: &str,
+) -> bool {
+    let mut pats: Vec<(Arc<Absyn::Exp>, BTreeSet<String>)> = Vec::new();
+    for case in cases {
+        match &**case {
+            // `else` matches everything, so it overlaps every other case.
+            Absyn::Case::ELSE { .. } => return false,
+            Absyn::Case::CASE { pattern, localDecls, .. } => {
+                let mut s = scope.clone();
+                collect_local_decl_names(localDecls, &mut s);
+                pats.push((pattern.clone(), s));
+            }
+        }
+    }
+    // A single case is the fallibility lint's business (a lone arm has nothing
+    // to fall through to); reporting it here too would duplicate the warning.
+    if pats.len() < 2 {
+        return false;
+    }
+    for (i, (p1, s1)) in pats.iter().enumerate() {
+        for (p2, s2) in &pats[i + 1..] {
+            if !pats_disjoint(p1, p2, s1, s2, top_level, caller_qname) {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Can no value match both patterns? Conservative: `false` whenever the shapes
+/// do not prove disjointness.
+fn pats_disjoint(
+    p1: &Absyn::Exp,
+    p2: &Absyn::Exp,
+    s1: &BTreeSet<String>,
+    s2: &BTreeSet<String>,
+    top_level: &BTreeMap<String, NameNode<'_>>,
+    caller_qname: &str,
+) -> bool {
+    use Absyn::Exp::*;
+    // `id as pat` matches whatever `pat` matches.
+    if let AS { exp, .. } = p1 {
+        return pats_disjoint(exp, p2, s1, s2, top_level, caller_qname);
+    }
+    if let AS { exp, .. } = p2 {
+        return pats_disjoint(p1, exp, s1, s2, top_level, caller_qname);
+    }
+    if absyn_pat_is_irrefutable(p1, s1) || absyn_pat_is_irrefutable(p2, s2) {
+        return false;
+    }
+    let elems = |e: &Absyn::Exp| -> Option<Vec<Arc<Absyn::Exp>>> {
+        match e {
+            ARRAY { arrayExp } => Some((&**arrayExp).into_iter().cloned().collect()),
+            LIST { exps } => Some((&**exps).into_iter().cloned().collect()),
+            _ => None,
+        }
+    };
+    match (p1, p2) {
+        (CONS { head: h1, rest: r1 }, CONS { head: h2, rest: r2 }) =>
+            pats_disjoint(h1, h2, s1, s2, top_level, caller_qname)
+                || pats_disjoint(r1, r2, s1, s2, top_level, caller_qname),
+        (TUPLE { expressions: e1 }, TUPLE { expressions: e2 }) => {
+            let v1: Vec<&Arc<Absyn::Exp>> = (&**e1).into_iter().collect();
+            let v2: Vec<&Arc<Absyn::Exp>> = (&**e2).into_iter().collect();
+            v1.len() == v2.len()
+                && v1.iter().zip(&v2).any(|(a, b)| pats_disjoint(a, b, s1, s2, top_level, caller_qname))
+        }
+        (CALL { function_: f1, functionArgs: a1, .. }, CALL { function_: f2, functionArgs: a2, .. }) => {
+            let n1 = cref_to_dotted(f1);
+            let n2 = cref_to_dotted(f2);
+            if !same_constructor(&n1, &n2, top_level, caller_qname) {
+                return true;
+            }
+            let (Absyn::FunctionArgs::FUNCTIONARGS { args: args1, argNames: names1 },
+                 Absyn::FunctionArgs::FUNCTIONARGS { args: args2, argNames: names2 }) = (&**a1, &**a2)
+                else { return false };
+            // Named-field patterns list a subset of the fields, so a positional
+            // comparison would pair up unrelated fields; compare field by name.
+            let v1: Vec<&Arc<Absyn::Exp>> = (&**args1).into_iter().collect();
+            let v2: Vec<&Arc<Absyn::Exp>> = (&**args2).into_iter().collect();
+            let named1: BTreeMap<&str, &Arc<Absyn::Exp>> =
+                (&**names1).into_iter().map(|n| (&*n.argName, &n.argValue)).collect();
+            let named2: BTreeMap<&str, &Arc<Absyn::Exp>> =
+                (&**names2).into_iter().map(|n| (&*n.argName, &n.argValue)).collect();
+            (v1.len() == v2.len()
+                && v1.iter().zip(&v2).any(|(a, b)| pats_disjoint(a, b, s1, s2, top_level, caller_qname)))
+                || named1.iter().any(|(k, a)| named2.get(k)
+                    .is_some_and(|b| pats_disjoint(a, b, s1, s2, top_level, caller_qname)))
+        }
+        (INTEGER { value: v1 }, INTEGER { value: v2 }) => v1 != v2,
+        (BOOL { value: v1 }, BOOL { value: v2 }) => v1 != v2,
+        (STRING { value: v1 }, STRING { value: v2 }) => v1 != v2,
+        (REAL { value: v1 }, REAL { value: v2 }) => v1 != v2,
+        _ => match (elems(p1), elems(p2)) {
+            // Two list literals: disjoint on differing length, else element-wise.
+            (Some(l1), Some(l2)) => l1.len() != l2.len()
+                || l1.iter().zip(&l2).any(|(a, b)| pats_disjoint(a, b, s1, s2, top_level, caller_qname)),
+            // `{}` matches only the empty list, which no `_ :: _` matches.
+            (Some(l1), None) => l1.is_empty() && matches!(p2, CONS { .. }),
+            (None, Some(l2)) => l2.is_empty() && matches!(p1, CONS { .. }),
+            (None, None) => is_literal(p1) != is_literal(p2),
+        },
+    }
+}
+
+/// A constant pattern. Two unequal constants are handled above; a constant and a
+/// structural pattern can never match the same value (mirrors the
+/// `PAT_CONSTANT` arms of `Patternm.patternsDoNotOverlap`).
+fn is_literal(e: &Absyn::Exp) -> bool {
+    matches!(e, Absyn::Exp::INTEGER { .. } | Absyn::Exp::REAL { .. }
+        | Absyn::Exp::STRING { .. } | Absyn::Exp::BOOL { .. })
+}
+
+/// Do two constructor names in pattern position denote the same constructor?
+/// Names are compared after resolution, so `DAE.CREF` and an imported `CREF`
+/// are recognised as one. An unresolvable name is assumed to be the same
+/// constructor as anything it is compared against, which keeps the enclosing
+/// patterns "overlapping".
+fn same_constructor(
+    n1: &str,
+    n2: &str,
+    top_level: &BTreeMap<String, NameNode<'_>>,
+    caller_qname: &str,
+) -> bool {
+    if n1 == n2 {
+        return true;
+    }
+    // `NONE`/`SOME` are builtins with no hierarchy node.
+    let builtin = |n: &str| matches!(n.rsplit('.').next().unwrap_or(n), "NONE" | "SOME");
+    if builtin(n1) || builtin(n2) {
+        return n1.rsplit('.').next() == n2.rsplit('.').next();
+    }
+    match (resolve_call_node(n1, top_level, caller_qname), resolve_call_node(n2, top_level, caller_qname)) {
+        (Some((q1, _)), Some((q2, _))) => q1 == q2,
+        _ => true,
+    }
+}

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJitFunctions.rs
@@ -996,7 +996,7 @@ pub(crate) fn reset_declined_externals() {
 
 pub(crate) fn note_declined_external(f: &SimCodeFunction::Function::Function, why: String) {
     let SimCodeFunction::Function::Function::EXTERNAL_FUNCTION { name, .. } = f else { return };
-    let Ok(ident) = AbsynUtil::pathLastIdent(name.clone()) else { return };
+    let ident = AbsynUtil::pathLastIdent(name.clone());
     DECLINED_EXTERNALS.with(|d| d.borrow_mut().insert(ident.to_string(), why));
 }
 
@@ -8171,7 +8171,7 @@ fn operand_sigty(e1: &DAE::Exp, e2: &DAE::Exp) -> Result<SigTy> {
 /// which matters where the frontend left the call itself untyped.
 fn identity_builtin_arg(exp: &DAE::Exp) -> Option<Arc<DAE::Exp>> {
     let DAE::Exp::CALL { path, expLst, .. } = exp else { return None };
-    let name = AbsynUtil::pathLastIdent(path.clone()).ok()?;
+    let name = AbsynUtil::pathLastIdent(path.clone());
     let args: Vec<&Arc<DAE::Exp>> = (&**expLst).into_iter().collect();
     match (name.as_str(), args.len()) {
         ("smooth", 2) => Some(args[1].clone()),
@@ -8896,7 +8896,7 @@ fn compile_call(
         return Ok(vec![rty]);
     }
     // Otherwise it must be a (builtin) math/string function.
-    let name = AbsynUtil::pathLastIdent(Arc::new(path.clone()))?.to_string();
+    let name = AbsynUtil::pathLastIdent(Arc::new(path.clone())).to_string();
     // `print(s)`: write the String to the model's stdout via the host `rt_print`.
     // A void procedure, so it yields no result; the owned handle is released after.
     if name == "print" {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend/src/Globals.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_frontend/src/Globals.rs
@@ -34,7 +34,7 @@ thread_local! {
         RefCell::new(openmodelica_util::BaseHashTable::emptyHashTableWork(
             openmodelica_util::Flags::getConfigInt(openmodelica_util::Flags::INST_CACHE_SIZE.clone()).unwrap_or(25343),
             (
-                (Arc::new(AbsynUtil::pathHash) as Arc<dyn ::std::ops::Fn(Arc<Absyn::Path>) -> metamodelica::Result<i32> + 'static>),
+                (Arc::new(metamodelica::fnptr!(AbsynUtil::pathHash, Arc<Absyn::Path>)) as Arc<dyn ::std::ops::Fn(Arc<Absyn::Path>) -> metamodelica::Result<i32> + 'static>),
                 (Arc::new(metamodelica::fnptr!(AbsynUtil::pathEqual, Arc<Absyn::Path>, Arc<Absyn::Path>)) as Arc<dyn ::std::ops::Fn(Arc<Absyn::Path>, Arc<Absyn::Path>) -> metamodelica::Result<bool> + 'static>),
                 (Arc::new(AbsynUtil::pathStringDefault) as Arc<dyn ::std::ops::Fn(Arc<Absyn::Path>) -> metamodelica::Result<ArcStr> + 'static>),
                 // `opaqVal` in InstHashTable is a private helper returning the

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/GCExt.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_util_datatypes_basic/src/GCExt.rs
@@ -58,7 +58,7 @@ pub fn getProfStats() -> ProfStats {
 
 // `profStatsStr` calls `intString` to format each field. `intString` is
 // infallible and now returns `ArcStr` directly (no `.unwrap()` needed).
-pub fn profStatsStr(stats: ProfStats, head: ArcStr, delimiter: ArcStr) -> Result<ArcStr> {
+pub fn profStatsStr(stats: ProfStats, head: ArcStr, delimiter: ArcStr) -> ArcStr {
     let s: ArcStr = (match stats.clone() {
         PROFSTATS { .. } => { let mut __mm_s = String::new();
             __mm_s.push_str(&*head);
@@ -97,7 +97,7 @@ pub fn profStatsStr(stats: ProfStats, head: ArcStr, delimiter: ArcStr) -> Result
             __mm_s.push_str(&*intString(stats.reclaimed_bytes_before_gc.clone()));
             ArcStr::from(__mm_s) },
     });
-    Ok(s)
+    s
 }
 
 pub fn setForceUnmapOnGcollect(forceUnmap: bool) {}

--- a/OMCompiler/Compiler/Script/Binding.mo
+++ b/OMCompiler/Compiler/Script/Binding.mo
@@ -249,7 +249,7 @@ input Ident typeName;
 input String pathInProg;
 output List<tuple<SCode.Element, String>> res_elem;
 algorithm
-  res_elem := matchcontinue el
+  res_elem := match el
   local
     list<SCode.Element> elist;
     String name, nName;
@@ -269,9 +269,8 @@ algorithm
       algorithm
       nName := if(pathInProg=="")then name else pathInProg+"."+name;
       then getAllElementsOfType(elist, typeName, nName, {});
-    case SCode.CLASS(_, _, _, _, _, SCode.PARTS(elist, _,_,_,_,_,_,_), _, _)
+    case SCode.CLASS(_, _, _, _, _, SCode.PARTS(elist, _,_,_,_,_,_,_), _, _) guard isOfType(elist, typeName)
       algorithm
-        true := isOfType(elist, typeName);
       print ("*** Found a " + typeName + "\n");
       then {(el,pathInProg)};
     case _
@@ -279,7 +278,7 @@ algorithm
        //print("not of right type " + typeName + "\n");
        //print(SCodeDump.unparseElementStr(el) + "\n");
       then {};
-   end matchcontinue;
+   end match;
 end getAllElementsOfType2;
 
 
@@ -1454,19 +1453,17 @@ output Boolean result;
 output Option<SCode.Mod> mods;
   algorithm
 
-  (result, mods) := matchcontinue elems
+  (result, mods) := match elems
    local
      list<SCode.Element> rest;
      SCode.Mod mod;
      String tName;
     case {} then (false, NONE());
-    case SCode.EXTENDS(Absyn.IDENT(tName), _, mod, _, _)::_
-      algorithm
-        true := (tName == typeName);
+    case SCode.EXTENDS(Absyn.IDENT(tName), _, mod, _, _)::_ guard (tName == typeName)
         then (true, SOME(mod));
     case _::rest
         then extendsType(rest, typeName);
-   end matchcontinue;
+   end match;
 end extendsType;
 
 protected function getValue

--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -2854,18 +2854,16 @@ protected function getChangedClass
   input String suffix;
   output String name;
 algorithm
-  name := matchcontinue elt
+  name := match elt
     local
       String fileName;
-    case SCode.CLASS(name=name,info=SOURCEINFO())
-      algorithm
-        false := System.regularFileExists(name + suffix);
+    case SCode.CLASS(name=name,info=SOURCEINFO()) guard not System.regularFileExists(name + suffix)
       then name;
     case SCode.CLASS(name=name,info=SOURCEINFO(fileName=fileName))
       algorithm
         true := System.fileIsNewerThan(fileName, name + suffix);
       then name;
-  end matchcontinue;
+  end match;
 end getChangedClass;
 
 protected function isChanged

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -6937,25 +6937,8 @@ protected function applyRewriteRulesOnBackend
   input BackendDAE.BackendDAE inBackendDAE;
   output BackendDAE.BackendDAE outBackendDAE;
 algorithm
-  outBackendDAE := matchcontinue inBackendDAE
-    local
-
-    // no rewrites!
-    case _
-      algorithm
-        true := RewriteRules.noRewriteRulesBackEnd();
-      then
-        inBackendDAE;
-
-    // some rewrites
-    case _
-      algorithm
-        false := RewriteRules.noRewriteRulesBackEnd();
-        outBackendDAE := BackendDAEOptimize.applyRewriteRulesBackend(inBackendDAE);
-      then
-        outBackendDAE;
-
-  end matchcontinue;
+  outBackendDAE := if RewriteRules.noRewriteRulesBackEnd() then inBackendDAE
+                   else BackendDAEOptimize.applyRewriteRulesBackend(inBackendDAE);
 end applyRewriteRulesOnBackend;
 
 protected function getClassnamesInClassList

--- a/OMCompiler/Compiler/Script/Figaro.mo
+++ b/OMCompiler/Compiler/Script/Figaro.mo
@@ -863,22 +863,19 @@ protected function removeTokens
   input list<Token> inTokenList;
   output list<Token> outTokenList;
 algorithm
-  outTokenList := matchcontinue inTokenList
+  outTokenList := match inTokenList
     local
       Token first;
       list<Token> rest, r;
       String tn;
     case {}
       then {};
-    case OPENTAG(tagName = tn) :: rest
+    case OPENTAG(tagName = tn) :: rest guard isKnownTag(tn) and not isInfoTag(tn)
       algorithm
-        true := isKnownTag(tn);
-        false := isInfoTag(tn);
         r := removeFirstIfText(rest);
       then OPENTAG(tn) :: removeTokens(r);
-    case OPENTAG(tagName = tn) :: rest
+    case OPENTAG(tagName = tn) :: rest guard not isKnownTag(tn)
       algorithm
-        false := isKnownTag(tn);
         r := removeUnknown(rest, tn);
       then removeTokens(r);
     case CLOSETAG(tagName = tn) :: rest
@@ -887,7 +884,7 @@ algorithm
       then CLOSETAG(tn) :: removeTokens(r);
     case first :: rest
       then first :: removeTokens(rest);
-  end matchcontinue;
+  end match;
 end removeTokens;
 
 protected function removeFirstIfText
@@ -909,19 +906,17 @@ protected function removeUnknown "Removes tokens until the closing tag is found.
   input String inTagName;
   output list<Token> outTokenList;
 algorithm
-  outTokenList := matchcontinue inTokenList
+  outTokenList := match inTokenList
     local
       String tn;
       list<Token> rest;
     case {}
       then {};
-    case CLOSETAG(tagName = tn) :: rest
-      algorithm
-        true := tn == inTagName;
+    case CLOSETAG(tagName = tn) :: rest guard tn == inTagName
       then removeFirstIfText(rest);
     case _ :: rest
       then removeUnknown(rest, inTagName);
-  end matchcontinue;
+  end match;
 end removeUnknown;
 
 protected function isKnownTag "Answers whether the tag contributes to the tree structure we want to
@@ -1081,36 +1076,32 @@ protected function isToBeReported "Answers whether an error should be reported."
 protected
   list<String> errorsToReport = {"FATAL" /*, "MAJOR" */} "list of errors we are interested in";
 algorithm
-  outBoolean := matchcontinue inStringTupleList
+  outBoolean := match inStringTupleList
     local
       String k, v;
       list<tuple<String, String>> rest;
     case {}
       then false;
-    case (k, v) :: _
-      algorithm
-        true := k == "CRITICITY";
+    case (k, v) :: _ guard k == "CRITICITY"
       then listMember(v, errorsToReport);
     case _ :: rest
       then isToBeReported(rest);
-  end matchcontinue;
+  end match;
 end isToBeReported;
 
 protected function getMessage "Retrieves the error message."
   input list<tuple<String, String>> inStringTupleList;
   output String outString;
 algorithm
-  outString := matchcontinue inStringTupleList
+  outString := match inStringTupleList
     local
       String k, v;
       list<tuple<String, String>> rest;
-    case (k, v) :: _
-      algorithm
-        true := k == "LABEL";
+    case (k, v) :: _ guard k == "LABEL"
       then v;
     case _ :: rest
       then getMessage(rest);
-  end matchcontinue;
+  end match;
 end getMessage;
 
 protected function reportErrors "Reports Figaro errors one by one."
@@ -1138,7 +1129,7 @@ end reportErrors;
 protected function printFigaroClassList
   input list<FigaroClass> inFigaroClassList;
 algorithm
-  () := matchcontinue inFigaroClassList
+  () := match inFigaroClassList
     local
       FigaroClass first;
       list<FigaroClass> rest;
@@ -1153,7 +1144,7 @@ algorithm
       algorithm
         printFigaroClassList(rest);
       then ();
-  end matchcontinue;
+  end match;
 end printFigaroClassList;
 
 protected function printFigaroClass
@@ -1173,7 +1164,7 @@ end printFigaroClass;
 protected function printFigaroObjectList
   input list<FigaroObject> inFigaroObjectList;
 algorithm
-  () := matchcontinue inFigaroObjectList
+  () := match inFigaroObjectList
     local
       FigaroObject first;
       list<FigaroObject> rest;
@@ -1188,13 +1179,13 @@ algorithm
       algorithm
         printFigaroObjectList(rest);
       then ();
-  end matchcontinue;
+  end match;
 end printFigaroObjectList;
 
 protected function printTokenList
   input list<Token> inTokenList;
 algorithm
-  () := matchcontinue inTokenList
+  () := match inTokenList
     local
       Token first;
       list<Token> rest;
@@ -1210,7 +1201,7 @@ algorithm
       algorithm
         printTokenList(rest);
       then ();
-  end matchcontinue;
+  end match;
 end printTokenList;
 
 protected function printToken

--- a/OMCompiler/Compiler/Script/Refactor.mo
+++ b/OMCompiler/Compiler/Script/Refactor.mo
@@ -2046,18 +2046,11 @@ protected function setDefaultFillColor "
   output list<Absyn.ElementArg> oList;
   output list<Absyn.ElementArg> tList;
 algorithm
-  (oList,tList)  := matchcontinue (oldList,transformedList)
-    local
-      list<Absyn.ElementArg> oLst,tLst;
-
-    case(oLst,tLst)
-      algorithm
-        false := isFillColorInList(listAppend(oLst,tLst));
-        tLst := Absyn.MODIFICATION(false,Absyn.NON_EACH(),Absyn.IDENT("fillColor"), SOME(Absyn.CLASSMOD({},Absyn.EQMOD(Absyn.INTEGER(3),Absyn.dummyInfo))),NONE(),Absyn.dummyInfo)::tLst;
-      then (oLst,tLst);
-
-    else (oldList,transformedList);
-  end matchcontinue;
+  oList := oldList;
+  tList := transformedList;
+  if not isFillColorInList(listAppend(oldList,transformedList)) then
+    tList := Absyn.MODIFICATION(false,Absyn.NON_EACH(),Absyn.IDENT("fillColor"), SOME(Absyn.CLASSMOD({},Absyn.EQMOD(Absyn.INTEGER(3),Absyn.dummyInfo))),NONE(),Absyn.dummyInfo)::tList;
+  end if;
 end setDefaultFillColor;
 
 protected function isFillColorInList "

--- a/OMCompiler/Compiler/Script/RewriteRules.mo
+++ b/OMCompiler/Compiler/Script/RewriteRules.mo
@@ -916,28 +916,24 @@ protected function expEqual
   input DAE.Exp e2;
   output Boolean isEqual;
 algorithm
-  isEqual := matchcontinue(e1, e2)
+  isEqual := match(e1, e2)
     local
       Integer i;
       Real r;
 
     // we need additional rules here for int/real
-    case (DAE.ICONST(i), DAE.RCONST(r))
-      algorithm
-        true := realEq(intReal(i), r);
+    case (DAE.ICONST(i), DAE.RCONST(r)) guard realEq(intReal(i), r)
       then
         true;
 
-    case (DAE.RCONST(r), DAE.ICONST(i))
-      algorithm
-        true := realEq(intReal(i), r);
+    case (DAE.RCONST(r), DAE.ICONST(i)) guard realEq(intReal(i), r)
       then
         true;
 
     // all others forward to expEqual
     else ExpressionBasics.expEqual(e1, e2);
 
-  end matchcontinue;
+  end match;
 end expEqual;
 
 protected function operatorMatches

--- a/OMCompiler/Compiler/Template/TplAbsyn.mo
+++ b/OMCompiler/Compiler/Template/TplAbsyn.mo
@@ -4880,15 +4880,12 @@ public function usedInImmediateLetScope
   output Boolean outIsUsed;
 algorithm
   outIsUsed
-  := matchcontinue inScopeEnv
+  := match inScopeEnv
     local
       Ident letIdent, freshIdent;
       ScopeEnv restEnv;
 
-    case LET_SCOPE(ident = letIdent, freshIdent = freshIdent) :: _
-      algorithm
-        true := stringEq(inIdent, letIdent);
-        true := stringEq(inFreshIdent, freshIdent);
+    case LET_SCOPE(ident = letIdent, freshIdent = freshIdent) :: _ guard stringEq(inIdent, letIdent) and stringEq(inFreshIdent, freshIdent)
       then
         true;
 
@@ -4898,10 +4895,7 @@ algorithm
       then
         usedInImmediateLetScope(inIdent, inFreshIdent, restEnv);
 
-    case RECURSIVE_SCOPE(recIdent = letIdent, freshIdent = freshIdent) :: _
-      algorithm
-        true := stringEq(inIdent, letIdent);
-        true := stringEq(inFreshIdent, freshIdent);
+    case RECURSIVE_SCOPE(recIdent = letIdent, freshIdent = freshIdent) :: _ guard stringEq(inIdent, letIdent) and stringEq(inFreshIdent, freshIdent)
       then
         true;
 
@@ -4913,7 +4907,7 @@ algorithm
 
     else false;
 
-  end matchcontinue;
+  end match;
 end usedInImmediateLetScope;
 
 
@@ -5804,16 +5798,14 @@ It assumes the input types are deAliasedType-ed.
   input list<ASTDef> inASTDefs;
 
 algorithm
-  ():= matchcontinue(inTypeA, inTypeB, inASTDefs)
+  ():= match(inTypeA, inTypeB, inASTDefs)
     local
       TypeSignature tyA, tyB;
       PathIdent na, nb;
       list<ASTDef> astDefs;
 
     //named types
-    case ( NAMED_TYPE(name = na), NAMED_TYPE(name = nb), _ )
-      algorithm
-        true := valueEq(na, nb);
+    case ( NAMED_TYPE(name = na), NAMED_TYPE(name = nb), _ ) guard valueEq(na, nb)
       then
         ();
 
@@ -5825,7 +5817,7 @@ algorithm
       then
         ();
 
-  end matchcontinue;
+  end match;
 end typesEqualConcrete;
 
 
@@ -6003,7 +5995,7 @@ public function checkPackageOpt
   input PathIdent inPackage;
   input Option<PathIdent> inPackageOpt;
 algorithm
-  () := matchcontinue (inPackage, inPackageOpt)
+  () := match (inPackage, inPackageOpt)
     local
       PathIdent path, pckgpath;
 
@@ -6011,9 +6003,7 @@ algorithm
       then
         ();
 
-    case ( path, SOME(pckgpath) )
-      algorithm
-        true := valueEq(path, pckgpath);
+    case ( path, SOME(pckgpath) ) guard valueEq(path, pckgpath)
       then
         ();
 
@@ -6023,7 +6013,7 @@ algorithm
       then
         fail();
 
-  end matchcontinue;
+  end match;
 end checkPackageOpt;
 
 
@@ -6416,19 +6406,17 @@ protected function lookupTupleList
   replaceable type Type_a subtypeof Any;
   replaceable type Type_b subtypeof Any;
 algorithm
-  outItemB := matchcontinue(inList, inItemA)
+  outItemB := match(inList, inItemA)
     local
        Type_a a, itemA;
        Type_b itemB;
        list<tuple<Type_a,Type_b>> rest;
 
-    case ( (a, itemB) :: _, itemA )
-      algorithm
-        true := valueEq(a, itemA);
+    case ( (a, itemB) :: _, itemA ) guard valueEq(a, itemA)
       then itemB;
     case ( _ :: rest, itemA)
       then lookupTupleList(rest, itemA);
-  end matchcontinue;
+  end match;
 end lookupTupleList;
 
 protected function updateTupleList
@@ -6463,16 +6451,14 @@ protected function lookupDeleteTupleList
   replaceable type Type_a subtypeof Any;
   replaceable type Type_b subtypeof Any;
 algorithm
-  (outItemB, outList) := matchcontinue(inList, inItemA)
+  (outItemB, outList) := match(inList, inItemA)
     local
        Type_a a, itemA;
        Type_b itemB;
        list<tuple<Type_a,Type_b>> rest;
        tuple<Type_a,Type_b> h;
 
-    case ( (a, itemB) :: rest, itemA )
-      algorithm
-        true := valueEq(a, itemA);
+    case ( (a, itemB) :: rest, itemA ) guard valueEq(a, itemA)
       then
         (itemB, rest);
 
@@ -6481,7 +6467,7 @@ algorithm
         (itemB, rest) := lookupDeleteTupleList(rest, itemA);
       then
         (itemB, h :: rest);
-  end matchcontinue;
+  end match;
 end lookupDeleteTupleList;
 
 protected function alignTupleList "
@@ -6637,22 +6623,16 @@ public function canBeEscapedUnquoted
     output Boolean outCanBeUnquoted;
 algorithm
   outCanBeUnquoted :=
-  matchcontinue inStringList
+  match inStringList
     local
       String str;
       list<String> rest;
 
-    case { str }
-      algorithm
-        true := stringLength(str) > 0;
-        true := canBeEscapedUnquotedChars(stringListStringChar(str));
+    case { str } guard (stringLength(str) > 0) and canBeEscapedUnquotedChars(stringListStringChar(str))
       then
         true;
 
-    case str :: (rest as (_::_))
-      algorithm
-        true := stringLength(str) > 0;
-        true := canBeEscapedUnquotedChars(stringListStringChar(str));
+    case str :: (rest as (_::_)) guard (stringLength(str) > 0) and canBeEscapedUnquotedChars(stringListStringChar(str))
       then
         canBeEscapedUnquoted(rest);
 
@@ -6660,7 +6640,7 @@ algorithm
     else
         false;
 
-  end matchcontinue;
+  end match;
 end canBeEscapedUnquoted;
 
 
@@ -6707,7 +6687,7 @@ public function pathIdentString
   input PathIdent inPathIndent;
   output String outPathIdentString;
 algorithm
-  outPathIdentString := matchcontinue inPathIndent
+  outPathIdentString := match inPathIndent
     local
       Ident ident;
       PathIdent path;
@@ -6729,7 +6709,7 @@ algorithm
       then
         fail();
 
-  end matchcontinue;
+  end match;
 end pathIdentString;
 
 

--- a/OMCompiler/Compiler/Template/TplMain.mo
+++ b/OMCompiler/Compiler/Template/TplMain.mo
@@ -261,7 +261,7 @@ public function tplMainTest
   input String inFile;
 algorithm
 
-  () := matchcontinue inFile
+  () := match inFile
     local
       //Tpl.Tokens toks, txttoks;
       String  str, strOut, ident, cval;
@@ -1427,7 +1427,7 @@ is\\n verbatim!
       then
         ();
 
-  end matchcontinue;
+  end match;
 end tplMainTest;
 
 

--- a/OMCompiler/Compiler/Util/GraphML.mo
+++ b/OMCompiler/Compiler/Util/GraphML.mo
@@ -524,11 +524,8 @@ protected
   AttributeTarget attTarget;
    Option<tuple<Attribute,Integer>> tmpAttribute;
 algorithm
-  oAttribute := matchcontinue iList
-    case (head as ATTRIBUTE(attIdx=attIdx,name=name,attTarget=attTarget))::rest
-      algorithm
-        true := stringEq(name, iAttributeName);
-        true := compareAttributeTargets(iAttributeTarget,attTarget);
+  oAttribute := match iList
+    case (head as ATTRIBUTE(attIdx=attIdx,name=name,attTarget=attTarget))::rest guard stringEq(name, iAttributeName) and compareAttributeTargets(iAttributeTarget,attTarget)
       then SOME((head,attIdx));
     case head::rest
       algorithm
@@ -536,7 +533,7 @@ algorithm
       then tmpAttribute;
     else
       then NONE();
-  end matchcontinue;
+  end match;
 end getAttributeByNameAndTargetTail;
 
 protected function compareAttributeTargets

--- a/OMCompiler/Compiler/Util/VarTransform.mo
+++ b/OMCompiler/Compiler/Util/VarTransform.mo
@@ -1194,22 +1194,16 @@ public function replaceExpRepeated2 "help function to replaceExpRepeated"
     output Boolean res;
   end VisitFunc;
 
+protected
+  DAE.Exp e1;
+  Boolean b;
 algorithm
-  outExp := matchcontinue equal
-    local
-      DAE.Exp e1,res;
-      Boolean b;
-    case _
-      algorithm
-        true := i > maxIter;
-      then e;
-    case true then e;
-    else
-      algorithm
-        (e1,b) := replaceExp(e,repl,func);
-        res := replaceExpRepeated2(e1,repl,func,maxIter,i+1,not b /*ExpressionBasics.expEqual(e,e1)*/);
-      then res;
-  end matchcontinue;
+  if i > maxIter or equal then
+    outExp := e;
+  else
+    (e1,b) := replaceExp(e,repl,func);
+    outExp := replaceExpRepeated2(e1,repl,func,maxIter,i+1,not b /*ExpressionBasics.expEqual(e,e1)*/);
+  end if;
 end replaceExpRepeated2;
 
 public function replaceExp


### PR DESCRIPTION
Three additions to the "this `matchcontinue` is really a `match`" lint, which `--fix` rewrites in the sources:

* Exhaustiveness now enumerates uniontype records.  Codegen's typed-IR `pats_cover_ty` already did; the Absyn-side predicate was stuck at list/option/bool, so every `match` over a uniontype made its function fallible.  25687 -> 25367 fallible functions.
* A `matchcontinue` whose case patterns are pairwise disjoint is a `match` whatever its arms call: nothing can fall through to an arm that would still match.  Mirrors `Patternm.optimizeContinueToMatch2`, which already performs the same downgrade while compiling.
* An arm that only falls through on a leading `true := COND;` is a `match` arm with `guard COND`.  `--fix` performs that rewrite too, lifting COND verbatim out of the statement's source span so the author's formatting survives.

`--mc-report FILE` writes one line per matchcontinue the lint could not clear, naming the arms that keep it alive and why.  Of the 2295 left, 4957 arm-blockers are transitively-fallible callees, 1040 a refutable `:=` pattern, and 36 are blocked only by print/log/flag calls.

Three hand-written files follow the sharper verdict, since they state a signature the analysis now derives differently:

| File                          | Was                        | Now              |
| ----------------------------- | -------------------------  | ---------------- |
| `GCExt.rs`                    | `profStatsStr -> Result`   | plain `ArcStr`   |
| `Globals.rs`                  | `pathHash` as a raw fn ptr | `fnptr!`-wrapped |
| `CodegenWasmJitFunctions.rs`  | `pathLastIdent` with `?`   | direct value     |

Running `--fix` over the compiler sources rewrites 81 `matchcontinue`:

| Reason                                       | Count |
| -------------------------------------------- | ----- |
| no fallible arm before the last              |     5 |
| pairwise disjoint case patterns              |     1 |
| falls through only on `true := …` asserts    |    75 |

The last group also moves the assert into the pattern:

    case CLOSETAG(tagName = tn) :: rest
      algorithm
        true := tn == inTagName;
      then removeFirstIfText(rest);

becomes

    case CLOSETAG(tagName = tn) :: rest guard tn == inTagName
      then removeFirstIfText(rest);

which is the same fall-through, expressed where `match` performs it too. Only arms whose remaining body is provably infallible are converted, so no arm loses a fall-through it was relying on.

21 of the rewritten functions then match on a scrutinee that no pattern inspects — every case is `_` or an irrefutable tuple — so they are written as `if`/`else` instead, and two collapse to one expression:

    equalLength := intEq(inValue, listLength(inLst));

`getHighestExecCost` had two arms under the identical guard, dead since the first arm's body cannot fail; the second becomes the catch-all its sibling `getHighestCommCost` already uses.  `dumpMatching1` and `nextGreaterPowerOf2_impl` each kept a `true := …` that the new guard made a tautology.

`nextGreaterPowerOf2_impl` also loses a `<=.`: no such operator exists, so `n <=. realPow(…)` was `n <= .realPow(…)` — a global-scope name that resolved only because `realPow` is a builtin.  It does not resolve for a local, so the comparison is now `<=`.

Verified: the bootstrapped omc builds, and the 1522 metamodelica / flattening / openmodelica testsuite cases fail in exactly the same 585 places as the unmodified tree (all of them simulation-side failures this build configuration already has).

Assisted-by: Claude Opus 5

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
