### PR TITLE
NB: causalize init_0 from init's matrices

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBPartition.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBPartition.mo
@@ -425,6 +425,12 @@ public
       partition.equations := EquationPointers.sort(partition.equations);
     end sort;
 
+    function hasIndex
+      input Partition partition;
+      input Integer index;
+      output Boolean b = partition.index == index;
+    end hasIndex;
+
     function isEmpty
       "returns true if the partition is empty.
       maybe check more than only equations?"

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
@@ -2243,6 +2243,12 @@ function isJacobianResultVar
       output Integer sz = ExpandableArray.getNumberOfElements(variables.varArr);
     end size;
 
+    function lastUsedIndex
+      "returns the last used index != size!"
+      input VariablePointers variables;
+      output Integer sz = ExpandableArray.getLastUsedIndex(variables.varArr);
+    end lastUsedIndex;
+
     function scalarSize
       "returns the scalar size."
       input VariablePointers variables;

--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBCausalize.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBCausalize.mo
@@ -92,7 +92,7 @@ public
   algorithm
     bdae := match (kind, bdae)
       local
-        list<Partition> partitions, clocked;
+        list<Partition> partitions, clocked, twins;
         VarData varData;
         EqData eqData;
 
@@ -111,11 +111,11 @@ public
           if Flags.isSet(Flags.INITIALIZATION) then
             print(StringUtil.headline_1("Balance Initialization") + "\n");
           end if;
-          (partitions, varData, eqData) := applyModule(partitions, kind, varData, eqData, bdae.funcMap, func);
+          // init_0 is init with the homotopy calls replaced by their simplified branch
+          (partitions, varData, eqData, twins) := applyModule(partitions, kind, varData, eqData, bdae.funcMap, func, Util.getOptionOrDefault(bdae.init_0, {}));
           bdae.init := partitions;
           if isSome(bdae.init_0) then
-            (partitions, varData, eqData) := applyModule(Util.getOption(bdae.init_0), kind, varData, eqData, bdae.funcMap, func);
-            bdae.init_0 := SOME(partitions);
+            bdae.init_0 := SOME(twins);
           end if;
           bdae.varData := varData;
           bdae.eqData := eqData;
@@ -143,15 +143,25 @@ public
     input output EqData eqData;
     input UnorderedMap<Path, Function> funcMap;
     input Module.causalizeInterface func;
+    input list<Partition> twins = {} "partitions of nearly the same systems, paired by index";
+    output list<Partition> new_twins = {};
   protected
     Partition new_partition;
+    list<Partition> paired, unpaired = twins;
     Boolean violated = false "true if any partition violated variability consistency";
   algorithm
     for partition in partitions loop
-      (new_partition, varData, eqData) := func(partition, varData, eqData, funcMap);
+      (paired, unpaired) := List.splitOnTrue(unpaired, function Partition.hasIndex(index = partition.index));
+      (new_partition, varData, eqData, paired) := func(partition, varData, eqData, funcMap, paired);
       new_partitions := if Partition.isEmpty(new_partition) then new_partitions else new_partition :: new_partitions;
+      new_twins := List.append_reverse(list(twin for twin guard(not Partition.isEmpty(twin)) in paired), new_twins);
+    end for;
+    for twin in unpaired loop
+      (new_partition, varData, eqData) := func(twin, varData, eqData, funcMap, {});
+      new_twins := if Partition.isEmpty(new_partition) then new_twins else new_partition :: new_twins;
     end for;
     new_partitions := listReverse(new_partitions);
+    new_twins := listReverse(new_twins);
 
     if not Partition.kindIsInitial(kind) then
       for partition in new_partitions loop
@@ -251,6 +261,7 @@ protected
     Adjacency.Matrix full, adj_matching, adj_sorting;
     Matching matching;
     list<StrongComponent> comps;
+    list<Partition> new_twins = {};
   algorithm
     (variables, equations, full, matching, comps) := match kind
       local
