### PR TITLE
FMU export: report the states' nominal values

### DIFF
--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c
@@ -25,6 +25,8 @@
  *
  */
 
+#include <math.h>
+
 #include "fmu2_model_interface.h"
 #include "fmu_read_flags.h"
 #include "../simulation/arrayIndex.h"
@@ -2119,10 +2121,16 @@ fmi2Status internalGetNominalsOfContinuousStates(fmi2Component c, fmi2Real x_nom
     return fmi2Error;
   if (nullPointer(comp, "fmi2GetNominalsOfContinuousStates", "x_nominal[]", x_nominal))
     return fmi2Error;
-  x_nominal[0] = 1;
-  FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2GetNominalsOfContinuousStates: x_nominal[0..%d] = 1.0", nx-1)
+#if NUMBER_OF_STATES > 0
+  DATA* fmudata = (DATA *) comp->fmuData;
   for (i = 0; i < nx; i++)
-    x_nominal[i] = 1;
+  {
+    /* Floored as ida_solver_setNominals floors it. */
+    modelica_real nominal = getNominalFromScalarIdx(fmudata->simulationInfo, fmudata->modelData, VAR_KIND_STATE, i);
+    x_nominal[i] = fmax(fabs(nominal), 1e-32);
+    FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2GetNominalsOfContinuousStates: x_nominal[%d] = %.16g", i, x_nominal[i])
+  }
+#endif
   return fmi2OK;
 }
 

--- a/testsuite/omsimulator/DualMassOscillator.mos
+++ b/testsuite/omsimulator/DualMassOscillator.mos
@@ -71,9 +71,9 @@ unloadOMSimulator();
 // info:      system1.s1: 1.0
 // info:      system2.s2: 2.5
 // info:    Simulation
-// info:      system1.s1: 0.9169316895219363
-// info:      system2.s2: 1.9495200849017982
+// info:      system1.s1: 0.9168577295013569
+// info:      system2.s2: 1.9496000393988535
 // info:    Final Statistics for 'DualMassOscillator.root':
-//          NumSteps = 3930 NumRhsEvals  = 4788 NumLinSolvSetups = 489
-//          NumNonlinSolvIters = 4787 NumNonlinSolvConvFails = 0 NumErrTestFails = 164
+//          NumSteps = 3943 NumRhsEvals  = 4816 NumLinSolvSetups = 501
+//          NumNonlinSolvIters = 4815 NumNonlinSolvConvFails = 0 NumErrTestFails = 166
 // endResult

--- a/testsuite/omsimulator/DualMassOscillator_me.mos
+++ b/testsuite/omsimulator/DualMassOscillator_me.mos
@@ -70,11 +70,11 @@ val(system2.s2, {0.0,0.1});
 // info:      system1.s1: 1.0
 // info:      system2.s2: 2.5
 // info:    Simulation
-// info:      system1.s1: 0.91153010887923
-// info:      system2.s2: 1.9553626027155
+// info:      system1.s1: 0.91152650486321
+// info:      system2.s2: 1.9553665042812
 // info:    Final Statistics for 'DualMassOscillator.root':
-//          NumSteps = 18242 NumRhsEvals  = 20006 NumLinSolvSetups = 1341
-//          NumNonlinSolvIters = 20005 NumNonlinSolvConvFails = 0 NumErrTestFails = 256
+//          NumSteps = 18185 NumRhsEvals  = 19938 NumLinSolvSetups = 1337
+//          NumNonlinSolvIters = 19937 NumNonlinSolvConvFails = 0 NumErrTestFails = 254
 // "
 // record SimulationResult
 //     resultFile = "DualMassOscillator.CoupledSystem_res.mat",


### PR DESCRIPTION
`fmi2GetNominalsOfContinuousStates` answered 1.0 for every state. The nominals are what scales an importer's absolute tolerance and the difference step of its numerical Jacobian, so a state whose magnitude is 1e5 was integrated to an absolute tolerance meant for a state of magnitude 1 -- a run that crawls where the model's own runtime, which reads `realVarsData[i].attribute.nominal`, does not.

It now reads the same attribute the solvers do
(`getNominalFromScalarIdx`), floored as `ida_solver_setNominals` floors it. The stray `x_nominal[0] = 1` ahead of the bounds-safe loop is gone with it; it wrote one element even when `nx` was 0.

Backport of 053cd6c7f1bf5 (the FMI 3 and wasm halves of that commit have no counterpart on this branch).

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
