### PR TITLE
SimRt: Fix leaks when a process runs many sims

### DIFF
--- a/OMCompiler/SimulationRuntime/c/moo/strategies.cpp
+++ b/OMCompiler/SimulationRuntime/c/moo/strategies.cpp
@@ -169,7 +169,7 @@ int MatEmitter::operator()(const PrimalDualTrajectory& trajectory) {
         sim_result.emit(&sim_result, data, threadData);
     }
 
-    sim_result.free(&sim_result, data, threadData);
+    deinitializeResultData(data, threadData);
 
     return 0;
 }

--- a/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result.cpp
@@ -27,6 +27,8 @@
 
 #include "simulation_result.h"
 
+#include <stdlib.h>
+
 extern "C" {
 
 static void sim_result_doNothing(simulation_result* self, DATA *data, threadData_t *threadData)
@@ -44,5 +46,21 @@ simulation_result sim_result = {
   sim_result_doNothing, /* writeParam */
   sim_result_doNothing, /* free */
 };
+
+void deinitializeResultData(DATA *data, threadData_t *threadData)
+{
+  if (sim_result.free) {
+    sim_result.free(&sim_result, data, threadData);
+  }
+  free((void*) sim_result.filename);
+  sim_result.filename = NULL;
+  sim_result.numpoints = 0;
+  sim_result.cpuTime = 0;
+  sim_result.storage = NULL;
+  sim_result.init = sim_result_doNothing;
+  sim_result.emit = sim_result_doNothing;
+  sim_result.writeParameterData = sim_result_doNothing;
+  sim_result.free = sim_result_doNothing;
+}
 
 }

--- a/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result.h
@@ -48,6 +48,9 @@ typedef struct simulation_result {
 
 extern simulation_result sim_result;
 
+/** Closes the writer of `sim_result` and resets it, undoing `initializeResultData`. */
+void deinitializeResultData(DATA *data, threadData_t *threadData);
+
 #ifdef __cplusplus
 }
 #endif /* cplusplus */

--- a/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_csv.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_csv.cpp
@@ -284,8 +284,12 @@ void omc_csv_init(simulation_result *self, DATA *data, threadData_t *threadData)
 void omc_csv_free(simulation_result *self, DATA *data, threadData_t *threadData)
 {
   FILE *fout = (FILE*) self->storage;
+  if (!fout) {
+    return;
+  }
   rt_tick(SIM_TIMER_OUTPUT);
   fclose(fout);
+  self->storage = NULL;
   rt_accumulate(SIM_TIMER_OUTPUT);
 }
 

--- a/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_ia.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_ia.cpp
@@ -291,6 +291,7 @@ void ia_free(simulation_result *self, DATA *data, threadData_t *threadData)
   rt_tick(SIM_TIMER_OUTPUT);
 
   delete (IA_DATA*)self->storage;
+  self->storage = NULL;
   communicateMsg(6, 0, 0);
 
   rt_accumulate(SIM_TIMER_OUTPUT);

--- a/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_mat4.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_mat4.cpp
@@ -1518,28 +1518,25 @@ void mat4_free4(simulation_result *self, DATA *data, threadData_t *threadData)
 {
   mat_data *matData = (mat_data *)self->storage;
 
-  rt_tick(SIM_TIMER_OUTPUT);
-
-  if (!matData->pFile)
+  if (!matData)
   {
-    rt_accumulate(SIM_TIMER_OUTPUT);
     return;
   }
 
-  if (matData->nEmits > 0)
+  rt_tick(SIM_TIMER_OUTPUT);
+
+  if (matData->pFile)
   {
-    updateHeader_matVer4(matData->pFile, matData->data2HdrPos, "data_2", matData->nData2, matData->nEmits, matData->type);
-    matData->nEmits = 0;
+    if (matData->nEmits > 0)
+    {
+      updateHeader_matVer4(matData->pFile, matData->data2HdrPos, "data_2", matData->nData2, matData->nEmits, matData->type);
+    }
+    fclose(matData->pFile);
   }
 
-  if (matData->data_2)
-  {
-    free(matData->data_2);
-    matData->data_2 = NULL;
-  }
-
-  fclose(matData->pFile);
-  matData->pFile = NULL;
+  free(matData->data_2);
+  delete matData;
+  self->storage = NULL;
 
   rt_accumulate(SIM_TIMER_OUTPUT);
 }