@@ -332,7 +343,55 @@ protected
     partition.adjacencyMatrix := SOME(full);
     partition.matching := SOME(matching);
     partition.strongComponents := SOME(listArray(comps));
+
+    for twin in twins loop
+      (twin, varData, eqData) := causalizeTwin(twin, partition, adj_matching, adj_sorting, funcMap, varData, eqData);
+      new_twins := twin :: new_twins;
+    end for;
+    twins := listReverse(new_twins);
   end causalizePseudoArray;
+
+  function causalizeTwin
+    "causalizes a partition over the same variables as the causalized seed and
+    nearly the same equations: the rows of equal equations are taken from the
+    seed's matrices and its matching is the starting point"
+    input output Partition twin;
+    input Partition seed;
+    input Adjacency.Matrix seed_matching;
+    input Adjacency.Matrix seed_sorting;
+    input UnorderedMap<Path, Function> funcMap;
+    input output VarData varData;
+    input output EqData eqData;
+  protected
+    BPartition.Kind kind = Partition.getKind(twin);
+    VariablePointers variables;
+    EquationPointers equations;
+    Adjacency.Matrix full, balanced, adj_matching, adj_sorting;
+    Matching matching;
+    array<Integer> seed_index;
+    list<StrongComponent> comps;
+  algorithm
+    twin.unknowns  := VariablePointers.compress(twin.unknowns);
+    twin.equations := EquationPointers.compress(twin.equations);
+    full := Adjacency.Matrix.createFull(twin.unknowns, twin.equations, kind);
+    seed_index := Adjacency.Matrix.equalRows(seed.equations, seed.unknowns, twin.equations, twin.unknowns);
+    adj_matching := Adjacency.Matrix.upgradeFrom(NBAdjacency.Matrix.EMPTY(NBAdjacency.MatrixStrictness.FULL), full, twin.unknowns.map, twin.equations.map, twin.equations, NBAdjacency.MatrixStrictness.MATCHING, seed_matching, seed_index);
+    matching := Matching.fromSeed(seed, adj_matching, twin.unknowns, twin.equations);
+    (matching, adj_matching, balanced, variables, equations, varData, eqData) := Matching.singular(matching, adj_matching, full, twin.unknowns, twin.equations, funcMap, varData, eqData, kind, false, false);
+    if referenceEq(balanced, full) then
+      adj_sorting := Adjacency.Matrix.upgradeFrom(adj_matching, full, variables.map, equations.map, equations, NBAdjacency.MatrixStrictness.SORTING, seed_sorting, seed_index);
+    else
+      full := balanced;
+      adj_sorting := Adjacency.Matrix.upgrade(adj_matching, full, variables.map, equations.map, equations, NBAdjacency.MatrixStrictness.SORTING);
+    end if;
+    comps := Sorting.tarjan(adj_sorting, matching, variables, equations);
+
+    twin.unknowns := variables;
+    twin.equations := equations;
+    twin.adjacencyMatrix := SOME(full);
+    twin.matching := SOME(matching);
+    twin.strongComponents := SOME(listArray(comps));
+  end causalizeTwin;
 
   function causalizeDAEMode extends Module.causalizeInterface;
   algorithm

--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBMatching.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBMatching.mo
@@ -184,6 +184,65 @@ public
     end if;
   end singular;
 
