### PR TITLE
Set array variables whole in the FMI simulator

### DIFF
--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/artifact.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_codegen_wasm_jit/src/CodegenWasmJit/artifact.rs
@@ -686,16 +686,22 @@ fn run_fmi(
         if matches!(name.as_str(), "startTime" | "stopTime" | "stepSize" | "tolerance") {
             continue;
         }
-        let Some(v) = md.variables.iter().find(|v| v.name == *name) else {
+        let Some((v, vr, len)) = override_target(md, name) else {
             return Err(format!("wasm artifact: -override names no variable `{name}`"));
         };
         let Ok(value) = value.parse::<f64>() else {
             return Err(format!("wasm artifact: -override={name}={value} is not a number"));
         };
+        if len != 1 {
+            return Err(format!(
+                "wasm artifact: -override={name} names an array of {len} elements; \
+                 override them one at a time (`{name}[1]`)"
+            ));
+        }
         opts.parameters.push(openmodelica_fmi_driver::Parameter {
-            value_reference: v.value_reference,
+            value_reference: vr,
             ty: v.ty,
-            value,
+            values: vec![value],
         });
     }
 
@@ -836,6 +842,41 @@ fn mb(bytes: u64) -> String {
         Ok(true) => String::new(),
         _ => format!(", {:.1} MB", bytes as f64 / 1.0e6),
     }
+}
+
+/// The variable `-override` names, its value reference and how many values it
+/// takes. C names an array element (`q[2]`); FMI lists the array under one value
+/// reference, with the element's own following it in the FMU's own order.
+fn override_target<'a>(
+    md: &'a openmodelica_fmi::ModelDescription,
+    name: &str,
+) -> Option<(&'a openmodelica_fmi::Variable, u32, usize)> {
+    if let Some(v) = md.variables.iter().find(|v| v.name == name) {
+        return Some((v, v.value_reference, v.fixed_len().unwrap_or(1) as usize));
+    }
+    let (base, subscripts) = name.strip_suffix(']')?.split_once('[')?;
+    let v = md.variables.iter().find(|v| v.name == base)?;
+    let subscripts: Vec<u64> =
+        subscripts.split(',').map(|s| s.trim().parse().ok()).collect::<Option<_>>()?;
+    let extents: Vec<u64> = v
+        .dimensions
+        .iter()
+        .map(|d| match d {
+            openmodelica_fmi::Dimension::Fixed(k) => Some(*k),
+            openmodelica_fmi::Dimension::ValueReference(_) => None,
+        })
+        .collect::<Option<_>>()?;
+    if subscripts.len() != extents.len() {
+        return None;
+    }
+    let mut index = 0u64;
+    for (s, extent) in subscripts.iter().zip(&extents) {
+        if *s < 1 || s > extent {
+            return None;
+        }
+        index = index * extent + (s - 1);
+    }
+    Some((v, v.value_reference + index as u32, 1))
 }
 
 fn instance_name(md: &openmodelica_fmi::ModelDescription) -> String {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/description.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi/src/description.rs
@@ -156,10 +156,15 @@ impl Start {
     /// The first element as an `f64`, for the numeric types a master can set
     /// without knowing which one it is.
     pub fn first_f64(&self) -> Option<f64> {
+        self.f64s().and_then(|v| v.first().copied())
+    }
+
+    /// Every element as an `f64`; `None` for the types that have no number.
+    pub fn f64s(&self) -> Option<Vec<f64>> {
         match self {
-            Start::Reals(v) => v.first().copied(),
-            Start::Ints(v) => v.first().map(|&i| i as f64),
-            Start::Bools(v) => v.first().map(|&b| b as u8 as f64),
+            Start::Reals(v) => Some(v.clone()),
+            Start::Ints(v) => Some(v.iter().map(|&i| i as f64).collect()),
+            Start::Bools(v) => Some(v.iter().map(|&b| b as u8 as f64).collect()),
             _ => None,
         }
     }

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/examples/fmusim.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/examples/fmusim.rs
@@ -2,7 +2,8 @@
 //! the masters, natively.
 //!
 //! Options: `--me`/`--cs`, `--start`, `--stop`, `--step`, `--tolerance`,
-//! `--solver <name>` (`Solver::all`), `--input vr=expr`, `--parameter vr=value`,
+//! `--solver <name>` (`Solver::all`), `--input vr=expr`, `--parameter vr=value`
+//! (an array takes one expression or value per element, comma separated),
 //! `--output file.mat`, `--csv` (the trajectory on stdout), `--log`,
 //! `--difference-jacobian` (ignore what the FMU offers).
 
@@ -31,7 +32,7 @@ struct Args {
     output: Option<PathBuf>,
     csv: bool,
     inputs: Vec<(u32, String)>,
-    parameters: Vec<(u32, f64)>,
+    parameters: Vec<(u32, Vec<f64>)>,
 }
 
 fn parse_args() -> Result<Args, String> {
@@ -78,7 +79,11 @@ fn parse_args() -> Result<Args, String> {
                 if arg == "--input" {
                     a.inputs.push((vr, rest.to_string()));
                 } else {
-                    a.parameters.push((vr, rest.trim().parse().map_err(|_| "bad parameter value")?));
+                    let values: Result<Vec<f64>, _> = rest
+                        .split(',')
+                        .map(|v| v.trim().parse::<f64>().map_err(|_| "bad parameter value"))
+                        .collect();
+                    a.parameters.push((vr, values?));
                 }
             }
             _ if arg.starts_with("--") => return Err(format!("unknown option {arg}")),
@@ -112,14 +117,14 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         opts.inputs.push(Input {
             value_reference: *vr,
             ty: v.ty,
-            value: expr::Expr::parse(text)?,
+            values: expr::Expr::parse_list(text)?,
         });
     }
-    for (vr, value) in &args.parameters {
+    for (vr, values) in &args.parameters {
         let v = md
             .variable_by_vr(*vr)
             .ok_or_else(|| format!("no variable has value reference {vr}"))?;
-        opts.parameters.push(Parameter { value_reference: *vr, ty: v.ty, value: *value });
+        opts.parameters.push(Parameter { value_reference: *vr, ty: v.ty, values: values.clone() });
     }
 
     // The FMU is unpacked next to itself; a native binary has to exist on disk

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/common.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/common.rs
@@ -12,7 +12,6 @@ const MAX_EVENT_ITERATIONS: usize = 100;
 /// expressions are separated out: FMI only wants them set once.
 pub struct Inputs {
     groups: Vec<(VarType, Vec<u32>, Vec<usize>)>,
-    values: Vec<f64>,
     time_varying: bool,
 }
 
@@ -30,8 +29,7 @@ impl Inputs {
             }
         }
         Inputs {
-            time_varying: opts.inputs.iter().any(|i| !i.value.is_constant()),
-            values: vec![0.0; opts.inputs.len()],
+            time_varying: opts.inputs.iter().any(|i| i.values.iter().any(|e| !e.is_constant())),
             groups,
         }
     }
@@ -43,11 +41,11 @@ impl Inputs {
 
     /// Evaluate every input at `time` and set it.
     pub fn apply(&mut self, inst: &mut dyn Fmi3, opts: &Options<'_>, time: f64) -> Result<()> {
-        for (i, input) in opts.inputs.iter().enumerate() {
-            self.values[i] = input.value.eval(time);
-        }
         for (ty, vrs, indices) in &self.groups {
-            let values: Vec<f64> = indices.iter().map(|&i| self.values[i]).collect();
+            let values: Vec<f64> = indices
+                .iter()
+                .flat_map(|&i| opts.inputs[i].values.iter().map(|e| e.eval(time)))
+                .collect();
             inst.set_numeric(*ty, vrs, &values)?;
         }
         Ok(())
@@ -78,7 +76,7 @@ pub fn initialize(
     }
     inst.enter_initialization_mode(opts.tolerance, opts.start_time, Some(opts.stop_time))?;
     for p in &opts.parameters {
-        inst.set_numeric(p.ty.wire(), &[p.value_reference], &[p.value])?;
+        inst.set_numeric(p.ty.wire(), &[p.value_reference], &p.values)?;
     }
     inputs.apply(inst, opts, opts.start_time)?;
     inst.exit_initialization_mode()

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/expr.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/expr.rs
@@ -111,6 +111,25 @@ impl Expr {
         Ok(e)
     }
 
+    /// A comma-separated list, for an array variable's elements. Commas inside a
+    /// function call belong to the call, not to the list.
+    pub fn parse_list(text: &str) -> Result<Vec<Expr>, ParseError> {
+        let mut p = Parser { s: text.as_bytes(), i: 0 };
+        let mut out = Vec::new();
+        loop {
+            p.space();
+            out.push(p.ternary()?);
+            p.space();
+            if !p.eat(",") {
+                break;
+            }
+        }
+        if p.i != p.s.len() {
+            return Err(p.error("unexpected trailing input"));
+        }
+        Ok(out)
+    }
+
     pub fn eval(&self, t: f64) -> f64 {
         match self {
             Expr::Const(v) => *v,

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_driver/src/lib.rs
@@ -148,20 +148,22 @@ impl Solver {
     }
 }
 
-/// A value the master feeds an input variable, as a function of time.
+/// A value the master feeds an input variable, as a function of time. An array
+/// variable has one value reference and one expression per element, in the
+/// row-major order FMI flattens them in.
 pub struct Input {
     pub value_reference: u32,
     pub ty: VarType,
-    /// An expression in `t` ([`expr`]).
-    pub value: expr::Expr,
+    /// Expressions in `t` ([`expr`]), one per element.
+    pub values: Vec<expr::Expr>,
 }
 
 /// A value applied once, in Initialization Mode. FMI allows no other time for a
-/// parameter.
+/// parameter; an array takes one value per element, as for [`Input`].
 pub struct Parameter {
     pub value_reference: u32,
     pub ty: VarType,
-    pub value: f64,
+    pub values: Vec<f64>,
 }
 
 pub struct Options<'a> {

--- a/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_web/src/lib.rs
+++ b/OMCompiler/Compiler/OpenModelica.rs/openmodelica_fmi_web/src/lib.rs
@@ -10,7 +10,10 @@
 //! Strings cross as JSON in one buffer ([`om_fmi_out_ptr`]/[`om_fmi_out_len`]);
 //! sample values are read straight out of the recorder's buffer.
 
-use openmodelica_fmi::{Causality, Fmu, Initial, InterfaceKind, ModelDescription, VarType, Variability};
+use openmodelica_fmi::{
+    Causality, Dimension, FmiVersion, Fmu, Initial, InterfaceKind, ModelDescription, VarType,
+    Variability, Variable,
+};
 use openmodelica_fmi_driver::api::{Fmi3CoSimulation, Fmi3ModelExchange};
 use openmodelica_fmi_driver::record::Recorder;
 use openmodelica_fmi_driver::wasm_host::{HostFmu, KIND_CO_SIMULATION, KIND_MODEL_EXCHANGE};
@@ -215,8 +218,10 @@ pub extern "C" fn om_fmi_info() -> i32 {
 /// `{"interface":"me"|"cs", "startTime":…, "stopTime":…, "stepSize":…,
 ///   "tolerance":…, "solver": one of the `solvers` [`om_fmi_info`] lists,
 ///   "eventMode":bool,
-///   "loggingOn":bool, "parameters":[{"vr":…,"value":…}],
+///   "loggingOn":bool, "parameters":[{"vr":…,"values":[…]}],
 ///   "inputs":[{"vr":…,"expr":"sin(t)"}], "resultFile":"…"}`.
+/// An array variable is one value reference: `values` holds one entry per
+/// element, and its input expression is a comma-separated list of them.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn om_fmi_run(ptr: *const u8, len: usize) -> i32 {
     let text = String::from_utf8_lossy(unsafe { std::slice::from_raw_parts(ptr, len) }).into_owned();
@@ -326,6 +331,22 @@ fn causality_name(c: Causality) -> &'static str {
     }
 }
 
+/// How many values a variable takes: the product of its extents, a structural
+/// parameter's start value standing in for the dimension it gives.
+fn n_values(md: &ModelDescription, v: &Variable) -> usize {
+    v.dimensions
+        .iter()
+        .map(|d| match d {
+            Dimension::Fixed(k) => *k as usize,
+            Dimension::ValueReference(vr) => md
+                .variable_by_vr(*vr)
+                .and_then(|s| s.start.as_ref())
+                .and_then(|s| s.first_f64())
+                .unwrap_or(1.0) as usize,
+        })
+        .product()
+}
+
 /// Everything the page shows about an FMU before it is run.
 fn describe(fmu: &Fmu) -> Value {
     let md = &fmu.model_description;
@@ -362,7 +383,8 @@ fn describe(fmu: &Fmu) -> Value {
                 },
                 "unit": v.unit,
                 "displayUnit": v.display_unit,
-                "start": v.start.as_ref().and_then(|s| s.first_f64()),
+                "start": v.start.as_ref().and_then(|s| s.f64s()),
+                "nValues": n_values(md, v),
                 "numeric": v.ty.is_numeric(),
                 "settable": v.is_settable(),
                 // Together these name an editable start value: `derivative` the
@@ -463,6 +485,15 @@ fn figure_json(f: &openmodelica_fmi::Figure) -> Value {
 }
 
 fn options_from(md: &ModelDescription, o: &Value) -> Result<Options<'static>, Error> {
+    // An FMI 1.0/2.0 FMU numbers its value references per base type, which only
+    // its own loader translates; driving one here would reach other variables.
+    if md.fmi_version != FmiVersion::Fmi3 {
+        return Err(Error::Unsupported(format!(
+            "this FMU is FMI {}; the simulator drives FMI 3.0. Export it with version=\"3.0\" \
+             to simulate it here",
+            md.fmi_version_string
+        )));
+    }
     let mut opts = Options::from_model_description(md);
     let num = |key: &str| o.get(key).and_then(Value::as_f64);
     opts.start_time = num("startTime").unwrap_or(opts.start_time);
@@ -484,16 +515,27 @@ fn options_from(md: &ModelDescription, o: &Value) -> Result<Options<'static>, Er
     let variable_type = |vr: u64| -> VarType {
         md.variable_by_vr(vr as u32).map(|v| v.ty).unwrap_or(VarType::Float64)
     };
+    // FMI sets an array whole: what the page sends must be as long as the variable.
+    let check = |vr: u64, n: usize| -> Result<(), Error> {
+        let Some(v) = md.variable_by_vr(vr as u32) else { return Ok(()) };
+        let len = n_values(md, v);
+        if n != len {
+            return Err(Error::Unsupported(format!("`{}` takes {len} value(s), not {n}", v.name)));
+        }
+        Ok(())
+    };
     for p in o.get("parameters").and_then(Value::as_array).into_iter().flatten() {
-        let (Some(vr), Some(value)) =
-            (p.get("vr").and_then(Value::as_u64), p.get("value").and_then(Value::as_f64))
+        let (Some(vr), Some(values)) =
+            (p.get("vr").and_then(Value::as_u64), p.get("values").and_then(Value::as_array))
         else {
             continue;
         };
+        let values: Vec<f64> = values.iter().filter_map(Value::as_f64).collect();
+        check(vr, values.len())?;
         opts.parameters.push(Parameter {
             value_reference: vr as u32,
             ty: variable_type(vr),
-            value,
+            values,
         });
     }
     for i in o.get("inputs").and_then(Value::as_array).into_iter().flatten() {
@@ -502,9 +544,10 @@ fn options_from(md: &ModelDescription, o: &Value) -> Result<Options<'static>, Er
         else {
             continue;
         };
-        let value = expr::Expr::parse(text)
+        let values = expr::Expr::parse_list(text)
             .map_err(|e| Error::Unsupported(format!("the input expression `{text}`: {e}")))?;
-        opts.inputs.push(Input { value_reference: vr as u32, ty: variable_type(vr), value });
+        check(vr, values.len())?;
+        opts.inputs.push(Input { value_reference: vr as u32, ty: variable_type(vr), values });
     }
     Ok(opts)
 }

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/README.md
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/README.md
@@ -117,11 +117,17 @@ name.
 
 Inputs are expressions in `t` (`sin(2*PI*t)`, `t < 1 ? 0 : 1`) evaluated by the
 driver wherever the solver asks for a value; parameters are constants applied
-during initialization, which is the only mode FMI allows them to be set in.
+during initialization, which is the only mode FMI allows them to be set in. An
+array variable is one value reference and is set whole, so its field takes one
+expression or value per element, separated by commas (`0, -9.81, 0`).
 
 ## Gaps
 
 * Scheduled Execution is not driven; such an FMU is reported as unsupported.
+* An FMI 1.0/2.0 FMU is read and shown but not simulated: those versions number
+  value references per base type, and only the FMU's own loader
+  (`openmodelica_fmi_ls_wasm_to_native`) translates that to the FMI 3.0
+  numbering the component uses. Run is disabled and the page says so.
 * String and binary variables are shown but cannot be set.
 * `fmi3GetFMUState`/`fmi3SetFMUState` are unused: no rollback, so a
   Co-Simulation FMU that discards a step fails the run rather than retrying it

--- a/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/index.html
+++ b/OMCompiler/Compiler/OpenModelica.rs/wasm/fmi-simulator/index.html
@@ -340,9 +340,17 @@ async function openFile(file) {
     renderDoc(documentationHtml(probe.documentation));
     renderFields();
     applyDefaults();
-    runBtn.disabled = false;
+    // An FMI 1.0/2.0 FMU numbers its value references per base type, which the
+    // masters do not translate: it is shown, but it cannot be run here.
+    const old = !/^3/.test(String(probe.fmiVersion));
+    runBtn.disabled = old;
     syncNativeDialog();
-    setStatus(`${fmu.md.modelName || file.name} loaded in ${ms} ms — the FMU reports FMI ${probe.fmiVersion}.`);
+    if (old) {
+      setStatus(`${fmu.md.modelName || file.name}: this FMU is FMI ${probe.fmiVersion}; `
+        + 'the simulator drives FMI 3.0. Export it with version="3.0" to simulate it here.', 'err');
+    } else {
+      setStatus(`${fmu.md.modelName || file.name} loaded in ${ms} ms — the FMU reports FMI ${probe.fmiVersion}.`);
+    }
   } catch (e) {
     fmu = null; archive = null;
     runBtn.disabled = true;
@@ -462,8 +470,10 @@ function renderFields() {
     const field = { v, input, kind: isInput ? 'input' : 'parameter', base, unit: chosen };
     const shown = (x) => (field.unit === base ? String(x) : toDisplay(x, displayUnitDef(base, field.unit)));
     // An input must be driven; a parameter with no declared start is left unset.
-    input.value = v.start != null ? shown(v.start)
-                : isInput ? (v.type === 'Boolean' ? 'false' : '0') : '';
+    // An array is one field, one element per comma.
+    input.value = v.start != null ? v.start.map(shown).join(', ')
+                : isInput ? Array(v.nValues || 1).fill(v.type === 'Boolean' ? 'false' : '0').join(', ')
+                : '';
     input.placeholder = input.value === '' ? 'unset' : '';
     input.spellcheck = false;
 
@@ -479,12 +489,14 @@ function renderFields() {
         unit.appendChild(o);
       }
       unit.onchange = () => {
-        const was = field.unit, now = unit.value, text = input.value.trim();
+        const was = field.unit, now = unit.value, parts = splitList(input.value);
         field.unit = now;
-        if (text === '' || !isFinite(Number(text))) return;   // an expression: leave it
-        const inBase = was === base ? text : fromDisplay(text, displayUnitDef(base, was));
-        const out = now === base ? inBase : toDisplay(inBase, displayUnitDef(base, now));
-        if (inBase != null && out != null) input.value = out;
+        if (parts.some((p) => p === '' || !isFinite(Number(p)))) return;   // an expression: leave it
+        const out = parts.map((p) => {
+          const inBase = was === base ? p : fromDisplay(p, displayUnitDef(base, was));
+          return inBase == null || now === base ? inBase : toDisplay(inBase, displayUnitDef(base, now));
+        });
+        if (out.every((v) => v != null)) input.value = out.join(', ');
       };
     } else {
       unit = document.createElement('span');
@@ -523,6 +535,21 @@ function compileExpr(src, name) {
   return fn;
 }
 
+// Split an array field into its elements: a comma inside a call — max(t,1) —
+// belongs to the call, not to the list.
+function splitList(text) {
+  const out = [];
+  let depth = 0, from = 0;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if ('([{'.includes(c)) depth++;
+    else if (')]}'.includes(c)) depth--;
+    else if (c === ',' && depth === 0) { out.push(text.slice(from, i)); from = i + 1; }
+  }
+  out.push(text.slice(from));
+  return out.map((p) => p.trim());
+}
+
 // The driver evaluates the expressions itself, so they travel as text; they are
 // still compiled here first, to catch a typo before the run starts.
 function collectFields() {
@@ -535,17 +562,25 @@ function collectFields() {
       log('warning', `${f.v.name}: string variables cannot be set yet; ignoring.`);
       continue;
     }
+    const n = f.v.nValues || 1;
     try {
-      const fn = compileExpr(src || '0', f.v.name);
-      const expr = src || '0';
+      const parts = splitList(src === '' ? Array(n).fill('0').join(',') : src);
+      if (parts.length !== n) {
+        throw new Error(`${f.v.name}: ${n} values expected, ${parts.length} given`);
+      }
       const d = displayUnitDef(f.base, f.unit);
-      if (f.kind === 'input') inputs.push({ vr: f.v.vr, expr: d ? backExpr(expr, d) : expr });
-      else {
-        const value = fn(num(startEl.value, 0));
+      const fns = parts.map((p) => compileExpr(p, f.v.name));
+      if (f.kind === 'input') {
+        inputs.push({ vr: f.v.vr, expr: parts.map((p) => (d ? backExpr(p, d) : p)).join(', ') });
+      } else {
+        const t = num(startEl.value, 0);
         // A plain number converts exactly; anything computed falls back to doubles.
-        const exact = d && /^[-+0-9.eE]+$/.test(src) ? fromDisplay(src, d) : null;
-        parameters.push({ vr: f.v.vr, value: exact != null ? Number(exact)
-                                            : d ? Number(fromDisplay(value, d) ?? value) : value });
+        const values = parts.map((p, i) => {
+          const value = fns[i](t);
+          const exact = d && /^[-+0-9.eE]+$/.test(p) ? fromDisplay(p, d) : null;
+          return exact != null ? Number(exact) : d ? Number(fromDisplay(value, d) ?? value) : value;
+        });
+        parameters.push({ vr: f.v.vr, values });
       }
     } catch (e) { f.input.classList.add('bad'); throw e; }
   }

--- a/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_arrays.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/3.0/fmi3_wasm_arrays.mos
@@ -2,11 +2,12 @@
 // keywords: FMI 3.0 export wasm array
 // status: correct
 // suite: wasm
-// teardown_command: rm -rf fmi3_wasm_arrays.fmu fmi3_wasm_arrays.fmu.log fmi3_wasm_arrays_artifact plain_res.mat art_cs.mat d_cs* plain* om-wasm-include-*
+// teardown_command: rm -rf fmi3_wasm_arrays.fmu fmi3_wasm_arrays.fmu.log fmi3_wasm_arrays_artifact plain_res.mat art_cs.mat art_q.mat d_cs* d_q* plain* om-wasm-include-*
 //
 // The FMI 3.0 modelDescription.xml lists the arrays x, der(x), y, p and q as one
 // variable each; the wasm component serves such a value reference with all the
-// array's values, as the C runtime does.
+// array's values, as the C runtime does. `-override` names an element the way C
+// does (`q[2]`), which is that value reference plus the element's offset.
 
 setCommandLineOptions("--simCodeTarget=wasm-jit"); getErrorString();
 loadString("
@@ -35,6 +36,11 @@ simulate(ArrPkg.M, stopTime=1.0, numberOfIntervals=10, simflags="-s fmi3:cs -r=a
 
 diffSimulationResults("art_cs.mat", "plain_res.mat", "d_cs", 1e-9, 1e-9);
 
+simulate(ArrPkg.M, stopTime=1.0, numberOfIntervals=10, fileNamePrefix="plainq", simflags="-override=q[2]=5"); getErrorString();
+simulate(ArrPkg.M, stopTime=1.0, numberOfIntervals=10, simflags="-s fmi3:cs -override=q[2]=5 -r=art_q.mat", resimulateExecutable="fmi3_wasm_arrays.fmu"); getErrorString();
+
+diffSimulationResults("art_q.mat", "plainq_res.mat", "d_q", 1e-9, 1e-9);
+
 // Result:
 // true
 // ""
@@ -55,6 +61,25 @@ diffSimulationResults("art_cs.mat", "plain_res.mat", "d_cs", 1e-9, 1e-9);
 // record SimulationResult
 //     resultFile = "art_cs.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 10, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ArrPkg.M', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s fmi3:cs -r=art_cs.mat'",
+//     messages = "LOG_STDOUT        | info    | wasm artifact loaded (compiled from the component)
+// LOG_STDOUT        | info    | CoSimulation instantiated
+// LOG_STDOUT        | info    | CoSimulation run: 500 communication steps, 0 events, 0 early returns, 501 samples
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// (true, {})
+// record SimulationResult
+//     resultFile = "plainq_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 10, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'plainq', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-override=q[2]=5'",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// record SimulationResult
+//     resultFile = "art_q.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 10, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ArrPkg.M', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-s fmi3:cs -override=q[2]=5 -r=art_q.mat'",
 //     messages = "LOG_STDOUT        | info    | wasm artifact loaded (compiled from the component)
 // LOG_STDOUT        | info    | CoSimulation instantiated
 // LOG_STDOUT        | info    | CoSimulation run: 500 communication steps, 0 events, 0 early returns, 501 samples


### PR DESCRIPTION
An FMI 3.0 array is one value reference set with all of its elements at once, but the page's setter side was scalar all the way down: `om_fmi_info` reported only the first start value, `index.html` sent one number per variable, and the driver's `Parameter`/`Input` held one value. Any FMU with an array parameter therefore died in Initialization Mode:

    [DoublePendulum] logStatusError: fmi3SetFloat64: 1 values
    for 3 value references

`world.groundAxis_u` and the seven other array parameters of `Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulum` are enough to stop the run before it starts. The recorder already read arrays correctly; only setting them was broken.

An array field now holds one expression or value per element, split at the commas that are not inside a call, so `max(t,1)` still parses:

    world.groundAxis_u    1, 0, 0
    n                     0, -9.81, 0

`Parameter.values`/`Input.values` carry them, the wire the page speaks takes `values: […]`, and the bridge checks the count against the variable's own extents before the FMU can complain.

`-override` reaches an array element the way C spells it — `-override=q[2]=5`, resolved to the array's value reference plus the element's offset — since `-override`'s own parser splits its value at top-level commas and the whole array cannot travel in one entry.

The page also refuses to simulate an FMI 1.0/2.0 FMU now. Those number their value references per base type and only the FMU's own loader translates that, so an FMI 2.0 export (from `platforms={"win64"}`, say) would set and read whatever variable happened to share the number; it is still shown, but Run is disabled and the page says to export with version="3.0".

Assisted-by: Claude Opus 5 (1M context)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
