### PR TITLE
mmtorust: sole-record `:=` patterns are irrefutable

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/codegen.rs
@@ -4569,7 +4569,7 @@ struct TailCallPlan {
 /// fallback case, which is handled by the leading `pat_is_irrefutable`
 /// check).
 fn pats_cover_ty(pats: &[&TypedPat], ty: &Ty, top_level: &BTreeMap<String, NameNode<'_>>) -> bool {
-    if pats.iter().any(|p| pat_is_irrefutable(p)) { return true; }
+    if pats.iter().any(|p| pat_is_irrefutable(p, top_level)) { return true; }
     match ty {
         Ty::Bool => {
             pats.iter().any(|p| matches!(p, TypedPat::Lit(Lit::Bool(true))))
@@ -4584,13 +4584,13 @@ fn pats_cover_ty(pats: &[&TypedPat], ty: &Ty, top_level: &BTreeMap<String, NameN
             let nil = pats.iter().any(|p| matches!(p, TypedPat::EmptyList));
             let cons = pats.iter().any(|p| matches!(p,
                 TypedPat::Cons { head, tail }
-                    if pat_is_irrefutable(head) && pat_is_irrefutable(tail)));
+                    if pat_is_irrefutable(head, top_level) && pat_is_irrefutable(tail, top_level)));
             nil && cons
         }
         Ty::Option(_) => {
             let none = pats.iter().any(|p| matches!(p, TypedPat::None_));
             let some = pats.iter().any(|p| matches!(p,
-                TypedPat::Some_(inner) if pat_is_irrefutable(inner)));
+                TypedPat::Some_(inner) if pat_is_irrefutable(inner, top_level)));
             none && some
         }
         Ty::Tuple(elem_tys) => {
@@ -4624,7 +4624,7 @@ fn pats_cover_ty(pats: &[&TypedPat], ty: &Ty, top_level: &BTreeMap<String, NameN
                 })
                 .collect();
             !variants.is_empty()