+  function fromSeed
+    "the matching of a causalized partition with nearly the same equations and
+    variables, transferred by name. A pair is kept when the variable is still a
+    solvable occurrence of the equation, the rest is left for the matching
+    algorithm to repair."
+    input Partition.Partition seed;
+    input Adjacency.Matrix adj;
+    input VariablePointers vars;
+    input EquationPointers eqns;
+    output Matching matching = EMPTY_MATCHING;
+  protected
+    Matching seed_matching;
+    Adjacency.Mapping seed_map, map;
+    array<Integer> var_to_eqn, eqn_to_var, data, var_index;
+    Integer e, v, eqn, var, eqn_start, eqn_len, seed_start, seed_len, seed_var_start, var_start, var_len, offset, first;
+  algorithm
+    if isNone(seed.matching) or isNone(seed.adjacencyMatrix) then return; end if;
+    seed_matching := Util.getOption(seed.matching);
+    () := match (Adjacency.Matrix.getMappingOpt(Util.getOption(seed.adjacencyMatrix)), adj)
+      case (SOME(seed_map), Adjacency.Matrix.FINAL(mapping = map)) algorithm
+        var_index := arrayCreate(arrayLength(seed_map.var_AtS), -1);
+        for i in 1:arrayLength(var_index) loop
+          var_index[i] := VariablePointers.getVarIndex(vars, BVariable.getVarName(VariablePointers.getVarAt(seed.unknowns, i)));
+        end for;
+        data := Adjacency.IntMatrix.entries(adj.m);
+        var_to_eqn := arrayCreate(arrayLength(map.var_StA), -1);
+        eqn_to_var := arrayCreate(arrayLength(map.eqn_StA), -1);
+        for i in 1:arrayLength(seed_map.eqn_AtS) loop
+          e := EquationPointers.getEqnIndex(eqns, Equation.getEqnName(EquationPointers.getEqnAt(seed.equations, i)));
+          if e < 1 then continue; end if;
+          (seed_start, seed_len) := seed_map.eqn_AtS[i];
+          (eqn_start, eqn_len) := map.eqn_AtS[e];
+          for k in 0:min(seed_len, eqn_len) - 1 loop
+            v := seed_matching.eqn_to_var[seed_start + k];
+            if v < 1 then continue; end if;
+            (seed_var_start, _) := seed_map.var_AtS[seed_map.var_StA[v]];
+            offset := v - seed_var_start;
+            v := var_index[seed_map.var_StA[v]];
+            if v < 1 then continue; end if;
+            (var_start, var_len) := map.var_AtS[v];
+            if offset >= var_len then continue; end if;
+            var := var_start + offset;
+            eqn := eqn_start + k;
+            first := adj.m.start[eqn];
+            for p in first:first + adj.m.len[eqn] - 1 loop
+              if data[p] == var then
+                eqn_to_var[eqn] := var;
+                var_to_eqn[var] := eqn;
+                break;
+              end if;
+            end for;
+          end for;
+        end for;
+        matching := MATCHING(var_to_eqn, eqn_to_var);
+      then ();
+      else ();
+    end match;
+  end fromSeed;
+
   function continue_
     input output Matching matching;
     input Adjacency.Matrix adj;

--- a/OMCompiler/Compiler/NBackEnd/Modules/NBModule.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/NBModule.mo
@@ -136,6 +136,7 @@ public
     input output VarData varData;
     input output EqData eqData;
     input UnorderedMap<Path, Function> funcMap;
+    input output list<Partition.Partition> twins "partitions of nearly the same system, causalized from this one's matrices";
   end causalizeInterface;
 
 //                           RESOLVING SINGULARITIES

--- a/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBAdjacency.mo
@@ -480,8 +480,12 @@ public
       "makes room for extra more entries so that adding them does not grow the buffer"
       input IntMatrix m;
       input Integer extra;
+      input Boolean withAux = false;
     algorithm
       Vector.reserve(m.data, Vector.size(m.data) + extra);
+      if withAux then
+        Vector.reserve(m.aux, Vector.size(m.aux) + extra);
+      end if;
     end reserveData;
 
     function clearRow
@@ -1167,6 +1171,135 @@ public
         print(toString(adj, "Final") + "\n");
       end if;
     end upgrade;
