### PR TITLE
[Testsuite] Abort partest when a test cannot be started

### DIFF
--- a/testsuite/partest/runtest.pl
+++ b/testsuite/partest/runtest.pl
@@ -11,6 +11,12 @@ use Term::ANSIColor;
 use File::Path qw(rmtree);
 use Encode qw(decode encode);
 
+# Exit status telling runtests.pl that the test never started, because the
+# operating system refused to create the process. It has to stay clear of the
+# statuses an actual run can produce: 0 is a failed test and 1 .. 100 is the
+# runtime of a test that passed.
+use constant SPAWN_FAILED => 111;
+
 # Get the testcase to run from the command line argument.
 my $test_full = $ARGV[0];
 my $no_colour = 0;
@@ -317,7 +323,14 @@ if ( $osname eq 'MSWin32' ) {
 my $cmd = "$rtest $test > $test.test_log 2>&1";
 # print ("CMD: ", $cmd, "\n");
 if (-e $test_suit_path_rel . "rtest") {
-  system("$cmd");
+  # A -1 here means the process was never created, which is not a test result:
+  # the machine is out of memory, commit charge or handles. Say so and let
+  # runtests.pl abandon the run, instead of blaming the test for it.
+  if (system("$cmd") == -1) {
+    print STDERR "Could not start '$cmd': $!\n";
+    exit_sandbox() if $sandbox_needed;
+    exit SPAWN_FAILED;
+  }
 } else {
   open(my $out, ">", "$test.test_log");
   print $out "No rtest at ${test_suit_path_rel}rtest (cwd " . cwd() . ").\n"

--- a/testsuite/partest/runtests.pl
+++ b/testsuite/partest/runtests.pl
@@ -36,6 +36,10 @@ use Time::HiRes qw( usleep gettimeofday tv_interval stat );
 
 use Fcntl;
 
+# The exit status runtest.pl uses to report that it could not start the test.
+# Kept in sync with the constant of the same name there.
+use constant SPAWN_FAILED => 111;
+
 # Force the children to not use parallel mark
 $ENV{GC_MARKERS}="1";
 
@@ -304,6 +308,11 @@ my @test_list;
 my $test_queue = Thread::Queue->new();
 my $tests_failed :shared = 0;
 my @failed_tests :shared;
+# Set when a test could not be started at all. That is a fault of the machine
+# and not of the tests, so the run is abandoned rather than reported: carrying
+# on would turn one exhausted machine into thousands of failed tests.
+my $spawn_failed :shared = 0;
+my $spawn_error :shared = "";
 my $testscript = cwd() . "/runtest.pl";
 -f $testscript or die "runtests.pl must be started from the partest directory; no runtest.pl in " . cwd() . "\n";
 if ( $osname eq 'MSWin32' ) {
@@ -398,13 +407,31 @@ sub add_tests {
 # Run the tests by dequeuing them from the list of tests and calling the
 # runtest.pl script.
 sub run_tests {
-  while(defined(my $test_full = $test_queue->dequeue_nb())) {
+  while(!$spawn_failed and defined(my $test_full = $test_queue->dequeue_nb())) {
     (my $test_dir, my $test) = $test_full =~ /(.*)\/([^\/]*)$/;
 
     my $t0 = [gettimeofday];
     my $cmd = "$testscript $test_full $have_dwdiff $nocolour $withxmlcmd $with_omc $rebase_test";
     # print ("CMD: ", $cmd, "\n");
-    my $x = system("$cmd") >> 8;
+    my $rc = system("$cmd");
+
+    # -1 is a process that was never created, and SPAWN_FAILED is runtest.pl
+    # saying the same thing about the test it was asked to start. Note that -1
+    # must be tested before the shift: Perl shifts it as an unsigned value, so
+    # $rc >> 8 would be a large positive number and the test that never ran
+    # would be counted as a passing one.
+    if ($rc == -1 or ($rc >> 8) == SPAWN_FAILED) {
+      lock($spawn_failed);
+      if (!$spawn_failed) {
+        lock($spawn_error);
+        $spawn_error = $rc == -1 ? "Could not start '$cmd': $!"
+                                 : "Could not start the test $test_full";
+        $spawn_failed = 1;
+      }
+      return;
+    }
+
+    my $x = $rc >> 8;
     my $elapsed = tv_interval ( $t0, [gettimeofday]);
 
     if($use_db) {
@@ -555,6 +582,22 @@ for(my $i = 0; $i < $thread_count; $i++) {
 foreach my $thr (threads->list()) {
   $thr->join();
   print "{joined thread: " . $thr->tid() . "}"
+}
+
+# Nothing below this point can say anything true about the testsuite if the
+# machine stopped being able to start processes part way through the run.
+if ($spawn_failed) {
+  print color 'reset';
+  # Whatever is left is from a previous run, and publishing it would present
+  # the tests that did run as the whole result.
+  unlink("$testsuite_root/result.xml", "$testsuite_root/partest/result.xml") if $withxml;
+  print STDERR "\n\nABORTED: a test could not be started.\n" .
+               "$spawn_error\n\n" .
+               "The operating system refused to create a process, which normally means\n" .
+               "this machine has run out of memory, commit charge or handles. That is\n" .
+               "not a test failure, and the rest of the run has been abandoned because\n" .
+               "every remaining test would have been reported as failed.\n";
+  exit 8;
 }
 
 


### PR DESCRIPTION
Fixes #16651.

### What was wrong

`system()` returns -1 when the process was never created, and neither partest script looked
at that.

In `testsuite/partest/runtests.pl` the return value went straight into a shift:

```perl
my $x = system("$cmd") >> 8;
...
if($x == 0) { # Add the test to the list of failed tests if it failed.
```

Perl shifts -1 as an unsigned value, so `$x` came out as `72057594037927935` and the test
that never ran was counted as a **passing** one. In `runtest.pl` the return value of the
`system()` that runs `rtest` was not examined at all.

So when the Windows Jenkins node ran out of commit charge, the run kept going on a machine
that could no longer start `omc`. Builds #5938 and #5939 of `Windows/OM_Win` took four
hours instead of forty five minutes, published 2319 failed tests that say nothing about the
tests, and still exited 7, which the job accepts as the ordinary "some tests failed"
outcome.

### What this does

`runtest.pl` exits `111` when it cannot start the test, printing the OS error. The status
is chosen so it cannot collide with the ones a real run produces: `0` is a failed test and
`1 .. 100` carry the test's runtime.

`runtests.pl` treats that status, and `-1` from its own `system()`, as a fault of the
machine rather than a test result. The workers stop dequeuing, no `result.xml` is written
so a stale one from a previous run cannot be published in its place, and the script exits
`8` with an explanation. The CI job whitelists `0` and `7` only, so the build now fails
instead of publishing thousands of invented failures.

The `-1` is compared before the shift, which is the actual bug in the original line.

### Testing

Ran the `-veryfew` selection with `runtest.pl` stubbed out three ways:

| stub | meaning | exit |
|---|---|---|
| `exit 111` | test could not be started | 8, run aborted after the first one |
| `exit 0` | every test fails | 7, all 87 reported |
| unmodified | real run against `/usr/bin/omc` | 0, 87 of 87 pass |

The abort prints:

```
ABORTED: a test could not be started.
Could not start the test ./flattening/modelica/modification/ArrayModTypeError.mo

The operating system refused to create a process, which normally means
this machine has run out of memory, commit charge or handles. That is
not a test failure, and the rest of the run has been abandoned because
every remaining test would have been reported as failed.
```

Why the Windows nodes ran out of commit charge in the first place is a separate matter and
is not addressed here. This only makes partest report it honestly.

---
generated by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f71NENbJrJv33xhpgx4KW
