### PR TITLE
FMU-only phase clocks; drop two redundant passes

### DIFF
--- a/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
@@ -1646,6 +1646,21 @@ protected
   FCore.Cache cache;
   FCore.Graph graph;
 algorithm
+  // Dependency analysis only, nothing to differentiate, and one partition: take
+  // the pattern from the system as it stands rather than causalizing a collapsed
+  // copy of it. Several partitions are clocked ones, which sample each other's
+  // variables, so those still have to be collapsed to be seen across.
+  if Flags.isSet(Flags.DIS_SYMJAC_FMI20) and listLength(inBackendDAE.eqs) == 1 then
+    (sparsePattern, sparseColoring) := fmiDerSparsePattern(inBackendDAE);
+    outJacobianMatrices := {(
+      SOME((BackendDAE.DAE({BackendDAEUtil.createEqSystem(BackendVariable.emptyVars(), BackendEquation.emptyEqns())},
+                           BackendDAEUtil.createEmptyShared(BackendDAE.JACOBIAN(), inBackendDAE.shared.info,
+                                                            inBackendDAE.shared.cache, inBackendDAE.shared.graph)),
+            "FMIDER", {}, {}, {}, {})),
+      sparsePattern, sparseColoring, BackendDAE.emptyNonlinearPattern)};
+    outFunctionTree := inBackendDAE.shared.functionTree;
+    return;
+  end if;
 try
   // for now perform on collapsed system
   backendDAE := BackendDAEUtil.copyBackendDAE(inBackendDAE);
@@ -1711,6 +1726,29 @@ else
   outFunctionTree := inBackendDAE.shared.functionTree;
 end try;
 end createFMIModelDerivatives;
+
+protected function fmiDerSparsePattern
+  "The FMIDER dependency pattern of a DAE that is a single partition, taken as it
+   stands: collapsing it is a no-op merge that drops the matching only for
+   transformBackendDAE to compute it again."
+  input BackendDAE.BackendDAE inDAE;
+  output BackendDAE.SparsePattern outSparsePattern;
+  output BackendDAE.SparseColoring outColoring;
+protected
+  // generateSparsePattern adds the seed variables to the system it is given.
+  BackendDAE.BackendDAE dae = BackendDAEUtil.copyBackendDAE(inDAE);
+  BackendDAE.EqSystem syst = listHead(dae.eqs);
+  list<BackendDAE.Var> states, inputvars, outputvars;
+algorithm
+  states := if Config.languageStandardAtLeast(Config.LanguageStandard._3_3) then
+    BackendVariable.getAllClockedStatesFromVariables(syst.orderedVars) else {};
+  states := listAppend(BackendVariable.getAllStateVarFromVariables(syst.orderedVars), states);
+  outputvars := List.select(BackendVariable.varList(syst.orderedVars), BackendVariable.isVarOnTopLevelAndOutput);
+  inputvars := List.select(BackendVariable.varList(dae.shared.globalKnownVars), BackendVariable.isVarOnTopLevelAndInput);
+
+  (outSparsePattern, outColoring) := generateSparsePattern(dae, listAppend(states, inputvars),
+                                                           listAppend(states, outputvars), withColoring = false);
+end fmiDerSparsePattern;
 
 public function createFMIModelDerivativesForInitialization
 "This function genererate the stucture output and the

--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -1115,6 +1115,11 @@ constant Integer RT_CLOCK_LINEARIZE = 16;
 constant Integer RT_CLOCK_TEMPLATES = 17;
 constant Integer RT_CLOCK_UNCERTAINTIES = 18;
 constant Integer RT_CLOCK_USER_RESERVED = 19;
+/* Accumulated over a whole translation, not a single tick/tock: the work only
+   an FMU export does, inside the phase clock of the same name. */
+constant Integer RT_CLOCK_FMU_BACKEND = 27;
+constant Integer RT_CLOCK_FMU_SIMCODE = 28;
+constant Integer RT_CLOCK_FMU_TEMPLATES = 31;
 
 function readableTime
   "Returns the time in seconds formatted as a string with four significant digits."
@@ -1149,6 +1154,16 @@ function timerTock
 external "builtin";
 annotation(preferredView="text");
 end timerTock;