+
+    function equalRows
+      "equation index -> index of the equal equation in seed_eqns, 0 if none.
+      Its rows in a final matrix over (seed_eqns, seed_vars) are its rows in one
+      over (eqns, vars), so nothing is shared unless the variables are the same
+      in the same order."
+      input EquationPointers seed_eqns;
+      input VariablePointers seed_vars;
+      input EquationPointers eqns;
+      input VariablePointers vars;
+      output array<Integer> seed_index = arrayCreate(EquationPointers.lastUsedIndex(eqns), 0);
+    protected
+      Integer n = VariablePointers.size(vars), i;
+      Pointer<Equation> seed_eqn;
+    algorithm
+      if n <> VariablePointers.size(seed_vars) or n <> VariablePointers.lastUsedIndex(vars) or n <> VariablePointers.lastUsedIndex(seed_vars) then return; end if;
+      for j in 1:n loop
+        if not referenceEq(VariablePointers.getVarAt(vars, j), VariablePointers.getVarAt(seed_vars, j)) then return; end if;
+      end for;
+      for eqn in EquationPointers.toList(eqns) loop
+        i := EquationPointers.getEqnIndex(seed_eqns, Equation.getEqnName(eqn));
+        if i > 0 then
+          seed_eqn := EquationPointers.getEqnAt(seed_eqns, i);
+          if Equation.isEqual(Pointer.access(eqn), Pointer.access(seed_eqn)) then
+            seed_index[EquationPointers.getEqnIndex(eqns, Equation.getEqnName(eqn))] := i;
+          end if;
+        end if;
+      end for;
+    end equalRows;
+
+    function upgradeFrom
+      "upgrade, taking the rows of equations with a seed_index (see equalRows)
+      from seed, a final matrix of strictness st that shares its variables"
+      input output Matrix adj;
+      input Matrix full;
+      input UnorderedMap<ComponentRef, Integer> vars_map;
+      input UnorderedMap<ComponentRef, Integer> eqns_map;
+      input EquationPointers eqns;
+      input MatrixStrictness st;
+      input Matrix seed;
+      input array<Integer> seed_index;
+    protected
+      Integer min, max, rows, eqn_start, eqn_size, seed_start, own_entries = 0, shared_entries = 0;
+      Boolean fresh = isEmpty(adj);
+      IntMatrix m, own_m;
+      IntMatrix.Builder builder;
+      list<Integer> own = {};
+      list<ComponentRef> filtered;
+      array<Integer> data, aux, seed_data, seed_aux;
+    algorithm
+      max := Solvability.rank(Solvability.fromStrictness(st));
+      min := if fresh then -1 else Solvability.rank(Solvability.fromStrictness(getStrictness(adj)));
+      adj := match (adj, full, seed)
+        case (_, FULL(), FINAL()) guard(min < max) algorithm
+          if fresh then
+            adj := initialize(full.mapping, st);
+          end if;
+          adj := match adj
+            case FINAL() algorithm
+              if fresh then
+                adj.modes := Vector.copy(seed.modes);
+              end if;
+              rows := IntMatrix.rows(adj.m);
+              for index in UnorderedMap.valueList(eqns_map) loop
+                (eqn_start, eqn_size) := adj.mapping.eqn_AtS[index];
+                if seed_index[index] > 0 then
+                  (seed_start, _) := seed.mapping.eqn_AtS[seed_index[index]];
+                  for k in 0:eqn_size - 1 loop
+                    shared_entries := shared_entries + seed.m.len[seed_start + k];
+                  end for;
+                else
+                  own := index :: own;
+                  for k in 0:eqn_size - 1 loop
+                    own_entries := own_entries + adj.m.len[eqn_start + k];
+                  end for;
+                  own_entries := own_entries + UnorderedSet.size(full.occurrences[index]) * eqn_size;
+                end if;
+              end for;
+              own := listReverse(own);
+
+              // the own rows are built the way upgrade builds all rows
+              builder := IntMatrix.newBuilder(own_entries, true);
+              data := IntMatrix.entries(adj.m);
+              aux := IntMatrix.payload(adj.m);
+              for index in own loop
+                (eqn_start, eqn_size) := adj.mapping.eqn_AtS[index];
+                for k in eqn_size - 1:-1:0 loop
+                  for p in adj.m.start[eqn_start + k] + adj.m.len[eqn_start + k] - 1:-1:adj.m.start[eqn_start + k] loop
+                    IntMatrix.builderAddAux(builder, eqn_start + k, data[p], if arrayLength(aux) > 0 then aux[p] else 0);
+                  end for;
+                end for;
+              end for;
+              for index in own loop
+                filtered := Solvability.filter(UnorderedSet.toList(full.occurrences[index]), full.solvabilities[index], vars_map, min + 1, max);
+                upgradeRow(EquationPointers.getEqnAt(eqns, index), index, filtered, full.dependencies[index], full.repetitions[index], vars_map, vars_map, builder, adj.mapping, adj.modes);
+              end for;
+              own_m := IntMatrix.fromBuilder(builder, rows);
+
+              m := IntMatrix.new(rows);
+              IntMatrix.reserveData(m, shared_entries + IntMatrix.nonZeroCount(own_m), true);
+              data := IntMatrix.entries(own_m);
+              aux := IntMatrix.payload(own_m);
+              seed_data := IntMatrix.entries(seed.m);
+              seed_aux := IntMatrix.payload(seed.m);
+              if arrayLength(seed_aux) == 0 then
+                seed_aux := arrayCreate(arrayLength(seed_data), 0);
+              end if;
+              for index in UnorderedMap.valueList(eqns_map) loop
+                (eqn_start, eqn_size) := adj.mapping.eqn_AtS[index];
+                if seed_index[index] > 0 then
+                  (seed_start, _) := seed.mapping.eqn_AtS[seed_index[index]];
+                  for k in 0:eqn_size - 1 loop
+                    IntMatrix.copyRow(seed.m, seed_start + k, seed_data, seed_aux, m, eqn_start + k);
+                  end for;
+                else
+                  for k in 0:eqn_size - 1 loop
+                    IntMatrix.copyRow(own_m, eqn_start + k, data, aux, m, eqn_start + k);
+                  end for;
+                end if;
+              end for;
+              adj.m  := m;
+              adj.mT := IntMatrix.transpose(m, arrayLength(adj.mapping.var_StA));
+            then adj;
+            else adj;
+          end match;
+        then adj;
+        else upgrade(adj, full, vars_map, eqns_map, eqns, st);
+      end match;
+    end upgradeFrom;
 
     function expand
       "expands the adjacency matrix adj with new information provided by vn and en.