--- a/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_plt.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_plt.cpp
@@ -242,12 +242,19 @@ void plt_free(simulation_result *self,DATA *data, threadData_t *threadData)
   int varn = 0, i, var;
   FILE* f = NULL;
 
+  if(!pltData)
+  {
+    return;
+  }
+
   rt_tick(SIM_TIMER_OUTPUT);
 
   f = omc_fopen(self->filename, "w");
   if(!f)
   {
     deallocResult(pltData);
+    free(pltData);
+    self->storage = NULL;
     throwStreamPrint(threadData, "Error, couldn't create output file: [%s] because of %s", self->filename, strerror(errno));
   }
 
@@ -343,12 +350,12 @@ void plt_free(simulation_result *self,DATA *data, threadData_t *threadData)
   }
 
   deallocResult(pltData);
+  free(pltData);
+  self->storage = NULL;
   if(fclose(f))
   {
     throwStreamPrint(threadData, "Error, couldn't write to output file %s\n", self->filename);
   }
-  free(self->storage);
-  self->storage = NULL;
   rt_accumulate(SIM_TIMER_OUTPUT);
 }
 

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -717,6 +717,7 @@ int initializeResultData(DATA* simData, threadData_t *threadData, int cpuTime)
   int resultFormatHasCheapAliasesAndParameters = 0;
   int retVal = 0;
   mmc_sint_t maxSteps = 4 * simData->simulationInfo->numSteps;
+  free((void*) sim_result.filename);
   sim_result.filename = omc_strdup(simData->modelData->resultFileName);
   sim_result.numpoints = maxSteps;
   sim_result.cpuTime = cpuTime;
@@ -864,7 +865,7 @@ static int callSolver(DATA* simData, threadData_t *threadData, string init_initM
   MMC_CATCH_INTERNAL(mmc_jumper)
   MMC_CATCH_INTERNAL(globalJumpBuffer)
 
-  sim_result.free(&sim_result, simData, threadData);
+  deinitializeResultData(simData, threadData);
 
   return retVal;
 }

--- a/OMCompiler/SimulationRuntime/c/util/omc_init.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_init.c
@@ -36,7 +36,7 @@ pthread_once_t mmc_init_once = PTHREAD_ONCE_INIT;
 threadData_t *OMC_MAIN_THREADDATA_NAME = 0;
 #endif
 
-void mmc_init_nogc(void)
+static void mmc_init_nogc_once(void)
 {
 #if defined(OM_HAVE_PTHREADS)
   pthread_key_create(&mmc_thread_data_key,NULL);
@@ -45,6 +45,22 @@ void mmc_init_nogc(void)
   /* Stack overflow detection is too expensive and fun for small targets
    * C-code is usually not generated for stack overflow detection anyway... */
   init_metamodelica_segv_handler();
+#endif
+}
+
+/* The key and the signal handler's alternate stack are per process, but
+ * fmi{1,2,3}Instantiate calls this once per instance. */
+void mmc_init_nogc(void)
+{
+#if defined(OM_HAVE_PTHREADS)
+  static pthread_once_t nogc_once = PTHREAD_ONCE_INIT;
+  pthread_once(&nogc_once, mmc_init_nogc_once);
+#else
+  static int initialized = 0;
+  if (!initialized) {
+    initialized = 1;
+    mmc_init_nogc_once();
+  }
 #endif
 }
 

--- a/OMCompiler/SimulationRuntime/rust/openmodelica_result_capi/src/writer.rs
+++ b/OMCompiler/SimulationRuntime/rust/openmodelica_result_capi/src/writer.rs
@@ -12,6 +12,7 @@ use std::fs::File;
 use std::io::{BufWriter, Seek, SeekFrom, Write};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::ptr;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{LazyLock, Mutex};
 
 use openmodelica_arrow_writer::{Affine, ArrowKind, ArrowStream, ArrowVar, ColTy, FileMeta, Resolve, VarTy};
