### PR TITLE
Generate revision.h in the Rust cmake build too

### DIFF
--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -107,6 +107,14 @@ endif()
 # may hold the autotools build's copy); source dir provides omc_config.h itself.
 target_include_directories(omc_config INTERFACE ${OMCompiler_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 
+# omc_config.h quote-includes revision.h on the MinGW/MSVC branch, so everything
+# linking omc::config needs it — including the simulation runtime, which is built
+# in Rust mode too. Generated here rather than in Compiler/runtime/CMakeLists.txt,
+# which Compiler/CMakeLists.txt's Rust early return() skips. SOURCE_REVISION comes
+# from cmake/omc_git_revision.cmake. Written in-source next to omc_config.h, where
+# the quoted include finds it ahead of any -I.
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/revision.h.in ${CMAKE_CURRENT_SOURCE_DIR}/revision.h)
+
 
 ## Subdirectories ##########################################################################################
 # We always link a Fortran-ABI BLAS, but SuiteSparse guesses *no* underscore

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -182,9 +182,6 @@ target_include_directories(omcbackendruntime PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 # for the configure_file inside it.
 include(${CMAKE_CURRENT_SOURCE_DIR}/omc_config_unix.cmake)
 
-configure_file(${OMCompiler_SOURCE_DIR}/revision.h.in ${OMCompiler_SOURCE_DIR}/revision.h)
-
-
 # Generate Autoconf.mo here since we have some of the variables already defined for omc_config.unix.h above.
 
 


### PR DESCRIPTION
`omc_config.h` quote-includes `revision.h` on its MinGW/MSVC branch, but the header was generated by `Compiler/runtime/CMakeLists.txt` — a file `Compiler/CMakeLists.txt` skips with an early `return()` when `OM_OMC_ENABLE_RUST` is on. The C simulation runtime is still built in Rust mode, so cross-compiling to `x86_64-pc-windows-msvc` failed on the first consumer of the header:

    OMCompiler/omc_config.h(139,10): fatal error:
      'revision.h' file not found

Linux and macOS never took that branch, so only the Windows cross-compile lane broke. This is the same gap `omc_config_unix.cmake` was factored out to close; `revision.h` was missed.

Move the `configure_file` up to `OMCompiler/CMakeLists.txt`, next to the `omc::config` include-dir setup, so it runs once for both the C and the Rust path. The destination stays in-source next to `omc_config.h`, where the quoted include resolves it before any `-I`.

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
