### PR TITLE
Improve handling of uninitialized record fields

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -678,17 +678,19 @@ protected
   list<Expression> expl;
   list<Type> types;
   Expression e;
+  InstNode node;
 algorithm
   if listLength(outputs) == 1 then
     exp := Ceval.evalExp(UnorderedMap.getOrFail(listHead(outputs), map));
-    assertAssignedOutput(listHead(outputs), exp);
+    node := listHead(outputs);
+    exp := assertAssignedOutput({InstNode.name(node)}, exp, InstNode.info(node));
   else
     expl := {};
     types := {};
 
     for o in outputs loop
       e := Ceval.evalExp(UnorderedMap.getOrFail(o, map));
-      assertAssignedOutput(o, e);
+      e := assertAssignedOutput({InstNode.name(o)}, e, InstNode.info(o));
       expl := e :: expl;
     end for;
 
@@ -699,18 +701,46 @@ algorithm
 end createResult;
 
 function assertAssignedOutput
-  input InstNode outputNode;
-  input Expression value;
+  input list<String> name;
+  input output Expression value;
+  input SourceInfo info;
+  input Boolean error = true;
+protected
+  list<Record.Field> fields;
+  list<Expression> expl;
 algorithm
-  () := match value
+  value := match value
     case Expression.EMPTY()
       algorithm
-        Error.addSourceMessageAsError(Error.UNASSIGNED_FUNCTION_OUTPUT,
-          {InstNode.name(outputNode)}, InstNode.info(outputNode));
+        if error then
+          Error.addSourceMessageAsError(Error.UNASSIGNED_FUNCTION_OUTPUT,
+            {stringDelimitList(listReverse(name), ".")}, info);
+          fail();
+        else
+          Error.addSourceMessage(Error.UNASSIGNED_FUNCTION_OUTPUT,
+            {stringDelimitList(listReverse(name), ".")}, info);
+        end if;
       then
-        fail();
+        // This will fail if the type is one that makeZero doesn't handle,
+        // but this should really be an error anyway so that's fine.
+        Expression.makeZero(value.ty);
 
-    else ();
+    case Expression.RECORD()
+      algorithm
+        fields := Type.recordFields(value.ty);
+        expl := {};
+
+        for e in value.elements loop
+          e := assertAssignedOutput(Record.Field.name(listHead(fields)) :: name, e, info, error = false);
+          expl := e :: expl;
+          fields := listRest(fields);
+        end for;
+
+        value.elements := listReverseInPlace(expl);
+      then
+        value;
+
+    else value;
   end match;
 end assertAssignedOutput;
 

--- a/testsuite/flattening/modelica/scodeinst/CevalFuncRecord5.mo
+++ b/testsuite/flattening/modelica/scodeinst/CevalFuncRecord5.mo
@@ -26,6 +26,8 @@ end CevalFuncRecord5;
 //   parameter Real r1.x = 2.0;
 //   parameter Real r1.y(fixed = false);
 //   parameter Real r2.x = 2.0;
-//   parameter Real r2.y(fixed = false);
+//   parameter Real r2.y(fixed = false) = 0.0;
 // end CevalFuncRecord5;
+// [flattening/modelica/scodeinst/CevalFuncRecord5.mo:14:3-14:16:writable] Warning: Output parameter outR.y was not assigned a value
+//
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -1041,6 +1041,7 @@ RecordBinding15.mo \
 RecordBinding16.mo \
 RecordBinding17.mo \
 RecordBinding18.mo \
+RecordBinding19.mo \
 RecordConstructor1.mo \
 RecordConstructor2.mo \
 RecordConstructor3.mo \

--- a/testsuite/flattening/modelica/scodeinst/RecordBinding17.mo
+++ b/testsuite/flattening/modelica/scodeinst/RecordBinding17.mo
@@ -22,9 +22,9 @@ end RecordBinding17;
 // Result:
 // class RecordBinding17
 //   final parameter Real m.x(start = 0.0) = 0.0;
