### PR TITLE
Fix display unit combobox editor issues in Variable browser

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/ItemDelegate.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ItemDelegate.cpp
@@ -38,8 +38,6 @@
  */
 
 #include "ItemDelegate.h"
-#include "Modeling/ModelWidgetContainer.h"
-#include "Modeling/LibraryTreeWidget.h"
 #include "Plotting/VariablesWidget.h"
 #include "Simulation/SimulationOutputWidget.h"
 #include "OMPlot.h"
@@ -342,7 +340,19 @@ QWidget* ItemDelegate::createEditor(QWidget *pParent, const QStyleOptionViewItem
       foreach (QString unit, pVariablesTreeItem->getDisplayUnits()) {
         pComboBox->addItem(OMPlot::Plot::convertUnitToSymbol(unit), unit);
       }
-      connect(pComboBox, SIGNAL(currentIndexChanged(int)), SLOT(unitComboBoxChanged(int)));
+      /* When a QComboBox is used as an item view delegate editor its popup is a child of the
+       * viewport. On some styles/platforms the popup list view is not painted with an opaque
+       * background, so the tree view's content shows through the drop down. Enable auto fill
+       * background and force the popup view to paint opaquely to prevent this. */
+      pComboBox->setAutoFillBackground(true);
+      pComboBox->view()->setAutoFillBackground(true);
+      /* Use the activated signal instead of currentIndexChanged.
+       * activated(int) is only emitted when the user actually selects an item in the dropdown,
+       * whereas currentIndexChanged(int) also fires during editor setup (e.g. when items are added
+       * in createEditor or when setEditorData sets the current index). Emitting commitData in that
+       * case calls QAbstractItemView::commitData before the editor belongs to the view, which
+       * results in "QAbstractItemView::commitData called with an editor that does not belong to this view". */
+      connect(pComboBox, qOverload<int>(&QComboBox::activated), this, &ItemDelegate::unitComboBoxChanged);
       return pComboBox;
     }
   }


### PR DESCRIPTION
Show the unit combobox with auto fill background to avoid transparent combobox popup. Fixed the error msg "QAbstractItemView::commitData called with an editor that does not belong to this view".