-                && variants.iter().all(|v| pats.iter().any(|p| pat_covers_variant(p, v)))
+                && variants.iter().all(|v| pats.iter().any(|p| pat_covers_variant(p, v, top_level)))
         }
         // Enumeration: exhaustive iff every declared literal is matched.
         Ty::Enumeration(qname) => {
@@ -4636,7 +4636,7 @@ fn pats_cover_ty(pats: &[&TypedPat], ty: &Ty, top_level: &BTreeMap<String, NameN
                 .map(|l| l.literal.to_string())
                 .collect();
             !lits.is_empty()
-                && lits.iter().all(|lit| pats.iter().any(|p| pat_covers_variant(p, lit)))
+                && lits.iter().all(|lit| pats.iter().any(|p| pat_covers_variant(p, lit, top_level)))
         }
         // Numeric / string scalars can only be made exhaustive by an
         // irrefutable case (handled at the top of this function).
@@ -4649,14 +4649,14 @@ fn pats_cover_ty(pats: &[&TypedPat], ty: &Ty, top_level: &BTreeMap<String, NameN
 /// simple name) whose field subpatterns are all irrefutable — i.e. it matches
 /// *every* value of that variant. Unit variants/literals are constructor
 /// patterns with no fields and so are covered unconditionally.
-fn pat_covers_variant(pat: &TypedPat, variant_simple: &str) -> bool {
+fn pat_covers_variant(pat: &TypedPat, variant_simple: &str, top_level: &BTreeMap<String, NameNode<'_>>) -> bool {
     match pat {
-        TypedPat::As { pat: inner, .. } => pat_covers_variant(inner, variant_simple),
+        TypedPat::As { pat: inner, .. } => pat_covers_variant(inner, variant_simple, top_level),
         TypedPat::Constructor { name, fields, named_fields, .. } => {
             let simple = name.rsplit('.').next().unwrap_or(name);
             simple == variant_simple
-                && fields.iter().all(pat_is_irrefutable)
-                && named_fields.iter().all(|(_, p)| pat_is_irrefutable(p))
+                && fields.iter().all(|p| pat_is_irrefutable(p, top_level))
+                && named_fields.iter().all(|(_, p)| pat_is_irrefutable(p, top_level))
         }
         _ => false,
     }
@@ -16017,6 +16017,17 @@ fn pat_has_str_lit(pat: &TypedPat) -> bool {
     }
 }
 
+fn pat_has_constructor(pat: &TypedPat) -> bool {
+    match pat {
+        TypedPat::Constructor { .. } => true,
+        TypedPat::Some_(inner) => pat_has_constructor(inner),
+        TypedPat::As { pat: inner, .. } => pat_has_constructor(inner),
+        TypedPat::Cons { head, tail } => pat_has_constructor(head) || pat_has_constructor(tail),
+        TypedPat::Tuple(ps) => ps.iter().any(pat_has_constructor),
+        _ => false,
+    }
+}
+
 /// Decide whether the match expression's outer scrutinee needs to be wrapped
 /// in `match_deref!{ ... }`. We switch into match_deref mode whenever any of
 /// the following holds for the input or its destructured sub-elements:
@@ -17262,14 +17273,37 @@ fn pat_introduces_binding(pat: &TypedPat) -> bool {
     }
 }
 
-fn pat_is_irrefutable(pat: &TypedPat) -> bool {
+/// Must agree with `fallibility`'s `resolve_cover_key`: a function typed
+/// infallible there must never be handed a `return Err` from here.
+fn pat_is_irrefutable(pat: &TypedPat, top_level: &BTreeMap<String, NameNode<'_>>) -> bool {
     match pat {
         TypedPat::Wildcard | TypedPat::Var(_) => true,
-        TypedPat::Tuple(ps) => ps.iter().all(pat_is_irrefutable),
-        TypedPat::As { pat, .. } => pat_is_irrefutable(pat),
+        TypedPat::Tuple(ps) => ps.iter().all(|p| pat_is_irrefutable(p, top_level)),
+        TypedPat::As { pat, .. } => pat_is_irrefutable(pat, top_level),
         TypedPat::Index { .. } => true,
         TypedPat::FieldAccess { .. } => true,
+        TypedPat::Constructor { name, fields, named_fields, ty } => {
+            ctor_is_sole_record(name, ty, top_level)
+                && fields.iter().all(|p| pat_is_irrefutable(p, top_level))
+                && named_fields.iter().all(|(_, p)| pat_is_irrefutable(p, top_level))
+        }
         _ => false,
+    }
+}
+
+/// See `hierarchy::record_is_sole_shape`; the sole record of a uniontype is
+/// typed with the uniontype's qname.
+fn ctor_is_sole_record(name: &str, ty: &Ty, top_level: &BTreeMap<String, NameNode<'_>>) -> bool {
+    let qname = match ty {
+        Ty::RustStruct(q) => q.clone(),
+        _ => match lookup_record_through_unions(name, top_level) {
+            Some((q, _)) => q,
+            None => return false,
+        },
+    };
+    match resolve_single_record_qname(&qname, top_level) {
+        Some(rec) => crate::hierarchy::record_is_sole_shape(&rec, top_level),
+        None => crate::hierarchy::record_is_sole_shape(&qname, top_level),
     }
 }
 
@@ -18268,8 +18302,11 @@ fn emit_pat_assign<'a>(
             // `render_shallow`'s deferral machinery — recursion through
             // nested Arc fields is handled directly by the macro's repeated
             // `Deref @ …` instead of follow-up `emit_pat_assign` calls.
+            let irrefutable = pat_is_irrefutable(pat_for_render, top_level);
+            // A sole-record constructor cannot mismatch, but still needs
+            // `match_deref!` to peel an Arc; its `_` arm is then dead.
             let pat_needs_match_deref =
-                !pat_is_irrefutable(pat_for_render)
+                (!irrefutable || pat_has_constructor(pat_for_render))
                 && (type_destructure_needs_borrow(scrut_ty, ctx)
                     || pat_has_str_lit(pat_for_render)
                     || pat_requires_arc_deref(pat_for_render, ctx));
@@ -18292,6 +18329,14 @@ fn emit_pat_assign<'a>(
                 };
                 let fail_owned;
                 let fail: &str = match &fail_mode {
+                    FailureMode::IfLetElse(else_code) => {
+                        // The else-recovery, used as the `_`-arm body. It is a
+                        // sequence of statements that diverges, so wrapping it
+                        // in a block expression type-checks against the Ok arm.
+                        fail_owned = format!("{{\n{else_code}{indent}    }}");
+                        &fail_owned
+                    }
+                    _ if irrefutable => "unreachable!()",
                     // Both `Function` and `TryArm` defer to `ctx.qmode`: a
                     // refutable destructuring is a `?`-like failure point, so it
                     // must follow the same propagation as `unwrap_break_err!`
@@ -18314,13 +18359,6 @@ fn emit_pat_assign<'a>(
                         _ => "return Err(\"pattern mismatch\")",
                     },
                     FailureMode::Failure => "()",
-                    FailureMode::IfLetElse(else_code) => {
-                        // The else-recovery, used as the `_`-arm body. It is a
-                        // sequence of statements that diverges, so wrapping it
-                        // in a block expression type-checks against the Ok arm.
-                        fail_owned = format!("{{\n{else_code}{indent}    }}");
-                        &fail_owned
-                    }
                 };
                 // Collect all binding names introduced by the (possibly
                 // re-named) pattern, together with their owned types. The
@@ -18409,7 +18447,7 @@ fn emit_pat_assign<'a>(
             // emitted in Bare mode (raw `Result<T>`), so we still need an
             // `Ok(..)` unwrap. The else-branch only runs on the Err case;
             // pattern mismatch is impossible by construction.
-            if pat_is_irrefutable(pat_for_render)
+            if irrefutable
                 && let FailureMode::IfLetElse(else_code) = &fail_mode
             {
                 let inner = format!("{indent}    ");
@@ -18420,7 +18458,7 @@ fn emit_pat_assign<'a>(
                 writeln!(out, "{indent}}}").unwrap();
                 return;
             }
-            if pat_is_irrefutable(pat_for_render) {
+            if irrefutable {
                 match pat_for_render {
                     TypedPat::Tuple(_) => {
                         writeln!(out, "{indent}let {surface} = {scrut_expr};").unwrap();

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/fallibility.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/fallibility.rs
@@ -327,6 +327,10 @@ struct Walk {
     /// [`resolve_walk`]; a `match` still not exhaustive there fails when no arm
     /// matches, which is observable to callers.
     match_keys: Vec<Vec<CoverKey>>,
+    /// Constructor patterns on the left of a `:=`, one per statement. They
+    /// mismatch unless the record is the only shape of its type, which needs
+    /// the hierarchy — decided in [`resolve_walk`].
+    assign_keys: Vec<CoverKey>,
     /// True if the body contains an explicit `fail()` call outside a catch
     /// boundary.  (Catch boundaries are not yet tracked; see module docs.)
     has_fail: bool,
@@ -511,20 +515,16 @@ impl Walk {
         }
         match alg {
             Absyn::Algorithm::ALG_ASSIGN { assignComponent, value } => {
-                // MetaModelica's `:=` is a *pattern* assignment: if the LHS is
-                // anything other than a plain variable reference (or a tuple
-                // of plain variable references), the match can fail at runtime
-                // and the surrounding function therefore fallible. Codegen
-                // lowers these to `let PAT = RHS else { bail!("pattern
-                // mismatch") };`, which only typechecks when the function
-                // returns `Result`. Examples:
-                //   `Cons(h, t) := xs;`        — list cons pattern
-                //   `SOME(x) := opt;`          — uniontype variant pattern
-                //   `(a, SOME(b)) := pair;`    — tuple containing a refutable
-                //                                sub-pattern
-                if exp_is_refutable_lhs(assignComponent) {
-                    self.has_fail = true;
-                    self.reasons.insert("refutable `:=` pattern");
+                // MetaModelica's `:=` is a *pattern* assignment: unless the
+                // LHS is irrefutable the match can fail at runtime, and codegen
+                // lowers it to `let PAT = RHS else { bail!(..) };`.
+                match assign_lhs_cover_key(assignComponent, &self.outer_scope) {
+                    CoverKey::Irrefutable => {}
+                    key @ CoverKey::Ctor(_) => self.assign_keys.push(key),
+                    _ => {
+                        self.has_fail = true;
+                        self.reasons.insert("refutable `:=` pattern");
+                    }
                 }
                 self.scan_exp(assignComponent);
                 self.scan_exp(value);
@@ -965,32 +965,25 @@ fn boolean_assert(item: &Absyn::AlgorithmItem) -> Option<(&Absyn::Exp, bool, &Ab
     Some((value, asserted, info))
 }
 
-/// True when an expression used on the LHS of a MetaModelica `:=` assignment
-/// produces a *refutable* pattern — one whose match can fail at runtime, in
-/// which case codegen emits `bail!("pattern mismatch")` to surface the failure
-/// to the caller, making the surrounding function fallible.
-///
-/// Plain variables and tuples-of-plain-variables are irrefutable; anything
-/// involving a constructor, cons-cell, literal, range, or destructuring
-/// expression is refutable. Wildcards (`_`) are irrefutable but appear in
-/// pattern position only inside a containing tuple.
-///
-/// Conservative: when in doubt, classify as refutable. A spurious "fallible"
-/// classification just keeps a `Result<>` return where it wasn't needed, while
-/// a spurious "infallible" classification produces uncompilable code.
-fn exp_is_refutable_lhs(e: &Absyn::Exp) -> bool {
+/// Coverage of the LHS of a `:=`. Variable references (subscripted or
+/// field-qualified too) and tuples of them assign; a constructor pattern with
+/// irrefutable sub-patterns is returned as [`CoverKey::Ctor`] for
+/// [`resolve_walk`] to settle; everything else can mismatch.
+fn assign_lhs_cover_key(e: &Absyn::Exp, scope: &BTreeSet<String>) -> CoverKey {
     use Absyn::Exp::*;
     match e {
-        // A plain identifier on the LHS is an ordinary assignment.
-        CREF { .. } => false,
-        // `(a, b, c) := rhs` — only irrefutable if every component is itself
-        // irrefutable on the LHS.
-        TUPLE { expressions } => (&**expressions).into_iter().any(|e| exp_is_refutable_lhs(e)),
-        // Every other Exp shape that can syntactically appear on the LHS of
-        // `:=` denotes a refutable pattern match: constructor applications
-        // (CALL), cons-cells (CONS), literal lists/arrays, as-patterns,
-        // ranges, and even bare literals.
-        _ => true,
+        CREF { .. } => CoverKey::Irrefutable,
+        TUPLE { expressions } => {
+            if (&**expressions).into_iter().all(|e| assign_lhs_cover_key(e, scope) == CoverKey::Irrefutable) {
+                CoverKey::Irrefutable
+            } else {
+                CoverKey::Other
+            }
+        }
+        _ => match pat_cover_key(e, scope) {
+            key @ (CoverKey::Irrefutable | CoverKey::Ctor(_)) => key,
+            _ => CoverKey::Other,
+        },
     }
 }
 
@@ -1168,8 +1161,9 @@ fn pat_cover_key(e: &Absyn::Exp, binding_names: &BTreeSet<String>) -> CoverKey {
 }
 
 /// Resolve a [`CoverKey::Ctor`]'s raw callee name: a record of a uniontype
-/// becomes [`CoverKey::Variant`], anything else [`CoverKey::Other`]. Records
-/// outside a uniontype stay unresolved, matching codegen's `pats_cover_ty`.
+/// becomes [`CoverKey::Variant`], anything else [`CoverKey::Other`]. A record
+/// that is the only shape of its type (`hierarchy::record_is_sole_shape`) is a
+/// `Variant` of itself with `total == 1`.
 fn resolve_cover_key(
     key: &CoverKey,
     top_level: &BTreeMap<String, NameNode<'_>>,
@@ -1182,6 +1176,9 @@ fn resolve_cover_key(
     let NodeKind::Class(rc) = &node.kind else { return CoverKey::Other };
     if !matches!(rc.restriction, Absyn::Restriction::R_RECORD | Absyn::Restriction::R_METARECORD { .. }) {
         return CoverKey::Other;
+    }
+    if crate::hierarchy::record_is_sole_shape(&qname, top_level) {
+        return CoverKey::Variant { union_: qname.clone(), variant: rc.name.clone(), total: 1 };
     }
     let Some((union_, _)) = qname.rsplit_once('.') else { return CoverKey::Other };
     let Some(unode) = crate::hierarchy::lookup_node(union_, top_level) else { return CoverKey::Other };
@@ -1679,6 +1676,12 @@ fn resolve_walk(
         if !cover_keys_exhaustive(&resolved) {
             rs.always = true;
             rs.reasons.insert("non-exhaustive `match`".to_owned());
+        }
+    }
+    for key in &w.assign_keys {
+        if !cover_keys_exhaustive(&[resolve_cover_key(key, top_level, caller_qname)]) {
+            rs.always = true;
+            rs.reasons.insert("refutable `:=` pattern".to_owned());
         }
     }
     for raw in &w.calls {

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/hierarchy.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/hierarchy.rs
@@ -1846,6 +1846,31 @@ pub(crate) fn collect_type_vars_in_env(env: &std::collections::HashMap<String, T
     }
 }
 
+fn record_child_count(node: &NameNode<'_>) -> usize {
+    node.children.values().filter(|ch| matches!(&ch.kind,
+        NodeKind::Class(cc) if matches!(cc.restriction,
+            Absyn::Restriction::R_RECORD | Absyn::Restriction::R_METARECORD { .. }))).count()
+}
+
+/// Is `qname` a record that is the only shape of its type — the sole record
+/// of a uniontype, or a record declared outside any uniontype? Such a
+/// constructor pattern can never mismatch. `fallibility::resolve_cover_key`
+/// and codegen's `pat_is_irrefutable` must both go through here.
+pub(crate) fn record_is_sole_shape(qname: &str, top_level: &BTreeMap<String, NameNode<'_>>) -> bool {
+    let Some(node) = lookup_node(qname, top_level) else { return false };
+    let NodeKind::Class(c) = &node.kind else { return false };
+    if !matches!(c.restriction, Absyn::Restriction::R_RECORD | Absyn::Restriction::R_METARECORD { .. }) {
+        return false;
+    }
+    let Some((parent, _)) = qname.rsplit_once('.') else { return true };
+    let Some(p) = lookup_node(parent, top_level) else { return false };
+    match &p.kind {
+        NodeKind::Class(pc) if matches!(pc.restriction, Absyn::Restriction::R_UNIONTYPE) =>
+            record_child_count(p) == 1,
+        _ => true,
+    }
+}
+
 pub(crate) fn lookup_node<'a>(dotted: &str, top_level: &'a BTreeMap<String, NameNode<'a>>) -> Option<&'a NameNode<'a>> {
     let mut parts = dotted.split('.');
     let first = parts.next().unwrap_or("");

--- a/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/typedexp.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/mmtorust/src/typedexp.rs
@@ -3070,7 +3070,15 @@ pub fn infer_pat<'a>(
                     // emitter mis-binds the bare last segment to a same-named
                     // top-level package and lists that package's members as
                     // "fields" (E0574).
-                    let ty = lookup_ctor_ty(&canonical, top_level);
+                    let mut ty = lookup_ctor_ty(&canonical, top_level);
+                    // `Sets.SETS` under `import DAE.Connect.{Sets}` resolves only
+                    // through the scope; codegen's `pat_is_irrefutable` needs the type.
+                    if ty == Ty::Unknown
+                        && let Some((q, node)) = resolve_call_node(&canonical, top_level, pkg_prefix)
+                        && crate::hierarchy::record_is_sole_shape(&q, top_level)
+                    {
+                        ty = node.ty.clone();
+                    }
                     TypedPat::Constructor { name: canonical, fields, named_fields, ty }
                 }
             }


### PR DESCRIPTION
`FLAGS(debugFlags = f) := flags`-style destructuring of a record that is the only shape of its type — the sole record of a uniontype, or a record declared outside any uniontype — cannot mismatch, yet both the fallibility analysis and codegen's `pat_is_irrefutable` treated every constructor on the left of a `:=` as refutable. Every function doing it therefore returned `Result`.

The analysis now records such a constructor as a `CoverKey::Ctor` and settles it in `resolve_walk` with the hierarchy, the same way `match` coverage is decided. Codegen's `pat_is_irrefutable` takes `top_level` and accepts a sole-record constructor whose fields are irrefutable. The one definition both sides use is `hierarchy::record_is_sole_shape`.

Two details keep the two sides in agreement:

* `infer_pat` types an import-alias-qualified constructor pattern (`Sets.SETS` under `import DAE.Connect.{Sets}`) when it names a sole record; codegen otherwise could not resolve what the analysis did, and emitted `return Err` into a function typed infallible.
* A sole-record pattern whose scrutinee crosses an Arc still goes through `match_deref!`, which needs a `_` arm; that arm is now `unreachable!()` instead of a `return Err`.

Measured with `--mc-report` over the compiler sources:

| Metric                           | Before | After |
| -------------------------------- | ------ | ----- |
| infallible functions             |   6898 |  7090 |
| blocked matchcontinue            |   2220 |  2217 |
| arms blocked by a refutable `:=` |   1165 |  1154 |

The flattening + metamodelica testsuite fails in the same known places as before (i32 Integer limits, StackOverflowTest, path listings) with no panics.

Assisted-by: Claude Fable 5.1

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