### PR DESCRIPTION
The lambda=0 initialization system is a clone of the initialization system in which every `homotopy(actual, simplified)` became `simplified`, yet it was causalized from scratch: adjacency, the three matching phases and the sorting all over again. On ScalableTestGrids `Type1_N_8_M_4` that second pass cost 1.14 GB and ~4 s for a system in which 9 of 25734 equations differ.

`Causalize.applyModule` now hands each init partition its init_0 twin (paired by partition index) and `causalizePseudoArray` causalizes the twin from what it just computed for the seed:

* `Adjacency.Matrix.equalRows` finds the equations that are equal to their namesake in the seed (`Equation.isEqual`), provided both partitions have the same variables in the same order, and `upgradeFrom` copies their rows and mode ids from the seed's matching and sorting matrices, building only the other rows. The full matrix is still built per partition: `expand` and `refine` mutate its per-equation maps in place, and Tearing and Jacobian run on init after init_0 was causalized.
* `Matching.fromSeed` starts from the seed's matching, keeping a pair when the variable is still a solvable occurrence of the equation in the twin, and the PF+ repair (`clear = false`) completes it.

Only the rows of the changed equations and the augmenting paths that repair their pairs can differ from a fresh causalization, so the lambda=0 strong components may come out different where the simplified branch drops an unknown: `impliedInner` swaps the two residuals of its `INI_0` NLS. The other five homotopy models of the NBackend suite generate byte-identical C, the suite passes as before (219/224, the 5 failures are environmental or known) and `Type1_N_8_M_4` translates identically up to its known `Solve.EXPLICIT` failure.

`Type1_N_8_M_4`, `[INI] Causalize`: 2.29 GB / 7.4 s -> 1.90 GB / 6.0 s. The init_0 pass alone: 1.14 GB -> 0.75 GB, of which createFull 86 MB and tarjan 494 MB remain.

Assisted-by: Claude Fable 5.1

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