+
+function timerAccumulated
+  "Reads the total time accumulated on the internal timer with the given index,
+   or -1 if that timer never ran. Timers that measure a stretch of work that
+   recurs during one command accumulate instead of ticking once."
+  input Integer index;
+  output Real total;
+external "builtin";
+annotation(preferredView="text");
+end timerAccumulated;
 
 function timerClear
   "Clears the internal timer with the given index."

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -1371,6 +1371,11 @@ constant Integer RT_CLOCK_LINEARIZE = 16;
 constant Integer RT_CLOCK_TEMPLATES = 17;
 constant Integer RT_CLOCK_UNCERTAINTIES = 18;
 constant Integer RT_CLOCK_USER_RESERVED = 19;
+/* Accumulated over a whole translation, not a single tick/tock: the work only
+   an FMU export does, inside the phase clock of the same name. */
+constant Integer RT_CLOCK_FMU_BACKEND = 27;
+constant Integer RT_CLOCK_FMU_SIMCODE = 28;
+constant Integer RT_CLOCK_FMU_TEMPLATES = 31;
 
 function readableTime
   "Returns the time in seconds formatted as a string with four significant digits."
@@ -1405,6 +1410,16 @@ function timerTock
 external "builtin";
 annotation(preferredView="text");
 end timerTock;
+
+function timerAccumulated
+  "Reads the total time accumulated on the internal timer with the given index,
+   or -1 if that timer never ran. Timers that measure a stretch of work that
+   recurs during one command accumulate instead of ticking once."
+  input Integer index;
+  output Real total;
+external "builtin";
+annotation(preferredView="text");
+end timerAccumulated;
 
 function timerClear
   "Clears the internal timer with the given index."

--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -1140,6 +1140,15 @@ algorithm
     case ("timerTock",_)
       then Values.REAL(-1.0);
 
+    case ("timerAccumulated",{Values.INTEGER(i)})
+      algorithm
+        true := System.realtimeNtick(i) > 0;
+      then
+        Values.REAL(System.realtimeAccumulated(i));
+
+    case ("timerAccumulated",_)
+      then Values.REAL(-1.0);
+
     case ("readFile",{Values.STRING(str)})
       then Values.STRING(System.readFile(str));
 

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -998,6 +998,7 @@ algorithm
   // The same templates the C target uses, so the XML is byte-identical to it. No
   // sourceFiles: a wasm FMU carries no C. The XML declaration comes from
   // fmuModelDescriptionFile, which the C target reaches these through.
+  System.realtimeTick(ClockIndexes.RT_CLOCK_FMU_TEMPLATES);
   if FMI.isFMIVersion20(FMUVersion) then
     modelDescriptionStr := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + Tpl.textString(
       CodegenFMU2.fmiModelDescription(Tpl.emptyTxt, simCode, guid, FMUType, {}));
@@ -1034,6 +1035,7 @@ algorithm
     documentationDir := fmutmp + "/documentation/";
     ExecStat.execStat("FMU documentation");
   end if;
+  System.realtimeAccumulate(ClockIndexes.RT_CLOCK_FMU_TEMPLATES);
   simulationFlagsJson := wasmFMUSimulationFlagsJson(simCode);
   if FMI.isFMIMEType(FMUType) and FMI.isFMICSType(FMUType) then
     CodegenWasmJit.emitMeCsFmu(simCode, simCode.fmuTargetName + ".fmu", guid, modelDescriptionStr, lsDaeManifestStr, documentationDir, terminalsDir, simulationFlagsJson);
@@ -1674,7 +1676,8 @@ algorithm
   // a failing translation would otherwise read an earlier command's tick.
   List.map_0({ClockIndexes.RT_CLOCK_FRONTEND,ClockIndexes.RT_CLOCK_BACKEND,
               ClockIndexes.RT_CLOCK_SIMCODE,ClockIndexes.RT_CLOCK_TEMPLATES,
-              ClockIndexes.RT_CLOCK_BUILD_MODEL},System.realtimeClear);
+              ClockIndexes.RT_CLOCK_BUILD_MODEL,ClockIndexes.RT_CLOCK_FMU_BACKEND,
+              ClockIndexes.RT_CLOCK_FMU_SIMCODE,ClockIndexes.RT_CLOCK_FMU_TEMPLATES},System.realtimeClear);
   FlagsUtil.setConfigBool(Flags.BUILDING_MODEL, true);
 
   outLibs := {};
@@ -1773,8 +1776,23 @@ algorithm
     print(flatString);
   end if;
 