@@ -71,7 +72,8 @@ fn cstr(p: *const c_char) -> String {
 }
 
 /// The String values the rows carry as ids (like `sim_meta::strings` in the
-/// Rust runtime): process-global, never emptied.
+/// Rust runtime): shared by every open writer, dropped once the last one
+/// closes, so a process that runs simulation after simulation does not grow.
 #[derive(Default)]
 struct Interned {
     by_id: Vec<String>,
@@ -79,6 +81,7 @@ struct Interned {
 }
 
 static STRINGS: LazyLock<Mutex<Interned>> = LazyLock::new(Mutex::default);
+static OPEN_WRITERS: AtomicUsize = AtomicUsize::new(0);
 
 fn intern(s: &str) -> u32 {
     let mut t = STRINGS.lock().unwrap_or_else(|e| e.into_inner());
@@ -582,7 +585,10 @@ pub extern "C" fn omc_result_writer_open(
         let params: &[f64] = if params.is_null() { &[] } else { unsafe { std::slice::from_raw_parts(params, n_params) } };
         let first: &[f64] = if first_row.is_null() { &[] } else { unsafe { std::slice::from_raw_parts(first_row, n_columns) } };
         match open(&cstr(path), &cstr(format), signals, &types, params, first, start_time, stop_time, single != 0, mat_sync.max(0) as usize) {
-            Ok(w) => Box::into_raw(Box::new(w)),
+            Ok(w) => {
+                OPEN_WRITERS.fetch_add(1, Ordering::AcqRel);
+                Box::into_raw(Box::new(w))
+            }
             Err(e) => {
                 set_error(error, &e);
                 ptr::null_mut()
@@ -612,7 +618,13 @@ pub extern "C" fn omc_result_writer_close(w: *mut omc_result_writer) -> c_int {
         return 0;
     }
     let mut w = unsafe { Box::from_raw(w) };
-    c_int::from(catch_unwind(AssertUnwindSafe(|| w.finish())).unwrap_or(false))
+    let ok = catch_unwind(AssertUnwindSafe(|| w.finish())).unwrap_or(false);
+    drop(w);
+    // finish() has joined the writer thread, so no id is resolved after this.
+    if OPEN_WRITERS.fetch_sub(1, Ordering::AcqRel) == 1 {
+        *STRINGS.lock().unwrap_or_else(|e| e.into_inner()) = Interned::default();
+    }
+    c_int::from(ok)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Everything allocated for one simulation run is now released, so a process that instantiates or simulates repeatedly stays flat. This picks up where #16439 left off, which freed the model data arrays.

| Leak                            | Per         | Fix                       |
| ------------------------------- | ----------- | ------------------------- |
| alt stack and `pthread_key`     | instantiate | `mmc_init_nogc` runs once |
| `sim_result.filename`           | run         | `deinitializeResultData`  |
| `mat_data` of the MAT v4 writer | run         | `mat4_free4` deletes it   |
| `plt_data` on the error paths   | run         | freed before the throw    |
| interned result Strings         | process     | go with the last writer   |

`fmi{1,2,3}Instantiate` call `mmc_init_nogc` per instance, but the signal handler's alternate stack and the thread-data key belong to the process; the key was leaked outright and a stale one orphaned the `threadData` stored under it.

The writers leave `self->storage` NULL and tolerate a second call, and `deinitializeResultData` pairs with `initializeResultData`: the moo `MatEmitter` re-initializes the result data per trajectory, which leaked a writer and a file name each round.

Verified with valgrind: 2000 `fmi2Instantiate`/`fmi2FreeInstance` cycles hold RSS flat, nothing definitely or indirectly lost over 50 of them, and a plain simulation now ends with nothing still reachable. What is left is the alternate stack the handler needs for the life of the process, plus GC marker-thread TLS.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