-//   final parameter Integer m.y(start = 0);
+//   final parameter Integer m.y(start = 0) = 0;
 //   final parameter Integer m_type = 1;
 // end RecordBinding17;
-// [flattening/modelica/scodeinst/RecordBinding17.mo:8:3-8:23:writable] Warning: Parameter m.y has no value, and is fixed during initialization (fixed=true), using available start value (start=0) as default value.
+// [flattening/modelica/scodeinst/RecordBinding17.mo:12:3-12:13:writable] Warning: Output parameter r.y was not assigned a value
 //
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/RecordBinding19.mo
+++ b/testsuite/flattening/modelica/scodeinst/RecordBinding19.mo
@@ -1,0 +1,38 @@
+// name: RecordBinding19
+// keywords:
+// status: correct
+//
+
+record R
+  Real x;
+  Real y;
+  Real z;
+end R;
+
+function f
+  input Real x;
+  input Real y;
+  output R r;
+algorithm
+  r.x := x;
+  r.y := y;
+end f;
+
+function f2
+  input R r;
+  output Real x = r.x;
+end f2;
+
+model RecordBinding19
+  parameter R r = f(1.0, 2.0) annotation(Evaluate=true);
+end RecordBinding19;
+
+// Result:
+// class RecordBinding19
+//   parameter Real r.x = 1.0;
+//   parameter Real r.y = 2.0;
+//   parameter Real r.z = 0.0;
+// end RecordBinding19;
+// [flattening/modelica/scodeinst/RecordBinding19.mo:15:3-15:13:writable] Warning: Output parameter r.z was not assigned a value
+//
+// endResult

--- a/testsuite/simulation/libraries/msl32/Modelica.Electrical.Spice3.Examples.Graetz.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Electrical.Spice3.Examples.Graetz.mos
@@ -31,8 +31,6 @@ runScript(modelTesting);getErrorString();
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!
-// Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions("-d=initialization").
-//
 // "true
 // "
 // ""

--- a/testsuite/simulation/libraries/msl32/Modelica.Electrical.Spice3.Examples.Spice3BenchmarkFourBitBinaryAdder.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Electrical.Spice3.Examples.Spice3BenchmarkFourBitBinaryAdder.mos
@@ -83,10 +83,9 @@ runScript(modelTesting);getErrorString();
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!
-// Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions("-d=initialization").
-// Notification: Tearing is skipped for linear strong component 128: solving it torn to 30 iteration variables is estimated at 22757 flops against 10665 for the untorn system of size 126.
-// Notification: Tearing is skipped for linear strong component 149: solving it torn to 30 iteration variables is estimated at 23794 flops against 10665 for the untorn system of size 126.
-// Notification: Tearing is skipped for linear strong component 175: solving it torn to 28 iteration variables is estimated at 20190 flops against 9517 for the untorn system of size 113.
+// Notification: Tearing is skipped for linear strong component 22: solving it torn to 24 iteration variables is estimated at 24592 flops against 9517 for the untorn system of size 113.
+// Notification: Tearing is skipped for linear strong component 128: solving it torn to 30 iteration variables is estimated at 23630 flops against 10665 for the untorn system of size 126.
+// Notification: Tearing is skipped for linear strong component 175: solving it torn to 28 iteration variables is estimated at 19232 flops against 9517 for the untorn system of size 113.
 //
 // "true
 // "

--- a/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.Tests.MediaTestModels.LinearFluid.LinearWater_pT.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.Tests.MediaTestModels.LinearFluid.LinearWater_pT.mos
@@ -30,6 +30,51 @@ runScript(modelTesting); getErrorString();
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pt was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pd was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pt was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pd was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pt was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pd was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pt was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pd was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pt was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pd was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pt was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pd was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pt was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pd was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pt was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pd was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pt was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pd was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pt was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pd was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pt was not assigned a value
+// [Modelica 3.2.1+maint.om/Media/Water/IF97_Utilities.mo:6291:5-6291:58:writable] Warning: Output parameter aux.pd was not assigned a value
+//
 // "true
 // "
 // ""

