### PR TITLE
[Runtime] Load LAPACK on demand on Windows (#16638)

### DIFF
--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -44,6 +44,7 @@ set(OMC_RUNTIME_SOURCES
     ErrorMessage.cpp
     System_omc.c
     Lapack_omc.cpp
+    omc_lapack.c
     Settings_omc.cpp
     UnitParserExt_omc.cpp
     unitparser.cpp
@@ -94,7 +95,32 @@ if(OM_OMC_ENABLE_COLPACK)
 endif()
 
 if(OM_OMC_USE_LAPACK)
-  target_link_libraries(omcruntime PUBLIC ${LAPACK_LIBRARIES})
+  if(WIN32)
+    # Do not import LAPACK into the compiler on Windows. OpenBLAS allocates its
+    # per-thread buffers in DllMain, which Windows charges as committed memory
+    # (~128 MB per hardware thread) on every omc process even though the
+    # compiler never writes to them. lapackimpl.c loads the library on demand
+    # instead, with the thread count pinned to one across the load. See #16638.
+    #
+    # Hand it the library the build resolved so it does not have to guess: an
+    # import library such as libopenblas.dll.a names the DLL beside it. Only the
+    # first entry is needed, it is the one carrying the LAPACK routines, and the
+    # loader in lapackimpl.c falls back to the usual names if it does not open.
+    list(GET LAPACK_LIBRARIES 0 OMC_LAPACK_DLL)
+    if(OMC_LAPACK_DLL MATCHES "^-l(.+)$")
+      # A bare linker flag rather than a path, e.g. -lopenblas.
+      set(OMC_LAPACK_DLL "lib${CMAKE_MATCH_1}")
+    endif()
+    get_filename_component(OMC_LAPACK_DLL "${OMC_LAPACK_DLL}" NAME)
+    string(REGEX REPLACE "\\.(a|lib)$" "" OMC_LAPACK_DLL "${OMC_LAPACK_DLL}")
+    if(NOT OMC_LAPACK_DLL MATCHES "\\.dll$")
+      set(OMC_LAPACK_DLL "${OMC_LAPACK_DLL}.dll")
+    endif()
+    message(STATUS "omc will load LAPACK on demand from ${OMC_LAPACK_DLL}")
+    target_compile_definitions(omcruntime PRIVATE OMC_LAPACK_DLL_NAMES="${OMC_LAPACK_DLL}")
+  else()
+    target_link_libraries(omcruntime PUBLIC ${LAPACK_LIBRARIES})
+  endif()
 endif()
 
 target_include_directories(omcruntime PUBLIC ${Intl_INCLUDE_DIRS})

--- a/OMCompiler/Compiler/runtime/lapackimpl.c
+++ b/OMCompiler/Compiler/runtime/lapackimpl.c
@@ -53,6 +53,7 @@ extern "C" {
 #include "util/rtclock.h"
 #include "omc_config.h"
 #include "errorext.h"
+#include "omc_lapack.h"
 
 /*
  * Platform specific includes and defines
@@ -91,70 +92,6 @@ static void OMC_NO_LAPACK_ERROR() {
 
 
 #ifdef HAVE_LAPACK
-
-#ifdef HAVE_LAPACK_DEPRECATED
-
-extern int dgeqpf_(integer *m, integer *n, doublereal *a, integer *lda,
-  integer *jpvt, doublereal *tau, doublereal *work, integer *info);
-
-extern int dgegv_(const char *jobvl, const char *jobvr, integer *n, doublereal *a,
-  integer *lda, doublereal *b, integer *ldb, doublereal *alphar,
-  doublereal *alphai, doublereal *beta, doublereal *vl, integer *ldvl,
-  doublereal *vr, integer *ldvr, doublereal *work, integer *lwork,
-  integer *info);
-
-extern int dgelsx_(integer *m, integer *n, integer *nrhs, doublereal *a,
-  integer *lda, doublereal *b, integer *ldb, integer *jpvt, doublereal *rcond,
-  integer *rank, doublereal *work, integer *info);
-
-#endif
-
-extern int dgeev_(const char *jobvl, const char *jobvr, integer *n,
-  doublereal *a, integer *lda, doublereal *wr, doublereal *wi, doublereal *vl,
-  integer *ldvl, doublereal *vr, integer *ldvr, doublereal *work,
-  integer *lwork, integer *info);
-
-extern int dgels_(const char *trans, integer *m, integer *n, integer *nrhs,
-  doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal *work,
-  integer *lwork, integer *info);
-
-extern int dgelsy_(integer *m, integer *n, integer *nrhs, doublereal *a,
-  integer *lda, doublereal *b, integer *ldb, integer *jpvt, doublereal *rcond,
-  integer *rank, doublereal *work, integer *lwork, integer *info);
-
-extern int dgesv_(integer *n, integer *nrhs, doublereal *a, integer *lda,
-  integer *ipiv, doublereal *b, integer *ldb, integer *info);
-
-extern int dgglse_(integer *m, integer *n, integer *p, doublereal *a,
-  integer *lda, doublereal *b, integer *ldb, doublereal *c, doublereal *d,
-  doublereal *x, doublereal *work, integer *lwork, integer *info);
-
-extern int dgtsv_(integer *n, integer *nrhs, doublereal *dl, doublereal *d,
-  doublereal *du, doublereal *b, integer *ldb, integer *info);
-
-extern int dgbsv_(integer *n, integer *kl, integer *ku, integer *nrhs,
-  doublereal *ab, integer *ldab, integer *ipiv, doublereal *b,
-  integer *ldb, integer *info);
-
-extern int dgesvd_(const char *jobu, const char *jobvt, integer *m, integer *n,
-  doublereal *a, integer *lda, doublereal *s, doublereal *u, integer *ldu,
-  doublereal *vt, integer *ldvt, doublereal *work, integer *lwork, integer *info);
-
-extern int dgetrf_(integer *m, integer *n, doublereal *a, integer *lda,
-  integer *ipiv, integer *info);
-
-extern int dgetrs_(const char *trans, integer *n, integer *nrhs, doublereal *a,
-  integer *lda, integer *ipiv, doublereal *b, integer *ldb, integer *info);
-
-extern int dgetri_(integer *n, doublereal *a, integer *lda, integer *ipiv,
-  doublereal *work, integer *lwork, integer *info);
-
-extern int dorgqr_(integer *m, integer *n, integer *k, doublereal *a,
-  integer *lda, doublereal *tau, doublereal *work, integer *lwork, integer *info);
-
-extern int dhseqr_(const char *job, const char *compz, integer *n, integer *ilo,
-  integer *ihi, doublereal *h, integer *ldh, doublereal *wr, doublereal *wi,
-  doublereal *z, integer *ldz, doublereal *work, integer *lwork, integer *info);
 
 static double* alloc_real_matrix(int N, int M, void *data)
 {
@@ -347,7 +284,7 @@ void LapackImpl__dgeev(const char *jobvl, const char *jobvr, int N, void *inA, i
   vl = alloc_zeroed_real_matrix(ldvl, n);
   vr = alloc_zeroed_real_matrix(ldvr, n);
 
-  dgeev_(jobvl, jobvr, &n, a, &lda, wr, wi, vl, &ldvl, vr, &ldvr, work,
+  OMC_LAPACK(dgeev_)(jobvl, jobvr, &n, a, &lda, wr, wi, vl, &ldvl, vr, &ldvr, work,
     &lwork, &info);
 
   *outA = mk_rml_real_matrix(lda, n, a);
@@ -394,7 +331,7 @@ void LapackImpl__dgegv(const char *jobvl, const char *jobvr, int N, void *A, int
   vr = alloc_zeroed_real_matrix(ldvl, n);
   work = alloc_real_vector(lwork, inWORK);
 
-  dgegv_(&*jobvl, &*jobvr, &n, a, &lda, b, &ldb, alphar, alphai, beta, vl,
+  OMC_LAPACK(dgegv_)(&*jobvl, &*jobvr, &n, a, &lda, b, &ldb, alphar, alphai, beta, vl,
     &ldvl, vr, &ldvr, work, &lwork, &info);
 
   *ALPHAR = mk_rml_real_vector(n, alphar);
@@ -437,7 +374,7 @@ void LapackImpl__dgels(const char *trans, int M, int N, int NRHS, void *inA,
   b = alloc_real_matrix(lda, nrhs, inB);
   work = alloc_real_vector(lwork, inWORK);
 
-  dgels_(&*trans, &m, &n, &nrhs, a, &lda, b, &ldb, work, &lwork, &info);
+  OMC_LAPACK(dgels_)(&*trans, &m, &n, &nrhs, a, &lda, b, &ldb, work, &lwork, &info);
 
   *outA = mk_rml_real_matrix(lda, n, a);
   *outB = mk_rml_real_matrix(lda, nrhs, b);
@@ -473,7 +410,7 @@ void LapackImpl__dgelsx(int M, int N, int NRHS, void *inA, int LDA,
   work = alloc_real_vector(lwork, WORK);
   jpvt = alloc_int_vector(n, inJPVT);
 
-  dgelsx_(&m, &n, &nrhs, a, &lda, b, &ldb, jpvt, &rcond, &rank, work, &info);
+  OMC_LAPACK(dgelsx_)(&m, &n, &nrhs, a, &lda, b, &ldb, jpvt, &rcond, &rank, work, &info);
 
   *outA = mk_rml_real_matrix(lda, n, a);
   *outB = mk_rml_real_matrix(lda, nrhs, b);
@@ -511,7 +448,7 @@ void LapackImpl__dgelsy(int M, int N, int NRHS, void *inA, int LDA,
   work = alloc_real_vector(lwork, inWORK);
   jpvt = alloc_int_vector(n, inJPVT);
 
-  dgelsy_(&m, &n, &nrhs, a, &lda, b, &ldb, jpvt, &rcond, &rank, work, &lwork, &info);
+  OMC_LAPACK(dgelsy_)(&m, &n, &nrhs, a, &lda, b, &ldb, jpvt, &rcond, &rank, work, &lwork, &info);
 
   *outA = mk_rml_real_matrix(lda, n, a);
   *outB = mk_rml_real_matrix(lda, nrhs, b);
@@ -546,7 +483,7 @@ void LapackImpl__dgesv(int N, int NRHS, void *inA, int LDA, void *inB,
   b = alloc_real_matrix(ldb, nrhs, inB);
   ipiv = alloc_zeroed_int_vector(n);
 
-  dgesv_(&n, &nrhs, a, &lda, ipiv, b, &ldb, &info);
+  OMC_LAPACK(dgesv_)(&n, &nrhs, a, &lda, ipiv, b, &ldb, &info);
 
   *outA = mk_rml_real_matrix(lda, n, a);
   *outB = mk_rml_real_matrix(ldb, nrhs, b);
@@ -584,7 +521,7 @@ void LapackImpl__dgglse(int M, int N, int P, void *inA, int LDA,
   x = alloc_zeroed_real_vector(n);
   work = alloc_real_vector(lwork, inWORK);
 
-  dgglse_(&m, &n, &p, a, &lda, b, &ldb, c, d, x, work, &lwork, &info);
+  OMC_LAPACK(dgglse_)(&m, &n, &p, a, &lda, b, &ldb, c, d, x, work, &lwork, &info);
 
   *outA = mk_rml_real_matrix(lda, n, a);
   *outB = mk_rml_real_matrix(ldb, n, b);
@@ -622,7 +559,7 @@ void LapackImpl__dgtsv(int N, int NRHS, void *inDL, void *inD, void *inDU,
   du = alloc_real_vector(n - 1, inDU);
   b = alloc_real_matrix(ldb, nrhs, inB);
 
-  dgtsv_(&n, &nrhs, dl, d, du, b, &ldb, &info);
+  OMC_LAPACK(dgtsv_)(&n, &nrhs, dl, d, du, b, &ldb, &info);
 
   *outDL = mk_rml_real_vector(n - 1, dl);
   *outD = mk_rml_real_vector(n, d);
@@ -659,7 +596,7 @@ void LapackImpl__dgbsv(int N, int KL, int KU, int NRHS, void *inAB,
   b = alloc_real_matrix(ldb, nrhs, inB);
   ipiv = alloc_zeroed_int_vector(n);
 
-  dgbsv_(&n, &kl, &ku, &nrhs, ab, &ldab, ipiv, b, &ldb, &info);
+  OMC_LAPACK(dgbsv_)(&n, &kl, &ku, &nrhs, ab, &ldab, ipiv, b, &ldb, &info);
 
   *outAB = mk_rml_real_matrix(ldab, n, ab);
   *outB = mk_rml_real_matrix(ldb, nrhs, b);
@@ -699,7 +636,7 @@ void LapackImpl__dgesvd(const char *jobu, const char *jobvt, int M, int N, void 
   vt = alloc_zeroed_real_matrix(ldvt, n);
   work = alloc_real_vector(lwork, inWORK);
 
-  dgesvd_(&*jobu, &*jobvt, &m, &n, a, &lda, s, u, &ldu, vt, &ldvt, work,
+  OMC_LAPACK(dgesvd_)(&*jobu, &*jobvt, &m, &n, a, &lda, s, u, &ldu, vt, &ldvt, work,
     &lwork, &info);
 
   *outA = mk_rml_real_matrix(lda, n, a);
@@ -735,7 +672,7 @@ void LapackImpl__dgetrf(int M, int N, void *inA, int LDA, void **outA,
   a = alloc_real_matrix(lda, n, inA);
   ipiv = alloc_zeroed_int_vector(ldipiv);
 
-  dgetrf_(&m, &n, a, &lda, ipiv, &info);
+  OMC_LAPACK(dgetrf_)(&m, &n, a, &lda, ipiv, &info);
 
   *outA = mk_rml_real_matrix(lda, n, a);
   *IPIV = mk_rml_int_vector(ldipiv, ipiv);
@@ -765,7 +702,7 @@ void LapackImpl__dgetrs(const char *trans, int N, int NRHS, void *inA, int LDA,
   b = alloc_real_matrix(ldb, nrhs, inB);
   ipiv = alloc_int_vector(n, IPIV);
 
-  dgetrs_(&*trans, &n, &nrhs, a, &lda, ipiv, b, &ldb, &info);
+  OMC_LAPACK(dgetrs_)(&*trans, &n, &nrhs, a, &lda, ipiv, b, &ldb, &info);
 
   *outB = mk_rml_real_matrix(ldb, nrhs, b);
   *INFO = info;
@@ -794,7 +731,7 @@ void LapackImpl__dgetri(int N, void *inA, int LDA, void *IPIV, void *inWORK,
   work = alloc_real_vector(lwork, inWORK);
   ipiv = alloc_int_vector(n, IPIV);
 
-  dgetri_(&n, a, &lda, ipiv, work, &lwork, &info);
+  OMC_LAPACK(dgetri_)(&n, a, &lda, ipiv, work, &lwork, &info);
 
   *outA = mk_rml_real_matrix(lda, n, a);
   *outWORK = mk_rml_real_vector(lwork, work);
@@ -827,7 +764,7 @@ void LapackImpl__dgeqpf(int M, int N, void *inA, int LDA, void *inJPVT,
   tau = alloc_zeroed_real_vector(ldtau);
   work = alloc_real_vector(lwork, WORK);
 
-  dgeqpf_(&m, &n, a, &lda, jpvt, tau, work, &info);
+  OMC_LAPACK(dgeqpf_)(&m, &n, a, &lda, jpvt, tau, work, &info);
 
   *outA = mk_rml_real_matrix(lda, n, a);
   *outJPVT = mk_rml_int_vector(n, jpvt);
@@ -861,7 +798,7 @@ void LapackImpl__dorgqr(int M, int N, int K, void *inA, int LDA,
   tau = alloc_real_vector(k, TAU);
   work = alloc_real_vector(lwork, inWORK);
 
-  dorgqr_(&m, &n, &k, a, &lda, tau, work, &lwork, &info);
+  OMC_LAPACK(dorgqr_)(&m, &n, &k, a, &lda, tau, work, &lwork, &info);
 
   *outA = mk_rml_real_matrix(lda, n, a);
   *outWORK = mk_rml_real_vector(lwork, work);
@@ -896,7 +833,7 @@ void LapackImpl__dhseqr(const char *job, const char *compz, int N, int ILO, int 
   wi = alloc_zeroed_real_vector(n);
   work = alloc_real_vector(lwork, inWORK);
 
-  dhseqr_(job, compz, &n, &ilo, &ihi, h, &ldh, wr, wi, z, &ldz, work, &lwork, &info);
+  OMC_LAPACK(dhseqr_)(job, compz, &n, &ilo, &ihi, h, &ldh, wr, wi, z, &ldz, work, &lwork, &info);
 
   *outH = mk_rml_real_matrix(ldh, n, h);
   *WR = mk_rml_real_vector(n, wr);

--- a/OMCompiler/Compiler/runtime/omc_lapack.c
+++ b/OMCompiler/Compiler/runtime/omc_lapack.c
@@ -1,0 +1,123 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+/*
+ * The Windows side of omc_lapack.h: loading the library and resolving the
+ * routines. Everywhere else the routines are linked in and this file is empty.
+ */
+
+#include "omc_lapack.h"
+
+#if defined(HAVE_LAPACK) && defined(_WIN32)
+
+#include <stdio.h>
+#include <string.h>
+#include <windows.h>
+
+#include "meta/meta_modelica.h"
+#include "errorext.h"
+
+#ifndef OMC_LAPACK_DLL_NAMES
+#define OMC_LAPACK_DLL_NAMES ""
+#endif
+
+/* Tried after whatever the build system derived from LAPACK_LIBRARIES. */
+#define OMC_LAPACK_DLL_FALLBACKS "libopenblas.dll;openblas.dll;liblapack.dll;lapack.dll"
+
+#define OMC_LAPACK_DEFINE_POINTER(name, ret, params) \
+  omc_lapack_fp_##name omc_lapack_ptr_##name = NULL;
+OMC_LAPACK_FUNCTIONS(OMC_LAPACK_DEFINE_POINTER)
+
+#define OMC_LAPACK_RESOLVE(name, ret, params) \
+  omc_lapack_ptr_##name = (omc_lapack_fp_##name) GetProcAddress(lib, #name);
+
+static HMODULE omc_lapack_load_library(void)
+{
+  /* Pin OpenBLAS to a single thread across the load, then put the variable
+     back the way it was so that child processes are unaffected. */
+  char names[1024];
+  char saved[64];
+  DWORD saved_len;
+  int had_saved;
+  HMODULE lib = NULL;
+  char *name;
+  char *rest;
+
+  snprintf(names, sizeof(names), "%s%s%s", OMC_LAPACK_DLL_NAMES,
+           OMC_LAPACK_DLL_NAMES[0] ? ";" : "", OMC_LAPACK_DLL_FALLBACKS);
+
+  saved_len = GetEnvironmentVariableA("OMP_NUM_THREADS", saved, sizeof(saved));
+  had_saved = saved_len > 0 && saved_len < sizeof(saved);
+  SetEnvironmentVariableA("OMP_NUM_THREADS", "1");
+
+  rest = names;
+  while ((name = strtok(rest, ";")) != NULL) {
+    rest = NULL;
+    lib = LoadLibraryA(name);
+    if (lib) {
+      break;
+    }
+  }
+
+  SetEnvironmentVariableA("OMP_NUM_THREADS", had_saved ? saved : NULL);
+  return lib;
+}
+
+void* omc_lapack_symbol(void **slot, const char *name)
+{
+  static int loaded = 0;
+
+  if (!loaded) {
+    HMODULE lib = omc_lapack_load_library();
+    loaded = 1;
+    if (lib) {
+      OMC_LAPACK_FUNCTIONS(OMC_LAPACK_RESOLVE)
+    }
+  }
+
+  if (!*slot) {
+    const char *ctokens[1];
+    ctokens[0] = name;
+    c_add_message(NULL, -1, ErrorType_runtime, ErrorLevel_error,
+                  "The LAPACK routine %s could not be loaded. Make sure a LAPACK "
+                  "library (libopenblas.dll for instance) can be found on the PATH.\n",
+                  ctokens, 1);
+    MMC_THROW();
+  }
+
+  return *slot;
+}
+
+#endif /* HAVE_LAPACK && _WIN32 */

--- a/OMCompiler/Compiler/runtime/omc_lapack.h
+++ b/OMCompiler/Compiler/runtime/omc_lapack.h
@@ -1,0 +1,154 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+/*
+ * Shared access to the LAPACK routines omc calls. Include this instead of
+ * declaring the routines yourself, and call them through OMC_LAPACK(), so that
+ * every caller goes through the same path on Windows.
+ */
+
+#ifndef OMC_LAPACK_H
+#define OMC_LAPACK_H
+
+#include "omc_config.h"
+#include "openmodelica_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef HAVE_LAPACK
+
+#ifdef HAVE_LAPACK_DEPRECATED
+#define OMC_LAPACK_DEPRECATED_FUNCTIONS(X) \
+  X(dgeqpf_, int, (integer *m, integer *n, doublereal *a, integer *lda, \
+      integer *jpvt, doublereal *tau, doublereal *work, integer *info)) \
+  X(dgegv_, int, (const char *jobvl, const char *jobvr, integer *n, doublereal *a, \
+      integer *lda, doublereal *b, integer *ldb, doublereal *alphar, \
+      doublereal *alphai, doublereal *beta, doublereal *vl, integer *ldvl, \
+      doublereal *vr, integer *ldvr, doublereal *work, integer *lwork, \
+      integer *info)) \
+  X(dgelsx_, int, (integer *m, integer *n, integer *nrhs, doublereal *a, \
+      integer *lda, doublereal *b, integer *ldb, integer *jpvt, doublereal *rcond, \
+      integer *rank, doublereal *work, integer *info))
+#else
+#define OMC_LAPACK_DEPRECATED_FUNCTIONS(X)
+#endif
+
+#define OMC_LAPACK_FUNCTIONS(X) \
+  OMC_LAPACK_DEPRECATED_FUNCTIONS(X) \
+  X(dgeev_, int, (const char *jobvl, const char *jobvr, integer *n, \
+      doublereal *a, integer *lda, doublereal *wr, doublereal *wi, doublereal *vl, \
+      integer *ldvl, doublereal *vr, integer *ldvr, doublereal *work, \
+      integer *lwork, integer *info)) \
+  X(dgels_, int, (const char *trans, integer *m, integer *n, integer *nrhs, \
+      doublereal *a, integer *lda, doublereal *b, integer *ldb, doublereal *work, \
+      integer *lwork, integer *info)) \
+  X(dgelsy_, int, (integer *m, integer *n, integer *nrhs, doublereal *a, \
+      integer *lda, doublereal *b, integer *ldb, integer *jpvt, doublereal *rcond, \
+      integer *rank, doublereal *work, integer *lwork, integer *info)) \
+  X(dgesv_, int, (integer *n, integer *nrhs, doublereal *a, integer *lda, \
+      integer *ipiv, doublereal *b, integer *ldb, integer *info)) \
+  X(dgglse_, int, (integer *m, integer *n, integer *p, doublereal *a, \
+      integer *lda, doublereal *b, integer *ldb, doublereal *c, doublereal *d, \
+      doublereal *x, doublereal *work, integer *lwork, integer *info)) \
+  X(dgtsv_, int, (integer *n, integer *nrhs, doublereal *dl, doublereal *d, \
+      doublereal *du, doublereal *b, integer *ldb, integer *info)) \
+  X(dgbsv_, int, (integer *n, integer *kl, integer *ku, integer *nrhs, \
+      doublereal *ab, integer *ldab, integer *ipiv, doublereal *b, \
+      integer *ldb, integer *info)) \
+  X(dgesvd_, int, (const char *jobu, const char *jobvt, integer *m, integer *n, \
+      doublereal *a, integer *lda, doublereal *s, doublereal *u, integer *ldu, \
+      doublereal *vt, integer *ldvt, doublereal *work, integer *lwork, integer *info)) \
+  X(dgetrf_, int, (integer *m, integer *n, doublereal *a, integer *lda, \
+      integer *ipiv, integer *info)) \
+  X(dgetrs_, int, (const char *trans, integer *n, integer *nrhs, doublereal *a, \
+      integer *lda, integer *ipiv, doublereal *b, integer *ldb, integer *info)) \
+  X(dgetri_, int, (integer *n, doublereal *a, integer *lda, integer *ipiv, \
+      doublereal *work, integer *lwork, integer *info)) \
+  X(dorgqr_, int, (integer *m, integer *n, integer *k, doublereal *a, \
+      integer *lda, doublereal *tau, doublereal *work, integer *lwork, integer *info)) \
+  X(dhseqr_, int, (const char *job, const char *compz, integer *n, integer *ilo, \
+      integer *ihi, doublereal *h, integer *ldh, doublereal *wr, doublereal *wi, \
+      doublereal *z, integer *ldz, doublereal *work, integer *lwork, integer *info))
+
+#if defined(_WIN32)
+
+/*
+ * On Windows the LAPACK library is loaded on demand rather than imported by
+ * the compiler DLL, and it is loaded with OMP_NUM_THREADS pinned to one.
+ *
+ * OpenBLAS allocates its per-thread buffers in DllMain, sized by the thread
+ * count, and Windows charges the whole allocation as committed memory even
+ * though the buffers are never written. That is roughly 128 MB per hardware
+ * thread on every omc process, several gigabytes on a build agent, while the
+ * working set stays a few tens of megabytes. The compiler only ever does
+ * small dense solves, so a threaded BLAS buys it nothing.
+ *
+ * Neither loading late nor asking for fewer threads afterwards helps on its
+ * own: DllMain runs either way, and by the time openblas_set_num_threads is
+ * reachable the memory is already committed. Only the environment, read once
+ * during DllMain, changes the outcome. It is restored right after the load so
+ * that compilers and simulations spawned by omc keep full threading.
+ */
+
+#define OMC_LAPACK_DECLARE_POINTER(name, ret, params) \
+  typedef ret (*omc_lapack_fp_##name) params; \
+  extern omc_lapack_fp_##name omc_lapack_ptr_##name;
+OMC_LAPACK_FUNCTIONS(OMC_LAPACK_DECLARE_POINTER)
+
+/* Loads the library on first use and hands back the routine, or reports an
+   error and throws if it cannot be resolved. */
+void* omc_lapack_symbol(void **slot, const char *name);
+
+#define OMC_LAPACK(name) \
+  (*(omc_lapack_fp_##name) omc_lapack_symbol((void**)&omc_lapack_ptr_##name, #name))
+
+#else /* not Windows: the library is linked in, call it directly */
+
+#define OMC_LAPACK_DECLARE_EXTERN(name, ret, params) extern ret name params;
+OMC_LAPACK_FUNCTIONS(OMC_LAPACK_DECLARE_EXTERN)
+
+#define OMC_LAPACK(name) name
+
+#endif
+
+#endif /* HAVE_LAPACK */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OMC_LAPACK_H */

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -63,6 +63,7 @@ extern "C" {
 #include "util/rtclock.h"
 #include "omc_config.h"
 #include "errorext.h"
+#include "omc_lapack.h"
 #include "settingsimpl.h"
 #include "printimpl.h"
 
@@ -2046,14 +2047,12 @@ static int SystemImpl__uriToClassAndPath(const char *uri, const char **scheme, c
 }
 
 /* adrpo 2011-06-23
- * extern definition to dgesv_ from -llapack
- * as we do not link with -lsim and the one
- * in matrix.h got renamed to _omc_dgesv_ to
- * avoid name clashes!
+ * dgesv_ comes from -llapack, since we do not link with -lsim and the one in
+ * matrix.h got renamed to _omc_dgesv_ to avoid name clashes. It is declared by
+ * omc_lapack.h and reached through OMC_LAPACK() so that this call shares the
+ * Windows on-demand loading with the rest of the compiler.
  */
 #ifdef HAVE_LAPACK
-
-extern int dgesv_(integer *n, integer *nrhs, doublereal *a, integer *lda, integer *ipiv, doublereal *b, integer *ldb, integer *info);
 
 int SystemImpl__dgesv(void *lA, void *lB, void **res)
 {
@@ -2085,7 +2084,7 @@ int SystemImpl__dgesv(void *lA, void *lB, void **res)
   assert(ipiv != 0);
   lda = sz;
   ldb = sz;
-  dgesv_(&sz,&nrhs,A,&lda,ipiv,B,&ldb,&info);
+  OMC_LAPACK(dgesv_)(&sz,&nrhs,A,&lda,ipiv,B,&ldb,&info);
 
   tmp = mmc_mk_nil();
   while (sz--) {


### PR DESCRIPTION
Fixes #16638

### The problem

On Windows every `omc.exe` committed roughly 128 MB per hardware thread at startup,
before doing any work: 3.2 GB on a 24-CPU machine, about 4.1 GB on a 32-CPU build
agent. The working set never left a few tens of megabytes, so the memory was
committed and never touched. Several `omc.exe` in parallel took the machine's commit
charge to nearly 100%.

`libOpenModelicaCompiler.dll` statically imported `libopenblas.dll` for the LAPACK
routines, so the loader mapped OpenBLAS before `main` ran on every invocation, whether
or not a LAPACK routine was ever called. OpenBLAS allocates its per-thread buffers in
`DllMain`, and Windows charges those pages as committed even though they are never
written. The identical allocation on Linux is a lazy mapping that costs nothing, which
is why this was invisible there.

### The fix

Drop the static import on Windows and resolve the routines through `GetProcAddress`,
with `OMP_NUM_THREADS` pinned to one across the load and restored immediately
afterwards so that compilers and simulations spawned by `omc` keep full threading.

Three things that do **not** work on their own, all measured:

- `OPENBLAS_NUM_THREADS`. OMDev's OpenBLAS 0.3.33 is built `USE_OPENMP=ON`, so only
  `OMP_NUM_THREADS` applies.
- Loading late with `LoadLibrary`. `DllMain` runs either way.
- `openblas_set_num_threads(1)` after the load. The memory is already committed.

Only the environment, read once during `DllMain`, changes the outcome.

The build passes the resolved library name down as `OMC_LAPACK_DLL_NAMES`, and the
loader falls back to the usual names if that one does not open. A routine that cannot
be resolved now reports an error instead of failing to link.

The declarations move into `omc_lapack.h`, driven off one list so the linked path and
the loaded path cannot drift apart, and both callers reach the routines through
`OMC_LAPACK()`: the scripting `Lapack` package in `lapackimpl.c` and
`SystemImpl__dgesv` in `systemimpl.c`. The loader itself lives in `omc_lapack.c`, so
the library is opened once no matter which caller gets there first.

Behaviour on every other platform is unchanged: there the routines are still linked
in and called directly.

### Measurements

Peak private bytes for the same 2x2 `dgesv` solve on a 24-CPU Windows machine, built
with the OMDev UCRT64 toolchain. Both probes produce the same answer.

| build | peak private bytes |
| --- | --- |
| static import, as before | 3208 MB |
| loaded on demand, solving | 258 MB |
| loaded on demand, never calling LAPACK | 1 MB |

The last row is the common case. `omc` only calls LAPACK for a few scripting API
routines, so most invocations now never load OpenBLAS at all.

Also verified on Windows, by compiling `omc_lapack.c` and two callers with the OMDev
UCRT64 toolchain, that the two translation units share one load and both get correct
results. And that the exe's import table no longer names
`libopenblas.dll`, that `OMP_NUM_THREADS` is left exactly as it was found (unset stays
unset, a preset value of 8 comes back as 8), and that an unreachable library gives the
new error message rather than a crash.

On Linux `testsuite/simulation/modelica/others/TestLapack.mos` passes.

### Not covered here

`libSimulationRuntimeC.dll` also statically imports `libopenblas.dll`, so generated
simulation executables on Windows likely pay the same startup commit. That is not
measured and not part of this PR.

---
generated by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169z6Q19ma3kw9VfwR5Z7RV
