### PR TITLE
Fix and publish the nightly Rust cross builds

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -956,7 +956,7 @@ void packageRustNightlyWindows(List stashes) {
   String zip = "OpenModelica-${tagName()}-x86_64-windows.zip"
   sh "rm -f ${zip} && (cd ${nightlyInstallDir('win64')} && zip -q -r -9 -y ${env.WORKSPACE}/${zip} .)"
   sh "ls -l ${zip}"
-  archiveArtifacts artifacts: zip, fingerprint: true
+  uploadRustNightly(zip)
 }
 
 // Stage 4, macOS: lipo the two per-architecture install trees into one universal
@@ -982,7 +982,19 @@ void packageRustNightlyMacUniversal(List stashes) {
   """
   String tgz = "OpenModelica-${tagName()}-macos-universal.tar.gz"
   sh "rm -f ${tgz} && tar -C ${out} -czf ${tgz} ."
-  archiveArtifacts artifacts: tgz, fingerprint: true
+  uploadRustNightly(tgz)
+}
+
+// build.openmodelica.org/omc/rust/latest/, under the artifact's own name
+// (tagName() is `latest` on master). `rust-builds` is the publisher config
+// rooted at omc/rust/.
+void uploadRustNightly(String archive) {
+  if (env.BRANCH_NAME != 'master') {
+    echo "${env.BRANCH_NAME} is not master: not publishing ${archive}"
+    return
+  }
+  sshPublisher(publishers: [sshPublisherDesc(configName: 'rust-builds',
+    transfers: [sshTransfer(sourceFiles: archive, remoteDirectory: 'latest')])])
 }
 
 // One partest shard against the Rust-built omc (unstashed) for one simCodeTarget.

--- a/OMCompiler/Compiler/.cmake/rust_omc.cmake
+++ b/OMCompiler/Compiler/.cmake/rust_omc.cmake
@@ -1231,6 +1231,12 @@ function(omc_rust_setup_codegen)
         COMMAND ${CMAKE_COMMAND} -E copy ${_wasi_p1_adapter} ${_wasm_out}/wasi_snapshot_preview1.reactor.wasm
         COMMAND ${CMAKE_COMMAND} -E copy_directory ${RUST_WASI_PIC_SYSROOT} ${_wasm_out}/wasi-pic-sysroot)
     set(_wasm_collect_deps rust_codegen rust_wasm_runtime rust_wasi_pic_sysroot)
+    # openmodelica_wasm_jit is a host build: its solver crates link these.
+    foreach(_native_collect rust_sundials_native_collect rust_ipopt_native_collect)
+      if(TARGET ${_native_collect})
+        list(APPEND _wasm_collect_deps ${_native_collect})
+      endif()
+    endforeach()
     if(_wasi_builtins)
       # In the sysroot copy, so the hand-over carries the builtins the libc.so
       # was linked against rather than relying on the consumer's clang.


### PR DESCRIPTION
`rust_wasm_artifacts` builds `openmodelica_wasm_jit` for the host, so cargo also builds `openmodelica_solvers` and `openmodelica_sim_meta`, whose build scripts link the host SUNDIALS and Ipopt archives out of `OMC_SUNDIALS_NATIVE_DIR` / `OMC_IPOPT_NATIVE_DIR`. Both variables are set whenever the archives' CMake targets exist, but the directories are filled only by `rust_sundials_native_collect` and
`rust_ipopt_native_collect`, which nothing in this target's dependency graph asked for. An ordinary build never noticed: it goes through `--target install`, where `rust_libopenmodelica` pulls both collect targets in. The nightly cross pipeline builds `rust_codegen rust_wasm_runtime rust_wasm_artifacts` and nothing else, so its stage 1 died in the build script:

    OMC_SUNDIALS_NATIVE_DIR=.../rust-sundials-native/lib is missing
    ["sundials_kinsol", ...]; the host SUNDIALS build failed

The two distributions are no longer Jenkins artifacts. They go to build.openmodelica.org/omc/rust/latest/ through the `rust-builds` SSH publisher config, whose root is omc/rust/, under the names they already carried:

    OpenModelica-latest-x86_64-windows.zip
    OpenModelica-latest-macos-universal.tar.gz

`latest` is what tagName() returns on master, so each platform keeps one URL across nightlies, and the windows-arm64 and win32 distributions to come need no more than their own packaging stage. Only master publishes -- a nightly on another branch is a test run someone asked for.

The upload runs in the packaging stage rather than one of its own, so that the archive (600 MB of macOS install tree) does not travel through the controller a second time.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