--- a/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.DynamicPipeInitialValues.mos
+++ b/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.DynamicPipeInitialValues.mos
@@ -23,7 +23,19 @@ simulate(OverdeterminedInitialization.Fluid.DynamicPipeInitialValues); getErrorS
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
+// "[Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
 // Warning: Assuming fixed start value for the following 1 variables:
 //          m_flow_initial:DISCRETE(unit = \"kg/s\" fixed = true )  type: Real
 // Warning: The initial conditions are over specified. The following 1 initial equations are redundant, so they are removed from the initialization system:

--- a/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.DynamicPipeLumpedPressureInitialization.mos
+++ b/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.DynamicPipeLumpedPressureInitialization.mos
@@ -17,7 +17,19 @@ buildModel(OverdeterminedInitialization.Fluid.DynamicPipeLumpedPressureInitializ
 // true
 // ""
 // {"OverdeterminedInitialization.Fluid.DynamicPipeLumpedPressureInitialization", "OverdeterminedInitialization.Fluid.DynamicPipeLumpedPressureInitialization_init.xml"}
-// "Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
+// "[Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
 // Warning: Assuming fixed start value for the following 1 variables:
 //          m_flow_initial:DISCRETE(unit = \"kg/s\" fixed = true )  type: Real
 // Warning: The initial conditions are over specified. The following 4 initial equations are redundant, so they are removed from the initialization system:

--- a/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.DynamicPipesSeriesLargeNSteadyStateInitial.mos
+++ b/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.DynamicPipesSeriesLargeNSteadyStateInitial.mos
@@ -17,7 +17,27 @@ buildModel(OverdeterminedInitialization.Fluid.DynamicPipesSeriesLargeNSteadyStat
 // true
 // ""
 // {"OverdeterminedInitialization.Fluid.DynamicPipesSeriesLargeNSteadyStateInitial", "OverdeterminedInitialization.Fluid.DynamicPipesSeriesLargeNSteadyStateInitial_init.xml"}
-// "Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
+// "[Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
 // Notification: The following initial equation is redundant and consistent due to simplifications in RemoveSimpleEquations and therefore removed from the initialization problem: der(pipe1.mediums[1].p) = 0.0 -> 0.0 = 0.0
 // Warning: The initial conditions are over specified. The following 1 initial equations are redundant, so they are removed from the initialization system:
 //          $DER.pipe1.mediums[50].p = 0.0.

--- a/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.DynamicPipesSeriesSteadyStateInitial.mos
+++ b/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.DynamicPipesSeriesSteadyStateInitial.mos
@@ -17,7 +17,27 @@ buildModel(OverdeterminedInitialization.Fluid.DynamicPipesSeriesSteadyStateIniti
 // true
 // ""
 // {"OverdeterminedInitialization.Fluid.DynamicPipesSeriesSteadyStateInitial", "OverdeterminedInitialization.Fluid.DynamicPipesSeriesSteadyStateInitial_init.xml"}
-// "Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
+// "[Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:897:9-897:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// [Modelica 4.0.0+maint.om/Media/Water/IF97_Utilities.mo:934:9-934:73:writable] Warning: Output parameter bpro.cv was not assigned a value
+// Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
 // Notification: The following initial equation is redundant and consistent due to simplifications in RemoveSimpleEquations and therefore removed from the initialization problem: der(pipe1.mediums[1].p) = 0.0 -> 0.0 = 0.0
 // Warning: The initial conditions are over specified. The following 1 initial equations are redundant, so they are removed from the initialization system:
 //          $DER.pipe1.mediums[5].p = 0.0.


### PR DESCRIPTION
- Give a warning if evaluating a function results in an uninitialized record field.
- Replace any empty expressions with zero when creating the result of an evaluated function.