+  // The simCode clock ticks on every FMU export and on nothing else.
+  if Flags.isSet(Flags.EXEC_STAT) and System.realtimeNtick(ClockIndexes.RT_CLOCK_FMU_SIMCODE) > 0 then
+    Error.addCompilerNotification("FMU-only work: backend " + fmuOverheadTime(ClockIndexes.RT_CLOCK_FMU_BACKEND)
+      + ", simCode " + fmuOverheadTime(ClockIndexes.RT_CLOCK_FMU_SIMCODE)
+      + ", templates " + fmuOverheadTime(ClockIndexes.RT_CLOCK_FMU_TEMPLATES));
+  end if;
+
   success := true;
 end translateModel;
+
+protected function fmuOverheadTime
+  "Seconds accumulated on one of the RT_CLOCK_FMU_* clocks, 0 if it never ran."
+  input Integer clockIndex;
+  output String str;
+algorithm
+  str := System.snprintff("%.4g", 20, if System.realtimeNtick(clockIndex) > 0 then System.realtimeAccumulated(clockIndex) else 0.0);
+end fmuOverheadTime;
 
 public function translateModelCallBackend
   input FlatModel flatModel;
@@ -1919,8 +1937,10 @@ algorithm
       if (isFMI2) and not Flags.isSet(Flags.FMI20_DEPENDENCIES) then
         // activate symolic jacobains for fmi 2.0
         // to provide dependence information and partial derivatives
+        System.realtimeTick(ClockIndexes.RT_CLOCK_FMU_BACKEND);
         (fmiDer, funcs) := SymbolicJacobian.createFMIModelDerivatives(dlow);
         dlow := BackendDAEUtil.setFunctionTree(dlow, funcs);
+        System.realtimeAccumulate(ClockIndexes.RT_CLOCK_FMU_BACKEND);
       else
         fmiDer := {};
       end if;
@@ -2408,11 +2428,13 @@ algorithm
     // DAE-mode model has none of. The specification lets an importer assume a
     // dependency on every known instead.
     if isFMU then
+      System.realtimeTick(ClockIndexes.RT_CLOCK_FMU_SIMCODE);
       if FMI.isFMIVersion20(FMUVersion) or FMI.isFMIVersion30(FMUVersion) then
         (_, modelStructure, modelInfo, _, uniqueEqIndex, _) :=
           SimCodeUtil.createFMIModelStructure({}, modelInfo, uniqueEqIndex, inInitDAE, inBackendDAE);
       end if;
       fmiSimulationFlags := SimCodeUtil.createFMISimulationFlags();
+      System.realtimeAccumulate(ClockIndexes.RT_CLOCK_FMU_SIMCODE);
     end if;
 
     // update hash table

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -90,6 +90,7 @@ import BaseHashTable;
 import Builtin;
 import CheckModel;
 import ClassInf;
+import ClockIndexes;
 import CommonSubExpression.isCSECref;
 import ComponentReference;
 import ComponentReferenceBasics;
@@ -612,18 +613,22 @@ algorithm
 
     // collect fmi partial derivative (FMI 2.0 and 3.0 both expose a ModelStructure)
     if FMI.isFMIVersion20(FMUVersion) or FMI.isFMIVersion30(FMUVersion) then
+      System.realtimeTick(ClockIndexes.RT_CLOCK_FMU_SIMCODE);
       (SymbolicJacsFMI, modelStructure, modelInfo, SymbolicJacsTemp, uniqueEqIndex, fmiDerInitFuncTree) := createFMIModelStructure(inFMIDer, modelInfo, uniqueEqIndex, inInitDAE, inBackendDAE);
       SymbolicJacsNLS := listAppend(SymbolicJacsTemp, SymbolicJacsNLS);
       // the FMIDERINIT jacobian is created here, i.e. after the functions have been
       // elaborated, so the functions it calls on its own have to be added now
       (modelInfo, literalsAcc, recordDeclsAcc) := addFmiDerInitFunctions(program, fmiDerInitFuncTree,
         BackendDAEUtil.getFunctions(inBackendDAE.shared), modelInfo, literalsAcc, recordDeclsAcc);
+      System.realtimeAccumulate(ClockIndexes.RT_CLOCK_FMU_SIMCODE);
       if debug then execStat("simCode: create FMI model structure"); end if;
     end if;
 
     // Collect FMI sim flags
     if isFMU then
+      System.realtimeTick(ClockIndexes.RT_CLOCK_FMU_SIMCODE);
       fmiSimulationFlags := createFMISimulationFlags();
+      System.realtimeAccumulate(ClockIndexes.RT_CLOCK_FMU_SIMCODE);
     end if;
 
     // collect symbolic jacobians in linear loops of the overall jacobians
