### PR TITLE
C+Rust: store pre values after functionAlgebraics

### DIFF
--- a/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/data.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/data.rs
@@ -728,8 +728,8 @@ fn layout_for(
         // equation itself, so this is a flag rather than a count.
         cb.functionRemovedInitialEquations.is_some() as u32,
         unsafe { crate::support::compiledWithSymSolver } as u8,
-        // `has_when` asks whether `functionAlgebraics` ends with `storePreValues`;
-        // only the wasm-jit codegen folds that in, C's runtime does it after.
+        // `has_when` marks the wasm-jit form of `functionAlgebraics` (the discrete
+        // update); C's is the plain algebraic pass, the engine adds `storePreValues`.
         false,
         has_homotopy,
         openmodelica_sim_meta::HomotopyMethod::from_code(cb.homotopyMethod as u8),

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/engine.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_simulation_runtime/src/engine.rs
@@ -168,6 +168,19 @@ impl CEngine {
         // own `longjmp` is what makes the driver print the initialization notice.
         Err(driver::ASSERT_ERR)
     }
+
+    /// C's `storePreValues` closing `updateContinuousSystem`, whose C body is
+    /// stubbed out under this runtime.
+    fn store_pre_values(&mut self) {
+        let md = self.rt.model();
+        let (sd, si) = (self.rt.local(0), self.rt.info());
+        unsafe {
+            core::ptr::copy_nonoverlapping(sd.realVars, si.realVarsPre, md.nVariablesReal.max(0) as usize);
+            core::ptr::copy_nonoverlapping(sd.integerVars, si.integerVarsPre, md.nVariablesInteger.max(0) as usize);
+            core::ptr::copy_nonoverlapping(sd.booleanVars, si.booleanVarsPre, md.nVariablesBoolean.max(0) as usize);
+        }
+        self.store_pre_strings();
+    }
 }
 
 impl SimEngine for CEngine {
@@ -252,7 +265,9 @@ impl SimEngine for CEngine {
             }
             "functionAlgebraics" => {
                 self.rt.info().callStatistics.functionAlgebraics += 1;
-                self.call_cb(cb.functionAlgebraics)
+                self.call_cb(cb.functionAlgebraics)?;
+                self.store_pre_values();
+                Ok(())
             }
             "functionDAE" => {
                 self.rt.info().callStatistics.updateDiscreteSystem += 1;
@@ -460,7 +475,11 @@ impl SimEngine for CEngine {
                         self.stage,
                     )
                 };
-                self.absorb(rc)
+                self.absorb(rc)?;
+                if b == driver::eval_stage::ALGEBRAIC {
+                    self.store_pre_values();
+                }
+                Ok(())
             }
             // The driver names a sub-clock by its flat index, which is what a wasm
             // module's dispatcher takes; C's takes the `(base, sub)` pair.


### PR DESCRIPTION
C's `updateContinuousSystem` ends with `storePreValues`; under the Rust runtime that function is a stub and the driver's `eval_continuous` replaces it. The wasm-jit codegen folds the store into the emitted `functionAlgebraics` of a `has_when` model, which is what the driver relies on, but the C host called the generated `functionAlgebraics` and stored nothing. So at a `sample()` event a when-body reading `pre(x)` of a state saw the previous accepted step's value. The backend emits that read for every `Modelica.Blocks.Math.Mean` (`y = f*x` beside a `reinit(x, 0)` becomes `f*pre(x)`), which is 85 of the 99 OMLT rows that verify on master and only simulate on `c-plus-rust`: the PowerConverters examples in every MSL version, Buildings VDI6007 TestCase3/6/9/10 and SingleSpeedPLR.

The engine now runs C's `storePreValues` after the `functionAlgebraics` callback and after the DAE-mode algebraic stage, where the C runtime ran it.

DiodeBridge2mPulse and VDI6007 TestCase3 now match C to the last bit and to 2.7e-7 respectively, as wasm-jit does; 101 of the 102 event / sample / pre tests of the C+Rust rtest list pass, the one failure being the pre-existing `FileNamePrefix.mos`.

Assisted-by: Claude Fable 5.1

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
