### PR TITLE
[Build] Add the missing license header to coi_server.py

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/coi_server.py
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/coi_server.py
@@ -1,4 +1,37 @@
 #!/usr/bin/env python3
+
+# This file is part of OpenModelica.
+#
+# Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+# c/o Linköpings universitet, Department of Computer and Information Science,
+# SE-58183 Linköping, Sweden.
+#
+# All rights reserved.
+#
+# THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+# THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+# ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+# RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+# VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+#
+# The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+# Public License (OSMC-PL) are obtained from OSMC, either from the above
+# address, from the URLs:
+# http://www.openmodelica.org or
+# https://github.com/OpenModelica/ or
+# http://www.ida.liu.se/projects/OpenModelica,
+# and in the OpenModelica distribution.
+#
+# GNU AGPL version 3 is obtained from:
+# https://www.gnu.org/licenses/licenses.html#GPL
+#
+# This program is distributed WITHOUT ANY WARRANTY; without
+# even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+# IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+#
+# See the full OSMC Public License conditions for more details.
+
 """Static file server with cross-origin isolation (COI) headers, for serving a
 local OpenModelica web build (OMEdit-qt / OMShell / OMNotebook / the omc page).
 


### PR DESCRIPTION
`OMCompiler/Compiler/OpenModelica.rs/wasm/coi_server.py` came in with #16686 without the OSMC-PL 1.8 license header, so the **Runtime license headers** workflow fails on it:

```
FAIL  OMCompiler/Compiler/OpenModelica.rs/wasm/coi_server.py: missing OSMC-PL 1.8 license header

FAILED: checked 2881 files, skipped 20609 (excluded), 1 failures.
```

That workflow only runs on pull requests, never on master, so the failure was not visible after the merge. It now fails on every pull request opened against master, whatever that pull request changes, because the check runs against the merge with master and the file is on master. It failed on #16689 that way, which is how this was found.

The header added here is the one `check_runtime_license.py --fix-license` writes. It goes after the shebang, so the script still runs and still keeps its module docstring. With it the check passes:

```
$ python3 .CI/scripts/check_runtime_license.py --summary OMCompiler/Compiler/OpenModelica.rs/wasm
PASSED: checked 1 files, skipped 2 (excluded), 0 failures.
```

cc @sjoelund

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017diJRM5MWBEEEeGAKZtD6b