@@ -14193,9 +14198,10 @@ protected
   BackendDAE.EqSystems eqs;
   DAE.Exp lhs, rhs;
   BackendDAE.Equation eqn;
-  String strMatchingAlgorithm, strIndexReductionMethod;
   BackendDAE.AdjacencyMatrix outAdjacencyMatrix;
-  array<Integer> match1,match2;
+  BackendDAE.StrongComponents comps;
+  array<list<Integer>> mapEqnIncRow;
+  array<Integer> match1,match2,mapIncRowEqn;
   Boolean debug = false;
   UnorderedSet<DAE.ComponentRef> initialUnknowns, indepCrefSet;
 algorithm
@@ -14236,18 +14242,21 @@ algorithm
     end if;
   end for;
 
-  // Calculate adjacencyMatrix, with the newly added equations and vars
-  (outAdjacencyMatrix, _, _, _) := BackendDAEUtil.adjacencyMatrixScalar(currentSystem, BackendDAE.NORMAL(), NONE(), BackendDAEUtil.isInitializationDAE(shared));
+  // Calculate adjacencyMatrix, with the newly added equations and vars. The
+  // function tree is what the BLT sorting below passes, so one matrix serves both.
+  (currentSystem, outAdjacencyMatrix, _, mapEqnIncRow, mapIncRowEqn) := BackendDAEUtil.getAdjacencyMatrixScalar(
+    currentSystem, BackendDAE.NORMAL(), SOME(BackendDAEUtil.getFunctions(shared)), BackendDAEUtil.isInitializationDAE(shared));
   // Perform the match on the adjacencyMatrix
   (match1, match2) := Matching.PerfectMatching(outAdjacencyMatrix);
-  currentSystem.matching := BackendDAE.MATCHING(match1, match2, BackendDAEUtil.getStrongComponents(currentSystem));
-  // update the DAE with the new matching information
-  tmpBDAE := BackendDAE.DAE({currentSystem}, shared);
+  comps := BackendDAEUtil.getStrongComponents(currentSystem);
+  currentSystem.matching := BackendDAE.MATCHING(match1, match2, comps);
 
-  // run the matching algorithm on the newly created DAE
-  strMatchingAlgorithm := BackendDAEUtil.getMatchingAlgorithmString();
-  strIndexReductionMethod := BackendDAEUtil.getIndexReductionMethodString();
-  tmpBDAE := BackendDAEUtil.causalizeDAE(tmpBDAE, NONE(), BackendDAEUtil.getMatchingAlgorithm(SOME(strMatchingAlgorithm)), BackendDAEUtil.getIndexReductionMethod(SOME(strIndexReductionMethod)), false);
+  // All causalizeDAE would still do on a matched system is sort it into BLT form,
+  // rebuilding the adjacency matrix to get there.
+  if listEmpty(comps) then
+    (currentSystem, _) := BackendDAETransform.strongComponentsScalar(currentSystem, shared, mapEqnIncRow, mapIncRowEqn);
+  end if;
+  tmpBDAE := BackendDAE.DAE({currentSystem}, shared);
 
   if debug then
     BackendDump.dumpBackendDAE(tmpBDAE, "Check Initilization DAE");

--- a/OMCompiler/Compiler/Util/ClockIndexes.mo
+++ b/OMCompiler/Compiler/Util/ClockIndexes.mo
@@ -64,10 +64,17 @@ public constant Integer RT_CLOCK_EXECSTAT_HPCOM_MODULES = 24;
 public constant Integer RT_CLOCK_SHOW_STATEMENT = 25;
 public constant Integer RT_CLOCK_FINST = 26;
 
+/* Work only an FMU export does, accumulated inside the phase clock of the same
+   name. Read with System.realtimeAccumulated. */
+public constant Integer RT_CLOCK_FMU_BACKEND = 27;
+public constant Integer RT_CLOCK_FMU_SIMCODE = 28;
+public constant Integer RT_CLOCK_FMU_TEMPLATES = 31;
+
 public constant Integer RT_CLOCK_NEW_BACKEND_MODULE = 29;
 public constant Integer RT_CLOCK_NEW_BACKEND_INITIALIZATION = 30;
 
-public constant list<Integer> buildModelClocks = {RT_CLOCK_BUILD_MODEL,RT_CLOCK_SIMULATE_TOTAL,RT_CLOCK_TEMPLATES,RT_CLOCK_LINEARIZE,RT_CLOCK_SIMCODE,RT_CLOCK_BACKEND,RT_CLOCK_FRONTEND};
+public constant list<Integer> buildModelClocks = {RT_CLOCK_BUILD_MODEL,RT_CLOCK_SIMULATE_TOTAL,RT_CLOCK_TEMPLATES,RT_CLOCK_LINEARIZE,RT_CLOCK_SIMCODE,RT_CLOCK_BACKEND,RT_CLOCK_FRONTEND,
+                                                 RT_CLOCK_FMU_BACKEND,RT_CLOCK_FMU_SIMCODE,RT_CLOCK_FMU_TEMPLATES};
 
 function toString
   input Integer clockIndex;
@@ -93,6 +100,9 @@ algorithm
     case RT_CLOCK_EXECSTAT_HPCOM_MODULES      then "HPC";
     case RT_CLOCK_SHOW_STATEMENT              then "STM";
     case RT_CLOCK_FINST                       then "FIN";
+    case RT_CLOCK_FMU_BACKEND                 then "FMB";
+    case RT_CLOCK_FMU_SIMCODE                 then "FMS";
+    case RT_CLOCK_FMU_TEMPLATES               then "FMT";
     case RT_CLOCK_NEW_BACKEND_MODULE          then "SIM";
     case RT_CLOCK_NEW_BACKEND_INITIALIZATION  then "INI";
     else "ERR";


### PR DESCRIPTION
`-d=execstat` charges the work only an FMU export does to whichever ordinary phase label fires next, so the library-testing wasm-jit lane's simcode column looked 29x master's - master runs `simulate()` and never enters that code at all. Three accumulating clocks now measure it, each inside the phase clock of the same name, read with a new `Internal.Time.timerAccumulated(index)` (-1 when the clock never ran, the convention `timerTock` already uses):

| clock                    | ix | accumulates                        |
| ------------------------ | -- | ---------------------------------- |
| `RT_CLOCK_FMU_BACKEND`   | 27 | `createFMIModelDerivatives`        |
| `RT_CLOCK_FMU_SIMCODE`   | 28 | `createFMIModelStructure` et al.   |
| `RT_CLOCK_FMU_TEMPLATES` | 31 | modelDescription.xml, manifest     |

The C target's templates clock stays 0: `CodegenFMU.translateModel` renders the model C and modelDescription.xml in one Tpl call, so there is nothing to separate. The backend and simcode clocks are target-independent, which is what makes them comparable across lanes.

Measured with them, the FMU overhead of Buildings ClientLBNL90 was 13 s of backend and 4 s of simcode in an 85 s translation - and the backend half was bookkeeping. `createFMIModelDerivatives` collapsed and re-causalized a copy of the whole simulation DAE only to hand `generateSparsePattern` a matching the solved system already had: `mergeIndependentBlocks` drops it, so `transformBackendDAE` computes it again. With `disableDirectionalDerivatives` (the default) there is nothing to differentiate, so a single-partition DAE now takes the pattern from the system as it stands. Several partitions are clocked ones, which sample each other's variables, and those still have to be collapsed to be seen across: done per partition,
`Clocked.Examples.Systems.ControlledMixingUnit` silently lost six of the eight dependencies of an `<Unknown>`.

`getFmiInitialUnknowns` built the initialization system's NORMAL scalar adjacency matrix twice - once to match on, then `causalizeDAE` rebuilt it for the BLT sort, its matching step having short-circuited on the already-matched system. It is built once now, passing the function tree the BLT sort passes; the two used to disagree, so Tarjan ran on a matrix that did not hold every edge the matching had used.

ClientLBNL90 under `--simCodeTarget=wasm-jit`, `translateModelFMU`, three runs of each:

| seconds           | before             | after              |
| ----------------- | ------------------ | ------------------ |
| FMU-only backend  | 12.8 / 12.9 / 15.3 | 0.31 / 0.35 / 0.36 |
| FMU-only simcode  | 3.97 / 4.08 / 4.41 | 3.68 / 3.71 / 3.82 |
| whole translation | 81.2 / 86.0 / 88.5 | 66.1 / 69.3 / 70.0 |

modelDescription.xml comes out byte-identical, modulo the guid and the generation timestamp, for 16 models: MSL MultiBody (including RobotR3.OneAxis), Fluid, Media, Machines, StateGraph, Blocks, three Modelica.Clocked models, ScalableTestSuite twice and ClientLBNL90 itself, over both FMI 2.0 and 3.0.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
